### PR TITLE
First draft of the compositor/subcompositor global handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*.bk

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -6,6 +6,5 @@ reorder_imports = true
 reorder_imported_names = true
 report_todo = "Never"
 report_fixme = "Never"
-normalize_comments = true
 use_try_shorthand = true
 max_width = 110

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ rental = "0.4.11"
 gl_generator = "0.5"
 
 [dev-dependencies]
-slog-term = "~1.5"
+slog-term = "2.0"
+slog-async = "2.0"
 
 [features]
 default = ["backend_winit", "backend_libinput", "renderer_glium"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ slog-stdlog = "2.0.0-0.2"
 libloading = "0.4.0"
 wayland-client = { version = "~0.8.6", optional = true }
 winit = { git = "https://github.com/tomaka/winit.git", optional = true }
-glium = { version = "~0.16.0", optional = true }
+glium = { version = "~0.16.0", optional = true, default-features="false" }
 input = { version = "~0.2.0", optional = true }
 clippy = { version = "*", optional = true }
 rental = "0.4.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ slog-stdlog = "2.0.0-0.2"
 libloading = "0.4.0"
 wayland-client = { version = "~0.8.6", optional = true }
 winit = { git = "https://github.com/tomaka/winit.git", optional = true }
-glium = { version = "~0.16.0", optional = true, default-features="false" }
+glium = { version = "~0.16.0", optional = true, default-features = false }
 input = { version = "~0.2.0", optional = true }
 clippy = { version = "*", optional = true }
 rental = "0.4.11"

--- a/examples/helpers/glium.rs
+++ b/examples/helpers/glium.rs
@@ -1,0 +1,116 @@
+use glium;
+use glium::Surface;
+use glium::index::PrimitiveType;
+
+#[derive(Copy, Clone)]
+struct Vertex {
+    position: [f32; 2],
+    tex_coords: [f32; 2],
+}
+
+implement_vertex!(Vertex, position, tex_coords);
+
+pub struct GliumDrawer<'a, F: 'a> {
+    display: &'a F,
+    vertex_buffer: glium::VertexBuffer<Vertex>,
+    index_buffer: glium::IndexBuffer<u16>,
+    program: glium::Program,
+}
+
+impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
+    pub fn new(display: &'a F) -> GliumDrawer<'a, F>
+    {
+
+        // building the vertex buffer, which contains all the vertices that we will draw
+        let vertex_buffer = glium::VertexBuffer::new(display,
+                                                     &[Vertex {
+                                                           position: [0.0, 0.0],
+                                                           tex_coords: [0.0, 0.0],
+                                                       },
+                                                       Vertex {
+                                                           position: [0.0, 1.0],
+                                                           tex_coords: [0.0, 1.0],
+                                                       },
+                                                       Vertex {
+                                                           position: [1.0, 1.0],
+                                                           tex_coords: [1.0, 1.0],
+                                                       },
+                                                       Vertex {
+                                                           position: [1.0, 0.0],
+                                                           tex_coords: [1.0, 0.0],
+                                                       }])
+                .unwrap();
+
+        // building the index buffer
+        let index_buffer =
+            glium::IndexBuffer::new(display, PrimitiveType::TriangleStrip, &[1 as u16, 2, 0, 3]).unwrap();
+
+        // compiling shaders and linking them together
+        let program = program!(display,
+			100 => {
+				vertex: "
+					#version 100
+					uniform lowp mat4 matrix;
+					attribute lowp vec2 position;
+					attribute lowp vec2 tex_coords;
+					varying lowp vec2 v_tex_coords;
+					void main() {
+						gl_Position = matrix * vec4(position, 0.0, 1.0);
+						v_tex_coords = tex_coords;
+					}
+				",
+
+				fragment: "
+					#version 100
+					uniform lowp sampler2D tex;
+					varying lowp vec2 v_tex_coords;
+					void main() {
+	                    lowp vec4 color = texture2D(tex, v_tex_coords);
+						gl_FragColor.r = color.z;
+                        gl_FragColor.g = color.y;
+                        gl_FragColor.b = color.x;
+                        gl_FragColor.a = color.w;
+					}
+				",
+			},
+        )
+                .unwrap();
+
+        GliumDrawer {
+            display,
+            vertex_buffer,
+            index_buffer,
+            program,
+        }
+    }
+
+    pub fn draw(&self, target: &mut glium::Frame, contents: &[u8], surface_dimensions: (u32, u32), surface_location: (i32,i32), screen_size: (u32,u32)) {
+
+        let image = glium::texture::RawImage2d {
+            data: contents.into(),
+            width: surface_dimensions.0,
+            height: surface_dimensions.1,
+            format: glium::texture::ClientFormat::U8U8U8U8
+        };
+        let opengl_texture = glium::texture::CompressedSrgbTexture2d::new(self.display, image).unwrap();
+
+        let xscale = 2.0*(surface_dimensions.0 as f32) / (screen_size.0 as f32);
+        let yscale = -2.0*(surface_dimensions.1 as f32) / (screen_size.1 as f32);
+
+        let x = 2.0*(surface_location.0 as f32) / (screen_size.0 as f32) - 1.0;
+        let y = 1.0 - 2.0*(surface_location.1 as f32) / (screen_size.1 as f32);
+
+        let uniforms = uniform! {
+            matrix: [
+                [xscale,   0.0  , 0.0, 0.0],
+                [  0.0 , yscale , 0.0, 0.0],
+                [  0.0 ,   0.0  , 1.0, 0.0],
+                [   x  ,    y   , 0.0, 1.0]
+            ],
+            tex: &opengl_texture
+        };
+
+        target.draw(&self.vertex_buffer, &self.index_buffer, &self.program, &uniforms, &Default::default()).unwrap();
+
+    }
+}

--- a/examples/helpers/glium.rs
+++ b/examples/helpers/glium.rs
@@ -90,7 +90,7 @@ impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
             height: surface_dimensions.1,
             format: glium::texture::ClientFormat::U8U8U8U8,
         };
-        let opengl_texture = glium::texture::CompressedSrgbTexture2d::new(self.display, image).unwrap();
+        let opengl_texture = glium::texture::Texture2d::new(self.display, image).unwrap();
 
         let xscale = 2.0 * (surface_dimensions.0 as f32) / (screen_size.0 as f32);
         let yscale = -2.0 * (surface_dimensions.1 as f32) / (screen_size.1 as f32);

--- a/examples/helpers/glium.rs
+++ b/examples/helpers/glium.rs
@@ -18,8 +18,7 @@ pub struct GliumDrawer<'a, F: 'a> {
 }
 
 impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
-    pub fn new(display: &'a F) -> GliumDrawer<'a, F>
-    {
+    pub fn new(display: &'a F) -> GliumDrawer<'a, F> {
 
         // building the vertex buffer, which contains all the vertices that we will draw
         let vertex_buffer = glium::VertexBuffer::new(display,
@@ -38,8 +37,7 @@ impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
                                                        Vertex {
                                                            position: [1.0, 0.0],
                                                            tex_coords: [1.0, 0.0],
-                                                       }])
-                .unwrap();
+                                                       }]).unwrap();
 
         // building the index buffer
         let index_buffer =
@@ -73,8 +71,7 @@ impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
 					}
 				",
 			},
-        )
-                .unwrap();
+        ).unwrap();
 
         GliumDrawer {
             display,
@@ -84,23 +81,25 @@ impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
         }
     }
 
-    pub fn draw(&self, target: &mut glium::Frame, contents: &[u8], surface_dimensions: (u32, u32), surface_location: (i32,i32), screen_size: (u32,u32)) {
+    pub fn draw(&self, target: &mut glium::Frame, contents: &[u8], surface_dimensions: (u32, u32),
+                surface_location: (i32, i32), screen_size: (u32, u32)) {
 
         let image = glium::texture::RawImage2d {
             data: contents.into(),
             width: surface_dimensions.0,
             height: surface_dimensions.1,
-            format: glium::texture::ClientFormat::U8U8U8U8
+            format: glium::texture::ClientFormat::U8U8U8U8,
         };
         let opengl_texture = glium::texture::CompressedSrgbTexture2d::new(self.display, image).unwrap();
 
-        let xscale = 2.0*(surface_dimensions.0 as f32) / (screen_size.0 as f32);
-        let yscale = -2.0*(surface_dimensions.1 as f32) / (screen_size.1 as f32);
+        let xscale = 2.0 * (surface_dimensions.0 as f32) / (screen_size.0 as f32);
+        let yscale = -2.0 * (surface_dimensions.1 as f32) / (screen_size.1 as f32);
 
-        let x = 2.0*(surface_location.0 as f32) / (screen_size.0 as f32) - 1.0;
-        let y = 1.0 - 2.0*(surface_location.1 as f32) / (screen_size.1 as f32);
+        let x = 2.0 * (surface_location.0 as f32) / (screen_size.0 as f32) - 1.0;
+        let y = 1.0 - 2.0 * (surface_location.1 as f32) / (screen_size.1 as f32);
 
-        let uniforms = uniform! {
+        let uniforms =
+            uniform! {
             matrix: [
                 [xscale,   0.0  , 0.0, 0.0],
                 [  0.0 , yscale , 0.0, 0.0],
@@ -110,7 +109,13 @@ impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
             tex: &opengl_texture
         };
 
-        target.draw(&self.vertex_buffer, &self.index_buffer, &self.program, &uniforms, &Default::default()).unwrap();
+        target
+            .draw(&self.vertex_buffer,
+                  &self.index_buffer,
+                  &self.program,
+                  &uniforms,
+                  &Default::default())
+            .unwrap();
 
     }
 }

--- a/examples/helpers/glium.rs
+++ b/examples/helpers/glium.rs
@@ -21,23 +21,27 @@ impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
     pub fn new(display: &'a F) -> GliumDrawer<'a, F> {
 
         // building the vertex buffer, which contains all the vertices that we will draw
-        let vertex_buffer = glium::VertexBuffer::new(display,
-                                                     &[Vertex {
-                                                           position: [0.0, 0.0],
-                                                           tex_coords: [0.0, 0.0],
-                                                       },
-                                                       Vertex {
-                                                           position: [0.0, 1.0],
-                                                           tex_coords: [0.0, 1.0],
-                                                       },
-                                                       Vertex {
-                                                           position: [1.0, 1.0],
-                                                           tex_coords: [1.0, 1.0],
-                                                       },
-                                                       Vertex {
-                                                           position: [1.0, 0.0],
-                                                           tex_coords: [1.0, 0.0],
-                                                       }]).unwrap();
+        let vertex_buffer = glium::VertexBuffer::new(
+            display,
+            &[
+                Vertex {
+                    position: [0.0, 0.0],
+                    tex_coords: [0.0, 0.0],
+                },
+                Vertex {
+                    position: [0.0, 1.0],
+                    tex_coords: [0.0, 1.0],
+                },
+                Vertex {
+                    position: [1.0, 1.0],
+                    tex_coords: [1.0, 1.0],
+                },
+                Vertex {
+                    position: [1.0, 0.0],
+                    tex_coords: [1.0, 0.0],
+                },
+            ],
+        ).unwrap();
 
         // building the index buffer
         let index_buffer =
@@ -110,11 +114,13 @@ impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
         };
 
         target
-            .draw(&self.vertex_buffer,
-                  &self.index_buffer,
-                  &self.program,
-                  &uniforms,
-                  &Default::default())
+            .draw(
+                &self.vertex_buffer,
+                &self.index_buffer,
+                &self.program,
+                &uniforms,
+                &Default::default(),
+            )
             .unwrap();
 
     }

--- a/examples/helpers/mod.rs
+++ b/examples/helpers/mod.rs
@@ -1,0 +1,5 @@
+mod shell;
+mod glium;
+
+pub use self::glium::GliumDrawer;
+pub use self::shell::WlShellStubHandler;

--- a/examples/helpers/shell.rs
+++ b/examples/helpers/shell.rs
@@ -67,16 +67,7 @@ impl<U, H> wl_shell::Handler for WlShellStubHandler<U, H>
     }
 }
 
-unsafe impl<U, H> ::wayland_server::Handler<wl_shell::WlShell> for WlShellStubHandler<U, H>
-    where U: Send + 'static,
-          H: CompositorHandler<U> + Send + 'static
-{
-    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client, resource: &wl_shell::WlShell,
-                      opcode: u32, args: *const ::wayland_server::sys::wl_argument)
-                      -> Result<(), ()> {
-        <WlShellStubHandler<U,H> as ::wayland_server::protocol::wl_shell::Handler>::__message(self, evq, client, resource, opcode, args)
-    }
-}
+server_declare_handler!(WlShellStubHandler<U: [Send], H: [CompositorHandler<U>, Send]>, wl_shell::Handler, wl_shell::WlShell);
 
 impl<U, H> wl_shell_surface::Handler for WlShellStubHandler<U, H>
     where U: Send + 'static,
@@ -84,14 +75,4 @@ impl<U, H> wl_shell_surface::Handler for WlShellStubHandler<U, H>
 {
 }
 
-unsafe impl<U, H> ::wayland_server::Handler<wl_shell_surface::WlShellSurface> for WlShellStubHandler<U, H>
-    where U: Send + 'static,
-          H: CompositorHandler<U> + Send + 'static
-{
-    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
-                      resource: &wl_shell_surface::WlShellSurface, opcode: u32,
-                      args: *const ::wayland_server::sys::wl_argument)
-                      -> Result<(), ()> {
-        <WlShellStubHandler<U,H> as ::wayland_server::protocol::wl_shell_surface::Handler>::__message(self, evq, client, resource, opcode, args)
-    }
-}
+server_declare_handler!(WlShellStubHandler<U: [Send], H: [CompositorHandler<U>, Send]>, wl_shell_surface::Handler, wl_shell_surface::WlShellSurface);

--- a/examples/helpers/shell.rs
+++ b/examples/helpers/shell.rs
@@ -49,17 +49,22 @@ impl<U, H> GlobalHandler<wl_shell::WlShell> for WlShellStubHandler<U, H>
 }
 
 impl<U, H> wl_shell::Handler for WlShellStubHandler<U, H>
-    where U: Send + 'static,
-          H: CompositorHandler<U> + Send + 'static
+where
+    U: Send + 'static,
+    H: CompositorHandler<U> + Send + 'static,
 {
     fn get_shell_surface(&mut self, evqh: &mut EventLoopHandle, client: &Client,
                          resource: &wl_shell::WlShell, id: wl_shell_surface::WlShellSurface,
                          surface: &wl_surface::WlSurface) {
-        let surface =  surface.clone().expect("WlShellStubHandler can only manage surfaces managed by Smithay's CompositorHandler.");
+        let surface = surface.clone().expect(
+            "WlShellStubHandler can only manage surfaces managed by Smithay's CompositorHandler.",
+        );
         if self.token.give_role(&surface).is_err() {
             // This surface already has a role, and thus cannot be given one!
-            resource.post_error(wl_shell::Error::Role as u32,
-                                "Surface already has a role.".into());
+            resource.post_error(
+                wl_shell::Error::Role as u32,
+                "Surface already has a role.".into(),
+            );
             return;
         }
         evqh.register::<_, Self>(&id, self.my_id.unwrap());
@@ -70,8 +75,9 @@ impl<U, H> wl_shell::Handler for WlShellStubHandler<U, H>
 server_declare_handler!(WlShellStubHandler<U: [Send], H: [CompositorHandler<U>, Send]>, wl_shell::Handler, wl_shell::WlShell);
 
 impl<U, H> wl_shell_surface::Handler for WlShellStubHandler<U, H>
-    where U: Send + 'static,
-          H: CompositorHandler<U> + Send + 'static
+where
+    U: Send + 'static,
+    H: CompositorHandler<U> + Send + 'static,
 {
 }
 

--- a/examples/helpers/shell.rs
+++ b/examples/helpers/shell.rs
@@ -1,0 +1,97 @@
+
+
+use smithay::compositor::{CompositorToken, Handler as CompositorHandler};
+use wayland_server::{Client, EventLoopHandle, GlobalHandler, Init, Resource};
+use wayland_server::protocol::{wl_shell, wl_shell_surface, wl_surface};
+
+/// A very basic handler for wl_shell
+///
+/// All it does is track which wl_shell_surface exist and which do not,
+/// as well as the roles associated to them.
+///
+/// That's it.
+pub struct WlShellStubHandler<U, H> {
+    my_id: Option<usize>,
+    token: CompositorToken<U, H>,
+    surfaces: Vec<(wl_shell_surface::WlShellSurface, wl_surface::WlSurface)>,
+}
+
+impl<U, H> WlShellStubHandler<U, H> {
+    pub fn new(compositor_token: CompositorToken<U, H>) -> WlShellStubHandler<U, H> {
+        WlShellStubHandler {
+            my_id: None,
+            token: compositor_token,
+            surfaces: Vec::new(),
+        }
+    }
+
+    pub fn surfaces(&self) -> &[(wl_shell_surface::WlShellSurface, wl_surface::WlSurface)] {
+        &self.surfaces
+    }
+}
+
+impl<U, H> Init for WlShellStubHandler<U, H> {
+    fn init(&mut self, evqh: &mut EventLoopHandle, index: usize) {
+        self.my_id = Some(index)
+    }
+}
+
+
+impl<U, H> GlobalHandler<wl_shell::WlShell> for WlShellStubHandler<U, H>
+    where U: Send + 'static,
+          H: CompositorHandler<U> + Send + 'static
+{
+    fn bind(&mut self, evqh: &mut EventLoopHandle, client: &Client, global: wl_shell::WlShell) {
+        evqh.register::<_, Self>(&global,
+                                 self.my_id
+                                     .expect("WlShellStubHandler was not properly initialized."));
+    }
+}
+
+impl<U, H> wl_shell::Handler for WlShellStubHandler<U, H>
+    where U: Send + 'static,
+          H: CompositorHandler<U> + Send + 'static
+{
+    fn get_shell_surface(&mut self, evqh: &mut EventLoopHandle, client: &Client,
+                         resource: &wl_shell::WlShell, id: wl_shell_surface::WlShellSurface,
+                         surface: &wl_surface::WlSurface) {
+        let surface =  surface.clone().expect("WlShellStubHandler can only manage surfaces managed by Smithay's CompositorHandler.");
+        if self.token.give_role(&surface).is_err() {
+            // This surface already has a role, and thus cannot be given one!
+            resource.post_error(wl_shell::Error::Role as u32,
+                                "Surface already has a role.".into());
+            return;
+        }
+        evqh.register::<_, Self>(&id, self.my_id.unwrap());
+        self.surfaces.push((id, surface))
+    }
+}
+
+unsafe impl<U, H> ::wayland_server::Handler<wl_shell::WlShell> for WlShellStubHandler<U, H>
+    where U: Send + 'static,
+          H: CompositorHandler<U> + Send + 'static
+{
+    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client, resource: &wl_shell::WlShell,
+                      opcode: u32, args: *const ::wayland_server::sys::wl_argument)
+                      -> Result<(), ()> {
+        <WlShellStubHandler<U,H> as ::wayland_server::protocol::wl_shell::Handler>::__message(self, evq, client, resource, opcode, args)
+    }
+}
+
+impl<U, H> wl_shell_surface::Handler for WlShellStubHandler<U, H>
+    where U: Send + 'static,
+          H: CompositorHandler<U> + Send + 'static
+{
+}
+
+unsafe impl<U, H> ::wayland_server::Handler<wl_shell_surface::WlShellSurface> for WlShellStubHandler<U, H>
+    where U: Send + 'static,
+          H: CompositorHandler<U> + Send + 'static
+{
+    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
+                      resource: &wl_shell_surface::WlShellSurface, opcode: u32,
+                      args: *const ::wayland_server::sys::wl_argument)
+                      -> Result<(), ()> {
+        <WlShellStubHandler<U,H> as ::wayland_server::protocol::wl_shell_surface::Handler>::__message(self, evq, client, resource, opcode, args)
+    }
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -7,26 +7,26 @@ extern crate slog;
 extern crate slog_async;
 extern crate slog_term;
 
-use slog::*;
 
 use glium::Surface;
+use slog::*;
 
 use smithay::backend::graphics::glium::IntoGlium;
 use smithay::backend::input::InputBackend;
 use smithay::backend::winit;
+use smithay::compositor::{self, CompositorHandler};
 use smithay::shm::ShmGlobal;
-use smithay::compositor::{CompositorHandler, self};
 
 use wayland_server::protocol::{wl_compositor, wl_shm, wl_subcompositor};
 
 struct SurfaceHandler;
 
-impl compositor::Handler for SurfaceHandler {
-}
+impl compositor::Handler for SurfaceHandler {}
 
 fn main() {
     // A logger facility, here we use the terminal for this example
-    let log = Logger::root(slog_async::Async::default(slog_term::term_full().fuse()).fuse(), o!());
+    let log = Logger::root(slog_async::Async::default(slog_term::term_full().fuse()).fuse(),
+                           o!());
 
     // Initialize a simple backend for testing
     let (renderer, mut input) = winit::init(log.clone()).unwrap();
@@ -38,8 +38,7 @@ fn main() {
      */
     // Insert the ShmGlobal as a handler to your event loop
     // Here, we specify tha the standard Argb8888 and Xrgb8888 is the only supported.
-    let shm_handler_id =
-        event_loop.add_handler_with_init(ShmGlobal::new(vec![], log.clone()));
+    let shm_handler_id = event_loop.add_handler_with_init(ShmGlobal::new(vec![], log.clone()));
     // Register this handler to advertise a wl_shm global of version 1
     event_loop.register_global::<wl_shm::WlShm, ShmGlobal>(shm_handler_id, 1);
 
@@ -47,7 +46,7 @@ fn main() {
      * Initialize the compositor global
      */
     let compositor_handler_id =
-        event_loop.add_handler_with_init(CompositorHandler::<(),_>::new(SurfaceHandler, log.clone()));
+        event_loop.add_handler_with_init(CompositorHandler::<(), _>::new(SurfaceHandler, log.clone()));
     // register it to handle wl_compositor and wl_subcompositor
     event_loop.register_global::<wl_compositor::WlCompositor, CompositorHandler<(),SurfaceHandler>>(compositor_handler_id, 4);
     event_loop.register_global::<wl_subcompositor::WlSubcompositor, CompositorHandler<(),SurfaceHandler>>(compositor_handler_id, 1);
@@ -57,10 +56,10 @@ fn main() {
      */
     let (shm_token, compositor_token) = {
         let state = event_loop.state();
-        (
-            state.get_handler::<ShmGlobal>(shm_handler_id).get_token(),
-            state.get_handler::<CompositorHandler<(),SurfaceHandler>>(compositor_handler_id).get_token()
-        )
+        (state.get_handler::<ShmGlobal>(shm_handler_id).get_token(),
+         state
+             .get_handler::<CompositorHandler<(), SurfaceHandler>>(compositor_handler_id)
+             .get_token())
     };
 
     /*

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,6 @@
 extern crate wayland_server;
 extern crate smithay;
+#[macro_use]
 extern crate glium;
 
 #[macro_use]
@@ -7,21 +8,59 @@ extern crate slog;
 extern crate slog_async;
 extern crate slog_term;
 
+mod helpers;
 
 use glium::Surface;
+
+use helpers::{WlShellStubHandler, GliumDrawer};
 use slog::*;
 
 use smithay::backend::graphics::glium::IntoGlium;
 use smithay::backend::input::InputBackend;
 use smithay::backend::winit;
-use smithay::compositor::{self, CompositorHandler};
-use smithay::shm::ShmGlobal;
+use smithay::compositor::{self, CompositorHandler, CompositorToken};
+use smithay::shm::{ShmGlobal, ShmToken, BufferData};
 
-use wayland_server::protocol::{wl_compositor, wl_shm, wl_subcompositor};
+use wayland_server::protocol::{wl_compositor, wl_shell, wl_shm, wl_subcompositor, wl_surface};
+use wayland_server::{EventLoopHandle,Client,Liveness, Resource};
 
-struct SurfaceHandler;
+struct SurfaceHandler {
+    shm_token: ShmToken
+}
 
-impl compositor::Handler for SurfaceHandler {}
+#[derive(Default)]
+struct SurfaceData {
+    buffer: Option<(Vec<u8>, (u32, u32))>
+}
+
+impl compositor::Handler<SurfaceData> for SurfaceHandler {
+    fn commit(&mut self, evlh: &mut EventLoopHandle, client: &Client, surface: &wl_surface::WlSurface, token: CompositorToken<SurfaceData, SurfaceHandler>) {
+        // we retrieve the contents of the associated buffer and copy it
+        token.with_surface_data(surface, |attributes| {
+            match attributes.buffer.take() {
+                Some(Some((buffer, (x,y)))) => {
+                    self.shm_token.with_buffer_contents(&buffer, |slice, data| {
+                        let offset = data.offset as usize;
+                        let stride = data.stride as usize;
+                        let width = data.width as usize;
+                        let height = data.height as usize;
+                        let mut new_vec = Vec::with_capacity(width*height*4);
+                        for i in 0..height {
+                            new_vec.extend(&slice[(offset+i*stride)..(offset+i*stride+width*4)]);
+                        }
+                        attributes.user_data.buffer = Some((new_vec, (data.width as u32, data.height as u32)));
+                    });
+
+                }
+                Some(None) => {
+                    // erase the contents
+                    attributes.user_data.buffer = None;
+                }
+                None => {}
+            }
+        });
+    }
+}
 
 fn main() {
     // A logger facility, here we use the terminal for this example
@@ -31,7 +70,7 @@ fn main() {
     // Initialize a simple backend for testing
     let (renderer, mut input) = winit::init(log.clone()).unwrap();
 
-    let (_display, mut event_loop) = wayland_server::create_display();
+    let (mut display, mut event_loop) = wayland_server::create_display();
 
     /*
      * Initialize wl_shm global
@@ -41,40 +80,91 @@ fn main() {
     let shm_handler_id = event_loop.add_handler_with_init(ShmGlobal::new(vec![], log.clone()));
     // Register this handler to advertise a wl_shm global of version 1
     event_loop.register_global::<wl_shm::WlShm, ShmGlobal>(shm_handler_id, 1);
+    // retreive the token
+    let shm_token = {
+        let state = event_loop.state();
+        state
+             .get_handler::<ShmGlobal>(shm_handler_id)
+             .get_token()
+    };
+
 
     /*
      * Initialize the compositor global
      */
     let compositor_handler_id =
-        event_loop.add_handler_with_init(CompositorHandler::<(), _>::new(SurfaceHandler, log.clone()));
+        event_loop.add_handler_with_init(CompositorHandler::<SurfaceData, _>::new(SurfaceHandler { shm_token: shm_token.clone() }, log.clone()));
     // register it to handle wl_compositor and wl_subcompositor
-    event_loop.register_global::<wl_compositor::WlCompositor, CompositorHandler<(),SurfaceHandler>>(compositor_handler_id, 4);
-    event_loop.register_global::<wl_subcompositor::WlSubcompositor, CompositorHandler<(),SurfaceHandler>>(compositor_handler_id, 1);
+    event_loop.register_global::<wl_compositor::WlCompositor, CompositorHandler<SurfaceData,SurfaceHandler>>(compositor_handler_id, 4);
+    event_loop.register_global::<wl_subcompositor::WlSubcompositor, CompositorHandler<SurfaceData,SurfaceHandler>>(compositor_handler_id, 1);
+    // retrieve the tokens
+    let compositor_token = {
+        let state = event_loop.state();
+         state
+             .get_handler::<CompositorHandler<SurfaceData, SurfaceHandler>>(compositor_handler_id)
+             .get_token()
+    };
 
     /*
-     * retrieve the tokens
+     * Initialize the shell stub global
      */
-    let (shm_token, compositor_token) = {
-        let state = event_loop.state();
-        (state.get_handler::<ShmGlobal>(shm_handler_id).get_token(),
-         state
-             .get_handler::<CompositorHandler<(), SurfaceHandler>>(compositor_handler_id)
-             .get_token())
-    };
+    let shell_handler_id =
+        event_loop.add_handler_with_init(WlShellStubHandler::new(compositor_token.clone()));
+    event_loop.register_global::<wl_shell::WlShell, WlShellStubHandler<SurfaceData, SurfaceHandler>>(shell_handler_id,
+                                                                                            1);
 
     /*
      * Initialize glium
      */
     let context = renderer.into_glium();
 
+    let drawer = GliumDrawer::new(&context);
+
+    /*
+     * Add a listening socket:
+     */
+    let name = display
+        .add_socket_auto()
+        .unwrap()
+        .into_string()
+        .unwrap();
+    println!("Listening on socket: {}", name);
 
     loop {
         input.dispatch_new_events().unwrap();
 
         let mut frame = context.draw();
-        frame.clear(None, Some((0.0, 0.0, 0.0, 1.0)), false, None, None);
+        frame.clear(None, Some((0.8, 0.8, 0.9, 1.0)), false, None, None);
+        // redraw the frame, in a simple but inneficient way
+        {
+            let screen_dimensions = context.get_framebuffer_dimensions();
+            let state = event_loop.state();
+            for &(_, ref surface) in
+                state
+                    .get_handler::<WlShellStubHandler<SurfaceData, SurfaceHandler>>(shell_handler_id)
+                    .surfaces() {
+                if surface.status() != Liveness::Alive {
+                    continue;
+                }
+                // this surface is a root of a subsurface tree that needs to be drawn
+                compositor_token.with_surface_tree(surface, |surface, attributes| {
+                    if let Some((ref contents, (w, h))) = attributes.user_data.buffer {
+                        // there is actually something to draw !
+                        let mut x = 100;
+                        let mut y = 100;
+                        if let Some(ref subdata) = attributes.subsurface_attributes {
+                            x += subdata.x;
+                            y += subdata.y;
+                        }
+                        drawer.draw(&mut frame, contents, (w, h), (x, y), screen_dimensions);
+                    }
+                    true
+                });
+            }
+        }
         frame.finish().unwrap();
 
         event_loop.dispatch(Some(16)).unwrap();
+        display.flush_clients();
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -147,18 +147,21 @@ fn main() {
                     continue;
                 }
                 // this surface is a root of a subsurface tree that needs to be drawn
-                compositor_token.with_surface_tree(surface, |surface, attributes| {
+                compositor_token.with_surface_tree(surface, (100, 100), |surface,
+                 attributes,
+                 &(mut x, mut y)| {
                     if let Some((ref contents, (w, h))) = attributes.user_data.buffer {
                         // there is actually something to draw !
-                        let mut x = 100;
-                        let mut y = 100;
                         if let Some(ref subdata) = attributes.subsurface_attributes {
                             x += subdata.x;
                             y += subdata.y;
                         }
                         drawer.draw(&mut frame, contents, (w, h), (x, y), screen_dimensions);
+                        TraversalAction::DoChildren((x, y))
+                    } else {
+                        // we are not display, so our children are neither
+                        TraversalAction::SkipChildren
                     }
-                    true
                 });
             }
         }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,3 +1,4 @@
+#[macro_use(server_declare_handler)]
 extern crate wayland_server;
 extern crate smithay;
 #[macro_use]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,36 +2,70 @@ extern crate wayland_server;
 extern crate smithay;
 extern crate glium;
 
+#[macro_use]
+extern crate slog;
+extern crate slog_async;
+extern crate slog_term;
+
+use slog::*;
+
 use glium::Surface;
+
 use smithay::backend::graphics::glium::IntoGlium;
 use smithay::backend::input::InputBackend;
 use smithay::backend::winit;
 use smithay::shm::ShmGlobal;
-use wayland_server::protocol::wl_shm;
+use smithay::compositor::{CompositorHandler, self};
+
+use wayland_server::protocol::{wl_compositor, wl_shm, wl_subcompositor};
+
+struct SurfaceHandler;
+
+impl compositor::Handler for SurfaceHandler {
+}
 
 fn main() {
+    // A logger facility, here we use the terminal for this example
+    let log = Logger::root(slog_async::Async::default(slog_term::term_full().fuse()).fuse(), o!());
+
     // Initialize a simple backend for testing
-    let (renderer, mut input) = winit::init().unwrap();
+    let (renderer, mut input) = winit::init(log.clone()).unwrap();
 
     let (_display, mut event_loop) = wayland_server::create_display();
 
+    /*
+     * Initialize wl_shm global
+     */
     // Insert the ShmGlobal as a handler to your event loop
     // Here, we specify tha the standard Argb8888 and Xrgb8888 is the only supported.
-    let handler_id = event_loop.add_handler_with_init(ShmGlobal::new(
-        vec![],
-        None, /* we don't provide a logger here */
-    ));
-
+    let shm_handler_id =
+        event_loop.add_handler_with_init(ShmGlobal::new(vec![], log.clone()));
     // Register this handler to advertise a wl_shm global of version 1
-    let shm_global = event_loop.register_global::<wl_shm::WlShm, ShmGlobal>(handler_id, 1);
+    event_loop.register_global::<wl_shm::WlShm, ShmGlobal>(shm_handler_id, 1);
 
-    // Retrieve the shm token for later use to access the buffers
-    let shm_token = {
+    /*
+     * Initialize the compositor global
+     */
+    let compositor_handler_id =
+        event_loop.add_handler_with_init(CompositorHandler::<(),_>::new(SurfaceHandler, log.clone()));
+    // register it to handle wl_compositor and wl_subcompositor
+    event_loop.register_global::<wl_compositor::WlCompositor, CompositorHandler<(),SurfaceHandler>>(compositor_handler_id, 4);
+    event_loop.register_global::<wl_subcompositor::WlSubcompositor, CompositorHandler<(),SurfaceHandler>>(compositor_handler_id, 1);
+
+    /*
+     * retrieve the tokens
+     */
+    let (shm_token, compositor_token) = {
         let state = event_loop.state();
-        state.get_handler::<ShmGlobal>(handler_id).get_token()
+        (
+            state.get_handler::<ShmGlobal>(shm_handler_id).get_token(),
+            state.get_handler::<CompositorHandler<(),SurfaceHandler>>(compositor_handler_id).get_token()
+        )
     };
 
-    // Init glium
+    /*
+     * Initialize glium
+     */
     let context = renderer.into_glium();
 
 

--- a/src/backend/graphics/glium.rs
+++ b/src/backend/graphics/glium.rs
@@ -3,7 +3,7 @@
 use backend::graphics::egl::{EGLGraphicsBackend, SwapBuffersError};
 use glium::Frame;
 use glium::SwapBuffersError as GliumSwapBuffersError;
-use glium::backend::{Backend, Context};
+use glium::backend::{Backend, Context, Facade};
 use glium::debug::DebugCallbackBehavior;
 use std::ops::Deref;
 use std::os::raw::c_void;
@@ -59,6 +59,12 @@ impl<T: EGLGraphicsBackend> Deref for GliumGraphicsBackend<T> {
     type Target = Context;
 
     fn deref(&self) -> &Context {
+        &self.context
+    }
+}
+
+impl<T: EGLGraphicsBackend> Facade for GliumGraphicsBackend<T> {
+    fn get_context(&self) -> &Rc<Context> {
         &self.context
     }
 }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -763,6 +763,7 @@ impl InputBackend for WinitInputBackend {
                     *time_counter += 1;
                 }
                 Event::DeviceEvent { .. } => {}
+                _ => {}
             });
         }
 

--- a/src/compositor/global.rs
+++ b/src/compositor/global.rs
@@ -8,6 +8,7 @@ impl<U: Default, H: UserHandler> GlobalHandler<wl_compositor::WlCompositor> for 
           H: Send + 'static
 {
     fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_compositor::WlCompositor) {
+        debug!(self.log, "New compositor global binded.");
         evlh.register::<_, CompositorHandler<U, H>>(&global, self.my_id);
     }
 }
@@ -17,6 +18,7 @@ impl<U, H> GlobalHandler<wl_subcompositor::WlSubcompositor> for CompositorHandle
           H: Send + 'static
 {
     fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_subcompositor::WlSubcompositor) {
+        debug!(self.log, "New subcompositor global binded.");
         evlh.register::<_, CompositorHandler<U, H>>(&global, self.my_id);
     }
 }

--- a/src/compositor/global.rs
+++ b/src/compositor/global.rs
@@ -1,58 +1,20 @@
-use super::CompositorToken;
-use super::handlers::CompositorHandler;
+use super::CompositorHandler;
 
 use wayland_server::{Client, EventLoopHandle, GlobalHandler, Init};
 use wayland_server::protocol::{wl_compositor, wl_subcompositor};
 
-pub struct CompositorGlobal<U> {
-    handler_id: Option<usize>,
-    log: ::slog::Logger,
-    _data: ::std::marker::PhantomData<*mut U>,
-}
-
-impl<U> CompositorGlobal<U> {
-    pub fn new<L>(logger: L) -> CompositorGlobal<U>
-        where L: Into<Option<::slog::Logger>>
-    {
-        let log = ::slog_or_stdlog(logger);
-        CompositorGlobal {
-            handler_id: None,
-            log: log.new(o!("smithay_module" => "wompositor_handler")),
-            _data: ::std::marker::PhantomData,
-        }
-    }
-
-    pub fn get_token(&self) -> CompositorToken<U> {
-        super::make_token(self.handler_id
-                              .expect("CompositorGlobal was not initialized."))
-    }
-}
-
-impl<U> Init for CompositorGlobal<U>
-    where U: Send + Sync + 'static
-{
-    fn init(&mut self, evlh: &mut EventLoopHandle, _index: usize) {
-        let id = evlh.add_handler_with_init(CompositorHandler::<U>::new(self.log.clone()));
-        self.handler_id = Some(id);
-    }
-}
-
-impl<U: Default> GlobalHandler<wl_compositor::WlCompositor> for CompositorGlobal<U>
+impl<U: Default> GlobalHandler<wl_compositor::WlCompositor> for CompositorHandler<U>
     where U: Send + Sync + 'static
 {
     fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_compositor::WlCompositor) {
-        let hid = self.handler_id
-            .expect("CompositorGlobal was not initialized.");
-        evlh.register::<_, CompositorHandler<U>>(&global, hid);
+        evlh.register::<_, CompositorHandler<U>>(&global, self.my_id);
     }
 }
 
-impl<U> GlobalHandler<wl_subcompositor::WlSubcompositor> for CompositorGlobal<U>
+impl<U> GlobalHandler<wl_subcompositor::WlSubcompositor> for CompositorHandler<U>
     where U: Send + Sync + 'static
 {
     fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_subcompositor::WlSubcompositor) {
-        let hid = self.handler_id
-            .expect("CompositorGlobal was not initialized.");
-        evlh.register::<_, CompositorHandler<U>>(&global, hid);
+        evlh.register::<_, CompositorHandler<U>>(&global, self.my_id);
     }
 }

--- a/src/compositor/global.rs
+++ b/src/compositor/global.rs
@@ -3,7 +3,7 @@ use super::{CompositorHandler, Handler as UserHandler};
 use wayland_server::{Client, EventLoopHandle, GlobalHandler};
 use wayland_server::protocol::{wl_compositor, wl_subcompositor};
 
-impl<U: Default, H: UserHandler> GlobalHandler<wl_compositor::WlCompositor> for CompositorHandler<U, H>
+impl<U: Default, H: UserHandler<U>> GlobalHandler<wl_compositor::WlCompositor> for CompositorHandler<U, H>
     where U: Send + 'static,
           H: Send + 'static
 {

--- a/src/compositor/global.rs
+++ b/src/compositor/global.rs
@@ -14,8 +14,9 @@ impl<U: Default, H: UserHandler<U>> GlobalHandler<wl_compositor::WlCompositor> f
 }
 
 impl<U, H> GlobalHandler<wl_subcompositor::WlSubcompositor> for CompositorHandler<U, H>
-    where U: Send + 'static,
-          H: Send + 'static
+where
+    U: Send + 'static,
+    H: Send + 'static,
 {
     fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_subcompositor::WlSubcompositor) {
         debug!(self.log, "New subcompositor global binded.");

--- a/src/compositor/global.rs
+++ b/src/compositor/global.rs
@@ -1,20 +1,22 @@
-use super::CompositorHandler;
+use super::{CompositorHandler, Handler as UserHandler};
 
-use wayland_server::{Client, EventLoopHandle, GlobalHandler, Init};
+use wayland_server::{Client, EventLoopHandle, GlobalHandler};
 use wayland_server::protocol::{wl_compositor, wl_subcompositor};
 
-impl<U: Default> GlobalHandler<wl_compositor::WlCompositor> for CompositorHandler<U>
-    where U: Send + Sync + 'static
+impl<U: Default, H: UserHandler> GlobalHandler<wl_compositor::WlCompositor> for CompositorHandler<U, H>
+    where U: Send + 'static,
+          H: Send + 'static
 {
     fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_compositor::WlCompositor) {
-        evlh.register::<_, CompositorHandler<U>>(&global, self.my_id);
+        evlh.register::<_, CompositorHandler<U, H>>(&global, self.my_id);
     }
 }
 
-impl<U> GlobalHandler<wl_subcompositor::WlSubcompositor> for CompositorHandler<U>
-    where U: Send + Sync + 'static
+impl<U, H> GlobalHandler<wl_subcompositor::WlSubcompositor> for CompositorHandler<U, H>
+    where U: Send + 'static,
+          H: Send + 'static
 {
     fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_subcompositor::WlSubcompositor) {
-        evlh.register::<_, CompositorHandler<U>>(&global, self.my_id);
+        evlh.register::<_, CompositorHandler<U, H>>(&global, self.my_id);
     }
 }

--- a/src/compositor/global.rs
+++ b/src/compositor/global.rs
@@ -1,0 +1,58 @@
+use super::CompositorToken;
+use super::handlers::CompositorHandler;
+
+use wayland_server::{Client, EventLoopHandle, GlobalHandler, Init};
+use wayland_server::protocol::{wl_compositor, wl_subcompositor};
+
+pub struct CompositorGlobal<U> {
+    handler_id: Option<usize>,
+    log: ::slog::Logger,
+    _data: ::std::marker::PhantomData<*mut U>,
+}
+
+impl<U> CompositorGlobal<U> {
+    pub fn new<L>(logger: L) -> CompositorGlobal<U>
+        where L: Into<Option<::slog::Logger>>
+    {
+        let log = ::slog_or_stdlog(logger);
+        CompositorGlobal {
+            handler_id: None,
+            log: log.new(o!("smithay_module" => "wompositor_handler")),
+            _data: ::std::marker::PhantomData,
+        }
+    }
+
+    pub fn get_token(&self) -> CompositorToken<U> {
+        super::make_token(self.handler_id
+                              .expect("CompositorGlobal was not initialized."))
+    }
+}
+
+impl<U> Init for CompositorGlobal<U>
+    where U: Send + Sync + 'static
+{
+    fn init(&mut self, evlh: &mut EventLoopHandle, _index: usize) {
+        let id = evlh.add_handler_with_init(CompositorHandler::<U>::new(self.log.clone()));
+        self.handler_id = Some(id);
+    }
+}
+
+impl<U: Default> GlobalHandler<wl_compositor::WlCompositor> for CompositorGlobal<U>
+    where U: Send + Sync + 'static
+{
+    fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_compositor::WlCompositor) {
+        let hid = self.handler_id
+            .expect("CompositorGlobal was not initialized.");
+        evlh.register::<_, CompositorHandler<U>>(&global, hid);
+    }
+}
+
+impl<U> GlobalHandler<wl_subcompositor::WlSubcompositor> for CompositorGlobal<U>
+    where U: Send + Sync + 'static
+{
+    fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_subcompositor::WlSubcompositor) {
+        let hid = self.handler_id
+            .expect("CompositorGlobal was not initialized.");
+        evlh.register::<_, CompositorHandler<U>>(&global, hid);
+    }
+}

--- a/src/compositor/handlers.rs
+++ b/src/compositor/handlers.rs
@@ -1,35 +1,13 @@
-use super::{Rectangle, RectangleKind, SubsurfaceAttributes, Damage};
+use super::{Rectangle, RectangleKind, SubsurfaceAttributes, Damage, CompositorHandler};
 use super::region::RegionData;
 use super::tree::SurfaceData;
+use super::CompositorToken;
 use wayland_server::{Client, Destroy, EventLoopHandle, Init, Resource};
 use wayland_server::protocol::{wl_buffer, wl_callback, wl_compositor, wl_output, wl_region,
                                wl_subcompositor, wl_subsurface, wl_surface};
 
-pub struct CompositorHandler<U> {
-    my_id: usize,
-    log: ::slog::Logger,
-    _data: ::std::marker::PhantomData<U>,
-}
-
 struct CompositorDestructor<U> {
     _t: ::std::marker::PhantomData<U>,
-}
-
-impl<U> Init for CompositorHandler<U> {
-    fn init(&mut self, _evqh: &mut EventLoopHandle, index: usize) {
-        self.my_id = index;
-        debug!(self.log, "Init finished")
-    }
-}
-
-impl<U> CompositorHandler<U> {
-    pub fn new(log: ::slog::Logger) -> CompositorHandler<U> {
-        CompositorHandler {
-            my_id: ::std::usize::MAX,
-            log: log,
-            _data: ::std::marker::PhantomData::<U>,
-        }
-    }
 }
 
 /*

--- a/src/compositor/handlers.rs
+++ b/src/compositor/handlers.rs
@@ -2,7 +2,7 @@ use super::{CompositorHandler, Damage, Handler as UserHandler, Rectangle, Rectan
             SubsurfaceAttributes};
 use super::region::RegionData;
 use super::tree::{Location, SurfaceData};
-use wayland_server::{Client, Destroy, EventLoopHandle, Resource, Liveness};
+use wayland_server::{Client, Destroy, EventLoopHandle, Liveness, Resource};
 use wayland_server::protocol::{wl_buffer, wl_callback, wl_compositor, wl_output, wl_region,
                                wl_subcompositor, wl_subsurface, wl_surface};
 
@@ -53,8 +53,9 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
               buffer: Option<&wl_buffer::WlBuffer>, x: i32, y: i32) {
         trace!(self.log, "Attaching buffer to surface.");
         unsafe {
-            SurfaceData::<U>::with_data(surface,
-                                        |d| d.buffer = Some(buffer.map(|b| (b.clone_unchecked(), (x, y)))));
+            SurfaceData::<U>::with_data(surface, |d| {
+                d.buffer = Some(buffer.map(|b| (b.clone_unchecked(), (x, y))))
+            });
         }
     }
     fn damage(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface, x: i32,
@@ -129,7 +130,8 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
     }
 }
 
-unsafe impl<U, H: UserHandler<U>> ::wayland_server::Handler<wl_surface::WlSurface> for CompositorHandler<U, H> {
+unsafe impl<U, H: UserHandler<U>> ::wayland_server::Handler<wl_surface::WlSurface>
+    for CompositorHandler<U, H> {
     unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
                       resource: &wl_surface::WlSurface, opcode: u32,
                       args: *const ::wayland_server::sys::wl_argument)
@@ -212,8 +214,9 @@ impl<U, H> wl_subcompositor::Handler for CompositorHandler<U, H>
         }
         id.set_user_data(Box::into_raw(Box::new(unsafe { surface.clone_unchecked() })) as *mut _);
         unsafe {
-            SurfaceData::<U>::with_data(surface,
-                                        |d| d.subsurface_attributes = Some(Default::default()));
+            SurfaceData::<U>::with_data(surface, |d| {
+                d.subsurface_attributes = Some(Default::default())
+            });
         }
         evqh.register_with_destructor::<_, CompositorHandler<U, H>, CompositorDestructor<U>>(&id, self.my_id);
     }

--- a/src/compositor/handlers.rs
+++ b/src/compositor/handlers.rs
@@ -32,17 +32,7 @@ impl<U, H> wl_compositor::Handler for CompositorHandler<U, H>
     }
 }
 
-unsafe impl<U, H> ::wayland_server::Handler<wl_compositor::WlCompositor> for CompositorHandler<U, H>
-    where U: Default + Send + 'static,
-          H: UserHandler<U> + Send + 'static
-{
-    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
-                      resource: &wl_compositor::WlCompositor, opcode: u32,
-                      args: *const ::wayland_server::sys::wl_argument)
-                      -> Result<(), ()> {
-        <CompositorHandler<U, H> as ::wayland_server::protocol::wl_compositor::Handler>::__message(self, evq, client, resource, opcode, args)
-    }
-}
+server_declare_handler!(CompositorHandler<U: [Default, Send], H: [UserHandler<U>, Send]>, wl_compositor::Handler, wl_compositor::WlCompositor);
 
 /*
  * wl_surface
@@ -130,15 +120,7 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
     }
 }
 
-unsafe impl<U, H: UserHandler<U>> ::wayland_server::Handler<wl_surface::WlSurface>
-    for CompositorHandler<U, H> {
-    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
-                      resource: &wl_surface::WlSurface, opcode: u32,
-                      args: *const ::wayland_server::sys::wl_argument)
-                      -> Result<(), ()> {
-        <CompositorHandler<U, H> as ::wayland_server::protocol::wl_surface::Handler>::__message(self, evq, client, resource, opcode, args)
-    }
-}
+server_declare_handler!(CompositorHandler<U:[], H: [UserHandler<U>]>, wl_surface::Handler, wl_surface::WlSurface);
 
 impl<U> Destroy<wl_surface::WlSurface> for CompositorDestructor<U> {
     fn destroy(surface: &wl_surface::WlSurface) {
@@ -181,14 +163,7 @@ impl<U, H> wl_region::Handler for CompositorHandler<U, H> {
     }
 }
 
-unsafe impl<U, H> ::wayland_server::Handler<wl_region::WlRegion> for CompositorHandler<U, H> {
-    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
-                      resource: &wl_region::WlRegion, opcode: u32,
-                      args: *const ::wayland_server::sys::wl_argument)
-                      -> Result<(), ()> {
-        <CompositorHandler<U, H> as ::wayland_server::protocol::wl_region::Handler>::__message(self, evq, client, resource, opcode, args)
-    }
-}
+server_declare_handler!(CompositorHandler<U: [], H: []>, wl_region::Handler, wl_region::WlRegion);
 
 impl<U> Destroy<wl_region::WlRegion> for CompositorDestructor<U> {
     fn destroy(region: &wl_region::WlRegion) {
@@ -222,17 +197,7 @@ impl<U, H> wl_subcompositor::Handler for CompositorHandler<U, H>
     }
 }
 
-unsafe impl<U, H> ::wayland_server::Handler<wl_subcompositor::WlSubcompositor> for CompositorHandler<U, H>
-    where U: Send + 'static,
-          H: Send + 'static
-{
-    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
-                      resource: &wl_subcompositor::WlSubcompositor, opcode: u32,
-                      args: *const ::wayland_server::sys::wl_argument)
-                      -> Result<(), ()> {
-        <CompositorHandler<U, H> as ::wayland_server::protocol::wl_subcompositor::Handler>::__message(self, evq, client, resource, opcode, args)
-    }
-}
+server_declare_handler!(CompositorHandler<U: [Send], H: [Send]>, wl_subcompositor::Handler, wl_subcompositor::WlSubcompositor);
 
 /*
  * wl_subsurface
@@ -293,14 +258,7 @@ impl<U, H> wl_subsurface::Handler for CompositorHandler<U, H> {
     }
 }
 
-unsafe impl<U, H> ::wayland_server::Handler<wl_subsurface::WlSubsurface> for CompositorHandler<U, H> {
-    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
-                      resource: &wl_subsurface::WlSubsurface, opcode: u32,
-                      args: *const ::wayland_server::sys::wl_argument)
-                      -> Result<(), ()> {
-        <CompositorHandler<U, H> as ::wayland_server::protocol::wl_subsurface::Handler>::__message(self, evq, client, resource, opcode, args)
-    }
-}
+server_declare_handler!(CompositorHandler<U: [], H: []>, wl_subsurface::Handler, wl_subsurface::WlSubsurface);
 
 impl<U> Destroy<wl_subsurface::WlSubsurface> for CompositorDestructor<U> {
     fn destroy(subsurface: &wl_subsurface::WlSubsurface) {

--- a/src/compositor/handlers.rs
+++ b/src/compositor/handlers.rs
@@ -112,7 +112,8 @@ impl<U, H: UserHandler> wl_surface::Handler for CompositorHandler<U, H> {
     }
     fn damage_buffer(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
                      x: i32, y: i32, width: i32, height: i32) {
-        trace!(self.log, "Registering damage to surface (buffer coordinates).");
+        trace!(self.log,
+               "Registering damage to surface (buffer coordinates).");
         unsafe {
             SurfaceData::<U>::with_data(surface, |d| {
                 d.damage = Damage::Buffer(Rectangle {

--- a/src/compositor/handlers.rs
+++ b/src/compositor/handlers.rs
@@ -1,0 +1,278 @@
+use super::{Rectangle, RectangleKind, SubsurfaceAttributes, Damage};
+use super::region::RegionData;
+use super::tree::SurfaceData;
+use wayland_server::{Client, Destroy, EventLoopHandle, Init, Resource};
+use wayland_server::protocol::{wl_buffer, wl_callback, wl_compositor, wl_output, wl_region,
+                               wl_subcompositor, wl_subsurface, wl_surface};
+
+pub struct CompositorHandler<U> {
+    my_id: usize,
+    log: ::slog::Logger,
+    _data: ::std::marker::PhantomData<U>,
+}
+
+struct CompositorDestructor<U> {
+    _t: ::std::marker::PhantomData<U>,
+}
+
+impl<U> Init for CompositorHandler<U> {
+    fn init(&mut self, _evqh: &mut EventLoopHandle, index: usize) {
+        self.my_id = index;
+        debug!(self.log, "Init finished")
+    }
+}
+
+impl<U> CompositorHandler<U> {
+    pub fn new(log: ::slog::Logger) -> CompositorHandler<U> {
+        CompositorHandler {
+            my_id: ::std::usize::MAX,
+            log: log,
+            _data: ::std::marker::PhantomData::<U>,
+        }
+    }
+}
+
+/*
+ * wl_compositor
+ */
+
+impl<U: Default + Send + 'static> wl_compositor::Handler for CompositorHandler<U> {
+    fn create_surface(&mut self, evqh: &mut EventLoopHandle, _: &Client,
+                      _: &wl_compositor::WlCompositor, id: wl_surface::WlSurface) {
+        unsafe { SurfaceData::<U>::init(&id) };
+        evqh.register_with_destructor::<_, CompositorHandler<U>, CompositorDestructor<U>>(&id, self.my_id);
+    }
+    fn create_region(&mut self, evqh: &mut EventLoopHandle, _: &Client,
+                     _: &wl_compositor::WlCompositor, id: wl_region::WlRegion) {
+        unsafe { RegionData::init(&id) };
+        evqh.register_with_destructor::<_, CompositorHandler<U>, CompositorDestructor<U>>(&id, self.my_id);
+    }
+}
+
+unsafe impl<U: Default + Send + 'static> ::wayland_server::Handler<wl_compositor::WlCompositor>
+    for CompositorHandler<U> {
+    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
+                      resource: &wl_compositor::WlCompositor, opcode: u32,
+                      args: *const ::wayland_server::sys::wl_argument)
+                      -> Result<(), ()> {
+        <CompositorHandler<U> as ::wayland_server::protocol::wl_compositor::Handler>::__message(self, evq, client, resource, opcode, args)
+    }
+}
+
+/*
+ * wl_surface
+ */
+
+impl<U> wl_surface::Handler for CompositorHandler<U> {
+    fn attach(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
+              buffer: Option<&wl_buffer::WlBuffer>, x: i32, y: i32) {
+        unsafe {
+            SurfaceData::<U>::with_data(surface,
+                                        |d| d.buffer = Some(buffer.map(|b| (b.clone_unchecked(), (x, y)))));
+        }
+    }
+    fn damage(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface, x: i32,
+              y: i32, width: i32, height: i32) {
+        unsafe {
+            SurfaceData::<U>::with_data(surface,
+                                        |d| d.damage = Damage::Surface(Rectangle { x, y, width, height }));
+        }
+    }
+    fn frame(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
+             callback: wl_callback::WlCallback) {
+        unimplemented!()
+    }
+    fn set_opaque_region(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
+                         region: Option<&wl_region::WlRegion>) {
+        unsafe {
+            let attributes = region.map(|r| RegionData::get_attributes(r));
+            SurfaceData::<U>::with_data(surface, |d| d.opaque_region = attributes);
+        }
+    }
+    fn set_input_region(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
+                        region: Option<&wl_region::WlRegion>) {
+        unsafe {
+            let attributes = region.map(|r| RegionData::get_attributes(r));
+            SurfaceData::<U>::with_data(surface, |d| d.input_region = attributes);
+        }
+    }
+    fn commit(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface) {
+        unimplemented!()
+    }
+    fn set_buffer_transform(&mut self, _: &mut EventLoopHandle, _: &Client,
+                            surface: &wl_surface::WlSurface, transform: wl_output::Transform) {
+        unsafe {
+            SurfaceData::<U>::with_data(surface, |d| d.buffer_transform = transform);
+        }
+    }
+    fn set_buffer_scale(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
+                        scale: i32) {
+        unsafe {
+            SurfaceData::<U>::with_data(surface, |d| d.buffer_scale = scale);
+        }
+    }
+    fn damage_buffer(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
+                     x: i32, y: i32, width: i32, height: i32) {
+        unsafe {
+            SurfaceData::<U>::with_data(surface,
+                                        |d| d.damage = Damage::Buffer(Rectangle { x, y, width, height }));
+        }
+    }
+}
+
+unsafe impl<U> ::wayland_server::Handler<wl_surface::WlSurface> for CompositorHandler<U> {
+    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
+                      resource: &wl_surface::WlSurface, opcode: u32,
+                      args: *const ::wayland_server::sys::wl_argument)
+                      -> Result<(), ()> {
+        <CompositorHandler<U> as ::wayland_server::protocol::wl_surface::Handler>::__message(self, evq, client, resource, opcode, args)
+    }
+}
+
+impl<U> Destroy<wl_surface::WlSurface> for CompositorDestructor<U> {
+    fn destroy(surface: &wl_surface::WlSurface) {
+        unsafe { SurfaceData::<U>::cleanup(surface) }
+    }
+}
+
+/*
+ * wl_region
+ */
+
+impl<U> wl_region::Handler for CompositorHandler<U> {
+    fn add(&mut self, _: &mut EventLoopHandle, _: &Client, region: &wl_region::WlRegion, x: i32, y: i32,
+           width: i32, height: i32) {
+        unsafe {
+            RegionData::add_rectangle(region, RectangleKind::Add,
+                                      Rectangle {
+                                          x,
+                                          y,
+                                          width,
+                                          height,
+                                      })
+        };
+    }
+    fn subtract(&mut self, _: &mut EventLoopHandle, _: &Client, region: &wl_region::WlRegion, x: i32,
+                y: i32, width: i32, height: i32) {
+        unsafe {
+            RegionData::add_rectangle(region, RectangleKind::Subtract,
+                                      Rectangle {
+                                          x,
+                                          y,
+                                          width,
+                                          height,
+                                      })
+        };
+    }
+}
+
+unsafe impl<U> ::wayland_server::Handler<wl_region::WlRegion> for CompositorHandler<U> {
+    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
+                      resource: &wl_region::WlRegion, opcode: u32,
+                      args: *const ::wayland_server::sys::wl_argument)
+                      -> Result<(), ()> {
+        <CompositorHandler<U> as ::wayland_server::protocol::wl_region::Handler>::__message(self, evq, client, resource, opcode, args)
+    }
+}
+
+impl<U> Destroy<wl_region::WlRegion> for CompositorDestructor<U> {
+    fn destroy(region: &wl_region::WlRegion) {
+        unsafe { RegionData::cleanup(region) };
+    }
+}
+
+/*
+ * wl_subcompositor
+ */
+
+impl<U: Send + 'static> wl_subcompositor::Handler for CompositorHandler<U> {
+    fn get_subsurface(&mut self, evqh: &mut EventLoopHandle, _: &Client,
+                      resource: &wl_subcompositor::WlSubcompositor, id: wl_subsurface::WlSubsurface,
+                      surface: &wl_surface::WlSurface, parent: &wl_surface::WlSurface) {
+        if let Err(()) = unsafe { SurfaceData::<U>::set_parent(surface, parent) } {
+            resource.post_error(wl_subcompositor::Error::BadSurface as u32, "Surface already has a role.".into());
+            return
+        }
+        id.set_user_data(Box::into_raw(Box::new(unsafe { surface.clone_unchecked() })) as *mut _);
+        unsafe {
+            SurfaceData::<U>::with_data(surface,
+                                        |d| d.subsurface_attributes = Some(Default::default()));
+        }
+        evqh.register_with_destructor::<_, CompositorHandler<U>, CompositorDestructor<U>>(&id, self.my_id);
+    }
+}
+
+unsafe impl<U: Send + 'static> ::wayland_server::Handler<wl_subcompositor::WlSubcompositor>
+    for CompositorHandler<U> {
+    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
+                      resource: &wl_subcompositor::WlSubcompositor, opcode: u32,
+                      args: *const ::wayland_server::sys::wl_argument)
+                      -> Result<(), ()> {
+        <CompositorHandler<U> as ::wayland_server::protocol::wl_subcompositor::Handler>::__message(self, evq, client, resource, opcode, args)
+    }
+}
+
+/*
+ * wl_subsurface
+ */
+
+unsafe fn with_subsurface_attributes<U, F>(subsurface: &wl_subsurface::WlSubsurface, f: F)
+    where F: FnOnce(&mut SubsurfaceAttributes)
+{
+    let ptr = subsurface.get_user_data();
+    let surface = &*(ptr as *mut wl_surface::WlSurface);
+    SurfaceData::<U>::with_data(surface, |d| f(d.subsurface_attributes.as_mut().unwrap()));
+}
+
+impl<U> wl_subsurface::Handler for CompositorHandler<U> {
+    fn set_position(&mut self, _: &mut EventLoopHandle, _: &Client,
+                    resource: &wl_subsurface::WlSubsurface, x: i32, y: i32) {
+        unsafe {
+            with_subsurface_attributes::<U, _>(resource, |attrs| {
+                attrs.x = x;
+                attrs.y = y;
+            });
+        }
+    }
+    fn place_above(&mut self, _: &mut EventLoopHandle, _: &Client,
+                   resource: &wl_subsurface::WlSubsurface, sibling: &wl_surface::WlSurface) {
+        unimplemented!()
+    }
+    fn place_below(&mut self, _: &mut EventLoopHandle, _: &Client,
+                   resource: &wl_subsurface::WlSubsurface, sibling: &wl_surface::WlSurface) {
+        unimplemented!()
+    }
+    fn set_sync(&mut self, _: &mut EventLoopHandle, _: &Client,
+                resource: &wl_subsurface::WlSubsurface) {
+        unsafe {
+            with_subsurface_attributes::<U, _>(resource, |attrs| { attrs.sync = true; });
+        }
+    }
+    fn set_desync(&mut self, _: &mut EventLoopHandle, _: &Client,
+                  resource: &wl_subsurface::WlSubsurface) {
+        unsafe {
+            with_subsurface_attributes::<U, _>(resource, |attrs| { attrs.sync = false; });
+        }
+    }
+}
+
+unsafe impl<U> ::wayland_server::Handler<wl_subsurface::WlSubsurface> for CompositorHandler<U> {
+    unsafe fn message(&mut self, evq: &mut EventLoopHandle, client: &Client,
+                      resource: &wl_subsurface::WlSubsurface, opcode: u32,
+                      args: *const ::wayland_server::sys::wl_argument)
+                      -> Result<(), ()> {
+        <CompositorHandler<U> as ::wayland_server::protocol::wl_subsurface::Handler>::__message(self, evq, client, resource, opcode, args)
+    }
+}
+
+impl<U> Destroy<wl_subsurface::WlSubsurface> for CompositorDestructor<U> {
+    fn destroy(subsurface: &wl_subsurface::WlSubsurface) {
+        let ptr = subsurface.get_user_data();
+        subsurface.set_user_data(::std::ptr::null_mut());
+        unsafe {
+            let surface = Box::from_raw(ptr as *mut wl_surface::WlSurface);
+            SurfaceData::<U>::with_data(&*surface, |d| d.subsurface_attributes = None);
+            SurfaceData::<U>::unset_parent(&surface);
+        }
+    }
+}

--- a/src/compositor/handlers.rs
+++ b/src/compositor/handlers.rs
@@ -15,8 +15,9 @@ struct CompositorDestructor<U> {
  */
 
 impl<U, H> wl_compositor::Handler for CompositorHandler<U, H>
-    where U: Default + Send + 'static,
-          H: UserHandler<U> + Send + 'static
+where
+    U: Default + Send + 'static,
+    H: UserHandler<U> + Send + 'static,
 {
     fn create_surface(&mut self, evqh: &mut EventLoopHandle, _: &Client, _: &wl_compositor::WlCompositor,
                       id: wl_surface::WlSurface) {
@@ -54,11 +55,11 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
         unsafe {
             SurfaceData::<U>::with_data(surface, |d| {
                 d.damage = Damage::Surface(Rectangle {
-                                               x,
-                                               y,
-                                               width,
-                                               height,
-                                           })
+                    x,
+                    y,
+                    width,
+                    height,
+                })
             });
         }
     }
@@ -105,16 +106,18 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
     }
     fn damage_buffer(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
                      x: i32, y: i32, width: i32, height: i32) {
-        trace!(self.log,
-               "Registering damage to surface (buffer coordinates).");
+        trace!(
+            self.log,
+            "Registering damage to surface (buffer coordinates)."
+        );
         unsafe {
             SurfaceData::<U>::with_data(surface, |d| {
                 d.damage = Damage::Buffer(Rectangle {
-                                              x,
-                                              y,
-                                              width,
-                                              height,
-                                          })
+                    x,
+                    y,
+                    width,
+                    height,
+                })
             });
         }
     }
@@ -137,28 +140,32 @@ impl<U, H> wl_region::Handler for CompositorHandler<U, H> {
            width: i32, height: i32) {
         trace!(self.log, "Adding rectangle to a region.");
         unsafe {
-            RegionData::add_rectangle(region,
-                                      RectangleKind::Add,
-                                      Rectangle {
-                                          x,
-                                          y,
-                                          width,
-                                          height,
-                                      })
+            RegionData::add_rectangle(
+                region,
+                RectangleKind::Add,
+                Rectangle {
+                    x,
+                    y,
+                    width,
+                    height,
+                },
+            )
         };
     }
     fn subtract(&mut self, _: &mut EventLoopHandle, _: &Client, region: &wl_region::WlRegion, x: i32,
                 y: i32, width: i32, height: i32) {
         trace!(self.log, "Subtracting rectangle to a region.");
         unsafe {
-            RegionData::add_rectangle(region,
-                                      RectangleKind::Subtract,
-                                      Rectangle {
-                                          x,
-                                          y,
-                                          width,
-                                          height,
-                                      })
+            RegionData::add_rectangle(
+                region,
+                RectangleKind::Subtract,
+                Rectangle {
+                    x,
+                    y,
+                    width,
+                    height,
+                },
+            )
         };
     }
 }
@@ -176,8 +183,9 @@ impl<U> Destroy<wl_region::WlRegion> for CompositorDestructor<U> {
  */
 
 impl<U, H> wl_subcompositor::Handler for CompositorHandler<U, H>
-    where U: Send + 'static,
-          H: Send + 'static
+where
+    U: Send + 'static,
+    H: Send + 'static,
 {
     fn get_subsurface(&mut self, evqh: &mut EventLoopHandle, _: &Client,
                       resource: &wl_subcompositor::WlSubcompositor, id: wl_subsurface::WlSubsurface,
@@ -187,7 +195,9 @@ impl<U, H> wl_subcompositor::Handler for CompositorHandler<U, H>
             resource.post_error(wl_subcompositor::Error::BadSurface as u32, "Surface already has a role.".into());
             return
         }
-        id.set_user_data(Box::into_raw(Box::new(unsafe { surface.clone_unchecked() })) as *mut _);
+        id.set_user_data(Box::into_raw(
+            Box::new(unsafe { surface.clone_unchecked() }),
+        ) as *mut _);
         unsafe {
             SurfaceData::<U>::with_data(surface, |d| {
                 d.subsurface_attributes = Some(Default::default())
@@ -204,7 +214,8 @@ server_declare_handler!(CompositorHandler<U: [Send], H: [Send]>, wl_subcomposito
  */
 
 unsafe fn with_subsurface_attributes<U, F>(subsurface: &wl_subsurface::WlSubsurface, f: F)
-    where F: FnOnce(&mut SubsurfaceAttributes)
+where
+    F: FnOnce(&mut SubsurfaceAttributes),
 {
     let ptr = subsurface.get_user_data();
     let surface = &*(ptr as *mut wl_surface::WlSurface);

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -285,10 +285,13 @@ impl<U: Send + 'static, H: Handler<U> + Send + 'static> CompositorToken<U, H> {
     /// If the surface is not managed by the CompositorGlobal that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn with_surface_data<F>(&self, surface: &wl_surface::WlSurface, f: F)
-        where F: FnOnce(&mut SurfaceAttributes<U>)
+    where
+        F: FnOnce(&mut SurfaceAttributes<U>),
     {
-        assert!(resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
-                "Accessing the data of foreign surfaces is not supported.");
+        assert!(
+            resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
+            "Accessing the data of foreign surfaces is not supported."
+        );
         unsafe {
             SurfaceData::<U>::with_data(surface, f);
         }
@@ -303,10 +306,13 @@ impl<U: Send + 'static, H: Handler<U> + Send + 'static> CompositorToken<U, H> {
     /// If the surface is not managed by the CompositorGlobal that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn with_surface_tree<F, T>(&self, surface: &wl_surface::WlSurface, initial: T, f: F) -> Result<(), ()>
-        where F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>, &T) -> TraversalAction<T>
+    where
+        F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>, &T) -> TraversalAction<T>,
     {
-        assert!(resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
-                "Accessing the data of foreign surfaces is not supported.");
+        assert!(
+            resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
+            "Accessing the data of foreign surfaces is not supported."
+        );
         unsafe {
             SurfaceData::<U>::map_tree(surface, initial, f);
         }
@@ -320,8 +326,10 @@ impl<U: Send + 'static, H: Handler<U> + Send + 'static> CompositorToken<U, H> {
     /// If the surface is not managed by the CompositorGlobal that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn get_parent(&self, surface: &wl_surface::WlSurface) -> Option<wl_surface::WlSurface> {
-        assert!(resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
-                "Accessing the data of foreign surfaces is not supported.");
+        assert!(
+            resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
+            "Accessing the data of foreign surfaces is not supported."
+        );
         unsafe { SurfaceData::<U>::get_parent(surface) }
     }
 
@@ -330,8 +338,10 @@ impl<U: Send + 'static, H: Handler<U> + Send + 'static> CompositorToken<U, H> {
     /// If the surface is not managed by the CompositorGlobal that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn get_children(&self, surface: &wl_surface::WlSurface) -> Vec<wl_surface::WlSurface> {
-        assert!(resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
-                "Accessing the data of foreign surfaces is not supported.");
+        assert!(
+            resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
+            "Accessing the data of foreign surfaces is not supported."
+        );
         unsafe { SurfaceData::<U>::get_children(surface) }
     }
 
@@ -340,8 +350,10 @@ impl<U: Send + 'static, H: Handler<U> + Send + 'static> CompositorToken<U, H> {
     /// If the surface is not managed by the CompositorGlobal that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn role_status(&self, surface: &wl_surface::WlSurface) -> RoleStatus {
-        assert!(resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
-                "Accessing the data of foreign surfaces is not supported.");
+        assert!(
+            resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
+            "Accessing the data of foreign surfaces is not supported."
+        );
         unsafe { SurfaceData::<U>::role_status(surface) }
     }
 
@@ -355,8 +367,10 @@ impl<U: Send + 'static, H: Handler<U> + Send + 'static> CompositorToken<U, H> {
     /// If the surface is not managed by the CompositorGlobal that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn give_role(&self, surface: &wl_surface::WlSurface) -> Result<(), ()> {
-        assert!(resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
-                "Accessing the data of foreign surfaces is not supported.");
+        assert!(
+            resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
+            "Accessing the data of foreign surfaces is not supported."
+        );
         unsafe { SurfaceData::<U>::give_role(surface) }
     }
 
@@ -369,8 +383,10 @@ impl<U: Send + 'static, H: Handler<U> + Send + 'static> CompositorToken<U, H> {
     /// If the surface is not managed by the CompositorGlobal that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn remove_role(&self, surface: &wl_surface::WlSurface) -> Result<(), ()> {
-        assert!(resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
-                "Accessing the data of foreign surfaces is not supported.");
+        assert!(
+            resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
+            "Accessing the data of foreign surfaces is not supported."
+        );
         unsafe { SurfaceData::<U>::remove_role(surface) }
     }
 
@@ -379,8 +395,10 @@ impl<U: Send + 'static, H: Handler<U> + Send + 'static> CompositorToken<U, H> {
     /// If the region is not managed by the CompositorGlobal that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn get_region_attributes(&self, region: &wl_region::WlRegion) -> RegionAttributes {
-        assert!(resource_is_registered::<_, CompositorHandler<U, H>>(region, self.hid),
-                "Accessing the data of foreign regions is not supported.");
+        assert!(
+            resource_is_registered::<_, CompositorHandler<U, H>>(region, self.hid),
+            "Accessing the data of foreign regions is not supported."
+        );
         unsafe { RegionData::get_attributes(region) }
     }
 }
@@ -410,7 +428,8 @@ impl<U, H> Init for CompositorHandler<U, H> {
 impl<U, H> CompositorHandler<U, H> {
     /// Create a new CompositorHandler
     pub fn new<L>(handler: H, logger: L) -> CompositorHandler<U, H>
-        where L: Into<Option<::slog::Logger>>
+    where
+        L: Into<Option<::slog::Logger>>,
     {
         let log = ::slog_or_stdlog(logger);
         CompositorHandler {
@@ -423,8 +442,10 @@ impl<U, H> CompositorHandler<U, H> {
 
     /// Create a token to access the data associated to the objects managed by this handler.
     pub fn get_token(&self) -> CompositorToken<U, H> {
-        assert!(self.my_id != ::std::usize::MAX,
-                "CompositorHandler is not initialized yet.");
+        assert!(
+            self.my_id != ::std::usize::MAX,
+            "CompositorHandler is not initialized yet."
+        );
         trace!(self.log, "Creating a compositor token.");
         CompositorToken {
             hid: self.my_id,

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -213,7 +213,7 @@ impl Default for SubsurfaceAttributes {
 }
 
 /// Kind of a rectangle part of a region
-#[derive(Copy,Clone)]
+#[derive(Copy, Clone)]
 pub enum RectangleKind {
     /// This rectangle should be added to the region
     Add,
@@ -223,7 +223,7 @@ pub enum RectangleKind {
 }
 
 /// A rectangle defined by its top-left corner and dimensions
-#[derive(Copy,Clone)]
+#[derive(Copy, Clone)]
 pub struct Rectangle {
     /// horizontal position of the top-leftcorner of the rectangle, in surface coordinates
     pub x: i32,
@@ -445,7 +445,7 @@ impl<U, H> CompositorHandler<U, H> {
 /// are forwarded directly to a handler implementing this trait that you must provide
 /// at creation of the `CompositorHandler`.
 #[allow(unused_variables)]
-pub trait Handler<U> : Sized{
+pub trait Handler<U>: Sized {
     /// The double-buffered state has been validated by the client
     ///
     /// At this point, the pending state that has been accumulated in the `SurfaceAttributes` associated
@@ -453,7 +453,9 @@ pub trait Handler<U> : Sized{
     ///
     /// See [`wayland_server::protocol::wl_surface::Handler::commit`](https://docs.rs/wayland-server/*/wayland_server/protocol/wl_surface/trait.Handler.html#method.commit)
     /// for more details
-    fn commit(&mut self, evlh: &mut EventLoopHandle, client: &Client, surface: &wl_surface::WlSurface, token: CompositorToken<U, Self>) {}
+    fn commit(&mut self, evlh: &mut EventLoopHandle, client: &Client, surface: &wl_surface::WlSurface,
+              token: CompositorToken<U, Self>) {
+    }
     /// The client asks to be notified when would be a good time to update the contents of this surface
     ///
     /// You must keep the provided `WlCallback` and trigger it at the appropriate time by calling

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -414,6 +414,7 @@ impl<U, H> CompositorHandler<U, H> {
     pub fn get_token(&self) -> CompositorToken<U, H> {
         assert!(self.my_id != ::std::usize::MAX,
                 "CompositorHandler is not initialized yet.");
+        trace!(self.log, "Creating a compositor token.");
         CompositorToken {
             hid: self.my_id,
             _data: ::std::marker::PhantomData,

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -192,7 +192,8 @@ impl<U: Send + 'static, H: Handler + Send + 'static> CompositorToken<U, H> {
     /// Access the data of a surface tree
     ///
     /// The provided closure is called successively on the surface and all its child subsurfaces,
-    /// in a depth-first order.
+    /// in a depth-first order. This matches the order in which the surfaces are supposed to be
+    /// drawn: top-most last.
     ///
     /// If the surface is not managed by the CompositorGlobal that provided this token, this
     /// will panic (having more than one compositor is not supported).

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -1,0 +1,276 @@
+mod global;
+mod handlers;
+mod tree;
+mod region;
+
+pub use self::global::CompositorGlobal;
+use self::handlers::CompositorHandler;
+pub use self::tree::RoleStatus;
+use self::tree::SurfaceData;
+
+use wayland_server::protocol::{wl_buffer, wl_output, wl_surface};
+use wayland_server::resource_is_registered;
+
+/// Description of which part of a surface
+/// should be considered damaged and needs to be redrawn
+pub enum Damage {
+    /// The whole surface must be considered damaged (this is the default)
+    Full,
+    /// A rectangle containing the damaged zone, in surface coordinates
+    Surface(Rectangle),
+    /// A rectangle containing the smaazed zone, in buffer coordinates
+    ///
+    /// Note: Buffer scaling must be taken into consideration
+    Buffer(Rectangle)
+}
+
+/// Data associated with a surface, aggreged by the handlers
+///
+/// Most of the fields of this struct represent a double-buffered state, which
+/// should only be applied once a `commit` request is received from the surface.
+///
+/// You are responsible for setting those values as you see fit to avoid
+/// processing them two times.
+pub struct SurfaceAttributes<U> {
+    /// Buffer defining the contents of the surface
+    ///
+    /// The tuple represent the coordinates of this buffer
+    /// relative to the location of the current buffer.
+    ///
+    /// If set to `Some(None)`, it means the user specifically asked for the
+    /// surface to be unmapped.
+    ///
+    /// You are free to set this field to `None` to avoid processing it several
+    /// times. It'll be set to `Some(...)` if the user attaches a buffer (or NULL) to
+    /// the surface.
+    pub buffer: Option<Option<(wl_buffer::WlBuffer, (i32, i32))>>,
+    /// Scale of the contents of the buffer, for higher-resolution contents.
+    ///
+    /// If it matches the one of the output displaying this surface, no change
+    /// is necessary.
+    pub buffer_scale: i32,
+    /// Transform under which interpret the contents of the buffer
+    ///
+    /// If it matches the one of the output displaying this surface, no change
+    /// is necessary.
+    pub buffer_transform: wl_output::Transform,
+    /// Region of the surface that is guaranteed to be opaque
+    ///
+    /// By default the whole surface is potentially transparent
+    pub opaque_region: Option<RegionAttributes>,
+    /// Region of the surface that is sensitive to user input
+    ///
+    /// By default the whole surface should be sensitive
+    pub input_region: Option<RegionAttributes>,
+    /// Damage rectangle
+    ///
+    /// Hint provided by the client to suggest that only this part
+    /// of the surface was changed and needs to be redrawn
+    pub damage: Damage,
+    /// Subsurface-related attribute
+    ///
+    /// Is `Some` if this surface is a sub-surface
+    ///
+    /// **Warning:** Changing this field by yourself can cause panics.
+    pub subsurface_attributes: Option<SubsurfaceAttributes>,
+    /// User-controlled data
+    ///
+    /// This is your field to host whatever you need.
+    pub user_data: U,
+}
+
+impl<U: Default> Default for SurfaceAttributes<U> {
+    fn default() -> SurfaceAttributes<U> {
+        SurfaceAttributes {
+            buffer: None,
+            buffer_scale: 1,
+            buffer_transform: wl_output::Transform::Normal,
+            opaque_region: None,
+            input_region: None,
+            damage: Damage::Full,
+            subsurface_attributes: None,
+            user_data: Default::default(),
+        }
+    }
+}
+
+/// Attributes defining the behaviour of a sub-surface relative to its parent
+pub struct SubsurfaceAttributes {
+    /// Horizontal location of the top-left corner of this sub-surface relative to
+    /// the top-left corner of its parent
+    pub x: i32,
+    /// Vertical location of the top-left corner of this sub-surface relative to
+    /// the top-left corner of its parent
+    pub y: i32,
+    /// Sync status of this sub-surface
+    ///
+    /// If `true`, this surface should be repainted synchronously with its parent
+    /// if `false`, it should be considered independant of its parent regarding
+    /// repaint timings.
+    pub sync: bool,
+}
+
+impl Default for SubsurfaceAttributes {
+    fn default() -> SubsurfaceAttributes {
+        SubsurfaceAttributes {
+            x: 0,
+            y: 0,
+            sync: true,
+        }
+    }
+}
+
+/// Kind of a rectangle part of a region
+#[derive(Copy,Clone)]
+pub enum RectangleKind {
+    /// This rectangle should be added to the region
+    Add,
+    /// The intersection of this rectangle with the region should
+    /// be removed from the region
+    Subtract,
+}
+
+/// A rectangle defined by its top-left corner and dimensions
+#[derive(Copy,Clone)]
+pub struct Rectangle {
+    /// horizontal position of the top-leftcorner of the rectangle, in surface coordinates
+    pub x: i32,
+    /// vertical position of the top-leftcorner of the rectangle, in surface coordinates
+    pub y: i32,
+    /// width of the rectangle
+    pub width: i32,
+    /// height of the rectangle
+    pub height: i32,
+}
+
+/// Description of the contents of a region
+///
+/// A region is defined as an union and difference of rectangle.
+///
+/// This struct contains an ordered Vec containing the rectangles defining
+/// a region. They should be added or substracted in this order to compute the
+/// actual contents of the region.
+#[derive(Clone)]
+pub struct RegionAttributes {
+    /// List of rectangle part of this region
+    pub rects: Vec<(RectangleKind, Rectangle)>,
+}
+
+impl Default for RegionAttributes {
+    fn default() -> RegionAttributes {
+        RegionAttributes { rects: Vec::new() }
+    }
+}
+
+/// A Compositor global token
+///
+/// This token can be cloned at will, and is the entry-point to
+/// access data associated with the wl_surface and wl_region managed
+/// by the `CompositorGlobal` that provided it.
+#[derive(Copy,Clone)]
+pub struct CompositorToken<U> {
+    hid: usize,
+    _data: ::std::marker::PhantomData<*mut U>,
+}
+
+fn make_token<U>(hid: usize) -> CompositorToken<U> {
+    CompositorToken {
+        hid: hid,
+        _data: ::std::marker::PhantomData,
+    }
+}
+
+impl<U: Send + 'static> CompositorToken<U> {
+    /// Access the data of a surface
+    ///
+    /// The closure will be called with the contents of the data associated with this surface.
+    ///
+    /// If the surface is not managed by the CompositorGlobal that provided this token, this
+    /// will panic (having more than one compositor is not supported).
+    pub fn with_surface_data<F>(&self, surface: &wl_surface::WlSurface, f: F)
+        where F: FnOnce(&mut SurfaceAttributes<U>)
+    {
+        assert!(resource_is_registered::<_, CompositorHandler<U>>(surface, self.hid),
+                "Accessing the data of foreign surfaces is not supported.");
+        unsafe {
+            SurfaceData::<U>::with_data(surface, f);
+        }
+    }
+
+    /// Access the data of a surface tree
+    ///
+    /// The provided closure is called successively on the surface and all its child subsurfaces,
+    /// in a depth-first order.
+    ///
+    /// If the surface is not managed by the CompositorGlobal that provided this token, this
+    /// will panic (having more than one compositor is not supported).
+    pub fn with_surface_tree<F>(&self, surface: &wl_surface::WlSurface, f: F) -> Result<(), ()>
+        where F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>) -> bool
+    {
+        assert!(resource_is_registered::<_, CompositorHandler<U>>(surface, self.hid),
+                "Accessing the data of foreign surfaces is not supported.");
+        unsafe {
+            SurfaceData::<U>::map_tree(surface, f);
+        }
+        Ok(())
+    }
+
+    /// Retrieve the parent of this surface
+    ///
+    /// Returns `None` is this surface is a root surface
+    ///
+    /// If the surface is not managed by the CompositorGlobal that provided this token, this
+    /// will panic (having more than one compositor is not supported).
+    pub fn get_parent(&self, surface: &wl_surface::WlSurface) -> Option<wl_surface::WlSurface> {
+        assert!(resource_is_registered::<_, CompositorHandler<U>>(surface, self.hid),
+                "Accessing the data of foreign surfaces is not supported.");
+        unsafe {
+            SurfaceData::<U>::get_parent(surface)
+        }
+    }
+    
+    /// Retrieve the role status this surface
+    ///
+    /// If the surface is not managed by the CompositorGlobal that provided this token, this
+    /// will panic (having more than one compositor is not supported).
+    pub fn role_status(&self, surface: &wl_surface::WlSurface) -> RoleStatus {
+        assert!(resource_is_registered::<_, CompositorHandler<U>>(surface, self.hid),
+                "Accessing the data of foreign surfaces is not supported.");
+        unsafe {
+            SurfaceData::<U>::role_status(surface)
+        }
+    }
+
+    /// Register that this surface has a role
+    ///
+    /// This makes this surface impossible to become a subsurface, as
+    /// a surface can only have a single role at a time.
+    ///
+    /// Fails if the surface already has a role.
+    ///
+    /// If the surface is not managed by the CompositorGlobal that provided this token, this
+    /// will panic (having more than one compositor is not supported).
+    pub fn give_role(&self, surface: &wl_surface::WlSurface) -> Result<(),()> {
+        assert!(resource_is_registered::<_, CompositorHandler<U>>(surface, self.hid),
+                "Accessing the data of foreign surfaces is not supported.");
+        unsafe {
+            SurfaceData::<U>::give_role(surface)
+        }
+    }
+
+    /// Register that this surface has no role
+    ///
+    /// It is a noop if this surface already didn't have one, but fails if
+    /// the role was "subsurface". This role is automatically managed and as such
+    /// cannot be removed manually.
+    ///
+    /// If the surface is not managed by the CompositorGlobal that provided this token, this
+    /// will panic (having more than one compositor is not supported).
+    pub fn remove_role(&self, surface: &wl_surface::WlSurface) -> Result<(),()> {
+        assert!(resource_is_registered::<_, CompositorHandler<U>>(surface, self.hid),
+                "Accessing the data of foreign surfaces is not supported.");
+        unsafe {
+            SurfaceData::<U>::remove_role(surface)
+        }
+    }
+}

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -330,10 +330,12 @@ impl<U, H> CompositorHandler<U, H> {
 /// The global provided by Smithay cannot process these events for you, so they
 /// are forwarded directly to a handler implementing this trait that you must provide
 /// at creation of the `CompositorHandler`.
+#[allow(unused_variables)]
 pub trait Handler {
     /// See `wayland_server::protocol::wl_surface::Handler::commit`
-    fn commit(&mut self, evlh: &mut EventLoopHandle, client: &Client, surface: &wl_surface::WlSurface);
+    fn commit(&mut self, evlh: &mut EventLoopHandle, client: &Client, surface: &wl_surface::WlSurface) {}
     /// See `wayland_server::protocol::wl_surface::Handler::frame`
     fn frame(&mut self, evlh: &mut EventLoopHandle, client: &Client, surface: &wl_surface::WlSurface,
-             callback: wl_callback::WlCallback);
+             callback: wl_callback::WlCallback) {
+    }
 }

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -220,6 +220,16 @@ impl<U: Send + 'static, H: Handler + Send + 'static> CompositorToken<U, H> {
         unsafe { SurfaceData::<U>::get_parent(surface) }
     }
 
+    /// Retrieve the children of this surface
+    ///
+    /// If the surface is not managed by the CompositorGlobal that provided this token, this
+    /// will panic (having more than one compositor is not supported).
+    pub fn get_children(&self, surface: &wl_surface::WlSurface) -> Vec<wl_surface::WlSurface> {
+        assert!(resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
+                "Accessing the data of foreign surfaces is not supported.");
+        unsafe { SurfaceData::<U>::get_children(surface) }
+    }
+
     /// Retrieve the role status this surface
     ///
     /// If the surface is not managed by the CompositorGlobal that provided this token, this
@@ -257,6 +267,16 @@ impl<U: Send + 'static, H: Handler + Send + 'static> CompositorToken<U, H> {
         assert!(resource_is_registered::<_, CompositorHandler<U, H>>(surface, self.hid),
                 "Accessing the data of foreign surfaces is not supported.");
         unsafe { SurfaceData::<U>::remove_role(surface) }
+    }
+
+    /// Retrieve the metadata associated with a wl_region
+    ///
+    /// If the region is not managed by the CompositorGlobal that provided this token, this
+    /// will panic (having more than one compositor is not supported).
+    pub fn get_region_attributes(&self, region: &wl_region::WlRegion) -> RegionAttributes {
+        assert!(resource_is_registered::<_, CompositorHandler<U, H>>(region, self.hid),
+                "Accessing the data of foreign regions is not supported.");
+        unsafe { RegionData::get_attributes(region) }
     }
 }
 

--- a/src/compositor/region.rs
+++ b/src/compositor/region.rs
@@ -13,7 +13,9 @@ pub struct RegionData {
 impl RegionData {
     /// Initialize the user_data of a region, must be called right when the surface is created
     pub unsafe fn init(region: &wl_region::WlRegion) {
-        region.set_user_data(Box::into_raw(Box::new(Mutex::new(RegionData::default()))) as *mut _)
+        region.set_user_data(Box::into_raw(
+            Box::new(Mutex::new(RegionData::default())),
+        ) as *mut _)
     }
 
     /// Cleans the user_data of that surface, must be called when it is destroyed

--- a/src/compositor/region.rs
+++ b/src/compositor/region.rs
@@ -1,0 +1,42 @@
+use super::{Rectangle, RegionAttributes, RectangleKind};
+
+use std::sync::Mutex;
+use wayland_server::Resource;
+
+use wayland_server::protocol::wl_region;
+
+#[derive(Default)]
+pub struct RegionData {
+    attributes: RegionAttributes,
+}
+
+impl RegionData {
+    /// Initialize the user_data of a region, must be called right when the surface is created
+    pub unsafe fn init(region: &wl_region::WlRegion) {
+        region.set_user_data(Box::into_raw(Box::new(Mutex::new(RegionData::default()))) as *mut _)
+    }
+
+    /// Cleans the user_data of that surface, must be called when it is destroyed
+    pub unsafe fn cleanup(region: &wl_region::WlRegion) {
+        let ptr = region.get_user_data();
+        region.set_user_data(::std::ptr::null_mut());
+        let _my_data_mutex: Box<Mutex<RegionData>> = Box::from_raw(ptr as *mut _);
+    }
+
+    unsafe fn get_data(region: &wl_region::WlRegion) -> &Mutex<RegionData> {
+        let ptr = region.get_user_data();
+        &*(ptr as *mut _)
+    }
+
+    pub unsafe fn get_attributes(region: &wl_region::WlRegion) -> RegionAttributes {
+        let data_mutex = Self::get_data(region);
+        let data_guard = data_mutex.lock().unwrap();
+        data_guard.attributes.clone()
+    }
+
+    pub unsafe fn add_rectangle(region: &wl_region::WlRegion, kind: RectangleKind, rect: Rectangle) {
+        let data_mutex = Self::get_data(region);
+        let mut data_guard = data_mutex.lock().unwrap();
+        data_guard.attributes.rects.push((kind, rect));
+    }
+}

--- a/src/compositor/region.rs
+++ b/src/compositor/region.rs
@@ -1,4 +1,4 @@
-use super::{Rectangle, RegionAttributes, RectangleKind};
+use super::{Rectangle, RectangleKind, RegionAttributes};
 
 use std::sync::Mutex;
 use wayland_server::Resource;

--- a/src/compositor/tree.rs
+++ b/src/compositor/tree.rs
@@ -1,0 +1,252 @@
+use super::SurfaceAttributes;
+use std::sync::Mutex;
+
+use wayland_server::{Liveness, Resource};
+use wayland_server::protocol::wl_surface;
+
+/// Node of a subsurface tree, holding some user specified data type U
+/// at each node
+///
+/// This type is internal to Smithay, and should not appear in the
+/// public API
+///
+/// It is a bidirectionnal tree, meaning we can move along it in both
+/// direction (top-bottom or bottom-up). We are taking advantage of the
+/// fact that lifetime of objects are decided by wayland-server to ensure
+/// the cleanup will be done properly, and we won't leak anything.
+///
+/// This implementation is not strictly a tree, but rather a directed graph
+/// with the constraint that node can have at most one incoming edge. Aka like
+/// a tree, but with loops allowed. This is because the wayland protocol does not
+/// have a failure case to forbid this. Note that if any node in such a graph does not
+/// have a parent, then the graph is a tree and this node is its root.
+///
+/// All the methods here are unsafe, because they assume the provided wl_surface object
+/// is correctly initialized regarding its user_data.
+pub struct SurfaceData<U> {
+    parent: Option<wl_surface::WlSurface>,
+    children: Vec<wl_surface::WlSurface>,
+    has_role: bool,
+    attributes: SurfaceAttributes<U>,
+}
+
+/// Status of a surface regarding its role
+pub enum RoleStatus {
+    /// This surface does not have any role
+    NoRole,
+    /// This surface is a subsurface
+    Sursurface,
+    /// This surface has a role other than subsurface
+    ///
+    /// It is thus the root of a subsurface tree that will
+    /// have to be displayed
+    HasRole,
+}
+
+impl<U: Default> SurfaceData<U> {
+    fn new() -> SurfaceData<U> {
+        SurfaceData {
+            parent: None,
+            children: Vec::new(),
+            has_role: false,
+            attributes: Default::default(),
+        }
+    }
+
+    /// Initialize the user_data of a surface, must be called right when the surface is created
+    pub unsafe fn init(surface: &wl_surface::WlSurface) {
+        surface.set_user_data(Box::into_raw(Box::new(Mutex::new(SurfaceData::<U>::new()))) as *mut _)
+    }
+}
+
+impl<U> SurfaceData<U> {
+    unsafe fn get_data(surface: &wl_surface::WlSurface) -> &Mutex<SurfaceData<U>> {
+        let ptr = surface.get_user_data();
+        &*(ptr as *mut _)
+    }
+
+    /// Cleans the user_data of that surface, must be called when it is destroyed
+    pub unsafe fn cleanup(surface: &wl_surface::WlSurface) {
+        let ptr = surface.get_user_data();
+        surface.set_user_data(::std::ptr::null_mut());
+        let my_data_mutex: Box<Mutex<SurfaceData<U>>> = Box::from_raw(ptr as *mut _);
+        let mut my_data = my_data_mutex.into_inner().unwrap();
+        if let Some(old_parent) = my_data.parent.take() {
+            if !old_parent.equals(surface) {
+                // We had a parent that is not ourselves, lets unregister ourselves from it
+                let old_parent_mutex = Self::get_data(&old_parent);
+                let mut old_parent_guard = old_parent_mutex.lock().unwrap();
+                old_parent_guard.children.retain(|c| !c.equals(surface));
+            }
+        }
+        // orphan all our children
+        for child in &my_data.children {
+            // don't do anything if this child is ourselves
+            if child.equals(surface) {
+                continue;
+            }
+            let child_mutex = Self::get_data(child);
+            let mut child_guard = child_mutex.lock().unwrap();
+            child_guard.parent = None;
+        }
+    }
+
+    /// Retrieve the current role status of this surface
+    pub unsafe fn role_status(surface: &wl_surface::WlSurface) -> RoleStatus {
+        debug_assert!(surface.status() == Liveness::Alive);
+        let data_mutex = Self::get_data(surface);
+        let data_guard = data_mutex.lock().unwrap();
+        match (data_guard.has_role, data_guard.parent.is_some()) {
+            (true, true) => RoleStatus::Sursurface,
+            (true, false) => RoleStatus::HasRole,
+            (false, false) => RoleStatus::NoRole,
+            (false, true) => unreachable!(),
+        }
+    }
+
+    /// Register that this surface has a role, fails if it already has one
+    pub unsafe fn give_role(surface: &wl_surface::WlSurface) -> Result<(), ()> {
+        debug_assert!(surface.status() == Liveness::Alive);
+        let data_mutex = Self::get_data(surface);
+        let mut data_guard = data_mutex.lock().unwrap();
+        if data_guard.has_role {
+            return Err(());
+        }
+        data_guard.has_role = true;
+        Ok(())
+    }
+
+    /// Register that this surface has no role
+    ///
+    /// It is a noop if this surface already didn't have one, but fails if
+    /// the role was "subsurface", it must be removed by the `unset_parent` method.
+    pub unsafe fn remove_role(surface: &wl_surface::WlSurface) -> Result<(), ()> {
+        debug_assert!(surface.status() == Liveness::Alive);
+        let data_mutex = Self::get_data(surface);
+        let mut data_guard = data_mutex.lock().unwrap();
+        if data_guard.has_role && data_guard.parent.is_some() {
+            return Err(());
+        }
+        data_guard.has_role = false;
+        Ok(())
+    }
+
+    /// Sets the parent of a surface
+    /// if this surface already has a role, does nothing and fails, otherwise
+    /// its role is now to be a subsurface
+    pub unsafe fn set_parent(child: &wl_surface::WlSurface, parent: &wl_surface::WlSurface)
+                             -> Result<(), ()> {
+        debug_assert!(child.status() == Liveness::Alive);
+        debug_assert!(parent.status() == Liveness::Alive);
+
+        // change child's parent
+        {
+            let child_mutex = Self::get_data(child);
+            let mut child_guard = child_mutex.lock().unwrap();
+            // if surface already has a role, it cannot be a subsurface
+            if child_guard.has_role {
+                return Err(());
+            }
+            debug_assert!(child_guard.parent.is_none());
+            child_guard.parent = Some(parent.clone_unchecked());
+            child_guard.has_role = true;
+        }
+        // register child to new parent
+        // double scoping is to be robust to have a child be its own parent
+        {
+            let parent_mutex = Self::get_data(parent);
+            let mut parent_guard = parent_mutex.lock().unwrap();
+            parent_guard.children.push(child.clone_unchecked())
+        }
+        Ok(())
+    }
+
+    /// Remove a pre-existing parent of this child
+    ///
+    /// Does nothing if it has no parent
+    pub unsafe fn unset_parent(child: &wl_surface::WlSurface) {
+        debug_assert!(child.status() == Liveness::Alive);
+        let old_parent = {
+            let child_mutex = Self::get_data(child);
+            let mut child_guard = child_mutex.lock().unwrap();
+            let old_parent = child_guard.parent.take();
+            if old_parent.is_some() {
+                // We had a parent, so this does not have a role any more
+                child_guard.has_role = false;
+            }
+            old_parent
+        };
+        // unregister from our parent
+        if let Some(old_parent) = old_parent {
+            let parent_mutex = Self::get_data(&old_parent);
+            let mut parent_guard = parent_mutex.lock().unwrap();
+            parent_guard.children.retain(|c| !c.equals(child));
+        }
+    }
+
+    /// Retrieve the parent surface (if any) of this surface
+    pub unsafe fn get_parent(child: &wl_surface::WlSurface) -> Option<wl_surface::WlSurface> {
+        let child_mutex = Self::get_data(child);
+        let child_guard = child_mutex.lock().unwrap();
+        child_guard.parent.as_ref().map(|p| p.clone_unchecked())
+    }
+
+    /// Access the attributes associated with a surface
+    ///
+    /// Note that an internal lock is taken during access of this data,
+    /// so the tree cannot be manipulated at the same time
+    pub unsafe fn with_data<F>(surface: &wl_surface::WlSurface, f: F)
+        where F: FnOnce(&mut SurfaceAttributes<U>)
+    {
+        let data_mutex = Self::get_data(surface);
+        let mut data_guard = data_mutex.lock().unwrap();
+        f(&mut data_guard.attributes)
+    }
+
+    /// Access sequentially the attributes associated with a surface tree,
+    /// in a depth-first order
+    ///
+    /// Note that an internal lock is taken during access of this data,
+    /// so the tree cannot be manipulated at the same time.
+    ///
+    /// The callback returns wether the traversal should continue or not. Returning
+    /// false will cause an early-stopping.
+    pub unsafe fn map_tree<F>(root: &wl_surface::WlSurface, mut f: F)
+        where F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>) -> bool
+    {
+        // helper function for recursion
+        unsafe fn map<U, F>(surface: &wl_surface::WlSurface, root: &wl_surface::WlSurface, f: &mut F) -> bool
+            where F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>) -> bool
+        {
+            // stop if we met the root, so to not deadlock/inifinte loop
+            if surface.equals(root) {
+                return true;
+            }
+
+            let data_mutex = SurfaceData::<U>::get_data(surface);
+            let mut data_guard = data_mutex.lock().unwrap();
+            // call the callback on ourselves
+            if f(surface, &mut data_guard.attributes) {
+                // loop over children
+                for c in &data_guard.children {
+                    if !map(c, root, f) {
+                        return false;
+                    }
+                }
+            }
+            true
+        }
+
+        let data_mutex = Self::get_data(root);
+        let mut data_guard = data_mutex.lock().unwrap();
+        // call the callback on ourselves
+        if f(root, &mut data_guard.attributes) {
+            // loop over children
+            for c in &data_guard.children {
+                if !map::<U, _>(c, root, &mut f) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/compositor/tree.rs
+++ b/src/compositor/tree.rs
@@ -70,7 +70,9 @@ impl<U: Default> SurfaceData<U> {
 
     /// Initialize the user_data of a surface, must be called right when the surface is created
     pub unsafe fn init(surface: &wl_surface::WlSurface) {
-        surface.set_user_data(Box::into_raw(Box::new(Mutex::new(SurfaceData::<U>::new()))) as *mut _)
+        surface.set_user_data(Box::into_raw(
+            Box::new(Mutex::new(SurfaceData::<U>::new())),
+        ) as *mut _)
     }
 }
 
@@ -270,7 +272,8 @@ impl<U> SurfaceData<U> {
     /// Note that an internal lock is taken during access of this data,
     /// so the tree cannot be manipulated at the same time
     pub unsafe fn with_data<F>(surface: &wl_surface::WlSurface, f: F)
-        where F: FnOnce(&mut SurfaceAttributes<U>)
+    where
+        F: FnOnce(&mut SurfaceAttributes<U>),
     {
         let data_mutex = Self::get_data(surface);
         let mut data_guard = data_mutex.lock().unwrap();
@@ -286,13 +289,15 @@ impl<U> SurfaceData<U> {
     /// The callback returns wether the traversal should continue or not. Returning
     /// false will cause an early-stopping.
     pub unsafe fn map_tree<F, T>(root: &wl_surface::WlSurface, initial: T, mut f: F)
-        where F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>, &T) -> TraversalAction<T>
+    where
+        F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>, &T) -> TraversalAction<T>,
     {
         // helper function for recursion
         unsafe fn map<U, F, T>(surface: &wl_surface::WlSurface, root: &wl_surface::WlSurface, initial: &T,
                                f: &mut F)
                                -> bool
-            where F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>, &T) -> TraversalAction<T>
+        where
+            F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>, &T) -> TraversalAction<T>,
         {
             // stop if we met the root, so to not deadlock/inifinte loop
             if surface.equals(root) {

--- a/src/compositor/tree.rs
+++ b/src/compositor/tree.rs
@@ -196,6 +196,17 @@ impl<U> SurfaceData<U> {
         child_guard.parent.as_ref().map(|p| p.clone_unchecked())
     }
 
+    /// Retrieve the parent surface (if any) of this surface
+    pub unsafe fn get_children(child: &wl_surface::WlSurface) -> Vec<wl_surface::WlSurface> {
+        let child_mutex = Self::get_data(child);
+        let child_guard = child_mutex.lock().unwrap();
+        child_guard
+            .children
+            .iter()
+            .map(|p| p.clone_unchecked())
+            .collect()
+    }
+
     /// Reorders a surface relative to one of its sibling
     ///
     /// Fails if `relative_to` is not a sibling or parent of `surface`.

--- a/src/compositor/tree.rs
+++ b/src/compositor/tree.rs
@@ -35,7 +35,7 @@ pub enum RoleStatus {
     /// This surface does not have any role
     NoRole,
     /// This surface is a subsurface
-    Sursurface,
+    Subsurface,
     /// This surface has a role other than subsurface
     ///
     /// It is thus the root of a subsurface tree that will
@@ -102,7 +102,7 @@ impl<U> SurfaceData<U> {
         let data_mutex = Self::get_data(surface);
         let data_guard = data_mutex.lock().unwrap();
         match (data_guard.has_role, data_guard.parent.is_some()) {
-            (true, true) => RoleStatus::Sursurface,
+            (true, true) => RoleStatus::Subsurface,
             (true, false) => RoleStatus::HasRole,
             (false, false) => RoleStatus::NoRole,
             (false, true) => unreachable!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,10 @@ extern crate glium;
 extern crate slog;
 extern crate slog_stdlog;
 
-pub mod shm;
 pub mod backend;
+
+pub mod compositor;
+pub mod shm;
 pub mod keyboard;
 
 fn slog_or_stdlog<L>(logger: L) -> ::slog::Logger

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! To use it, first add a `ShmGlobal` to your event loop, specifying the formats
 //! you want to support (ARGB8888 and XRGB8888 are always considered as supported,
-//! as specified by the wayland protocol) and obtain its `ShmGlobalToken`.
+//! as specified by the wayland protocol) and obtain its `ShmToken`.
 //!
 //! ```
 //! extern crate wayland_server;
@@ -110,8 +110,8 @@ impl ShmGlobal {
     /// and has been initialized. If it is not the case, this method will panic.
     ///
     /// This is needed to retrieve the contents of the shm pools and buffers.
-    pub fn get_token(&self) -> ShmGlobalToken {
-        ShmGlobalToken { hid: self.handler_id.expect("ShmGlobal was not initialized.") }
+    pub fn get_token(&self) -> ShmToken {
+        ShmToken { hid: self.handler_id.expect("ShmGlobal was not initialized.") }
     }
 }
 
@@ -119,7 +119,8 @@ impl ShmGlobal {
 ///
 /// It is needed to access the contents of the buffers & pools managed by the
 /// associated `ShmGlobal`.
-pub struct ShmGlobalToken {
+#[derive(Clone)]
+pub struct ShmToken {
     hid: usize,
 }
 
@@ -136,7 +137,7 @@ pub enum BufferAccessError {
     BadMap,
 }
 
-impl ShmGlobalToken {
+impl ShmToken {
     /// Call given closure with the contents of the given buffer
     ///
     /// If the buffer is managed by the associated ShmGlobal, its contents are


### PR DESCRIPTION
There are still a some things to do before merging.

Two requests of `wl_surface` are missing:

- [x] `wl_surface.frame`
- [x] `wl_surface.commit`

I plan make the user provide a Handler to directly retrieve these, as they cannot be simply accumulated for double-buffering like the others.

Two requests of `wl_subsurface` are missing:

- [x] `wl_subsurface.place_above`
- [x] `wl_subsurface.place_below`

I'm not yet sure how to handle these, the current tree structure could handle ordering of the children of a surface, but we need to _also_ handle ordering the parent relative to each of its children.

EDIT: subsequent needs:

- [x] documentation
- [x] logging
- [ ] find a clean way to handle ordering of the children relative to the parent ? (I can think of ugly ways to do so, but...)
