### PR TITLE
Decouple EGLSurface from EGLContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ winit = { git = "https://github.com/tomaka/winit.git", optional = true }
 glium = { version = "~0.16.0", optional = true }
 input = { version = "~0.2.0", optional = true }
 clippy = { version = "*", optional = true }
+rental = "0.4.11"
 
 [build-dependencies]
 gl_generator = "0.5"

--- a/build.rs
+++ b/build.rs
@@ -12,22 +12,25 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let mut file = File::create(&dest.join("egl_bindings.rs")).unwrap();
-    Registry::new(Api::Egl,
-                  (1, 5),
-                  Profile::Core,
-                  Fallbacks::All,
-                  ["EGL_KHR_create_context",
-                   "EGL_EXT_create_context_robustness",
-                   "EGL_KHR_create_context_no_error",
-                   "EGL_KHR_platform_x11",
-                   "EGL_KHR_platform_android",
-                   "EGL_KHR_platform_wayland",
-                   "EGL_KHR_platform_gbm",
-                   "EGL_EXT_platform_base",
-                   "EGL_EXT_platform_x11",
-                   "EGL_MESA_platform_gbm",
-                   "EGL_EXT_platform_wayland",
-                   "EGL_EXT_platform_device"])
-            .write_bindings(gl_generator::StructGenerator, &mut file)
-            .unwrap();
+    Registry::new(
+        Api::Egl,
+        (1, 5),
+        Profile::Core,
+        Fallbacks::All,
+        [
+            "EGL_KHR_create_context",
+            "EGL_EXT_create_context_robustness",
+            "EGL_KHR_create_context_no_error",
+            "EGL_KHR_platform_x11",
+            "EGL_KHR_platform_android",
+            "EGL_KHR_platform_wayland",
+            "EGL_KHR_platform_gbm",
+            "EGL_EXT_platform_base",
+            "EGL_EXT_platform_x11",
+            "EGL_MESA_platform_gbm",
+            "EGL_EXT_platform_wayland",
+            "EGL_EXT_platform_device",
+        ],
+    ).write_bindings(gl_generator::StructGenerator, &mut file)
+        .unwrap();
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -17,9 +17,10 @@ fn main() {
 
     // Insert the ShmGlobal as a handler to your event loop
     // Here, we specify tha the standard Argb8888 and Xrgb8888 is the only supported.
-    let handler_id =
-        event_loop.add_handler_with_init(ShmGlobal::new(vec![],
-                                                        None /* we don't provide a logger here */));
+    let handler_id = event_loop.add_handler_with_init(ShmGlobal::new(
+        vec![],
+        None, /* we don't provide a logger here */
+    ));
 
     // Register this handler to advertise a wl_shm global of version 1
     let shm_global = event_loop.register_global::<wl_shm::WlShm, ShmGlobal>(handler_id, 1);

--- a/src/backend/graphics/egl.rs
+++ b/src/backend/graphics/egl.rs
@@ -521,7 +521,7 @@ impl EGLContext {
         debug!(log, "EGL context successfully created");
 
         let surface_attributes = {
-            let mut out: Vec<c_int> = Vec::with_capacity(2);
+            let mut out: Vec<c_int> = Vec::with_capacity(3);
 
             match reqs.double_buffer {
                 Some(true) => {
@@ -537,6 +537,7 @@ impl EGLContext {
                 None => {}
             }
 
+            out.push(ffi::egl::NONE as i32);
             out
         };
 

--- a/src/backend/graphics/egl.rs
+++ b/src/backend/graphics/egl.rs
@@ -117,14 +117,12 @@ impl error::Error for CreationError {
             CreationError::OpenGlVersionNotSupported => {
                 "The requested OpenGL version is not \
                                                          supported."
-            },
+            }
             CreationError::NoAvailablePixelFormat => {
                 "Couldn't find any pixel format that matches \
                                                       the criterias."
-            },
-            CreationError::NonMatchingSurfaceType => {
-                "Surface type does not match the context type."
             }
+            CreationError::NonMatchingSurfaceType => "Surface type does not match the context type.",
             CreationError::NotSupported => "Context creation is not supported on the current window system",
         }
     }
@@ -571,11 +569,16 @@ impl EGLContext {
         trace!(self.logger, "Creating EGL window surface...");
 
         match native {
-            NativeSurface::X11(_) if self.backend_type != NativeType::X11 => return Err(CreationError::NonMatchingSurfaceType),
-            NativeSurface::Wayland(_) if self.backend_type != NativeType::Wayland => return Err(CreationError::NonMatchingSurfaceType),
-            NativeSurface::Gbm(_) if self.backend_type != NativeType::Gbm =>
-                return Err(CreationError::NonMatchingSurfaceType),
-            _ => {},
+            NativeSurface::X11(_) if self.backend_type != NativeType::X11 => {
+                return Err(CreationError::NonMatchingSurfaceType)
+            }
+            NativeSurface::Wayland(_) if self.backend_type != NativeType::Wayland => {
+                return Err(CreationError::NonMatchingSurfaceType)
+            }
+            NativeSurface::Gbm(_) if self.backend_type != NativeType::Gbm => {
+                return Err(CreationError::NonMatchingSurfaceType)
+            }
+            _ => {}
         };
 
         let surface = {

--- a/src/backend/graphics/egl.rs
+++ b/src/backend/graphics/egl.rs
@@ -168,8 +168,8 @@ impl EGLContext {
     ///
     /// # Unsafety
     ///
-    /// This method is marked unsafe, because the contents of `NativeDisplay` cannot be verified and msy
-    /// contain dangeling pointers are similar unsafe content
+    /// This method is marked unsafe, because the contents of `NativeDisplay` cannot be verified and may
+    /// contain dangling pointers or similar unsafe content
     pub unsafe fn new<L>(native: NativeDisplay, mut attributes: GlAttributes,
                          reqs: PixelFormatRequirements, logger: L)
                          -> Result<EGLContext, CreationError>
@@ -563,8 +563,8 @@ impl EGLContext {
     ///
     /// # Unsafety
     ///
-    /// This method is marked unsafe, because the contents of `NativeSurface` cannot be verified and msy
-    /// contain dangeling pointers are similar unsafe content
+    /// This method is marked unsafe, because the contents of `NativeSurface` cannot be verified and may
+    /// contain dangling pointers or similar unsafe content
     pub unsafe fn create_surface<'a>(&'a self, native: NativeSurface)
                                      -> Result<EGLSurface<'a>, CreationError> {
         trace!(self.logger, "Creating EGL window surface...");

--- a/src/backend/graphics/glium.rs
+++ b/src/backend/graphics/glium.rs
@@ -48,8 +48,10 @@ impl<T: EGLGraphicsBackend + 'static> GliumGraphicsBackend<T> {
     /// Note that destroying a `Frame` is immediate, even if vsync is enabled.
     #[inline]
     pub fn draw(&self) -> Frame {
-        Frame::new(self.context.clone(),
-                   self.backend.get_framebuffer_dimensions())
+        Frame::new(
+            self.context.clone(),
+            self.backend.get_framebuffer_dimensions(),
+        )
     }
 }
 

--- a/src/backend/input.rs
+++ b/src/backend/input.rs
@@ -49,7 +49,8 @@ impl ::std::cmp::PartialEq for Seat {
 
 impl ::std::hash::Hash for Seat {
     fn hash<H>(&self, state: &mut H)
-        where H: ::std::hash::Hasher
+    where
+        H: ::std::hash::Hasher,
     {
         self.id.hash(state);
     }
@@ -275,7 +276,10 @@ pub trait PointerMotionAbsoluteEvent: Event {
     /// Device position converted to the targets coordinate space.
     /// E.g. the focused output's resolution.
     fn position_transformed(&self, coordinate_space: (u32, u32)) -> (u32, u32) {
-        (self.x_transformed(coordinate_space.0), self.y_transformed(coordinate_space.1))
+        (
+            self.x_transformed(coordinate_space.0),
+            self.y_transformed(coordinate_space.1),
+        )
     }
 
     /// Device x position converted to the targets coordinate space's width.
@@ -336,7 +340,10 @@ pub trait TouchDownEvent: Event {
     /// Touch position converted into the target coordinate space.
     /// E.g. the focused output's resolution.
     fn position_transformed(&self, coordinate_space: (u32, u32)) -> (u32, u32) {
-        (self.x_transformed(coordinate_space.0), self.y_transformed(coordinate_space.1))
+        (
+            self.x_transformed(coordinate_space.0),
+            self.y_transformed(coordinate_space.1),
+        )
     }
 
     /// Touch event's x-coordinate in the device's native coordinate space
@@ -395,7 +402,10 @@ pub trait TouchMotionEvent: Event {
     /// Touch position converted into the target coordinate space.
     /// E.g. the focused output's resolution.
     fn position_transformed(&self, coordinate_space: (u32, u32)) -> (u32, u32) {
-        (self.x_transformed(coordinate_space.0), self.y_transformed(coordinate_space.1))
+        (
+            self.x_transformed(coordinate_space.0),
+            self.y_transformed(coordinate_space.1),
+        )
     }
 
     /// Touch event's x-coordinate in the device's native coordinate space

--- a/src/backend/libinput.rs
+++ b/src/backend/libinput.rs
@@ -26,7 +26,8 @@ impl LibinputInputBackend {
     /// Initialize a new `LibinputInputBackend` from a given already initialized libinput
     /// context.
     pub fn new<L>(context: libinput::Libinput, logger: L) -> Self
-        where L: Into<Option<::slog::Logger>>
+    where
+        L: Into<Option<::slog::Logger>>,
     {
         let log = ::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_libinput"));
         info!(log, "Initializing a libinput backend");
@@ -270,9 +271,9 @@ impl backend::InputBackend for LibinputInputBackend {
     }
 
     fn get_handler(&mut self) -> Option<&mut backend::InputHandler<Self>> {
-        self.handler
-            .as_mut()
-            .map(|handler| handler as &mut backend::InputHandler<Self>)
+        self.handler.as_mut().map(|handler| {
+            handler as &mut backend::InputHandler<Self>
+        })
     }
 
     fn clear_handler(&mut self) {
@@ -328,8 +329,8 @@ impl backend::InputBackend for LibinputInputBackend {
                                 Entry::Vacant(seat_entry) => {
                                     let mut hasher = DefaultHasher::default();
                                     seat_entry.key().hash(&mut hasher);
-                                    let seat = seat_entry
-                                        .insert(backend::Seat::new(hasher.finish(), new_caps));
+                                    let seat =
+                                        seat_entry.insert(backend::Seat::new(hasher.finish(), new_caps));
                                     if let Some(ref mut handler) = self.handler {
                                         trace!(self.logger, "Calling on_seat_created with {:?}", seat);
                                         handler.on_seat_created(seat);
@@ -378,7 +379,7 @@ impl backend::InputBackend for LibinputInputBackend {
                                 } else {
                                     panic!("Seat destroyed that was never created");
                                 }
-                                // it has, notify about updates
+                            // it has, notify about updates
                             } else if let Some(ref mut handler) = self.handler {
                                 let seat = self.seats[&device_seat];
                                 trace!(self.logger, "Calling on_seat_changed with {:?}", seat);
@@ -394,18 +395,20 @@ impl backend::InputBackend for LibinputInputBackend {
                     use input::event::touch::*;
                     if let Some(ref mut handler) = self.handler {
                         let device_seat = touch_event.device().seat();
-                        let seat = &self.seats
-                                        .get(&device_seat)
-                                        .expect("Recieved touch event of non existing Seat");
+                        let seat = &self.seats.get(&device_seat).expect(
+                            "Recieved touch event of non existing Seat",
+                        );
                         match touch_event {
                             TouchEvent::Down(down_event) => {
                                 trace!(self.logger, "Calling on_touch_down with {:?}", down_event);
                                 handler.on_touch_down(seat, down_event)
                             }
                             TouchEvent::Motion(motion_event) => {
-                                trace!(self.logger,
-                                       "Calling on_touch_motion with {:?}",
-                                       motion_event);
+                                trace!(
+                                    self.logger,
+                                    "Calling on_touch_motion with {:?}",
+                                    motion_event
+                                );
                                 handler.on_touch_motion(seat, motion_event)
                             }
                             TouchEvent::Up(up_event) => {
@@ -413,9 +416,11 @@ impl backend::InputBackend for LibinputInputBackend {
                                 handler.on_touch_up(seat, up_event)
                             }
                             TouchEvent::Cancel(cancel_event) => {
-                                trace!(self.logger,
-                                       "Calling on_touch_cancel with {:?}",
-                                       cancel_event);
+                                trace!(
+                                    self.logger,
+                                    "Calling on_touch_cancel with {:?}",
+                                    cancel_event
+                                );
                                 handler.on_touch_cancel(seat, cancel_event)
                             }
                             TouchEvent::Frame(frame_event) => {
@@ -431,9 +436,9 @@ impl backend::InputBackend for LibinputInputBackend {
                         KeyboardEvent::Key(key_event) => {
                             if let Some(ref mut handler) = self.handler {
                                 let device_seat = key_event.device().seat();
-                                let seat = &self.seats
-                                                .get(&device_seat)
-                                                .expect("Recieved key event of non existing Seat");
+                                let seat = &self.seats.get(&device_seat).expect(
+                                    "Recieved key event of non existing Seat",
+                                );
                                 trace!(self.logger, "Calling on_keyboard_key with {:?}", key_event);
                                 handler.on_keyboard_key(seat, key_event);
                             }
@@ -444,49 +449,63 @@ impl backend::InputBackend for LibinputInputBackend {
                     use input::event::pointer::*;
                     if let Some(ref mut handler) = self.handler {
                         let device_seat = pointer_event.device().seat();
-                        let seat = &self.seats
-                                        .get(&device_seat)
-                                        .expect("Recieved pointer event of non existing Seat");
+                        let seat = &self.seats.get(&device_seat).expect(
+                            "Recieved pointer event of non existing Seat",
+                        );
                         match pointer_event {
                             PointerEvent::Motion(motion_event) => {
-                                trace!(self.logger,
-                                       "Calling on_pointer_move with {:?}",
-                                       motion_event);
+                                trace!(
+                                    self.logger,
+                                    "Calling on_pointer_move with {:?}",
+                                    motion_event
+                                );
                                 handler.on_pointer_move(seat, motion_event);
                             }
                             PointerEvent::MotionAbsolute(motion_abs_event) => {
-                                trace!(self.logger,
-                                       "Calling on_pointer_move_absolute with {:?}",
-                                       motion_abs_event);
+                                trace!(
+                                    self.logger,
+                                    "Calling on_pointer_move_absolute with {:?}",
+                                    motion_abs_event
+                                );
                                 handler.on_pointer_move_absolute(seat, motion_abs_event);
                             }
                             PointerEvent::Axis(axis_event) => {
                                 let rc_axis_event = Rc::new(axis_event);
                                 if rc_axis_event.has_axis(Axis::Vertical) {
-                                    trace!(self.logger,
-                                           "Calling on_pointer_axis for Axis::Vertical with {:?}",
-                                           *rc_axis_event);
-                                    handler.on_pointer_axis(seat,
-                                                            self::PointerAxisEvent {
-                                                                axis: Axis::Vertical,
-                                                                event: rc_axis_event.clone(),
-                                                            });
+                                    trace!(
+                                        self.logger,
+                                        "Calling on_pointer_axis for Axis::Vertical with {:?}",
+                                        *rc_axis_event
+                                    );
+                                    handler.on_pointer_axis(
+                                        seat,
+                                        self::PointerAxisEvent {
+                                            axis: Axis::Vertical,
+                                            event: rc_axis_event.clone(),
+                                        },
+                                    );
                                 }
                                 if rc_axis_event.has_axis(Axis::Horizontal) {
-                                    trace!(self.logger,
-                                           "Calling on_pointer_axis for Axis::Horizontal with {:?}",
-                                           *rc_axis_event);
-                                    handler.on_pointer_axis(seat,
-                                                            self::PointerAxisEvent {
-                                                                axis: Axis::Horizontal,
-                                                                event: rc_axis_event.clone(),
-                                                            });
+                                    trace!(
+                                        self.logger,
+                                        "Calling on_pointer_axis for Axis::Horizontal with {:?}",
+                                        *rc_axis_event
+                                    );
+                                    handler.on_pointer_axis(
+                                        seat,
+                                        self::PointerAxisEvent {
+                                            axis: Axis::Horizontal,
+                                            event: rc_axis_event.clone(),
+                                        },
+                                    );
                                 }
                             }
                             PointerEvent::Button(button_event) => {
-                                trace!(self.logger,
-                                       "Calling on_pointer_button with {:?}",
-                                       button_event);
+                                trace!(
+                                    self.logger,
+                                    "Calling on_pointer_button with {:?}",
+                                    button_event
+                                );
                                 handler.on_pointer_button(seat, button_event);
                             }
                         }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -61,13 +61,16 @@ pub struct WinitInputBackend {
 /// graphics backend trait and a corresponding `WinitInputBackend`, which implements
 /// the `InputBackend` trait
 pub fn init<L>(logger: L) -> Result<(WinitGraphicsBackend, WinitInputBackend), CreationError>
-    where L: Into<Option<::slog::Logger>>
+where
+    L: Into<Option<::slog::Logger>>,
 {
-    init_from_builder(WindowBuilder::new()
-                          .with_dimensions(1280, 800)
-                          .with_title("Smithay")
-                          .with_visibility(true),
-                      logger)
+    init_from_builder(
+        WindowBuilder::new()
+            .with_dimensions(1280, 800)
+            .with_title("Smithay")
+            .with_visibility(true),
+        logger,
+    )
 }
 
 /// Create a new `WinitGraphicsBackend`, which implements the `EGLGraphicsBackend`
@@ -75,26 +78,30 @@ pub fn init<L>(logger: L) -> Result<(WinitGraphicsBackend, WinitInputBackend), C
 /// `WinitInputBackend`, which implements the `InputBackend` trait
 pub fn init_from_builder<L>(builder: WindowBuilder, logger: L)
                             -> Result<(WinitGraphicsBackend, WinitInputBackend), CreationError>
-    where L: Into<Option<::slog::Logger>>
+where
+    L: Into<Option<::slog::Logger>>,
 {
-    init_from_builder_with_gl_attr(builder,
-                                   GlAttributes {
-                                       version: None,
-                                       profile: None,
-                                       debug: cfg!(debug_assertions),
-                                       vsync: true,
-                                   },
-                                   logger)
+    init_from_builder_with_gl_attr(
+        builder,
+        GlAttributes {
+            version: None,
+            profile: None,
+            debug: cfg!(debug_assertions),
+            vsync: true,
+        },
+        logger,
+    )
 }
 
 /// Create a new `WinitGraphicsBackend`, which implements the `EGLGraphicsBackend`
 /// graphics backend trait, from a given `WindowBuilder` struct, as well as given
 /// `GlAttributes` for further customization of the rendering pipeline and a
 /// corresponding `WinitInputBackend`, which implements the `InputBackend` trait.
-pub fn init_from_builder_with_gl_attr<L>
-    (builder: WindowBuilder, attributes: GlAttributes, logger: L)
-     -> Result<(WinitGraphicsBackend, WinitInputBackend), CreationError>
-    where L: Into<Option<::slog::Logger>>
+pub fn init_from_builder_with_gl_attr<L>(
+    builder: WindowBuilder, attributes: GlAttributes, logger: L)
+    -> Result<(WinitGraphicsBackend, WinitInputBackend), CreationError>
+where
+    L: Into<Option<::slog::Logger>>,
 {
     let log = ::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_winit"));
     info!(log, "Initializing a winit backend");
@@ -103,33 +110,45 @@ pub fn init_from_builder_with_gl_attr<L>
     let window = Rc::new(builder.build(&events_loop)?);
     debug!(log, "Window created");
 
-    let (native_display, native_surface, surface) = if let (Some(conn), Some(window)) =
-        (get_x11_xconnection(), window.get_xlib_window()) {
-        debug!(log, "Window is backed by X11");
-        (NativeDisplay::X11(conn.display as *const _), NativeSurface::X11(window), None)
-    } else if let (Some(display), Some(surface)) =
-        (window.get_wayland_display(), window.get_wayland_client_surface()) {
-        debug!(log, "Window is backed by Wayland");
-        let (w, h) = window.get_inner_size().unwrap();
-        let egl_surface = wegl::WlEglSurface::new(surface, w as i32, h as i32);
-        (NativeDisplay::Wayland(display),
-         NativeSurface::Wayland(egl_surface.ptr() as *const _),
-         Some(egl_surface))
-    } else {
-        error!(log, "Window is backed by an unsupported graphics framework");
-        return Err(CreationError::NotSupported);
-    };
+    let (native_display, native_surface, surface) =
+        if let (Some(conn), Some(window)) = (get_x11_xconnection(), window.get_xlib_window()) {
+            debug!(log, "Window is backed by X11");
+            (
+                NativeDisplay::X11(conn.display as *const _),
+                NativeSurface::X11(window),
+                None,
+            )
+        } else if let (Some(display), Some(surface)) =
+            (
+                window.get_wayland_display(),
+                window.get_wayland_client_surface(),
+            )
+        {
+            debug!(log, "Window is backed by Wayland");
+            let (w, h) = window.get_inner_size().unwrap();
+            let egl_surface = wegl::WlEglSurface::new(surface, w as i32, h as i32);
+            (
+                NativeDisplay::Wayland(display),
+                NativeSurface::Wayland(egl_surface.ptr() as *const _),
+                Some(egl_surface),
+            )
+        } else {
+            error!(log, "Window is backed by an unsupported graphics framework");
+            return Err(CreationError::NotSupported);
+        };
 
     let context = unsafe {
-        match EGLContext::new(native_display,
-                              attributes,
-                              PixelFormatRequirements {
-                                  hardware_accelerated: Some(true),
-                                  color_bits: Some(24),
-                                  alpha_bits: Some(8),
-                                  ..Default::default()
-                              },
-                              log.clone()) {
+        match EGLContext::new(
+            native_display,
+            attributes,
+            PixelFormatRequirements {
+                hardware_accelerated: Some(true),
+                color_bits: Some(24),
+                alpha_bits: Some(8),
+                ..Default::default()
+            },
+            log.clone(),
+        ) {
             Ok(context) => context,
             Err(err) => {
                 error!(log, "EGLContext creation failed:\n {}", err);
@@ -138,11 +157,12 @@ pub fn init_from_builder_with_gl_attr<L>
         }
     };
 
-    Ok((WinitGraphicsBackend {
+    Ok((
+        WinitGraphicsBackend {
             window: window.clone(),
             context: match egl::RentEGL::try_new(Box::new(context), move |context| unsafe {
-        context.create_surface(native_surface)
-    }) {
+                context.create_surface(native_surface)
+            }) {
                 Ok(x) => x,
                 Err(::rental::TryNewError(err, _)) => return Err(err),
             },
@@ -154,16 +174,19 @@ pub fn init_from_builder_with_gl_attr<L>
             surface: surface,
             time_counter: 0,
             key_counter: 0,
-            seat: Seat::new(0,
-                            SeatCapabilities {
-                                pointer: true,
-                                keyboard: true,
-                                touch: true,
-                            }),
+            seat: Seat::new(
+                0,
+                SeatCapabilities {
+                    pointer: true,
+                    keyboard: true,
+                    touch: true,
+                },
+            ),
             input_config: (),
             handler: None,
             logger: log.new(o!("smithay_winit_component" => "input")),
-        }))
+        },
+    ))
 }
 
 impl GraphicsBackend for WinitGraphicsBackend {
@@ -193,9 +216,9 @@ impl EGLGraphicsBackend for WinitGraphicsBackend {
     }
 
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
-        self.window
-            .get_inner_size_pixels()
-            .expect("Window does not exist anymore")
+        self.window.get_inner_size_pixels().expect(
+            "Window does not exist anymore",
+        )
     }
 
     fn is_current(&self) -> bool {
@@ -288,16 +311,17 @@ impl PointerMotionAbsoluteEvent for WinitMouseMovedEvent {
     }
 
     fn x_transformed(&self, width: u32) -> u32 {
-        cmp::min((self.x * width as f64 /
-                  self.window.get_inner_size_points().unwrap_or((width, 0)).0 as f64) as u32,
-                 0)
+        cmp::min(
+            (self.x * width as f64 / self.window.get_inner_size_points().unwrap_or((width, 0)).0 as f64) as u32,
+            0,
+        )
     }
 
     fn y_transformed(&self, height: u32) -> u32 {
-        cmp::min((self.y * height as f64 /
-                  self.window.get_inner_size_points().unwrap_or((0, height)).1 as f64) as
-                 u32,
-                 0)
+        cmp::min(
+            (self.y * height as f64 / self.window.get_inner_size_points().unwrap_or((0, height)).1 as f64) as u32,
+            0,
+        )
     }
 }
 
@@ -390,15 +414,19 @@ impl TouchDownEvent for WinitTouchStartedEvent {
     }
 
     fn x_transformed(&self, width: u32) -> u32 {
-        cmp::min(self.location.0 as i32 * width as i32 /
-                 self.window.get_inner_size_points().unwrap_or((width, 0)).0 as i32,
-                 0) as u32
+        cmp::min(
+            self.location.0 as i32 * width as i32 /
+                self.window.get_inner_size_points().unwrap_or((width, 0)).0 as i32,
+            0,
+        ) as u32
     }
 
     fn y_transformed(&self, height: u32) -> u32 {
-        cmp::min(self.location.1 as i32 * height as i32 /
-                 self.window.get_inner_size_points().unwrap_or((0, height)).1 as i32,
-                 0) as u32
+        cmp::min(
+            self.location.1 as i32 * height as i32 /
+                self.window.get_inner_size_points().unwrap_or((0, height)).1 as i32,
+            0,
+        ) as u32
     }
 }
 
@@ -503,16 +531,18 @@ impl InputBackend for WinitInputBackend {
     }
 
     fn get_handler(&mut self) -> Option<&mut InputHandler<Self>> {
-        self.handler
-            .as_mut()
-            .map(|handler| handler as &mut InputHandler<Self>)
+        self.handler.as_mut().map(|handler| {
+            handler as &mut InputHandler<Self>
+        })
     }
 
     fn clear_handler(&mut self) {
         if let Some(mut handler) = self.handler.take() {
-            trace!(self.logger,
-                   "Calling on_seat_destroyed with {:?}",
-                   self.seat);
+            trace!(
+                self.logger,
+                "Calling on_seat_destroyed with {:?}",
+                self.seat
+            );
             handler.on_seat_destroyed(&self.seat);
         }
         info!(self.logger, "Removing input handler");
@@ -552,168 +582,188 @@ impl InputBackend for WinitInputBackend {
             let mut handler = self.handler.as_mut();
             let logger = &self.logger;
 
-            self.events_loop
-                .poll_events(move |event| match event {
-                                 Event::WindowEvent { event, .. } => {
-                                     match (event, handler.as_mut()) {
-                                         (WindowEvent::Resized(x, y), _) => {
-                                             trace!(logger, "Resizing window to {:?}", (x, y));
-                                             window.set_inner_size(x, y);
-                                             if let Some(wl_egl_surface) = surface.as_ref() {
-                                                 wl_egl_surface.resize(x as i32, y as i32, 0, 0);
-                                             }
-                                         }
-                                         (WindowEvent::KeyboardInput {
-                                              input: KeyboardInput { scancode, state, .. }, ..
-                                          },
-                                          Some(handler)) => {
-                                             match state {
-                                                 ElementState::Pressed => *key_counter += 1,
-                                                 ElementState::Released => {
-                                                     *key_counter = key_counter.checked_sub(1).unwrap_or(0)
-                                                 }
-                                             };
-                                             trace!(logger,
-                                                    "Calling on_keyboard_key with {:?}",
-                                                    (scancode, state));
-                                             handler.on_keyboard_key(seat,
-                                                                     WinitKeyboardInputEvent {
-                                                                         time: *time_counter,
-                                                                         key: scancode,
-                                                                         count: *key_counter,
-                                                                         state: state,
-                                                                     })
-                                         }
-                                         (WindowEvent::MouseMoved { position: (x, y), .. },
-                                          Some(handler)) => {
-                                             trace!(logger,
-                                                    "Calling on_pointer_move_absolute with {:?}",
-                                                    (x, y));
-                                             handler.on_pointer_move_absolute(seat,
-                                                                              WinitMouseMovedEvent {
-                                                                                  window: window.clone(),
-                                                                                  time: *time_counter,
-                                                                                  x: x,
-                                                                                  y: y,
-                                                                              })
-                                         }
-                                         (WindowEvent::MouseWheel { delta, .. }, Some(handler)) => {
-                                             match delta {
-                                                 MouseScrollDelta::LineDelta(x, y) |
-                                                 MouseScrollDelta::PixelDelta(x, y) => {
-                                                     if x != 0.0 {
-                            let event = WinitMouseWheelEvent {
-                                axis: Axis::Horizontal,
-                                time: *time_counter,
-                                delta: delta,
-                            };
-                            trace!(logger,
-                                   "Calling on_pointer_axis for Axis::Horizontal with {:?}",
-                                   x);
-                            handler.on_pointer_axis(seat, event);
+            self.events_loop.poll_events(move |event| match event {
+                Event::WindowEvent { event, .. } => {
+                    match (event, handler.as_mut()) {
+                        (WindowEvent::Resized(x, y), _) => {
+                            trace!(logger, "Resizing window to {:?}", (x, y));
+                            window.set_inner_size(x, y);
+                            if let Some(wl_egl_surface) = surface.as_ref() {
+                                wl_egl_surface.resize(x as i32, y as i32, 0, 0);
+                            }
                         }
-                                                     if y != 0.0 {
-                            let event = WinitMouseWheelEvent {
-                                axis: Axis::Vertical,
-                                time: *time_counter,
-                                delta: delta,
+                        (WindowEvent::KeyboardInput {
+                             input: KeyboardInput { scancode, state, .. }, ..
+                         },
+                         Some(handler)) => {
+                            match state {
+                                ElementState::Pressed => *key_counter += 1,
+                                ElementState::Released => {
+                                    *key_counter = key_counter.checked_sub(1).unwrap_or(0)
+                                }
                             };
-                            trace!(logger,
-                                   "Calling on_pointer_axis for Axis::Vertical with {:?}",
-                                   y);
-                            handler.on_pointer_axis(seat, event);
+                            trace!(
+                                logger,
+                                "Calling on_keyboard_key with {:?}",
+                                (scancode, state)
+                            );
+                            handler.on_keyboard_key(
+                                seat,
+                                WinitKeyboardInputEvent {
+                                    time: *time_counter,
+                                    key: scancode,
+                                    count: *key_counter,
+                                    state: state,
+                                },
+                            )
                         }
-                                                 }
-                                             }
-                                         }
-                                         (WindowEvent::MouseInput { state, button, .. }, Some(handler)) => {
-                                             trace!(logger,
-                                                    "Calling on_pointer_button with {:?}",
-                                                    (button, state));
-                                             handler.on_pointer_button(seat,
-                                                                       WinitMouseInputEvent {
-                                                                           time: *time_counter,
-                                                                           button: button,
-                                                                           state: state,
-                                                                       })
-                                         }
-                                         (WindowEvent::Touch(Touch {
-                                                                 phase: TouchPhase::Started,
-                                                                 location: (x, y),
-                                                                 id,
-                                                                 ..
-                                                             }),
-                                          Some(handler)) => {
-                                             trace!(logger, "Calling on_touch_down at {:?}", (x, y));
-                                             handler.on_touch_down(seat,
-                                                                   WinitTouchStartedEvent {
-                                                                       window: window.clone(),
-                                                                       time: *time_counter,
-                                                                       location: (x, y),
-                                                                       id: id,
-                                                                   })
-                                         }
-                                         (WindowEvent::Touch(Touch {
-                                                                 phase: TouchPhase::Moved,
-                                                                 location: (x, y),
-                                                                 id,
-                                                                 ..
-                                                             }),
-                                          Some(handler)) => {
-                                             trace!(logger, "Calling on_touch_motion at {:?}", (x, y));
-                                             handler.on_touch_motion(seat,
-                                                                     WinitTouchMovedEvent {
-                                                                         window: window.clone(),
-                                                                         time: *time_counter,
-                                                                         location: (x, y),
-                                                                         id: id,
-                                                                     })
-                                         }
-                                         (WindowEvent::Touch(Touch {
-                                                                 phase: TouchPhase::Ended,
-                                                                 location: (x, y),
-                                                                 id,
-                                                                 ..
-                                                             }),
-                                          Some(handler)) => {
-                                             trace!(logger, "Calling on_touch_motion at {:?}", (x, y));
-                                             handler.on_touch_motion(seat,
-                                                                     WinitTouchMovedEvent {
-                                                                         window: window.clone(),
-                                                                         time: *time_counter,
-                                                                         location: (x, y),
-                                                                         id: id,
-                                                                     });
-                                             trace!(logger, "Calling on_touch_up");
-                                             handler.on_touch_up(seat,
-                                                                 WinitTouchEndedEvent {
-                                                                     time: *time_counter,
-                                                                     id: id,
-                                                                 });
-                                         }
-                                         (WindowEvent::Touch(Touch {
-                                                                 phase: TouchPhase::Cancelled,
-                                                                 id,
-                                                                 ..
-                                                             }),
-                                          Some(handler)) => {
-                                             trace!(logger, "Calling on_touch_cancel");
-                                             handler.on_touch_cancel(seat,
-                                                                     WinitTouchCancelledEvent {
-                                                                         time: *time_counter,
-                                                                         id: id,
-                                                                     })
-                                         }
-                                         (WindowEvent::Closed, _) => {
-                                             warn!(logger, "Window closed");
-                                             *closed_ptr = true;
-                                         }
-                                         _ => {}
-                                     }
-                                     *time_counter += 1;
-                                 }
-                                 Event::DeviceEvent { .. } => {}
-                             });
+                        (WindowEvent::MouseMoved { position: (x, y), .. }, Some(handler)) => {
+                            trace!(logger, "Calling on_pointer_move_absolute with {:?}", (x, y));
+                            handler.on_pointer_move_absolute(
+                                seat,
+                                WinitMouseMovedEvent {
+                                    window: window.clone(),
+                                    time: *time_counter,
+                                    x: x,
+                                    y: y,
+                                },
+                            )
+                        }
+                        (WindowEvent::MouseWheel { delta, .. }, Some(handler)) => {
+                            match delta {
+                                MouseScrollDelta::LineDelta(x, y) |
+                                MouseScrollDelta::PixelDelta(x, y) => {
+                                    if x != 0.0 {
+                                        let event = WinitMouseWheelEvent {
+                                            axis: Axis::Horizontal,
+                                            time: *time_counter,
+                                            delta: delta,
+                                        };
+                                        trace!(
+                                            logger,
+                                            "Calling on_pointer_axis for Axis::Horizontal with {:?}",
+                                            x
+                                        );
+                                        handler.on_pointer_axis(seat, event);
+                                    }
+                                    if y != 0.0 {
+                                        let event = WinitMouseWheelEvent {
+                                            axis: Axis::Vertical,
+                                            time: *time_counter,
+                                            delta: delta,
+                                        };
+                                        trace!(
+                                            logger,
+                                            "Calling on_pointer_axis for Axis::Vertical with {:?}",
+                                            y
+                                        );
+                                        handler.on_pointer_axis(seat, event);
+                                    }
+                                }
+                            }
+                        }
+                        (WindowEvent::MouseInput { state, button, .. }, Some(handler)) => {
+                            trace!(
+                                logger,
+                                "Calling on_pointer_button with {:?}",
+                                (button, state)
+                            );
+                            handler.on_pointer_button(
+                                seat,
+                                WinitMouseInputEvent {
+                                    time: *time_counter,
+                                    button: button,
+                                    state: state,
+                                },
+                            )
+                        }
+                        (WindowEvent::Touch(Touch {
+                                                phase: TouchPhase::Started,
+                                                location: (x, y),
+                                                id,
+                                                ..
+                                            }),
+                         Some(handler)) => {
+                            trace!(logger, "Calling on_touch_down at {:?}", (x, y));
+                            handler.on_touch_down(
+                                seat,
+                                WinitTouchStartedEvent {
+                                    window: window.clone(),
+                                    time: *time_counter,
+                                    location: (x, y),
+                                    id: id,
+                                },
+                            )
+                        }
+                        (WindowEvent::Touch(Touch {
+                                                phase: TouchPhase::Moved,
+                                                location: (x, y),
+                                                id,
+                                                ..
+                                            }),
+                         Some(handler)) => {
+                            trace!(logger, "Calling on_touch_motion at {:?}", (x, y));
+                            handler.on_touch_motion(
+                                seat,
+                                WinitTouchMovedEvent {
+                                    window: window.clone(),
+                                    time: *time_counter,
+                                    location: (x, y),
+                                    id: id,
+                                },
+                            )
+                        }
+                        (WindowEvent::Touch(Touch {
+                                                phase: TouchPhase::Ended,
+                                                location: (x, y),
+                                                id,
+                                                ..
+                                            }),
+                         Some(handler)) => {
+                            trace!(logger, "Calling on_touch_motion at {:?}", (x, y));
+                            handler.on_touch_motion(
+                                seat,
+                                WinitTouchMovedEvent {
+                                    window: window.clone(),
+                                    time: *time_counter,
+                                    location: (x, y),
+                                    id: id,
+                                },
+                            );
+                            trace!(logger, "Calling on_touch_up");
+                            handler.on_touch_up(
+                                seat,
+                                WinitTouchEndedEvent {
+                                    time: *time_counter,
+                                    id: id,
+                                },
+                            );
+                        }
+                        (WindowEvent::Touch(Touch {
+                                                phase: TouchPhase::Cancelled,
+                                                id,
+                                                ..
+                                            }),
+                         Some(handler)) => {
+                            trace!(logger, "Calling on_touch_cancel");
+                            handler.on_touch_cancel(
+                                seat,
+                                WinitTouchCancelledEvent {
+                                    time: *time_counter,
+                                    id: id,
+                                },
+                            )
+                        }
+                        (WindowEvent::Closed, _) => {
+                            warn!(logger, "Window closed");
+                            *closed_ptr = true;
+                        }
+                        _ => {}
+                    }
+                    *time_counter += 1;
+                }
+                Event::DeviceEvent { .. } => {}
+            });
         }
 
         if closed {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,11 @@ pub mod backend;
 pub mod keyboard;
 
 fn slog_or_stdlog<L>(logger: L) -> ::slog::Logger
-    where L: Into<Option<::slog::Logger>>
+where
+    L: Into<Option<::slog::Logger>>,
 {
     use slog::Drain;
-    logger
-        .into()
-        .unwrap_or_else(|| ::slog::Logger::root(::slog_stdlog::StdLog.fuse(), o!()))
+    logger.into().unwrap_or_else(|| {
+        ::slog::Logger::root(::slog_stdlog::StdLog.fuse(), o!())
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ extern crate wayland_server;
 extern crate nix;
 extern crate xkbcommon;
 extern crate tempfile;
+#[macro_use]
+extern crate rental;
 
 #[cfg(feature = "backend_winit")]
 extern crate winit;


### PR DESCRIPTION
So this is hopefully the last piece refactored in the egl stuff to get drm working.

Most graphical backends will probably yield more then one surface to draw, which all need to be bound to the same egl context, which is why this is necessary.

This actually makes the winit backend more difficult to implement, because the surfaces need to be deconstructed before the context is, which is reflected by lifetimes. However storing an owned var (context) + a reference to that (surface) in a struct is not representable normally in rust. I had to introduce another dependency here to work around this problem, which only changes internal stuff (nothing, that is exposed) and I do think this is actually the best solution to the problem, because:

- This gets the dependency between `EGLSurface` and `EGLContext` right and safe in case we want to expose this as part of public api
- This will not be the case for most backends (when you have multiple outputs, all holding their own surface, this problem ist gone)
-  This implementation works already as an example for everybody running into the same problem, when implementing your own backends as a library user.

Let me know what you think. :)