### PR TITLE
compositor: rework roles

### DIFF
--- a/examples/helpers/mod.rs
+++ b/examples/helpers/mod.rs
@@ -2,4 +2,4 @@ mod shell;
 mod glium;
 
 pub use self::glium::GliumDrawer;
-pub use self::shell::WlShellStubHandler;
+pub use self::shell::{ShellSurfaceRole, WlShellStubHandler};

--- a/src/compositor/global.rs
+++ b/src/compositor/global.rs
@@ -1,25 +1,34 @@
-use super::{CompositorHandler, Handler as UserHandler};
+use super::{CompositorHandler, Handler as UserHandler, Role, RoleType, SubsurfaceRole};
 
 use wayland_server::{Client, EventLoopHandle, GlobalHandler};
 use wayland_server::protocol::{wl_compositor, wl_subcompositor};
 
-impl<U: Default, H: UserHandler<U>> GlobalHandler<wl_compositor::WlCompositor> for CompositorHandler<U, H>
-    where U: Send + 'static,
-          H: Send + 'static
+impl<U, R, H> GlobalHandler<wl_compositor::WlCompositor> for CompositorHandler<U, R, H>
+where
+    U: Default
+        + Send
+        + 'static,
+    R: Default
+        + Send
+        + 'static,
+    H: UserHandler<U, R>
+        + Send
+        + 'static,
 {
     fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_compositor::WlCompositor) {
         debug!(self.log, "New compositor global binded.");
-        evlh.register::<_, CompositorHandler<U, H>>(&global, self.my_id);
+        evlh.register::<_, CompositorHandler<U, R, H>>(&global, self.my_id);
     }
 }
 
-impl<U, H> GlobalHandler<wl_subcompositor::WlSubcompositor> for CompositorHandler<U, H>
+impl<U, R, H> GlobalHandler<wl_subcompositor::WlSubcompositor> for CompositorHandler<U, R, H>
 where
     U: Send + 'static,
+    R: RoleType + Role<SubsurfaceRole> + Send + 'static,
     H: Send + 'static,
 {
     fn bind(&mut self, evlh: &mut EventLoopHandle, _: &Client, global: wl_subcompositor::WlSubcompositor) {
         debug!(self.log, "New subcompositor global binded.");
-        evlh.register::<_, CompositorHandler<U, H>>(&global, self.my_id);
+        evlh.register::<_, CompositorHandler<U, R, H>>(&global, self.my_id);
     }
 }

--- a/src/compositor/handlers.rs
+++ b/src/compositor/handlers.rs
@@ -1,50 +1,58 @@
-use super::{CompositorHandler, Damage, Handler as UserHandler, Rectangle, RectangleKind,
-            SubsurfaceAttributes};
+use super::{CompositorHandler, Damage, Handler as UserHandler, Rectangle, RectangleKind, Role, RoleType,
+            SubsurfaceRole};
 use super::region::RegionData;
 use super::tree::{Location, SurfaceData};
 use wayland_server::{Client, Destroy, EventLoopHandle, Liveness, Resource};
 use wayland_server::protocol::{wl_buffer, wl_callback, wl_compositor, wl_output, wl_region,
                                wl_subcompositor, wl_subsurface, wl_surface};
 
-struct CompositorDestructor<U> {
+struct CompositorDestructor<U, R> {
     _t: ::std::marker::PhantomData<U>,
+    _r: ::std::marker::PhantomData<R>,
 }
 
 /*
  * wl_compositor
  */
 
-impl<U, H> wl_compositor::Handler for CompositorHandler<U, H>
+impl<U, R, H> wl_compositor::Handler for CompositorHandler<U, R, H>
 where
     U: Default + Send + 'static,
-    H: UserHandler<U> + Send + 'static,
+    R: Default + Send + 'static,
+    H: UserHandler<U, R> + Send + 'static,
 {
     fn create_surface(&mut self, evqh: &mut EventLoopHandle, _: &Client, _: &wl_compositor::WlCompositor,
                       id: wl_surface::WlSurface) {
         trace!(self.log, "New surface created.");
-        unsafe { SurfaceData::<U>::init(&id) };
-        evqh.register_with_destructor::<_, CompositorHandler<U, H>, CompositorDestructor<U>>(&id, self.my_id);
+        unsafe { SurfaceData::<U, R>::init(&id) };
+        evqh.register_with_destructor::<_, CompositorHandler<U, R, H>, CompositorDestructor<U, R>>(
+            &id,
+            self.my_id,
+        );
     }
     fn create_region(&mut self, evqh: &mut EventLoopHandle, _: &Client, _: &wl_compositor::WlCompositor,
                      id: wl_region::WlRegion) {
         trace!(self.log, "New region created.");
         unsafe { RegionData::init(&id) };
-        evqh.register_with_destructor::<_, CompositorHandler<U, H>, CompositorDestructor<U>>(&id, self.my_id);
+        evqh.register_with_destructor::<_, CompositorHandler<U, R, H>, CompositorDestructor<U, R>>(
+            &id,
+            self.my_id,
+        );
     }
 }
 
-server_declare_handler!(CompositorHandler<U: [Default, Send], H: [UserHandler<U>, Send]>, wl_compositor::Handler, wl_compositor::WlCompositor);
+server_declare_handler!(CompositorHandler<U: [Default, Send], R: [Default, Send], H: [UserHandler<U, R>, Send]>, wl_compositor::Handler, wl_compositor::WlCompositor);
 
 /*
  * wl_surface
  */
 
-impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
+impl<U, R, H: UserHandler<U, R>> wl_surface::Handler for CompositorHandler<U, R, H> {
     fn attach(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
               buffer: Option<&wl_buffer::WlBuffer>, x: i32, y: i32) {
         trace!(self.log, "Attaching buffer to surface.");
         unsafe {
-            SurfaceData::<U>::with_data(surface, |d| {
+            SurfaceData::<U, R>::with_data(surface, |d| {
                 d.buffer = Some(buffer.map(|b| (b.clone_unchecked(), (x, y))))
             });
         }
@@ -53,7 +61,7 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
               y: i32, width: i32, height: i32) {
         trace!(self.log, "Registering damage to surface.");
         unsafe {
-            SurfaceData::<U>::with_data(surface, |d| {
+            SurfaceData::<U, R>::with_data(surface, |d| {
                 d.damage = Damage::Surface(Rectangle {
                     x,
                     y,
@@ -74,7 +82,7 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
         trace!(self.log, "Setting surface opaque region.");
         unsafe {
             let attributes = region.map(|r| RegionData::get_attributes(r));
-            SurfaceData::<U>::with_data(surface, |d| d.opaque_region = attributes);
+            SurfaceData::<U, R>::with_data(surface, |d| d.opaque_region = attributes);
         }
     }
     fn set_input_region(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
@@ -82,7 +90,7 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
         trace!(self.log, "Setting surface input region.");
         unsafe {
             let attributes = region.map(|r| RegionData::get_attributes(r));
-            SurfaceData::<U>::with_data(surface, |d| d.input_region = attributes);
+            SurfaceData::<U, R>::with_data(surface, |d| d.input_region = attributes);
         }
     }
     fn commit(&mut self, evlh: &mut EventLoopHandle, client: &Client, surface: &wl_surface::WlSurface) {
@@ -94,14 +102,14 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
                             surface: &wl_surface::WlSurface, transform: wl_output::Transform) {
         trace!(self.log, "Setting surface's buffer transform.");
         unsafe {
-            SurfaceData::<U>::with_data(surface, |d| d.buffer_transform = transform);
+            SurfaceData::<U, R>::with_data(surface, |d| d.buffer_transform = transform);
         }
     }
     fn set_buffer_scale(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
                         scale: i32) {
         trace!(self.log, "Setting surface's buffer scale.");
         unsafe {
-            SurfaceData::<U>::with_data(surface, |d| d.buffer_scale = scale);
+            SurfaceData::<U, R>::with_data(surface, |d| d.buffer_scale = scale);
         }
     }
     fn damage_buffer(&mut self, _: &mut EventLoopHandle, _: &Client, surface: &wl_surface::WlSurface,
@@ -111,7 +119,7 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
             "Registering damage to surface (buffer coordinates)."
         );
         unsafe {
-            SurfaceData::<U>::with_data(surface, |d| {
+            SurfaceData::<U, R>::with_data(surface, |d| {
                 d.damage = Damage::Buffer(Rectangle {
                     x,
                     y,
@@ -123,11 +131,11 @@ impl<U, H: UserHandler<U>> wl_surface::Handler for CompositorHandler<U, H> {
     }
 }
 
-server_declare_handler!(CompositorHandler<U:[], H: [UserHandler<U>]>, wl_surface::Handler, wl_surface::WlSurface);
+server_declare_handler!(CompositorHandler<U:[], R: [], H: [UserHandler<U, R>]>, wl_surface::Handler, wl_surface::WlSurface);
 
-impl<U> Destroy<wl_surface::WlSurface> for CompositorDestructor<U> {
+impl<U, R> Destroy<wl_surface::WlSurface> for CompositorDestructor<U, R> {
     fn destroy(surface: &wl_surface::WlSurface) {
-        unsafe { SurfaceData::<U>::cleanup(surface) }
+        unsafe { SurfaceData::<U, R>::cleanup(surface) }
     }
 }
 
@@ -135,7 +143,7 @@ impl<U> Destroy<wl_surface::WlSurface> for CompositorDestructor<U> {
  * wl_region
  */
 
-impl<U, H> wl_region::Handler for CompositorHandler<U, H> {
+impl<U, R, H> wl_region::Handler for CompositorHandler<U, R, H> {
     fn add(&mut self, _: &mut EventLoopHandle, _: &Client, region: &wl_region::WlRegion, x: i32, y: i32,
            width: i32, height: i32) {
         trace!(self.log, "Adding rectangle to a region.");
@@ -170,9 +178,9 @@ impl<U, H> wl_region::Handler for CompositorHandler<U, H> {
     }
 }
 
-server_declare_handler!(CompositorHandler<U: [], H: []>, wl_region::Handler, wl_region::WlRegion);
+server_declare_handler!(CompositorHandler<U: [], R: [], H: []>, wl_region::Handler, wl_region::WlRegion);
 
-impl<U> Destroy<wl_region::WlRegion> for CompositorDestructor<U> {
+impl<U, R> Destroy<wl_region::WlRegion> for CompositorDestructor<U, R> {
     fn destroy(region: &wl_region::WlRegion) {
         unsafe { RegionData::cleanup(region) };
     }
@@ -182,52 +190,63 @@ impl<U> Destroy<wl_region::WlRegion> for CompositorDestructor<U> {
  * wl_subcompositor
  */
 
-impl<U, H> wl_subcompositor::Handler for CompositorHandler<U, H>
+impl<U, R, H> wl_subcompositor::Handler for CompositorHandler<U, R, H>
 where
     U: Send + 'static,
+    R: RoleType
+        + Role<SubsurfaceRole>
+        + Send
+        + 'static,
     H: Send + 'static,
 {
     fn get_subsurface(&mut self, evqh: &mut EventLoopHandle, _: &Client,
                       resource: &wl_subcompositor::WlSubcompositor, id: wl_subsurface::WlSubsurface,
                       surface: &wl_surface::WlSurface, parent: &wl_surface::WlSurface) {
         trace!(self.log, "Creating new subsurface.");
-        if let Err(()) = unsafe { SurfaceData::<U>::set_parent(surface, parent) } {
-            resource.post_error(wl_subcompositor::Error::BadSurface as u32, "Surface already has a role.".into());
-            return
+        if let Err(()) = unsafe { SurfaceData::<U, R>::set_parent(surface, parent) } {
+            resource.post_error(
+                wl_subcompositor::Error::BadSurface as u32,
+                "Surface already has a role.".into(),
+            );
+            return;
         }
         id.set_user_data(Box::into_raw(
             Box::new(unsafe { surface.clone_unchecked() }),
         ) as *mut _);
-        unsafe {
-            SurfaceData::<U>::with_data(surface, |d| {
-                d.subsurface_attributes = Some(Default::default())
-            });
-        }
-        evqh.register_with_destructor::<_, CompositorHandler<U, H>, CompositorDestructor<U>>(&id, self.my_id);
+        evqh.register_with_destructor::<_, CompositorHandler<U, R, H>, CompositorDestructor<U, R>>(
+            &id,
+            self.my_id,
+        );
     }
 }
 
-server_declare_handler!(CompositorHandler<U: [Send], H: [Send]>, wl_subcompositor::Handler, wl_subcompositor::WlSubcompositor);
+server_declare_handler!(CompositorHandler<U: [Send], R: [RoleType, Role<SubsurfaceRole>, Send], H: [Send]>, wl_subcompositor::Handler, wl_subcompositor::WlSubcompositor);
 
 /*
  * wl_subsurface
  */
 
-unsafe fn with_subsurface_attributes<U, F>(subsurface: &wl_subsurface::WlSubsurface, f: F)
+unsafe fn with_subsurface_attributes<U, R, F>(subsurface: &wl_subsurface::WlSubsurface, f: F)
 where
-    F: FnOnce(&mut SubsurfaceAttributes),
+    F: FnOnce(&mut SubsurfaceRole),
+    R: RoleType + Role<SubsurfaceRole>,
 {
     let ptr = subsurface.get_user_data();
     let surface = &*(ptr as *mut wl_surface::WlSurface);
-    SurfaceData::<U>::with_data(surface, |d| f(d.subsurface_attributes.as_mut().unwrap()));
+    SurfaceData::<U, R>::with_role_data::<SubsurfaceRole, _, _>(surface, |d| f(d)).expect(
+        "The surface does not have a subsurface role while it has a wl_subsurface?!",
+    );
 }
 
-impl<U, H> wl_subsurface::Handler for CompositorHandler<U, H> {
+impl<U, R, H> wl_subsurface::Handler for CompositorHandler<U, R, H>
+where
+    R: RoleType + Role<SubsurfaceRole>,
+{
     fn set_position(&mut self, _: &mut EventLoopHandle, _: &Client,
                     subsurface: &wl_subsurface::WlSubsurface, x: i32, y: i32) {
         trace!(self.log, "Setting subsurface position.");
         unsafe {
-            with_subsurface_attributes::<U, _>(subsurface, |attrs| {
+            with_subsurface_attributes::<U, R, _>(subsurface, |attrs| {
                 attrs.x = x;
                 attrs.y = y;
             });
@@ -239,7 +258,7 @@ impl<U, H> wl_subsurface::Handler for CompositorHandler<U, H> {
         unsafe {
             let ptr = subsurface.get_user_data();
             let surface = &*(ptr as *mut wl_surface::WlSurface);
-            if let Err(()) = SurfaceData::<U>::reorder(surface, Location::After, sibling) {
+            if let Err(()) = SurfaceData::<U, R>::reorder(surface, Location::After, sibling) {
                 subsurface.post_error(wl_subsurface::Error::BadSurface as u32, "Provided surface is not a sibling or parent.".into());
             }
         }
@@ -250,7 +269,7 @@ impl<U, H> wl_subsurface::Handler for CompositorHandler<U, H> {
         unsafe {
             let ptr = subsurface.get_user_data();
             let surface = &*(ptr as *mut wl_surface::WlSurface);
-            if let Err(()) = SurfaceData::<U>::reorder(surface, Location::Before, sibling) {
+            if let Err(()) = SurfaceData::<U, R>::reorder(surface, Location::Before, sibling) {
                 subsurface.post_error(wl_subsurface::Error::BadSurface as u32, "Provided surface is not a sibling or parent.".into());
             }
         }
@@ -258,28 +277,29 @@ impl<U, H> wl_subsurface::Handler for CompositorHandler<U, H> {
     fn set_sync(&mut self, _: &mut EventLoopHandle, _: &Client, subsurface: &wl_subsurface::WlSubsurface) {
         trace!(self.log, "Setting subsurface sync."; "sync_status" => true);
         unsafe {
-            with_subsurface_attributes::<U, _>(subsurface, |attrs| { attrs.sync = true; });
+            with_subsurface_attributes::<U, R, _>(subsurface, |attrs| { attrs.sync = true; });
         }
     }
     fn set_desync(&mut self, _: &mut EventLoopHandle, _: &Client, subsurface: &wl_subsurface::WlSubsurface) {
         trace!(self.log, "Setting subsurface sync."; "sync_status" => false);
         unsafe {
-            with_subsurface_attributes::<U, _>(subsurface, |attrs| { attrs.sync = false; });
+            with_subsurface_attributes::<U, R, _>(subsurface, |attrs| { attrs.sync = false; });
         }
     }
 }
 
-server_declare_handler!(CompositorHandler<U: [], H: []>, wl_subsurface::Handler, wl_subsurface::WlSubsurface);
+server_declare_handler!(CompositorHandler<U: [], R: [RoleType, Role<SubsurfaceRole>], H: []>, wl_subsurface::Handler, wl_subsurface::WlSubsurface);
 
-impl<U> Destroy<wl_subsurface::WlSubsurface> for CompositorDestructor<U> {
+impl<U, R> Destroy<wl_subsurface::WlSubsurface> for CompositorDestructor<U, R>
+    where R: RoleType + Role<SubsurfaceRole>
+{
     fn destroy(subsurface: &wl_subsurface::WlSubsurface) {
         let ptr = subsurface.get_user_data();
         subsurface.set_user_data(::std::ptr::null_mut());
         unsafe {
             let surface = Box::from_raw(ptr as *mut wl_surface::WlSurface);
             if surface.status() == Liveness::Alive {
-                SurfaceData::<U>::with_data(&*surface, |d| d.subsurface_attributes = None);
-                SurfaceData::<U>::unset_parent(&surface);
+                SurfaceData::<U, R>::unset_parent(&surface);
             }
         }
     }

--- a/src/compositor/roles.rs
+++ b/src/compositor/roles.rs
@@ -1,0 +1,239 @@
+//! Tools for handling surface roles
+//!
+//! In the wayland protocol, surfaces can have several different roles, which
+//! define how they are to be used. The core protocol defines 3 of these roles:
+//!
+//! - `shell_surface`: This surface is to be considered as what is most often
+//!   called a "window".
+//! - `pointer_surface`: This surface represent the contents of a pointer icon
+//!   and replaces the default pointer.
+//! - `subsurface`: This surface is part of a subsurface tree, and as such has
+//!   a parent surface.
+//!
+//! A surface can have only one role at any given time. To change he role of a
+//! surface, the client must first remove the previous role before assigning the
+//! new one. A surface without a role is not displayed at all.
+//!
+//! This module provides tools to manage roles of a surface in a composable way
+//! allowing all handlers of smithay to manage surface roles while being aware
+//! of the possible role conflicts.
+//!
+//! ## General mechanism
+//!
+//! First, all roles need to have an unique type, holding its metadata and identifying it
+//! to the type-system. Even if your role does not hold any metadata, you still need its
+//! unique type, using a unit-like struct rather than `()`.
+//!
+//! You then need a type for managing the roles of a surface. This type holds information
+//! about what is the current role of a surface, and what is the metadata associated with
+//! it.
+//!
+//! For convenience, you can use the `define_roles!` macro provided by Smithay to define this
+//! type. You can call it like this:
+//!
+//! ```
+//! # #[macro_use]
+//! # extern crate smithay;
+//! #
+//! // Metadata for a first role
+//! #[derive(Default)]
+//! pub struct MyRoleMetadata {
+//! }
+//!
+//! // Metadata for a second role
+//! #[derive(Default)]
+//! pub struct MyRoleMetadata2 {
+//! }
+//!
+//! define_roles!(Roles =>
+//!     // You can put several roles like this
+//!     // first identifier is the name of the variant for this
+//!     // role in the generated enum, second is the token type
+//!     // for this role
+//!     [MyRoleName, MyRoleMetadata]
+//!     [MyRoleName2, MyRoleMetadata2]
+//!     /* ... */
+//! );
+//!
+//! # fn main() {}
+//! ```
+//!
+//! And this will expand to an enum like this:
+//!
+//! ```ignore
+//! pub enum Roles {
+//!     NoRole,
+//!     // The subsurface role is always inserted, as it is required
+//!     // by the CompositorHandler
+//!     Subsurface(::smithay::compositor::SubsurfaceAttributes),
+//!     // all your other roles come here
+//!     MyRoleName(MyRoleMetadata),
+//!     MyRoleName2(MyRoleMetadata2),
+//!     /* ... */
+//! }
+//! ```
+//!
+//! as well as implement a few trait for it, allowing it to be used by
+//! all smithay handlers:
+//!
+//! - The trait `RoleType`, which defines it as a type handling roles
+//! - For each of your roles, the trait `Role<Token>` (where `Token` is your
+//!   token type), marking its hability to handle this given role.
+//!
+//! All handlers that handle a specific role will require you to provide
+//! them with a `CompositorToken<U, R, H>` where `R: Role<TheToken>`.
+//!
+//! See the documentation of these traits for their specific definition and
+//! capabilities.
+
+/// An error type signifying that the surface does not have expected role
+///
+/// Generated if you attempt a role operation on a surface that does
+/// not have the role you asked for.
+#[derive(Debug)]
+pub struct WrongRole;
+
+/// A trait representing a type that can manage surface roles
+pub trait RoleType {
+    /// Check if the associated surface has a role
+    ///
+    /// Only reports if the surface has any role or no role.
+    /// To check for a role in particular, see `Role::has`.
+    fn has_role(&self) -> bool;
+}
+
+/// A trait representing the capability of a RoleType to handle a given role
+///
+/// This trait allows to interact with the different roles a RoleType can
+/// handle.
+///
+/// This trait is meant to be used generically, for example, to retrieve the
+/// data associated with a given role with token `TheRole`:
+///
+/// ```ignore
+/// let data = <MyRoles as Role<RoleData>>::data(my_roles)
+///                 .expect("The surface does not have this role.");
+/// ```
+///
+/// The methods of this trait are mirrored on `CompositorToken` for easy
+/// access to the role data of the surfaces.
+///
+/// Note that if a role is automatically handled for you by a Handler provided
+/// by smithay, you should not set or unset it manually on a surface. Doing so
+/// would likely corrupt the internal state of these handlers, causing spurious
+/// protocol errors and unreliable behaviour overall.
+pub trait Role<R>: RoleType {
+    /// Set the role for the associated surface with default associated data
+    ///
+    /// Fails if the surface already has a role
+    fn set(&mut self) -> Result<(), ()>
+    where
+        R: Default,
+    {
+        self.set_with(Default::default()).map_err(|_| ())
+    }
+
+    /// Set the role for the associated surface with given data
+    ///
+    /// Fails if the surface already has a role and returns the data
+    fn set_with(&mut self, data: R) -> Result<(), R>;
+
+    /// Check if the associated surface has this role
+    fn has(&self) -> bool;
+
+    /// Access the data associated with this role if its the current one
+    fn data(&self) -> Result<&R, WrongRole>;
+
+    /// Mutably access the data associated with this role if its the current one
+    fn data_mut(&mut self) -> Result<&mut R, WrongRole>;
+
+    /// Remove this role from the associated surface
+    ///
+    /// Fails if the surface does not currently have this role
+    fn unset(&mut self) -> Result<R, WrongRole>;
+}
+
+#[macro_export]
+macro_rules! define_roles(
+    ($enum_name: ident) => {
+        define_roles!($enum_name =>);
+    };
+    ($enum_name:ident => $([ $role_name: ident, $role_data: ty])*) => {
+        define_roles!(__impl $enum_name =>
+            // add in subsurface role
+            [Subsurface, $crate::compositor::SubsurfaceRole]
+            $([$role_name, $role_data])*
+        );
+    };
+    (__impl $enum_name:ident => $([ $role_name: ident, $role_data: ty])*) => {
+        pub enum $enum_name {
+            NoRole,
+            $($role_name($role_data)),*
+        }
+
+        impl Default for $enum_name {
+            fn default() -> $enum_name {
+                $enum_name::NoRole
+            }
+        }
+
+        impl $crate::compositor::roles::RoleType for $enum_name {
+            fn has_role(&self) -> bool {
+                if let $enum_name::NoRole = *self {
+                    false
+                } else {
+                    true
+                }
+            }
+        }
+
+        $(
+            impl $crate::compositor::roles::Role<$role_data> for $enum_name {
+                fn set_with(&mut self, data: $role_data) -> ::std::result::Result<(), $role_data> {
+                    if let $enum_name::NoRole = *self {
+                        *self = $enum_name::$role_name(data);
+                        Ok(())
+                    } else {
+                        Err(data)
+                    }
+                }
+
+                fn has(&self) -> bool {
+                    if let $enum_name::$role_name(_) = *self {
+                        true
+                    } else {
+                        false
+                    }
+                }
+
+                fn data(&self) -> ::std::result::Result<&$role_data, $crate::compositor::roles::WrongRole> {
+                    if let $enum_name::$role_name(ref data) = *self {
+                        Ok(data)
+                    } else {
+                        Err($crate::compositor::roles::WrongRole)
+                    }
+                }
+
+                fn data_mut(&mut self) -> ::std::result::Result<&mut $role_data, $crate::compositor::roles::WrongRole> {
+                    if let $enum_name::$role_name(ref mut data) = *self {
+                        Ok(data)
+                    } else {
+                        Err($crate::compositor::roles::WrongRole)
+                    }
+                }
+
+                fn unset(&mut self) -> ::std::result::Result<$role_data, $crate::compositor::roles::WrongRole> {
+                    // remove self to make borrow checker happy
+                    let temp = ::std::mem::replace(self, $enum_name::NoRole);
+                    if let $enum_name::$role_name(data) = temp {
+                        Ok(data)
+                    } else {
+                        // put it back in place
+                        ::std::mem::replace(self, temp);
+                        Err($crate::compositor::roles::WrongRole)
+                    }
+                }
+            }
+        )*
+    };
+);

--- a/src/compositor/tree.rs
+++ b/src/compositor/tree.rs
@@ -1,4 +1,5 @@
-use super::SurfaceAttributes;
+use super::{SubsurfaceRole, SurfaceAttributes};
+use super::roles::*;
 use std::sync::Mutex;
 
 use wayland_server::{Liveness, Resource};
@@ -23,24 +24,11 @@ use wayland_server::protocol::wl_surface;
 ///
 /// All the methods here are unsafe, because they assume the provided wl_surface object
 /// is correctly initialized regarding its user_data.
-pub struct SurfaceData<U> {
+pub struct SurfaceData<U, R> {
     parent: Option<wl_surface::WlSurface>,
     children: Vec<wl_surface::WlSurface>,
-    has_role: bool,
+    role: R,
     attributes: SurfaceAttributes<U>,
-}
-
-/// Status of a surface regarding its role
-pub enum RoleStatus {
-    /// This surface does not have any role
-    NoRole,
-    /// This surface is a subsurface
-    Subsurface,
-    /// This surface has a role other than subsurface
-    ///
-    /// It is thus the root of a subsurface tree that will
-    /// have to be displayed
-    HasRole,
 }
 
 pub enum Location {
@@ -58,12 +46,12 @@ pub enum TraversalAction<T> {
     Break,
 }
 
-impl<U: Default> SurfaceData<U> {
-    fn new() -> SurfaceData<U> {
+impl<U: Default, R: Default> SurfaceData<U, R> {
+    fn new() -> SurfaceData<U, R> {
         SurfaceData {
             parent: None,
             children: Vec::new(),
-            has_role: false,
+            role: Default::default(),
             attributes: Default::default(),
         }
     }
@@ -71,13 +59,13 @@ impl<U: Default> SurfaceData<U> {
     /// Initialize the user_data of a surface, must be called right when the surface is created
     pub unsafe fn init(surface: &wl_surface::WlSurface) {
         surface.set_user_data(Box::into_raw(
-            Box::new(Mutex::new(SurfaceData::<U>::new())),
+            Box::new(Mutex::new(SurfaceData::<U, R>::new())),
         ) as *mut _)
     }
 }
 
-impl<U> SurfaceData<U> {
-    unsafe fn get_data(surface: &wl_surface::WlSurface) -> &Mutex<SurfaceData<U>> {
+impl<U, R> SurfaceData<U, R> {
+    unsafe fn get_data(surface: &wl_surface::WlSurface) -> &Mutex<SurfaceData<U, R>> {
         let ptr = surface.get_user_data();
         &*(ptr as *mut _)
     }
@@ -86,7 +74,7 @@ impl<U> SurfaceData<U> {
     pub unsafe fn cleanup(surface: &wl_surface::WlSurface) {
         let ptr = surface.get_user_data();
         surface.set_user_data(::std::ptr::null_mut());
-        let my_data_mutex: Box<Mutex<SurfaceData<U>>> = Box::from_raw(ptr as *mut _);
+        let my_data_mutex: Box<Mutex<SurfaceData<U, R>>> = Box::from_raw(ptr as *mut _);
         let mut my_data = my_data_mutex.into_inner().unwrap();
         if let Some(old_parent) = my_data.parent.take() {
             if !old_parent.equals(surface) {
@@ -107,48 +95,85 @@ impl<U> SurfaceData<U> {
             child_guard.parent = None;
         }
     }
+}
 
-    /// Retrieve the current role status of this surface
-    pub unsafe fn role_status(surface: &wl_surface::WlSurface) -> RoleStatus {
+impl<U, R: RoleType> SurfaceData<U, R> {
+    pub unsafe fn has_a_role(surface: &wl_surface::WlSurface) -> bool {
         debug_assert!(surface.status() == Liveness::Alive);
         let data_mutex = Self::get_data(surface);
         let data_guard = data_mutex.lock().unwrap();
-        match (data_guard.has_role, data_guard.parent.is_some()) {
-            (true, true) => RoleStatus::Subsurface,
-            (true, false) => RoleStatus::HasRole,
-            (false, false) => RoleStatus::NoRole,
-            (false, true) => unreachable!(),
-        }
+        <R as RoleType>::has_role(&data_guard.role)
+    }
+
+    /// Check wether a surface has a given role
+    pub unsafe fn has_role<RoleData>(surface: &wl_surface::WlSurface) -> bool
+    where
+        R: Role<RoleData>,
+    {
+        debug_assert!(surface.status() == Liveness::Alive);
+        let data_mutex = Self::get_data(surface);
+        let data_guard = data_mutex.lock().unwrap();
+        <R as Role<RoleData>>::has(&data_guard.role)
     }
 
     /// Register that this surface has a role, fails if it already has one
-    pub unsafe fn give_role(surface: &wl_surface::WlSurface) -> Result<(), ()> {
+    pub unsafe fn give_role<RoleData>(surface: &wl_surface::WlSurface) -> Result<(), ()>
+    where
+        R: Role<RoleData>,
+        RoleData: Default,
+    {
         debug_assert!(surface.status() == Liveness::Alive);
         let data_mutex = Self::get_data(surface);
         let mut data_guard = data_mutex.lock().unwrap();
-        if data_guard.has_role {
-            return Err(());
-        }
-        data_guard.has_role = true;
-        Ok(())
+        <R as Role<RoleData>>::set(&mut data_guard.role)
     }
 
-    /// Register that this surface has no role
+    /// Register that this surface has a role with given data
+    ///
+    /// Fails if it already has one and returns the data
+    pub unsafe fn give_role_with<RoleData>(surface: &wl_surface::WlSurface, data: RoleData)
+                                           -> Result<(), RoleData>
+    where
+        R: Role<RoleData>,
+    {
+        debug_assert!(surface.status() == Liveness::Alive);
+        let data_mutex = Self::get_data(surface);
+        let mut data_guard = data_mutex.lock().unwrap();
+        <R as Role<RoleData>>::set_with(&mut data_guard.role, data)
+    }
+
+    /// Register that this surface has no role and returns the data
     ///
     /// It is a noop if this surface already didn't have one, but fails if
     /// the role was "subsurface", it must be removed by the `unset_parent` method.
-    pub unsafe fn remove_role(surface: &wl_surface::WlSurface) -> Result<(), ()> {
+    pub unsafe fn remove_role<RoleData>(surface: &wl_surface::WlSurface) -> Result<RoleData, WrongRole>
+    where
+        R: Role<RoleData>,
+    {
         debug_assert!(surface.status() == Liveness::Alive);
         let data_mutex = Self::get_data(surface);
         let mut data_guard = data_mutex.lock().unwrap();
-        if data_guard.has_role && data_guard.parent.is_some() {
-            return Err(());
-        }
-        data_guard.has_role = false;
-        Ok(())
+        <R as Role<RoleData>>::unset(&mut data_guard.role)
     }
 
+    /// Access to the role data
+    pub unsafe fn with_role_data<RoleData, F, T>(surface: &wl_surface::WlSurface, f: F)
+                                                 -> Result<T, WrongRole>
+    where
+        R: Role<RoleData>,
+        F: FnOnce(&mut RoleData) -> T,
+    {
+        debug_assert!(surface.status() == Liveness::Alive);
+        let data_mutex = Self::get_data(surface);
+        let mut data_guard = data_mutex.lock().unwrap();
+        let data = <R as Role<RoleData>>::data_mut(&mut data_guard.role)?;
+        Ok(f(data))
+    }
+}
+
+impl<U, R: RoleType + Role<SubsurfaceRole>> SurfaceData<U, R> {
     /// Sets the parent of a surface
+    ///
     /// if this surface already has a role, does nothing and fails, otherwise
     /// its role is now to be a subsurface
     pub unsafe fn set_parent(child: &wl_surface::WlSurface, parent: &wl_surface::WlSurface)
@@ -160,13 +185,10 @@ impl<U> SurfaceData<U> {
         {
             let child_mutex = Self::get_data(child);
             let mut child_guard = child_mutex.lock().unwrap();
-            // if surface already has a role, it cannot be a subsurface
-            if child_guard.has_role {
-                return Err(());
-            }
+            // if surface already has a role, it cannot become a subsurface
+            <R as Role<SubsurfaceRole>>::set(&mut child_guard.role)?;
             debug_assert!(child_guard.parent.is_none());
             child_guard.parent = Some(parent.clone_unchecked());
-            child_guard.has_role = true;
         }
         // register child to new parent
         // double scoping is to be robust to have a child be its own parent
@@ -189,7 +211,8 @@ impl<U> SurfaceData<U> {
             let old_parent = child_guard.parent.take();
             if old_parent.is_some() {
                 // We had a parent, so this does not have a role any more
-                child_guard.has_role = false;
+                <R as Role<SubsurfaceRole>>::unset(&mut child_guard.role)
+                    .expect("Surface had a parent but not the subsurface role?!");
             }
             old_parent
         };
@@ -266,14 +289,16 @@ impl<U> SurfaceData<U> {
         parent_guard.children.insert(new_index, me);
         Ok(())
     }
+}
 
+impl<U, R> SurfaceData<U, R> {
     /// Access the attributes associated with a surface
     ///
     /// Note that an internal lock is taken during access of this data,
     /// so the tree cannot be manipulated at the same time
-    pub unsafe fn with_data<F>(surface: &wl_surface::WlSurface, f: F)
+    pub unsafe fn with_data<T, F>(surface: &wl_surface::WlSurface, f: F) -> T
     where
-        F: FnOnce(&mut SurfaceAttributes<U>),
+        F: FnOnce(&mut SurfaceAttributes<U>) -> T,
     {
         let data_mutex = Self::get_data(surface);
         let mut data_guard = data_mutex.lock().unwrap();
@@ -290,28 +315,42 @@ impl<U> SurfaceData<U> {
     /// false will cause an early-stopping.
     pub unsafe fn map_tree<F, T>(root: &wl_surface::WlSurface, initial: T, mut f: F)
     where
-        F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>, &T) -> TraversalAction<T>,
+        F: FnMut(&wl_surface::WlSurface,
+              &mut SurfaceAttributes<U>,
+              &mut R,
+              &T)
+              -> TraversalAction<T>,
     {
         // helper function for recursion
-        unsafe fn map<U, F, T>(surface: &wl_surface::WlSurface, root: &wl_surface::WlSurface, initial: &T,
-                               f: &mut F)
-                               -> bool
+        unsafe fn map<U, R, F, T>(surface: &wl_surface::WlSurface, root: &wl_surface::WlSurface, initial: &T,
+                                  f: &mut F)
+                                  -> bool
         where
-            F: FnMut(&wl_surface::WlSurface, &mut SurfaceAttributes<U>, &T) -> TraversalAction<T>,
+            F: FnMut(&wl_surface::WlSurface,
+                  &mut SurfaceAttributes<U>,
+                  &mut R,
+                  &T)
+                  -> TraversalAction<T>,
         {
             // stop if we met the root, so to not deadlock/inifinte loop
             if surface.equals(root) {
                 return true;
             }
 
-            let data_mutex = SurfaceData::<U>::get_data(surface);
+            let data_mutex = SurfaceData::<U, R>::get_data(surface);
             let mut data_guard = data_mutex.lock().unwrap();
+            let data_guard = &mut *data_guard;
             // call the callback on ourselves
-            match f(surface, &mut data_guard.attributes, initial) {
+            match f(
+                surface,
+                &mut data_guard.attributes,
+                &mut data_guard.role,
+                initial,
+            ) {
                 TraversalAction::DoChildren(t) => {
                     // loop over children
                     for c in &data_guard.children {
-                        if !map(c, root, &t, f) {
+                        if !map::<U, R, _, _>(c, root, &t, f) {
                             return false;
                         }
                     }
@@ -324,12 +363,18 @@ impl<U> SurfaceData<U> {
 
         let data_mutex = Self::get_data(root);
         let mut data_guard = data_mutex.lock().unwrap();
+        let data_guard = &mut *data_guard;
         // call the callback on ourselves
-        match f(root, &mut data_guard.attributes, &initial) {
+        match f(
+            root,
+            &mut data_guard.attributes,
+            &mut data_guard.role,
+            &initial,
+        ) {
             TraversalAction::DoChildren(t) => {
                 // loop over children
                 for c in &data_guard.children {
-                    if !map::<U, _, _>(c, root, &t, &mut f) {
+                    if !map::<U, R, _, _>(c, root, &t, &mut f) {
                         break;
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@ extern crate slog;
 extern crate slog_stdlog;
 
 pub mod backend;
-
 pub mod compositor;
 pub mod shm;
 pub mod keyboard;


### PR DESCRIPTION
This is a large rework of the machinery handling surface roles, making it much more convenient to use.

The general idea is that the user of smithay will use the `define_roles!()` macro to create an enum that represents all the roles of interest. The generated enum has several properties:

- It implements the trait `RoleType`, meaning to smithay that it is a type that manages roles, and a method of this trait can be used to query if a surface currently has a role or not (but now which role).
- For each role of interest, in implements the `Role<RoleTokenType>` trait, where `RoleTokenType` is a unit-like type, implementing the `RoleToken` trait, allowing it to define a `Data` associated type, defining the type holding the data associated with this role. The `Role<_>` trait provides some methods allowing to add or remove a role, check if a surface has a given role, or access the role-specific data.

All the methods of `Role<_>` are mirrored on the `CompositorToken`, allowing easy access to the role data of any surface.

I'll improve the docs of this new API before merging.