### PR TITLE
Drm Backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ renderer_glium = ["glium"]
 "wayland-server:0.9.9" = { git = "https://github.com/Drakulix/wayland-rs", branch = "raw_handler_access"}
 "wayland-protocols:0.9.9" = { git = "https://github.com/Drakulix/wayland-rs", branch = "raw_handler_access"}
 "wayland-client:0.9.9" = { git = "https://github.com/Drakulix/wayland-rs", branch = "raw_handler_access"}
-"drm:0.2.1" = { git = "https://github.com/Drakulix/drm-rs", branch = "fix/userdata" }
+"drm:0.2.1" = { git = "https://github.com/Drakulix/drm-rs", branch = "future" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ clippy = { version = "*", optional = true }
 rental = "0.4.11"
 wayland-protocols = { version = "0.10.1", features = ["unstable_protocols", "server"] }
 image = "0.15.0"
+error-chain = "0.11.0"
 
 [build-dependencies]
 gl_generator = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,4 @@ backend_libinput = ["input"]
 renderer_glium = ["glium"]
 
 [replace]
-"wayland-server:0.9.9" = { git = "https://github.com/Drakulix/wayland-rs", branch = "raw_handler_access"}
-"wayland-protocols:0.9.9" = { git = "https://github.com/Drakulix/wayland-rs", branch = "raw_handler_access"}
-"wayland-client:0.9.9" = { git = "https://github.com/Drakulix/wayland-rs", branch = "raw_handler_access"}
 "drm:0.2.1" = { git = "https://github.com/Drakulix/drm-rs", branch = "future" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,15 @@ slog = { version = "2.0.0" }
 slog-stdlog = "2.0.0-0.2"
 libloading = "0.4.0"
 wayland-client = { version = "0.9.9", optional = true }
-winit = { version = "0.7.0", optional = true }
-glium = { version = "0.16.0", optional = true, default-features = false }
+winit = { version = "0.7.5", optional = true }
+drm = { version = "0.2.1", optional = true }
+gbm = { version = "0.2.1", optional = true }
+glium = { version = "0.17.1", optional = true, default-features = false }
 input = { version = "0.2.0", optional = true }
 clippy = { version = "*", optional = true }
 rental = "0.4.11"
 wayland-protocols = { version = "0.10.1", features = ["unstable_protocols", "server"] }
+image = "0.15.0"
 
 [build-dependencies]
 gl_generator = "0.5"
@@ -29,7 +32,14 @@ slog-async = "2.0"
 rand = "0.3"
 
 [features]
-default = ["backend_winit", "backend_libinput", "renderer_glium"]
+default = ["backend_winit", "backend_drm", "backend_libinput", "renderer_glium"]
 backend_winit = ["winit", "wayland-server/dlopen", "wayland-client/dlopen"]
-renderer_glium = ["glium"]
+backend_drm = ["drm", "gbm"]
 backend_libinput = ["input"]
+renderer_glium = ["glium"]
+
+[replace]
+"wayland-server:0.9.9" = { git = "https://github.com/Drakulix/wayland-rs", branch = "raw_handler_access"}
+"wayland-protocols:0.9.9" = { git = "https://github.com/Drakulix/wayland-rs", branch = "raw_handler_access"}
+"wayland-client:0.9.9" = { git = "https://github.com/Drakulix/wayland-rs", branch = "raw_handler_access"}
+"drm:0.2.1" = { git = "https://github.com/Drakulix/drm-rs", branch = "fix/userdata" }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
 extern crate gl_generator;
 
 use gl_generator::{Api, Fallbacks, Profile, Registry};
-
 use std::env;
 use std::fs::File;
 use std::path::PathBuf;

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -4,7 +4,6 @@ extern crate glium;
 extern crate rand;
 #[macro_use(define_roles)]
 extern crate smithay;
-extern crate wayland_protocols;
 extern crate wayland_server;
 
 #[macro_use]
@@ -18,153 +17,19 @@ use drm::control::{Device as ControlDevice, ResourceInfo};
 use drm::control::connector::{Info as ConnectorInfo, State as ConnectorState};
 use drm::control::encoder::Info as EncoderInfo;
 use glium::Surface;
-use helpers::GliumDrawer;
-use slog::*;
-use smithay::backend::drm::{DrmBackend, DrmDevice, DrmHandler, Id};
+use helpers::{shell_implementation, surface_implementation, GliumDrawer, Roles, SurfaceData};
+use slog::{Drain, Logger};
+use smithay::backend::drm::{drm_device_bind, DrmBackend, DrmDevice, DrmHandler, Id};
 use smithay::backend::graphics::egl::EGLGraphicsBackend;
 use smithay::backend::graphics::glium::{GliumGraphicsBackend, IntoGlium};
-use smithay::compositor::{self, CompositorHandler, CompositorToken, SubsurfaceRole, TraversalAction};
+use smithay::compositor::{compositor_init, CompositorToken, SubsurfaceRole, TraversalAction};
 use smithay::compositor::roles::Role;
-use smithay::shell::{self, PopupConfigure, PopupSurface, ShellClient, ShellHandler, ShellSurfaceRole,
-                     ToplevelConfigure, ToplevelSurface};
-use smithay::shm::{ShmGlobal, ShmToken};
+use smithay::shell::{shell_init, ShellState};
+use smithay::shm::init_shm_global;
 use std::fs::OpenOptions;
 use std::io::Error as IoError;
-use std::os::unix::io::AsRawFd;
 use std::time::Duration;
-use wayland_protocols::unstable::xdg_shell::server::{zxdg_shell_v6, zxdg_toplevel_v6};
-use wayland_server::{Client, EventLoopHandle};
-use wayland_server::protocol::{wl_callback, wl_compositor, wl_output, wl_seat, wl_shell, wl_shm,
-                               wl_subcompositor, wl_surface};
-use wayland_server::sources::READ;
-
-define_roles!(Roles => [ ShellSurface, ShellSurfaceRole ] );
-
-struct SurfaceHandler {
-    shm_token: ShmToken,
-}
-
-#[derive(Default)]
-struct SurfaceData {
-    buffer: Option<(Vec<u8>, (u32, u32))>,
-    location: Option<(i32, i32)>,
-}
-
-impl compositor::Handler<SurfaceData, Roles> for SurfaceHandler {
-    fn commit(&mut self, _evlh: &mut EventLoopHandle, _client: &Client, surface: &wl_surface::WlSurface,
-              token: CompositorToken<SurfaceData, Roles, SurfaceHandler>) {
-        // we retrieve the contents of the associated buffer and copy it
-        token.with_surface_data(surface, |attributes| {
-            match attributes.buffer.take() {
-                Some(Some((buffer, (_x, _y)))) => {
-                    // we ignore hotspot coordinates in this simple example
-                    self.shm_token
-                        .with_buffer_contents(&buffer, |slice, data| {
-                            let offset = data.offset as usize;
-                            let stride = data.stride as usize;
-                            let width = data.width as usize;
-                            let height = data.height as usize;
-                            let mut new_vec = Vec::with_capacity(width * height * 4);
-                            for i in 0..height {
-                                new_vec.extend(
-                                    &slice[(offset + i * stride)..(offset + i * stride + width * 4)],
-                                );
-                            }
-                            attributes.user_data.buffer =
-                                Some((new_vec, (data.width as u32, data.height as u32)));
-                        })
-                        .unwrap();
-                    buffer.release();
-                }
-                Some(None) => {
-                    // erase the contents
-                    attributes.user_data.buffer = None;
-                }
-                None => {}
-            }
-        });
-    }
-
-    fn frame(&mut self, _evlh: &mut EventLoopHandle, _client: &Client, _surface: &wl_surface::WlSurface,
-             callback: wl_callback::WlCallback,
-             _token: CompositorToken<SurfaceData, Roles, SurfaceHandler>) {
-        callback.done(0);
-    }
-}
-
-struct ShellSurfaceHandler {
-    token: CompositorToken<SurfaceData, Roles, SurfaceHandler>,
-}
-
-impl ShellSurfaceHandler {
-    fn new(token: CompositorToken<SurfaceData, Roles, SurfaceHandler>) -> ShellSurfaceHandler {
-        ShellSurfaceHandler { token }
-    }
-}
-
-impl shell::Handler<SurfaceData, Roles, SurfaceHandler, ()> for ShellSurfaceHandler {
-    fn new_client(&mut self, _evlh: &mut EventLoopHandle, _client: ShellClient<()>) {}
-    fn client_pong(&mut self, _evlh: &mut EventLoopHandle, _client: ShellClient<()>) {}
-    fn new_toplevel(&mut self, _evlh: &mut EventLoopHandle,
-                    surface: ToplevelSurface<SurfaceData, Roles, SurfaceHandler, ()>)
-                    -> ToplevelConfigure {
-        let wl_surface = surface.get_surface().unwrap();
-        self.token.with_surface_data(wl_surface, |data| {
-            // place the window at a random location in the [0;300]x[0;300] square
-            use rand::distributions::{IndependentSample, Range};
-            let range = Range::new(0, 300);
-            let mut rng = rand::thread_rng();
-            let x = range.ind_sample(&mut rng);
-            let y = range.ind_sample(&mut rng);
-            data.user_data.location = Some((x, y))
-        });
-        ToplevelConfigure {
-            size: None,
-            states: vec![],
-            serial: 42,
-        }
-    }
-    fn new_popup(&mut self, _evlh: &mut EventLoopHandle,
-                 _surface: PopupSurface<SurfaceData, Roles, SurfaceHandler, ()>)
-                 -> PopupConfigure {
-        PopupConfigure {
-            size: (10, 10),
-            position: (10, 10),
-            serial: 42,
-        }
-    }
-    fn move_(&mut self, _evlh: &mut EventLoopHandle,
-             _surface: ToplevelSurface<SurfaceData, Roles, SurfaceHandler, ()>, _seat: &wl_seat::WlSeat,
-             _serial: u32) {
-    }
-    fn resize(&mut self, _evlh: &mut EventLoopHandle,
-              _surface: ToplevelSurface<SurfaceData, Roles, SurfaceHandler, ()>, _seat: &wl_seat::WlSeat,
-              _serial: u32, _edges: zxdg_toplevel_v6::ResizeEdge) {
-    }
-    fn grab(&mut self, _evlh: &mut EventLoopHandle,
-            _surface: PopupSurface<SurfaceData, Roles, SurfaceHandler, ()>, _seat: &wl_seat::WlSeat,
-            _serial: u32) {
-    }
-    fn change_display_state(&mut self, _evlh: &mut EventLoopHandle,
-                            _surface: ToplevelSurface<SurfaceData, Roles, SurfaceHandler, ()>,
-                            _maximized: Option<bool>, _minimized: Option<bool>, _fullscreen: Option<bool>,
-                            _output: Option<&wl_output::WlOutput>)
-                            -> ToplevelConfigure {
-        ToplevelConfigure {
-            size: None,
-            states: vec![],
-            serial: 42,
-        }
-    }
-    fn show_window_menu(&mut self, _evlh: &mut EventLoopHandle,
-                        _surface: ToplevelSurface<SurfaceData, Roles, SurfaceHandler, ()>,
-                        _seat: &wl_seat::WlSeat, _serial: u32, _x: i32, _y: i32) {
-    }
-}
-
-
-type MyCompositorHandler = CompositorHandler<SurfaceData, Roles, SurfaceHandler>;
-type MyShellHandler = ShellHandler<SurfaceData, Roles, SurfaceHandler, ShellSurfaceHandler, ()>;
+use wayland_server::{EventLoopHandle, StateToken};
 
 fn main() {
     // A logger facility, here we use the terminal for this example
@@ -220,52 +85,21 @@ fn main() {
         .unwrap();
 
     /*
-     * Initialize wl_shm global
+     * Initialize the globals
      */
-    // Insert the ShmGlobal as a handler to your event loop
-    // Here, we specify tha the standard Argb8888 and Xrgb8888 is the only supported.
-    let shm_handler_id = event_loop.add_handler_with_init(ShmGlobal::new(vec![], log.clone()));
-    // Register this handler to advertise a wl_shm global of version 1
-    event_loop.register_global::<wl_shm::WlShm, ShmGlobal>(shm_handler_id, 1);
-    // retreive the token
-    let shm_token = {
-        let state = event_loop.state();
-        state.get_handler::<ShmGlobal>(shm_handler_id).get_token()
-    };
 
+    init_shm_global(&mut event_loop, vec![], log.clone());
 
-    /*
-     * Initialize the compositor global
-     */
-    let compositor_handler_id = event_loop.add_handler_with_init(MyCompositorHandler::new(
-        SurfaceHandler {
-            shm_token: shm_token.clone(),
-        },
-        log.clone(),
-    ));
-    // register it to handle wl_compositor and wl_subcompositor
-    event_loop.register_global::<wl_compositor::WlCompositor, MyCompositorHandler>(compositor_handler_id, 4);
-    event_loop
-        .register_global::<wl_subcompositor::WlSubcompositor, MyCompositorHandler>(compositor_handler_id, 1);
-    // retrieve the tokens
-    let compositor_token = {
-        let state = event_loop.state();
-        state
-            .get_handler::<MyCompositorHandler>(compositor_handler_id)
-            .get_token()
-    };
+    let (compositor_token, _, _) =
+        compositor_init(&mut event_loop, surface_implementation(), (), log.clone());
 
-    /*
-     * Initialize the shell global
-     */
-    let shell_handler_id = event_loop.add_handler_with_init(MyShellHandler::new(
-        ShellSurfaceHandler::new(compositor_token),
+    let (shell_state_token, _, _) = shell_init(
+        &mut event_loop,
+        compositor_token,
+        shell_implementation(),
         compositor_token,
         log.clone(),
-    ));
-    event_loop.register_global::<wl_shell::WlShell, MyShellHandler>(shell_handler_id, 1);
-    event_loop.register_global::<zxdg_shell_v6::ZxdgShellV6, MyShellHandler>(shell_handler_id, 1);
-
+    );
 
     /*
      * Initialize glium
@@ -281,29 +115,27 @@ fn main() {
     let name = display.add_socket_auto().unwrap().into_string().unwrap();
     println!("Listening on socket: {}", name);
 
-    // Set the DrmHandler
-    device.set_handler(DrmHandlerImpl {
-        drawer: drawer,
-        shell_handler_id,
-        compositor_token,
-        logger: log,
-    });
-
     /*
      * Register the DrmDevice on the EventLoop
      */
-    let fd = device.as_raw_fd();
-    let drm_device_id = event_loop.add_handler(device);
-    let _drm_event_source =
-        event_loop.add_fd_event_source::<DrmDevice<DrmHandlerImpl>>(fd, drm_device_id, READ);
+    let _source = drm_device_bind(
+        &mut event_loop,
+        device,
+        DrmHandlerImpl {
+            drawer,
+            shell_state_token,
+            compositor_token,
+            logger: log,
+        },
+    ).unwrap();
 
     event_loop.run().unwrap();
 }
 
 pub struct DrmHandlerImpl {
     drawer: GliumDrawer<GliumGraphicsBackend<DrmBackend>>,
-    shell_handler_id: usize,
-    compositor_token: CompositorToken<SurfaceData, Roles, SurfaceHandler>,
+    shell_state_token: StateToken<ShellState<SurfaceData, Roles, (), ()>>,
+    compositor_token: CompositorToken<SurfaceData, Roles, ()>,
     logger: ::slog::Logger,
 }
 
@@ -314,10 +146,8 @@ impl DrmHandler for DrmHandlerImpl {
         // redraw the frame, in a simple but inneficient way
         {
             let screen_dimensions = self.drawer.get_framebuffer_dimensions();
-            for toplevel_surface in unsafe {
-                evlh.get_handler_unchecked::<MyShellHandler>(self.shell_handler_id)
-                    .toplevel_surfaces()
-            } {
+            let state = evlh.state();
+            for toplevel_surface in state.get(&self.shell_state_token).toplevel_surfaces() {
                 if let Some(wl_surface) = toplevel_surface.get_surface() {
                     // this surface is a root of a subsurface tree that needs to be drawn
                     let initial_place = self.compositor_token

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -1,0 +1,349 @@
+
+extern crate drm;
+#[macro_use]
+extern crate glium;
+extern crate rand;
+#[macro_use(define_roles)]
+extern crate smithay;
+extern crate wayland_protocols;
+extern crate wayland_server;
+
+#[macro_use]
+extern crate slog;
+extern crate slog_async;
+extern crate slog_term;
+
+mod helpers;
+
+use drm::control::{Device as ControlDevice, ResourceInfo};
+use drm::control::connector::{Info as ConnectorInfo, State as ConnectorState};
+
+use glium::Surface;
+
+use helpers::GliumDrawer;
+use slog::*;
+
+use smithay::backend::drm::{DrmBackend, DrmDevice, DrmHandler, Id};
+use smithay::backend::graphics::egl::EGLGraphicsBackend;
+use smithay::backend::graphics::glium::{GliumGraphicsBackend, IntoGlium};
+use smithay::compositor::{self, CompositorHandler, CompositorToken, SubsurfaceRole, TraversalAction};
+use smithay::compositor::roles::Role;
+use smithay::shell::{self, PopupConfigure, PopupSurface, ShellClient, ShellHandler, ShellSurfaceRole,
+                     ToplevelConfigure, ToplevelSurface};
+use smithay::shm::{ShmGlobal, ShmToken};
+
+use std::fs::OpenOptions;
+use std::io::Error as IoError;
+use std::time::Duration;
+use std::os::unix::io::AsRawFd;
+
+use wayland_protocols::unstable::xdg_shell::server::{zxdg_shell_v6, zxdg_toplevel_v6};
+
+use wayland_server::{Client, EventLoopHandle};
+use wayland_server::sources::READ;
+use wayland_server::protocol::{wl_callback, wl_compositor, wl_output, wl_seat, wl_shell, wl_shm,
+                               wl_subcompositor, wl_surface};
+
+define_roles!(Roles => [ ShellSurface, ShellSurfaceRole ] );
+
+struct SurfaceHandler {
+    shm_token: ShmToken,
+}
+
+#[derive(Default)]
+struct SurfaceData {
+    buffer: Option<(Vec<u8>, (u32, u32))>,
+    location: Option<(i32, i32)>,
+}
+
+impl compositor::Handler<SurfaceData, Roles> for SurfaceHandler {
+    fn commit(&mut self, _evlh: &mut EventLoopHandle, _client: &Client, surface: &wl_surface::WlSurface,
+              token: CompositorToken<SurfaceData, Roles, SurfaceHandler>) {
+        // we retrieve the contents of the associated buffer and copy it
+        token.with_surface_data(surface, |attributes| {
+            match attributes.buffer.take() {
+                Some(Some((buffer, (_x, _y)))) => {
+                    // we ignore hotspot coordinates in this simple example
+                    self.shm_token
+                        .with_buffer_contents(&buffer, |slice, data| {
+                            let offset = data.offset as usize;
+                            let stride = data.stride as usize;
+                            let width = data.width as usize;
+                            let height = data.height as usize;
+                            let mut new_vec = Vec::with_capacity(width * height * 4);
+                            for i in 0..height {
+                                new_vec.extend(
+                                    &slice[(offset + i * stride)..(offset + i * stride + width * 4)],
+                                );
+                            }
+                            attributes.user_data.buffer =
+                                Some((new_vec, (data.width as u32, data.height as u32)));
+                        })
+                        .unwrap();
+                    buffer.release();
+                }
+                Some(None) => {
+                    // erase the contents
+                    attributes.user_data.buffer = None;
+                }
+                None => {}
+            }
+        });
+    }
+
+    fn frame(&mut self, _evlh: &mut EventLoopHandle, _client: &Client, _surface: &wl_surface::WlSurface,
+             callback: wl_callback::WlCallback,
+             _token: CompositorToken<SurfaceData, Roles, SurfaceHandler>) {
+        callback.done(0);
+    }
+}
+
+struct ShellSurfaceHandler {
+    token: CompositorToken<SurfaceData, Roles, SurfaceHandler>,
+}
+
+impl ShellSurfaceHandler {
+    fn new(token: CompositorToken<SurfaceData, Roles, SurfaceHandler>) -> ShellSurfaceHandler {
+        ShellSurfaceHandler { token }
+    }
+}
+
+impl shell::Handler<SurfaceData, Roles, SurfaceHandler, ()> for ShellSurfaceHandler {
+    fn new_client(&mut self, _evlh: &mut EventLoopHandle, _client: ShellClient<()>) {}
+    fn client_pong(&mut self, _evlh: &mut EventLoopHandle, _client: ShellClient<()>) {}
+    fn new_toplevel(&mut self, _evlh: &mut EventLoopHandle,
+                    surface: ToplevelSurface<SurfaceData, Roles, SurfaceHandler, ()>)
+                    -> ToplevelConfigure {
+        let wl_surface = surface.get_surface().unwrap();
+        self.token.with_surface_data(wl_surface, |data| {
+            // place the window at a random location in the [0;300]x[0;300] square
+            use rand::distributions::{IndependentSample, Range};
+            let range = Range::new(0, 300);
+            let mut rng = rand::thread_rng();
+            let x = range.ind_sample(&mut rng);
+            let y = range.ind_sample(&mut rng);
+            data.user_data.location = Some((x, y))
+        });
+        ToplevelConfigure {
+            size: None,
+            states: vec![],
+            serial: 42,
+        }
+    }
+    fn new_popup(&mut self, _evlh: &mut EventLoopHandle,
+                 _surface: PopupSurface<SurfaceData, Roles, SurfaceHandler, ()>)
+                 -> PopupConfigure {
+        PopupConfigure {
+            size: (10, 10),
+            position: (10, 10),
+            serial: 42,
+        }
+    }
+    fn move_(&mut self, _evlh: &mut EventLoopHandle,
+             _surface: ToplevelSurface<SurfaceData, Roles, SurfaceHandler, ()>, _seat: &wl_seat::WlSeat,
+             _serial: u32) {
+    }
+    fn resize(&mut self, _evlh: &mut EventLoopHandle,
+              _surface: ToplevelSurface<SurfaceData, Roles, SurfaceHandler, ()>, _seat: &wl_seat::WlSeat,
+              _serial: u32, _edges: zxdg_toplevel_v6::ResizeEdge) {
+    }
+    fn grab(&mut self, _evlh: &mut EventLoopHandle,
+            _surface: PopupSurface<SurfaceData, Roles, SurfaceHandler, ()>, _seat: &wl_seat::WlSeat,
+            _serial: u32) {
+    }
+    fn change_display_state(&mut self, _evlh: &mut EventLoopHandle,
+                            _surface: ToplevelSurface<SurfaceData, Roles, SurfaceHandler, ()>,
+                            _maximized: Option<bool>, _minimized: Option<bool>, _fullscreen: Option<bool>,
+                            _output: Option<&wl_output::WlOutput>)
+                            -> ToplevelConfigure {
+        ToplevelConfigure {
+            size: None,
+            states: vec![],
+            serial: 42,
+        }
+    }
+    fn show_window_menu(&mut self, _evlh: &mut EventLoopHandle,
+                        _surface: ToplevelSurface<SurfaceData, Roles, SurfaceHandler, ()>,
+                        _seat: &wl_seat::WlSeat, _serial: u32, _x: i32, _y: i32) {
+    }
+}
+
+
+type MyCompositorHandler = CompositorHandler<SurfaceData, Roles, SurfaceHandler>;
+type MyShellHandler = ShellHandler<SurfaceData, Roles, SurfaceHandler, ShellSurfaceHandler, ()>;
+
+fn main() {
+    // A logger facility, here we use the terminal for this example
+    let log = Logger::root(
+        slog_async::Async::default(slog_term::term_full().fuse()).fuse(),
+        o!(),
+    );
+
+    // Initialize the wayland server
+    let (mut display, mut event_loop) = wayland_server::create_display();
+
+    // "Find" a suitable drm device
+    let mut options = OpenOptions::new();
+    options.read(true);
+    options.write(true);
+    let mut device =
+        DrmDevice::new_from_file(options.clone().open("/dev/dri/card0").unwrap(), log.clone()).unwrap();
+
+    // Get a set of all modesetting resource handles (excluding planes):
+    let res_handles = device.resource_handles().unwrap();
+
+    // Use first connected connector
+    let connector_info = res_handles
+        .connectors()
+        .iter()
+        .map(|conn| {
+            ConnectorInfo::load_from_device(&device, *conn).unwrap()
+        })
+        .find(|conn| conn.connection_state() == ConnectorState::Connected)
+        .unwrap();
+
+    // Use the first crtc (should be successful in most cases)
+    let crtc = res_handles.crtcs()[0];
+
+    // Assuming we found a good connector and loaded the info into `connector_info`
+    let mode = connector_info.modes()[0]; // Use first mode (usually highest resoltion, but in reality you should filter and sort and check and match with other connectors, if you use more then one.)
+
+    // Initialize the hardware backends
+    let renderer = device
+        .create_backend(crtc, mode, vec![connector_info.handle()])
+        .unwrap();
+
+    /*
+     * Initialize wl_shm global
+     */
+    // Insert the ShmGlobal as a handler to your event loop
+    // Here, we specify tha the standard Argb8888 and Xrgb8888 is the only supported.
+    let shm_handler_id = event_loop.add_handler_with_init(ShmGlobal::new(vec![], log.clone()));
+    // Register this handler to advertise a wl_shm global of version 1
+    event_loop.register_global::<wl_shm::WlShm, ShmGlobal>(shm_handler_id, 1);
+    // retreive the token
+    let shm_token = {
+        let state = event_loop.state();
+        state.get_handler::<ShmGlobal>(shm_handler_id).get_token()
+    };
+
+
+    /*
+     * Initialize the compositor global
+     */
+    let compositor_handler_id = event_loop.add_handler_with_init(MyCompositorHandler::new(
+        SurfaceHandler {
+            shm_token: shm_token.clone(),
+        },
+        log.clone(),
+    ));
+    // register it to handle wl_compositor and wl_subcompositor
+    event_loop.register_global::<wl_compositor::WlCompositor, MyCompositorHandler>(compositor_handler_id, 4);
+    event_loop
+        .register_global::<wl_subcompositor::WlSubcompositor, MyCompositorHandler>(compositor_handler_id, 1);
+    // retrieve the tokens
+    let compositor_token = {
+        let state = event_loop.state();
+        state
+            .get_handler::<MyCompositorHandler>(compositor_handler_id)
+            .get_token()
+    };
+
+    /*
+     * Initialize the shell global
+     */
+    let shell_handler_id = event_loop.add_handler_with_init(MyShellHandler::new(
+        ShellSurfaceHandler::new(compositor_token),
+        compositor_token,
+        log.clone(),
+    ));
+    event_loop.register_global::<wl_shell::WlShell, MyShellHandler>(shell_handler_id, 1);
+    event_loop.register_global::<zxdg_shell_v6::ZxdgShellV6, MyShellHandler>(shell_handler_id, 1);
+
+
+    /*
+     * Initialize glium
+     */
+    let drawer = GliumDrawer::new(renderer.into_glium());
+    let mut frame = drawer.draw();
+    frame.clear_color(0.8, 0.8, 0.9, 1.0);
+    frame.finish().unwrap();
+
+    /*
+     * Add a listening socket:
+     */
+    let name = display.add_socket_auto().unwrap().into_string().unwrap();
+    println!("Listening on socket: {}", name);
+
+    device.set_handler(DrmHandlerImpl {
+        drawer: drawer,
+        shell_handler_id,
+        compositor_token,
+        logger: log,
+    });
+
+    let fd = device.as_raw_fd();
+    let drm_device_id = event_loop.add_handler(device);
+    let _drm_event_source = event_loop.add_fd_event_source::<DrmDevice<DrmHandlerImpl>>(fd, drm_device_id, READ);
+
+    event_loop.run().unwrap();
+}
+
+pub struct DrmHandlerImpl {
+    drawer: GliumDrawer<GliumGraphicsBackend<DrmBackend>>,
+    shell_handler_id: usize,
+    compositor_token: CompositorToken<SurfaceData, Roles, SurfaceHandler>,
+    logger: ::slog::Logger,
+}
+
+impl DrmHandler for DrmHandlerImpl {
+    fn ready(&mut self, evlh: &mut EventLoopHandle, _id: Id, _frame: u32, _duration: Duration) {
+        let mut frame = self.drawer.draw();
+        frame.clear_color(0.8, 0.8, 0.9, 1.0);
+        // redraw the frame, in a simple but inneficient way
+        {
+            let screen_dimensions = self.drawer.get_framebuffer_dimensions();
+            for toplevel_surface in unsafe {
+                evlh.get_handler_unchecked::<MyShellHandler>(self.shell_handler_id)
+                    .toplevel_surfaces()
+            } {
+                if let Some(wl_surface) = toplevel_surface.get_surface() {
+                    // this surface is a root of a subsurface tree that needs to be drawn
+                    let initial_place = self.compositor_token
+                        .with_surface_data(wl_surface, |data| data.user_data.location.unwrap_or((0, 0)));
+                    self.compositor_token
+                        .with_surface_tree(
+                            wl_surface,
+                            initial_place,
+                            |_surface, attributes, role, &(mut x, mut y)| {
+                                if let Some((ref contents, (w, h))) = attributes.user_data.buffer {
+                                    // there is actually something to draw !
+                                    if let Ok(subdata) = Role::<SubsurfaceRole>::data(role) {
+                                        x += subdata.x;
+                                        y += subdata.y;
+                                    }
+                                    self.drawer.render(
+                                        &mut frame,
+                                        contents,
+                                        (w, h),
+                                        (x, y),
+                                        screen_dimensions,
+                                    );
+                                    TraversalAction::DoChildren((x, y))
+                                } else {
+                                    // we are not display, so our children are neither
+                                    TraversalAction::SkipChildren
+                                }
+                            },
+                        )
+                        .unwrap();
+                }
+            }
+        }
+        frame.finish().unwrap();
+    }
+
+    fn error(&mut self, _evlh: &mut EventLoopHandle, error: IoError) {
+        error!(self.logger, "{:?}", error);
+    }
+}

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -1,4 +1,3 @@
-
 extern crate drm;
 #[macro_use]
 extern crate glium;
@@ -34,15 +33,15 @@ use smithay::shm::{ShmGlobal, ShmToken};
 
 use std::fs::OpenOptions;
 use std::io::Error as IoError;
-use std::time::Duration;
 use std::os::unix::io::AsRawFd;
+use std::time::Duration;
 
 use wayland_protocols::unstable::xdg_shell::server::{zxdg_shell_v6, zxdg_toplevel_v6};
 
 use wayland_server::{Client, EventLoopHandle};
-use wayland_server::sources::READ;
 use wayland_server::protocol::{wl_callback, wl_compositor, wl_output, wl_seat, wl_shell, wl_shm,
                                wl_subcompositor, wl_surface};
+use wayland_server::sources::READ;
 
 define_roles!(Roles => [ ShellSurface, ShellSurfaceRole ] );
 
@@ -284,7 +283,8 @@ fn main() {
 
     let fd = device.as_raw_fd();
     let drm_device_id = event_loop.add_handler(device);
-    let _drm_event_source = event_loop.add_fd_event_source::<DrmDevice<DrmHandlerImpl>>(fd, drm_device_id, READ);
+    let _drm_event_source =
+        event_loop.add_fd_event_source::<DrmDevice<DrmHandlerImpl>>(fd, drm_device_id, READ);
 
     event_loop.run().unwrap();
 }

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -181,6 +181,9 @@ fn main() {
     // Initialize the wayland server
     let (mut display, mut event_loop) = wayland_server::create_display();
 
+    /*
+     * Initialize the drm backend
+     */
     // "Find" a suitable drm device
     let mut options = OpenOptions::new();
     options.read(true);
@@ -207,7 +210,7 @@ fn main() {
     // Assuming we found a good connector and loaded the info into `connector_info`
     let mode = connector_info.modes()[0]; // Use first mode (usually highest resoltion, but in reality you should filter and sort and check and match with other connectors, if you use more then one.)
 
-    // Initialize the hardware backends
+    // Initialize the hardware backend
     let renderer = device
         .create_backend(crtc, mode, vec![connector_info.handle()])
         .unwrap();
@@ -274,6 +277,7 @@ fn main() {
     let name = display.add_socket_auto().unwrap().into_string().unwrap();
     println!("Listening on socket: {}", name);
 
+    // Set the DrmHandler
     device.set_handler(DrmHandlerImpl {
         drawer: drawer,
         shell_handler_id,
@@ -281,6 +285,9 @@ fn main() {
         logger: log,
     });
 
+    /*
+     * Register the DrmDevice on the EventLoop
+     */
     let fd = device.as_raw_fd();
     let drm_device_id = event_loop.add_handler(device);
     let _drm_event_source =
@@ -344,6 +351,6 @@ impl DrmHandler for DrmHandlerImpl {
     }
 
     fn error(&mut self, _evlh: &mut EventLoopHandle, error: IoError) {
-        error!(self.logger, "{:?}", error);
+        panic!("{:?}", error);
     }
 }

--- a/examples/helpers/glium.rs
+++ b/examples/helpers/glium.rs
@@ -2,6 +2,8 @@ use glium;
 use glium::Surface;
 use glium::index::PrimitiveType;
 
+use std::ops::Deref;
+
 #[derive(Copy, Clone)]
 struct Vertex {
     position: [f32; 2],
@@ -10,18 +12,26 @@ struct Vertex {
 
 implement_vertex!(Vertex, position, tex_coords);
 
-pub struct GliumDrawer<'a, F: 'a> {
-    display: &'a F,
+pub struct GliumDrawer<F> {
+    display: F,
     vertex_buffer: glium::VertexBuffer<Vertex>,
     index_buffer: glium::IndexBuffer<u16>,
     program: glium::Program,
 }
 
-impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
-    pub fn new(display: &'a F) -> GliumDrawer<'a, F> {
+impl<F> Deref for GliumDrawer<F> {
+    type Target = F;
+
+    fn deref(&self) -> &F {
+        &self.display
+    }
+}
+
+impl<F: glium::backend::Facade> GliumDrawer<F> {
+    pub fn new(display: F) -> GliumDrawer<F> {
         // building the vertex buffer, which contains all the vertices that we will draw
         let vertex_buffer = glium::VertexBuffer::new(
-            display,
+            &display,
             &[
                 Vertex {
                     position: [0.0, 0.0],
@@ -44,10 +54,10 @@ impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
 
         // building the index buffer
         let index_buffer =
-            glium::IndexBuffer::new(display, PrimitiveType::TriangleStrip, &[1 as u16, 2, 0, 3]).unwrap();
+            glium::IndexBuffer::new(&display, PrimitiveType::TriangleStrip, &[1 as u16, 2, 0, 3]).unwrap();
 
         // compiling shaders and linking them together
-        let program = program!(display,
+        let program = program!(&display,
 			100 => {
 				vertex: "
 					#version 100
@@ -84,15 +94,15 @@ impl<'a, F: glium::backend::Facade + 'a> GliumDrawer<'a, F> {
         }
     }
 
-    pub fn draw(&self, target: &mut glium::Frame, contents: &[u8], surface_dimensions: (u32, u32),
-                surface_location: (i32, i32), screen_size: (u32, u32)) {
+    pub fn render(&self, target: &mut glium::Frame, contents: &[u8], surface_dimensions: (u32, u32),
+                  surface_location: (i32, i32), screen_size: (u32, u32)) {
         let image = glium::texture::RawImage2d {
             data: contents.into(),
             width: surface_dimensions.0,
             height: surface_dimensions.1,
             format: glium::texture::ClientFormat::U8U8U8U8,
         };
-        let opengl_texture = glium::texture::Texture2d::new(self.display, image).unwrap();
+        let opengl_texture = glium::texture::Texture2d::new(&self.display, image).unwrap();
 
         let xscale = 2.0 * (surface_dimensions.0 as f32) / (screen_size.0 as f32);
         let yscale = -2.0 * (surface_dimensions.1 as f32) / (screen_size.1 as f32);

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -7,7 +7,6 @@ extern crate slog_async;
 extern crate slog_term;
 #[macro_use(define_roles)]
 extern crate smithay;
-extern crate wayland_protocols;
 extern crate wayland_server;
 
 mod helpers;
@@ -16,8 +15,6 @@ use glium::Surface;
 use helpers::{shell_implementation, surface_implementation, GliumDrawer};
 use slog::{Drain, Logger};
 use smithay::backend::graphics::egl::EGLGraphicsBackend;
-
-use smithay::backend::graphics::glium::IntoGlium;
 use smithay::backend::input::InputBackend;
 use smithay::backend::winit;
 use smithay::compositor::{compositor_init, SubsurfaceRole, TraversalAction};
@@ -57,7 +54,7 @@ fn main() {
     /*
      * Initialize glium
      */
-    let drawer = GliumDrawer::new(renderer.into_glium());
+    let drawer = GliumDrawer::from(renderer);
 
     /*
      * Add a listening socket:

--- a/src/backend/drm/backend.rs
+++ b/src/backend/drm/backend.rs
@@ -196,6 +196,10 @@ impl DrmBackendInternal {
             })
         });
     }
+
+    pub(crate) fn is_crtc(&self, crtc: crtc::Handle) -> bool {
+        crtc == self.crtc
+    }
 }
 
 impl DrmBackend {

--- a/src/backend/drm/backend.rs
+++ b/src/backend/drm/backend.rs
@@ -1,0 +1,419 @@
+
+use super::{DrmError, ModeError};
+
+use super::devices;
+
+use backend::graphics::GraphicsBackend;
+use backend::graphics::egl::{EGLGraphicsBackend, EGLSurface, PixelFormat, SwapBuffersError};
+use drm::buffer::Buffer;
+use drm::control::{connector, crtc, framebuffer, Mode};
+use drm::control::ResourceInfo;
+
+use gbm::{BufferObject, BufferObjectFlags, Format as GbmFormat, Surface as GbmSurface, SurfaceBufferHandle};
+
+use image::{ImageBuffer, Rgba};
+
+use nix::c_void;
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+pub struct DrmBackend(Rc<RefCell<DrmBackendInternal>>);
+
+impl DrmBackend {
+    pub(crate) fn new(drm: Rc<RefCell<DrmBackendInternal>>) -> DrmBackend {
+        DrmBackend(drm)
+    }
+}
+
+/*
+    Dependency graph
+    - drm
+        - gbm
+            - context
+            - gbm_surface
+                - egl_surface
+                - gbm_buffers
+            - cursor
+*/
+
+pub(crate) struct GbmTypes<'dev, 'context> {
+    cursor: BufferObject<'dev, ()>,
+    surface: Surface<'context>,
+}
+
+pub(crate) struct EGL<'gbm, 'context> {
+    surface: EGLSurface<'context, 'gbm, GbmSurface<'context, framebuffer::Info>>,
+    buffers: GbmBuffers<'gbm>,
+}
+
+pub(crate) struct GbmBuffers<'gbm> {
+    front_buffer: Cell<SurfaceBufferHandle<'gbm, framebuffer::Info>>,
+    next_buffer: Cell<Option<SurfaceBufferHandle<'gbm, framebuffer::Info>>>,
+}
+
+rental! {
+    mod graphics {
+        use drm::control::framebuffer;
+        use gbm::Surface as GbmSurface;
+        use std::rc::Rc;
+        use super::devices::{Context, Context_Borrow};
+        use super::GbmTypes;
+
+        #[rental]
+        pub(crate) struct Surface<'context> {
+            gbm: Box<GbmSurface<'context, framebuffer::Info>>,
+            egl: super::EGL<'gbm, 'context>,
+        }
+
+        #[rental]
+        pub(crate) struct Graphics {
+            #[subrental(arity = 3)]
+            context: Rc<Context>,
+            gbm: GbmTypes<'context_1, 'context_2>,
+        }
+    }
+}
+use self::graphics::{Graphics, Surface};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Id(usize);
+
+impl Id {
+    pub(crate) fn raw(&self) -> usize {
+        self.0
+    }
+}
+
+pub(crate) struct DrmBackendInternal {
+    graphics: Graphics,
+    crtc: crtc::Handle,
+    mode: Mode,
+    connectors: Vec<connector::Handle>,
+    own_id: Id,
+    logger: ::slog::Logger,
+}
+
+impl DrmBackendInternal {
+    pub(crate) fn new<I, L>(context: Rc<devices::Context>, crtc: crtc::Handle, mode: Mode, connectors: I,
+                            own_id: usize, logger: L)
+                            -> Result<DrmBackendInternal, DrmError>
+    where
+        I: Into<Vec<connector::Handle>>,
+        L: Into<Option<::slog::Logger>>,
+    {
+        let log = ::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_drm"));
+        info!(log, "Initializing a drm backend");
+
+        let connectors = connectors.into();
+
+        for connector in connectors.iter() {
+            if !connector::Info::load_from_device(context.head().head(), *connector)?
+                .modes()
+                .contains(&mode)
+            {
+                return Err(DrmError::Mode(ModeError::ModeNotSuitable));
+            }
+        }
+
+        let (w, h) = mode.size();
+
+        info!(log, "Drm Backend initialized");
+
+        Ok(DrmBackendInternal {
+            graphics: Graphics::try_new(context, |context| {
+                debug!(log, "GBM EGLContext initialized");
+
+                Ok(GbmTypes {
+                    cursor: {
+                        // Create an unused cursor buffer (we don't want an Option here)
+                        context.devices.gbm.create_buffer_object(
+                            1,
+                            1,
+                            GbmFormat::ARGB8888,
+                            &[BufferObjectFlags::Cursor, BufferObjectFlags::Write],
+                        )?
+                    },
+                    surface: Surface::try_new(
+                        Box::new(context.devices.gbm.create_surface(
+                            w as u32,
+                            h as u32,
+                            GbmFormat::XRGB8888,
+                            &[BufferObjectFlags::Scanout, BufferObjectFlags::Rendering],
+                        )?),
+                        |surface| {
+                            let egl_surface = context.egl.create_surface(&surface)?;
+                            unsafe { egl_surface.make_current()? };
+                            egl_surface.swap_buffers()?;
+
+                            let mut front_bo = surface.lock_front_buffer()?;
+                            debug!(log, "FrontBuffer color format: {:?}", front_bo.format());
+                            let fb = framebuffer::create(context.devices.drm, &*front_bo)?;
+                            crtc::set(
+                                context.devices.drm,
+                                crtc,
+                                fb.handle(),
+                                &connectors,
+                                (0, 0),
+                                Some(mode),
+                            )?;
+                            front_bo.set_userdata(fb);
+
+                            Ok(EGL {
+                                surface: egl_surface,
+                                buffers: GbmBuffers {
+                                    front_buffer: Cell::new(front_bo),
+                                    next_buffer: Cell::new(None),
+                                },
+                            })
+                        },
+                    ).map_err(DrmError::from)?,
+                })
+            })?,
+            crtc,
+            mode,
+            connectors,
+            own_id: Id(own_id),
+            logger: log.clone(),
+        })
+    }
+
+    pub(crate) fn unlock_buffer(&self) {
+        self.graphics.rent(|gbm| {
+            gbm.surface.rent(|egl| {
+                let next_bo = egl.buffers.next_buffer.replace(None);
+
+                if let Some(next_buffer) = next_bo {
+                    egl.buffers.front_buffer.set(next_buffer);
+                // drop and release the old buffer
+                } else {
+                    unreachable!();
+                }
+            })
+        });
+    }
+}
+
+impl DrmBackend {
+    pub fn add_connector(&mut self, connector: connector::Handle) -> Result<(), ModeError> {
+        let info =
+            connector::Info::load_from_device(self.0.borrow().graphics.head().head().head(), connector)
+                .map_err(|err| ModeError::FailedToLoad(err))?;
+        let mut internal = self.0.borrow_mut();
+        if info.modes().contains(&internal.mode) {
+            internal.connectors.push(connector);
+            Ok(())
+        } else {
+            Err(ModeError::ModeNotSuitable)
+        }
+    }
+
+    pub fn used_connectors(&self) -> Vec<connector::Handle> {
+        self.0.borrow().connectors.clone()
+    }
+
+    pub fn remove_connector(&mut self, connector: connector::Handle) {
+        self.0.borrow_mut().connectors.retain(|x| *x != connector);
+    }
+
+    pub fn use_mode(&mut self, mode: Mode) -> Result<(), DrmError> {
+        for connector in self.0.borrow().connectors.iter() {
+            if !connector::Info::load_from_device(self.0.borrow().graphics.head().head().head(), *connector)?
+                .modes()
+                .contains(&mode)
+            {
+                return Err(DrmError::Mode(ModeError::ModeNotSuitable));
+            }
+        }
+
+        let crtc = self.0.borrow().crtc;
+        let mut internal = self.0.borrow_mut();
+        let connectors = internal.connectors.clone();
+        let logger = internal.logger.clone();
+
+        let (w, h) = mode.size();
+
+        internal
+            .graphics
+            .rent_all_mut(|graphics| -> Result<(), DrmError> {
+                graphics.gbm.surface = Surface::try_new(
+                    Box::new(graphics.context.devices.gbm.create_surface(
+                        w as u32,
+                        h as u32,
+                        GbmFormat::XRGB8888,
+                        &[BufferObjectFlags::Scanout, BufferObjectFlags::Rendering],
+                    )?),
+                    |surface| {
+                        let egl_surface = graphics.context.egl.create_surface(&surface)?;
+                        unsafe { egl_surface.make_current()? };
+                        egl_surface.swap_buffers()?;
+
+                        let mut front_bo = surface.lock_front_buffer()?;
+                        debug!(logger, "FrontBuffer color format: {:?}", front_bo.format());
+                        let fb = framebuffer::create(graphics.context.devices.drm, &*front_bo)?;
+                        crtc::set(
+                            graphics.context.devices.drm,
+                            crtc,
+                            fb.handle(),
+                            &connectors,
+                            (0, 0),
+                            Some(mode),
+                        )?;
+                        front_bo.set_userdata(fb);
+
+                        Ok(EGL {
+                            surface: egl_surface,
+                            buffers: GbmBuffers {
+                                front_buffer: Cell::new(front_bo),
+                                next_buffer: Cell::new(None),
+                            },
+                        })
+                    },
+                )?;
+
+                Ok(())
+            })?;
+
+        internal.mode = mode;
+        Ok(())
+    }
+
+    pub fn is(&self, id: Id) -> bool {
+        self.0.borrow().own_id == id
+    }
+}
+
+impl GraphicsBackend for DrmBackend {
+    type CursorFormat = ImageBuffer<Rgba<u8>, Vec<u8>>;
+    type Error = DrmError;
+
+    fn set_cursor_position(&self, x: u32, y: u32) -> Result<(), DrmError> {
+        crtc::move_cursor(
+            self.0.borrow().graphics.head().head().head(),
+            self.0.borrow().crtc,
+            (x as i32, y as i32),
+        ).map_err(DrmError::from)
+    }
+
+    fn set_cursor_representation(&self, buffer: ImageBuffer<Rgba<u8>, Vec<u8>>, hotspot: (u32, u32))
+                                 -> Result<(), DrmError> {
+        let (w, h) = buffer.dimensions();
+        self.0
+            .borrow_mut()
+            .graphics
+            .rent_all_mut(|graphics| -> Result<(), DrmError> {
+                graphics.gbm.cursor = {
+                    let mut cursor = graphics.context.devices.gbm.create_buffer_object(
+                        w,
+                        h,
+                        GbmFormat::ARGB8888,
+                        &[BufferObjectFlags::Cursor, BufferObjectFlags::Write],
+                    )?;
+                    cursor.write(&*buffer.into_raw())?;
+                    cursor
+                };
+                Ok(())
+            })?;
+
+        if crtc::set_cursor2(
+            self.0.borrow().graphics.head().head().head(),
+            self.0.borrow().crtc,
+            self.0
+                .borrow()
+                .graphics
+                .rent(|gbm| Buffer::handle(&gbm.cursor)),
+            (w, h),
+            (hotspot.0 as i32, hotspot.1 as i32),
+        ).is_err()
+        {
+            crtc::set_cursor(
+                self.0.borrow().graphics.head().head().head(),
+                self.0.borrow().crtc,
+                self.0
+                    .borrow()
+                    .graphics
+                    .rent(|gbm| Buffer::handle(&gbm.cursor)),
+                (w, h),
+            ).map_err(DrmError::from)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl EGLGraphicsBackend for DrmBackend {
+    fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
+        self.0.borrow().graphics.rent_all(|graphics| {
+            // We cannot call lock_front_buffer anymore without releasing the previous buffer, which will happen when the page flip is done
+            if graphics.gbm.surface.rent(|egl| {
+                let next = egl.buffers.next_buffer.take();
+                let res = next.is_some();
+                egl.buffers.next_buffer.set(next);
+                res
+            }) {
+                return Err(SwapBuffersError::AlreadySwapped);
+            }
+
+            graphics.gbm.surface.rent(|egl| egl.surface.swap_buffers())?;
+
+            graphics.gbm.surface.rent_all(|surface| {
+                // supporting this would cause a lot of inconvinience and
+                // would most likely result in a lot of flickering.
+                // neither weston, wlc or wlroots bother with that as well.
+                let mut next_bo = surface.gbm.lock_front_buffer().expect("Surface only has one front buffer. Not supported by smithay");
+
+                let maybe_fb = next_bo.userdata().cloned();
+                let fb = if let Some(info) = maybe_fb {
+                    info
+                } else {
+                    let fb = framebuffer::create(graphics.context.devices.drm, &*next_bo).map_err(|_| SwapBuffersError::ContextLost)?;
+                    next_bo.set_userdata(fb);
+                    fb
+                };
+                surface.egl.buffers.next_buffer.set(Some(next_bo));
+
+                trace!(self.0.borrow().logger, "Page flip queued");
+
+                let id: Id = self.0.borrow().own_id;
+
+                crtc::page_flip(graphics.context.devices.drm, self.0.borrow().crtc, fb.handle(), &[crtc::PageFlipFlags::PageFlipEvent], id).map_err(|_| SwapBuffersError::ContextLost)
+            })
+        })
+    }
+
+    unsafe fn get_proc_address(&self, symbol: &str) -> *const c_void {
+        self.0
+            .borrow()
+            .graphics
+            .head()
+            .rent(|context| context.get_proc_address(symbol))
+    }
+
+    fn get_framebuffer_dimensions(&self) -> (u32, u32) {
+        let (w, h) = self.0.borrow().mode.size();
+        (w as u32, h as u32)
+    }
+
+    fn is_current(&self) -> bool {
+        self.0
+            .borrow()
+            .graphics
+            .head()
+            .rent(|context| context.is_current())
+    }
+
+    unsafe fn make_current(&self) -> Result<(), SwapBuffersError> {
+        self.0
+            .borrow()
+            .graphics
+            .rent(|gbm| gbm.surface.rent(|egl| egl.surface.make_current()))
+    }
+
+    fn get_pixel_format(&self) -> PixelFormat {
+        self.0
+            .borrow()
+            .graphics
+            .head()
+            .rent(|context| context.get_pixel_format())
+    }
+}

--- a/src/backend/drm/backend.rs
+++ b/src/backend/drm/backend.rs
@@ -476,7 +476,7 @@ impl GraphicsBackend for DrmBackend {
                                  -> Result<()> {
         let (w, h) = buffer.dimensions();
         debug!(self.0.borrow().logger, "Importing cursor");
-        /// import the cursor into a buffer we can render
+        // import the cursor into a buffer we can render
         self.0
             .borrow_mut()
             .graphics
@@ -548,7 +548,7 @@ impl EGLGraphicsBackend for DrmBackend {
                 return Err(SwapBuffersError::AlreadySwapped);
             }
 
-            /// flip normally
+            // flip normally
             graphics.gbm.surface.rent(|egl| egl.surface.swap_buffers())?;
 
             graphics.gbm.surface.rent_all(|surface| {

--- a/src/backend/drm/backend.rs
+++ b/src/backend/drm/backend.rs
@@ -1,4 +1,3 @@
-
 use super::{DrmError, ModeError};
 
 use super::devices;

--- a/src/backend/drm/error.rs
+++ b/src/backend/drm/error.rs
@@ -1,184 +1,57 @@
-use backend::graphics::egl::{CreationError, SwapBuffersError};
-use drm::result::Error as DrmError;
-use gbm::FrontBufferError;
+//!
+//! Errors thrown by the `DrmDevice` and `DrmBackend`
+//!
+
+use backend::graphics::egl;
+use drm::control::{connector, crtc, Mode};
 use rental::TryNewError;
 
-use std::error::{self, Error as ErrorTrait};
-use std::fmt;
-use std::io::Error as IoError;
+error_chain! {
+    errors {
+        #[doc = "The `DrmDevice` encountered an access error"]
+        DrmDev(dev: String) {
+            description("The drm device encountered an access error"),
+            display("The drm device ({:?}) encountered an access error", dev),
+        }
 
-/// Error summing up error types related to all underlying libraries
-/// involved in creating the a `DrmDevice`/`DrmBackend`
-#[derive(Debug)]
-pub enum Error {
-    /// The `DrmDevice` has encountered an error on an ioctl
-    Drm(DrmError),
-    /// The `EGLContext` could not be created
-    EGLCreation(CreationError),
-    /// Swapping Buffers via EGL was not possible
-    EGLSwap(SwapBuffersError),
-    /// Locking the front buffer of the underlying `GbmSurface` failed
-    Gbm(FrontBufferError),
-    /// A generic IO-Error happened accessing the underlying devices
-    Io(IoError),
-    /// Selected an invalid Mode
-    Mode(ModeError),
-    /// Error related to the selected crtc
-    Crtc(CrtcError),
-}
+        #[doc = "Creation of gbm resource failed"]
+        GbmInitFailed {
+            description("Creation of gbm resource failed"),
+            display("Creation of gbm resource failed"),
+        }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "DrmBackend error: {}",
-            match self {
-                &Error::Drm(ref x) => x as &error::Error,
-                &Error::EGLCreation(ref x) => x as &error::Error,
-                &Error::EGLSwap(ref x) => x as &error::Error,
-                &Error::Gbm(ref x) => x as &error::Error,
-                &Error::Io(ref x) => x as &error::Error,
-                &Error::Mode(ref x) => x as &error::Error,
-                &Error::Crtc(ref x) => x as &error::Error,
-            }
-        )
-    }
-}
+        #[doc = "Swapping front buffers failed"]
+        FailedToSwap {
+            description("Swapping front buffers failed"),
+            display("Swapping front buffers failed"),
+        }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        "DrmBackend error"
-    }
+        #[doc = "mode is not compatible with all given connectors"]
+        ModeNotSuitable(mode: Mode) {
+            description("Mode is not compatible with all given connectors"),
+            display("Mode ({:?}) is not compatible with all given connectors", mode),
+        }
 
-    fn cause(&self) -> Option<&error::Error> {
-        match self {
-            &Error::Drm(ref x) => Some(x as &error::Error),
-            &Error::EGLCreation(ref x) => Some(x as &error::Error),
-            &Error::EGLSwap(ref x) => Some(x as &error::Error),
-            &Error::Gbm(ref x) => Some(x as &error::Error),
-            &Error::Io(ref x) => Some(x as &error::Error),
-            &Error::Mode(ref x) => Some(x as &error::Error),
-            &Error::Crtc(ref x) => Some(x as &error::Error),
+        #[doc = "The given crtc is already in use by another backend"]
+        CrtcAlreadyInUse(crtc: crtc::Handle) {
+            description("The given crtc is already in use by another backend"),
+            display("The given crtc ({:?}) is already in use by another backend", crtc),
+        }
+
+        #[doc = "No encoder was found for a given connector on the set crtc"]
+        NoSuitableEncoder(connector: connector::Info, crtc: crtc::Handle) {
+            description("No encoder found for given connector on set crtc"),
+            display("No encoder found for the given connector '{:?}' on the set crtc ({:?})", connector.connector_type(), crtc),
         }
     }
-}
 
-impl From<DrmError> for Error {
-    fn from(err: DrmError) -> Error {
-        Error::Drm(err)
-    }
-}
-
-impl From<CreationError> for Error {
-    fn from(err: CreationError) -> Error {
-        Error::EGLCreation(err)
-    }
-}
-
-impl From<SwapBuffersError> for Error {
-    fn from(err: SwapBuffersError) -> Error {
-        Error::EGLSwap(err)
-    }
-}
-
-impl From<FrontBufferError> for Error {
-    fn from(err: FrontBufferError) -> Error {
-        Error::Gbm(err)
-    }
-}
-
-impl From<IoError> for Error {
-    fn from(err: IoError) -> Error {
-        Error::Io(err)
-    }
-}
-
-impl From<ModeError> for Error {
-    fn from(err: ModeError) -> Error {
-        match err {
-            err @ ModeError::ModeNotSuitable => Error::Mode(err),
-            ModeError::FailedToLoad(err) => Error::Drm(err),
-        }
-    }
-}
-
-impl From<CrtcError> for Error {
-    fn from(err: CrtcError) -> Error {
-        Error::Crtc(err)
+    links {
+        EGL(egl::Error, egl::ErrorKind) #[doc = "EGL error"];
     }
 }
 
 impl<H> From<TryNewError<Error, H>> for Error {
     fn from(err: TryNewError<Error, H>) -> Error {
         err.0
-    }
-}
-
-/// Error when trying to select an invalid mode
-#[derive(Debug)]
-pub enum ModeError {
-    /// `Mode` is not compatible with all given connectors
-    ModeNotSuitable,
-    /// Failed to load `Mode` information
-    FailedToLoad(DrmError),
-}
-
-impl fmt::Display for ModeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())?;
-        if let Some(cause) = self.cause() {
-            write!(f, "\tCause: {}", cause)?;
-        }
-        Ok(())
-    }
-}
-
-impl error::Error for ModeError {
-    fn description(&self) -> &str {
-        match self {
-            &ModeError::ModeNotSuitable => "Mode does not match all attached connectors",
-            &ModeError::FailedToLoad(_) => "Failed to load mode information from device",
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match self {
-            &ModeError::FailedToLoad(ref err) => Some(err as &error::Error),
-            _ => None,
-        }
-    }
-}
-
-/// Errors related to the selected crtc
-#[derive(Debug)]
-pub enum CrtcError {
-    /// Selected crtc is already in use by another `DrmBackend`
-    AlreadyInUse,
-    /// For the selected crtc no encoder exists that supports all connectors
-    NoSuitableEncoder,
-}
-
-impl fmt::Display for CrtcError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())?;
-        if let Some(cause) = self.cause() {
-            write!(f, "\tCause: {}", cause)?;
-        }
-        Ok(())
-    }
-}
-
-impl error::Error for CrtcError {
-    fn description(&self) -> &str {
-        match self {
-            &CrtcError::AlreadyInUse => "Crtc is already in use by another DrmBackend",
-            &CrtcError::NoSuitableEncoder => "Crtc has no supported encoder that can drive all connectors",
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match self {
-            _ => None,
-        }
     }
 }

--- a/src/backend/drm/error.rs
+++ b/src/backend/drm/error.rs
@@ -1,0 +1,131 @@
+
+
+use backend::graphics::egl::{CreationError, SwapBuffersError};
+use drm::result::Error as DrmError;
+use gbm::FrontBufferError;
+use rental::TryNewError;
+
+use std::error::{self, Error as ErrorTrait};
+use std::fmt;
+use std::io::Error as IoError;
+
+#[derive(Debug)]
+pub enum Error {
+    Drm(DrmError),
+    EGLCreation(CreationError),
+    EGLSwap(SwapBuffersError),
+    Gbm(FrontBufferError),
+    Io(IoError),
+    Mode(ModeError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "DrmBackend error: {}",
+            match self {
+                &Error::Drm(ref x) => x as &error::Error,
+                &Error::EGLCreation(ref x) => x as &error::Error,
+                &Error::EGLSwap(ref x) => x as &error::Error,
+                &Error::Gbm(ref x) => x as &error::Error,
+                &Error::Io(ref x) => x as &error::Error,
+                &Error::Mode(ref x) => x as &error::Error,
+            }
+        )
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        "DrmBackend error"
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match self {
+            &Error::Drm(ref x) => Some(x as &error::Error),
+            &Error::EGLCreation(ref x) => Some(x as &error::Error),
+            &Error::EGLSwap(ref x) => Some(x as &error::Error),
+            &Error::Gbm(ref x) => Some(x as &error::Error),
+            &Error::Io(ref x) => Some(x as &error::Error),
+            &Error::Mode(ref x) => Some(x as &error::Error),
+        }
+    }
+}
+
+impl From<DrmError> for Error {
+    fn from(err: DrmError) -> Error {
+        Error::Drm(err)
+    }
+}
+
+impl From<CreationError> for Error {
+    fn from(err: CreationError) -> Error {
+        Error::EGLCreation(err)
+    }
+}
+
+impl From<SwapBuffersError> for Error {
+    fn from(err: SwapBuffersError) -> Error {
+        Error::EGLSwap(err)
+    }
+}
+
+impl From<FrontBufferError> for Error {
+    fn from(err: FrontBufferError) -> Error {
+        Error::Gbm(err)
+    }
+}
+
+impl From<IoError> for Error {
+    fn from(err: IoError) -> Error {
+        Error::Io(err)
+    }
+}
+
+impl From<ModeError> for Error {
+    fn from(err: ModeError) -> Error {
+        match err {
+            err @ ModeError::ModeNotSuitable => Error::Mode(err),
+            ModeError::FailedToLoad(err) => Error::Drm(err),
+        }
+    }
+}
+
+impl<H> From<TryNewError<Error, H>> for Error {
+    fn from(err: TryNewError<Error, H>) -> Error {
+        err.0
+    }
+}
+
+#[derive(Debug)]
+pub enum ModeError {
+    ModeNotSuitable,
+    FailedToLoad(DrmError),
+}
+
+impl fmt::Display for ModeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())?;
+        if let Some(cause) = self.cause() {
+            write!(f, "\tCause: {}", cause)?;
+        }
+        Ok(())
+    }
+}
+
+impl error::Error for ModeError {
+    fn description(&self) -> &str {
+        match self {
+            &ModeError::ModeNotSuitable => "Mode does not match all attached connectors",
+            &ModeError::FailedToLoad(_) => "Failed to load mode information from device",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match self {
+            &ModeError::FailedToLoad(ref err) => Some(err as &error::Error),
+            _ => None,
+        }
+    }
+}

--- a/src/backend/drm/error.rs
+++ b/src/backend/drm/error.rs
@@ -154,6 +154,8 @@ impl error::Error for ModeError {
 pub enum CrtcError {
     /// Selected crtc is already in use by another `DrmBackend`
     AlreadyInUse,
+    /// For the selected crtc no encoder exists that supports all connectors
+    NoSuitableEncoder,
 }
 
 impl fmt::Display for CrtcError {
@@ -170,6 +172,7 @@ impl error::Error for CrtcError {
     fn description(&self) -> &str {
         match self {
             &CrtcError::AlreadyInUse => "Crtc is already in use by another DrmBackend",
+            &CrtcError::NoSuitableEncoder => "Crtc has no supported encoder that can drive all connectors",
         }
     }
 

--- a/src/backend/drm/error.rs
+++ b/src/backend/drm/error.rs
@@ -153,7 +153,7 @@ impl error::Error for ModeError {
 #[derive(Debug)]
 pub enum CrtcError {
     /// Selected crtc is already in use by another `DrmBackend`
-    AlreadyInUse
+    AlreadyInUse,
 }
 
 impl fmt::Display for CrtcError {

--- a/src/backend/drm/error.rs
+++ b/src/backend/drm/error.rs
@@ -1,5 +1,3 @@
-
-
 use backend::graphics::egl::{CreationError, SwapBuffersError};
 use drm::result::Error as DrmError;
 use gbm::FrontBufferError;
@@ -9,13 +7,21 @@ use std::error::{self, Error as ErrorTrait};
 use std::fmt;
 use std::io::Error as IoError;
 
+/// Error summing up error types related to all underlying libraries
+/// involved in creating the a `DrmDevice`/`DrmBackend`
 #[derive(Debug)]
 pub enum Error {
+    /// The `DrmDevice` has encountered an error on an ioctl
     Drm(DrmError),
+    /// The `EGLContext` could not be created
     EGLCreation(CreationError),
+    /// Swapping Buffers via EGL was not possible
     EGLSwap(SwapBuffersError),
+    /// Locking the front buffer of the underlying `GbmSurface` failed
     Gbm(FrontBufferError),
+    /// A generic IO-Error happened accessing the underlying devices
     Io(IoError),
+    /// Selected an invalid Mode
     Mode(ModeError),
 }
 
@@ -98,9 +104,12 @@ impl<H> From<TryNewError<Error, H>> for Error {
     }
 }
 
+/// Error when trying to select an invalid mode
 #[derive(Debug)]
 pub enum ModeError {
+    /// `Mode` is not compatible with all given connectors
     ModeNotSuitable,
+    /// Failed to load `Mode` information
     FailedToLoad(DrmError),
 }
 

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -156,7 +156,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::rc::{Rc, Weak};
 use std::time::Duration;
 
-use wayland_server::{EventLoopHandle};
+use wayland_server::EventLoopHandle;
 use wayland_server::sources::{FdEventSourceHandler, FdInterest};
 
 mod backend;
@@ -164,7 +164,7 @@ mod error;
 
 pub use self::backend::{DrmBackend, Id};
 use self::backend::DrmBackendInternal;
-pub use self::error::{Error as DrmError, ModeError, CrtcError};
+pub use self::error::{CrtcError, Error as DrmError, ModeError};
 
 /// Internal struct as required by the drm crate
 #[derive(Debug)]
@@ -255,7 +255,7 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
     /// The file descriptor might not be valid and needs to be owned by smithay,
     /// make sure not to share it. Otherwise undefined behavior might occur.
     pub unsafe fn new_from_fd_with_gl_attr<L>(fd: RawFd, attributes: GlAttributes, logger: L)
-        -> Result<Self, DrmError>
+                                              -> Result<Self, DrmError>
     where
         L: Into<Option<::slog::Logger>>,
     {
@@ -427,10 +427,7 @@ impl<H: DrmHandler + 'static> FdEventSourceHandler for DrmDevice<H> {
         impl BasicDevice for DrmDeviceRef {}
         impl ControlDevice for DrmDeviceRef {}
 
-        struct PageFlipHandler<'a, 'b, H: DrmHandler + 'static>(
-            &'a mut DrmDevice<H>,
-            &'b mut EventLoopHandle,
-        );
+        struct PageFlipHandler<'a, 'b, H: DrmHandler + 'static>(&'a mut DrmDevice<H>, &'b mut EventLoopHandle);
 
         impl<'a, 'b, H: DrmHandler + 'static> crtc::PageFlipHandler<DrmDeviceRef> for PageFlipHandler<'a, 'b, H> {
             fn handle_event(&mut self, _device: &DrmDeviceRef, frame: u32, duration: Duration,
@@ -451,10 +448,7 @@ impl<H: DrmHandler + 'static> FdEventSourceHandler for DrmDevice<H> {
             &DrmDeviceRef(fd),
             2,
             None::<&mut ()>,
-            Some(&mut PageFlipHandler(
-                self,
-                evlh,
-            )),
+            Some(&mut PageFlipHandler(self, evlh)),
             None::<&mut ()>,
         ).unwrap();
     }

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -366,17 +366,33 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
         // check if the given connectors and crtc match
         let connectors = connectors.into();
         // get all encoders supported by this device
-        let mut set = self.context.head().head().resource_handles()?.encoders().iter().cloned().collect::<HashSet<encoder::Handle>>();
+        let mut set = self.context
+            .head()
+            .head()
+            .resource_handles()?
+            .encoders()
+            .iter()
+            .cloned()
+            .collect::<HashSet<encoder::Handle>>();
         for connector in connectors.iter() {
             let info = connector::Info::load_from_device(self.context.head().head(), *connector)?;
             // then check for every connector which encoders it does support
-            let conn_set = info.encoders().iter().cloned().collect::<HashSet<encoder::Handle>>();
+            let conn_set = info.encoders()
+                .iter()
+                .cloned()
+                .collect::<HashSet<encoder::Handle>>();
             // and update the list of supported encoders for this combination
-            set = set.intersection(&conn_set).cloned().collect::<HashSet<encoder::Handle>>();
+            set = set.intersection(&conn_set)
+                .cloned()
+                .collect::<HashSet<encoder::Handle>>();
         }
 
         // check if there is any encoder left that can be connected to the crtc
-        let encoders: Vec<encoder::Info> = set.iter().map(|handle| encoder::Info::load_from_device(self.context.head().head(), *handle).map_err(DrmError::from)).collect::<Result<Vec<encoder::Info>, DrmError>>()?;
+        let encoders: Vec<encoder::Info> = set.iter()
+            .map(|handle| {
+                encoder::Info::load_from_device(self.context.head().head(), *handle).map_err(DrmError::from)
+            })
+            .collect::<Result<Vec<encoder::Info>, DrmError>>()?;
         if !encoders.iter().any(|enc| enc.supports_crtc(crtc)) {
             return Err(DrmError::Crtc(CrtcError::NoSuitableEncoder));
         }

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -3,7 +3,29 @@
 //! This module provide a `DrmDevice` which acts as a reprensentation for any drm
 //! device and can be used to create the second provided structure a `DrmBackend`.
 //!
-//! The latter represents a crtc of the graphics card you can render to.
+//! Initialization happens through the types provided by [`drm-rs`](https://docs.rs/drm/).
+//!
+//! Three entities are relevant for the initialization procedure.
+//!
+//! "Crtc"s represent scanout engines of the device pointer to one framebuffer. There responsibility
+//! is to read the data of the framebuffer and export it into an "Encoder". The number of crtc's
+//! represent the number of independant output devices the hardware may handle.
+//!
+//! An "Encoder" encodes the data of connected crtcs into a video signal for a fixed set
+//! of connectors. E.g. you might have an analog encoder based on a DAG for VGA ports, but another
+//! one for digital ones. Also not every encoder might be connected to every crtc.
+//!
+//! The last entity the "Connector" represents a port on your computer, possibly with a connected
+//! monitor, TV, capture card, etc.
+//!
+//! The `DrmBackend` created from a `DrmDevice` represents a crtc of the device you can render to
+//! and that feeds a given set of connectors, that can be manipulated at runtime.
+//!
+//! From these circumstances it becomes clear, that one crtc might only send it's data to a connector,
+//! that is attached to any encoder that is attached to the crtc itself. It is the responsibility of the
+//! user to ensure that a given set of a crtc with it's connectors is valid or an error will be thrown.
+//!
+//! For more details refer to the [`drm-rs` documentation](https://docs.rs/drm).
 //!
 //!
 //! ## How to use it

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -398,8 +398,6 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
     where
         I: Into<Vec<connector::Handle>>,
     {
-        use std::collections::hash_set::HashSet;
-
         for backend in self.backends.iter() {
             if let Some(backend) = backend.upgrade() {
                 if backend.borrow().is_crtc(crtc) {
@@ -410,36 +408,25 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
 
         // check if the given connectors and crtc match
         let connectors = connectors.into();
-        // get all encoders supported by this device
-        let mut set = self.context
-            .head()
-            .head()
-            .resource_handles()?
-            .encoders()
-            .iter()
-            .cloned()
-            .collect::<HashSet<encoder::Handle>>();
-        for connector in connectors.iter() {
-            let info = connector::Info::load_from_device(self.context.head().head(), *connector)?;
-            // then check for every connector which encoders it does support
-            let conn_set = info.encoders()
-                .iter()
-                .cloned()
-                .collect::<HashSet<encoder::Handle>>();
-            // and update the list of supported encoders for this combination
-            set = set.intersection(&conn_set)
-                .cloned()
-                .collect::<HashSet<encoder::Handle>>();
-        }
 
-        // check if there is any encoder left that can be connected to the crtc
-        let encoders: Vec<encoder::Info> = set.iter()
-            .map(|handle| {
-                encoder::Info::load_from_device(self.context.head().head(), *handle).map_err(DrmError::from)
-            })
-            .collect::<Result<Vec<encoder::Info>, DrmError>>()?;
-        if !encoders.iter().any(|enc| enc.supports_crtc(crtc)) {
-            return Err(DrmError::Crtc(CrtcError::NoSuitableEncoder));
+        // check if we have an encoder for every connector
+        for connector in connectors.iter() {
+            let con_info = connector::Info::load_from_device(self.context.head().head(), *connector)?;
+
+            // then check for every connector which encoders it does support
+            let encoders = con_info
+                .encoders()
+                .iter()
+                .map(|encoder| {
+                    encoder::Info::load_from_device(self.context.head().head(), *encoder)
+                        .map_err(DrmError::from)
+                })
+                .collect::<Result<Vec<encoder::Info>, DrmError>>()?;
+
+            // and if any encoder supports the selected crtc
+            if !encoders.iter().any(|encoder| encoder.supports_crtc(crtc)) {
+                return Err(DrmError::Crtc(CrtcError::NoSuitableEncoder));
+            }
         }
 
         // configuration is valid, the kernel will figure out the rest

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -1,4 +1,144 @@
-
+//! Drm/Kms types and backend implementations
+//!
+//! This module provide a `DrmDevice` which acts as a reprensentation for any drm
+//! device and can be used to create the second provided structure a `DrmBackend`.
+//!
+//! The latter represents a crtc of the graphics card you can render to.
+//!
+//!
+//! ## How to use it
+//!
+//! ### Initialization
+//!
+//! To initialize the `DrmDevice` you need either a `RawFd` or a `File` of
+//! your drm node. The `File` is recommended as it represents the save api.
+//!
+//! Once you got your `DrmDevice` you can then use it to create `DrmBackend`s.
+//! You will need to use the `drm` crate to provide the required types to create
+//! a backend.
+//!
+//! ```rust,ignore
+//! extern crate drm;
+//! extern crate smithay;
+//! # extern crate wayland_server;
+//!
+//! use drm::control::{Device as ControlDevice, ResourceInfo};
+//! use drm::control::connector::{Info as ConnectorInfo, State as ConnectorState};
+//! use std::fs::OpenOptions;
+//! use smithay::backend::drm::DrmDevice;
+//!
+//! # fn main() {
+//! // Open the drm device
+//! let mut options = OpenOptions::new();
+//! options.read(true);
+//! options.write(true);
+//! let mut device = DrmDevice::new_from_file(
+//!     options.open("/dev/dri/card0").unwrap(), // try to detect it properly
+//!     None /*put a logger here*/
+//! ).unwrap();
+//!
+//! // Get a set of all modesetting resource handles
+//! let res_handles = device.resource_handles().unwrap();
+//!
+//! // Use first connected connector for this example
+//! let connector_info = res_handles.connectors().iter()
+//!     .map(|conn| ConnectorInfo::load_from_device(&device, *conn).unwrap())
+//!     .find(|conn| conn.connection_state() == ConnectorState::Connected)
+//!     .unwrap();
+//!
+//! // Use first crtc (should be successful in most cases)
+//! let crtc = res_handles.crtcs()[0];
+//!
+//! // Use first mode (usually the highest resolution)
+//! let mode = connector_info.modes()[0];
+//!
+//! // Create the backend
+//! let backend = device.create_backend(
+//!         crtc,
+//!         mode,
+//!         vec![connector_info.handle()]
+//!     ).unwrap();
+//! # }
+//! ```
+//!
+//! ### Page Flips / Tear-free video
+//! Calling the usual `EglGraphicsBackend::swap_buffers` function on a
+//! `DrmBackend` works the same to finish the rendering, but will return
+//! `SwapBuffersError::AlreadySwapped` for any new calls until the page flip of the
+//! crtc has happened.
+//!
+//! You can monitor the page flips by registering the `DrmDevice` as and
+//! `FdEventSourceHandler` and setting a `DrmHandler` on it. You will be notified
+//! whenever a page flip has happend, so you can render the next frame immediately
+//! and get a tear-free reprensentation on the display.
+//!
+//! You need to render at least once to successfully trigger the first event.
+//!
+//! ```rust,no_run
+//! # extern crate drm;
+//! # extern crate smithay;
+//! # extern crate wayland_server;
+//! #
+//! # use drm::control::{Device as ControlDevice, ResourceInfo};
+//! # use drm::control::connector::{Info as ConnectorInfo, State as ConnectorState};
+//! use std::io::Error as IoError;
+//! use std::os::unix::io::AsRawFd;
+//! # use std::fs::OpenOptions;
+//! # use std::time::Duration;
+//! use smithay::backend::drm::{DrmDevice, DrmBackend, DrmHandler, Id};
+//! use smithay::backend::graphics::egl::EGLGraphicsBackend;
+//! use wayland_server::sources::READ;
+//! # use wayland_server::EventLoopHandle;
+//! #
+//! # fn main() {
+//! #
+//! # let (_display, mut event_loop) = wayland_server::create_display();
+//! #
+//! # let mut options = OpenOptions::new();
+//! # options.read(true);
+//! # options.write(true);
+//! # let mut device = DrmDevice::new_from_file(
+//! #     options.open("/dev/dri/card0").unwrap(), // try to detect it properly
+//! #     None /*put a logger here*/
+//! # ).unwrap();
+//! # let res_handles = device.resource_handles().unwrap();
+//! # let connector_info = res_handles.connectors().iter()
+//! #     .map(|conn| ConnectorInfo::load_from_device(&device, *conn).unwrap())
+//! #     .find(|conn| conn.connection_state() == ConnectorState::Connected)
+//! #     .unwrap();
+//! # let crtc = res_handles.crtcs()[0];
+//! # let mode = connector_info.modes()[0];
+//! # let backend = device.create_backend(
+//! #         crtc,
+//! #         mode,
+//! #         vec![connector_info.handle()]
+//! #     ).unwrap();
+//!
+//! struct MyDrmHandler(DrmBackend);
+//!
+//! impl DrmHandler for MyDrmHandler {
+//!     fn ready(&mut self, _: &mut EventLoopHandle, id: Id, _frame: u32, _duration: Duration) {
+//!         if self.0.is(id) { // check id in case you got multiple backends
+//!             // ... render surfaces ...
+//!             self.0.swap_buffers().unwrap(); // trigger the swap
+//!         }
+//!     }
+//!     fn error(&mut self, _: &mut EventLoopHandle, error: IoError) {
+//!         panic!("DrmDevice errored: {}", error);
+//!     }
+//! }
+//!
+//! // render something (like clear_color)
+//! backend.swap_buffers().unwrap();
+//!
+//! device.set_handler(MyDrmHandler(backend));
+//! let fd = device.as_raw_fd();
+//! let drm_device_id = event_loop.add_handler(device);
+//! let _drm_event_source = event_loop.add_fd_event_source::<DrmDevice<MyDrmHandler>>(fd, drm_device_id, READ);
+//!
+//! event_loop.run().unwrap();
+//! # }
+//! ```
 
 use backend::graphics::egl::{EGLContext, GlAttributes, PixelFormatRequirements};
 use drm::Device as BasicDevice;
@@ -26,6 +166,7 @@ pub use self::backend::{DrmBackend, Id};
 use self::backend::DrmBackendInternal;
 pub use self::error::{Error as DrmError, ModeError};
 
+/// Internal struct as required by the drm crate
 #[derive(Debug)]
 pub(crate) struct DrmDev(File);
 
@@ -72,8 +213,7 @@ rental! {
 }
 use self::devices::{Context, Devices};
 
-
-// odd naming, but makes sense for the user
+/// Representation of an open drm device node to create rendering backends
 pub struct DrmDevice<H: DrmHandler + 'static> {
     context: Rc<Context>,
     backends: Vec<Weak<RefCell<DrmBackendInternal>>>,
@@ -82,6 +222,14 @@ pub struct DrmDevice<H: DrmHandler + 'static> {
 }
 
 impl<H: DrmHandler + 'static> DrmDevice<H> {
+    /// Create a new `DrmDevice` from a raw file descriptor
+    ///
+    /// Returns an error of opening the device failed or context creation was not
+    /// successful.
+    ///
+    /// # Safety
+    /// The file descriptor might not be valid and needs to be owned by smithay,
+    /// make sure not to share it. Otherwise undefined behavior might occur.
     pub unsafe fn new_from_fd<L>(fd: RawFd, logger: L) -> Result<Self, DrmError>
     where
         L: Into<Option<::slog::Logger>>,
@@ -98,6 +246,14 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
         )
     }
 
+    /// Create a new `DrmDevice` from a raw file descriptor and given `GlAttributes`
+    ///
+    /// Returns an error of opening the device failed or context creation was not
+    /// successful.
+    ///
+    /// # Safety
+    /// The file descriptor might not be valid and needs to be owned by smithay,
+    /// make sure not to share it. Otherwise undefined behavior might occur.
     pub unsafe fn new_from_fd_with_gl_attr<L>(fd: RawFd, attributes: GlAttributes, logger: L)
         -> Result<Self, DrmError>
     where
@@ -106,6 +262,10 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
         DrmDevice::new(DrmDev::new_from_fd(fd), attributes, logger)
     }
 
+    /// Create a new `DrmDevice` from a `File` of an open drm node
+    ///
+    /// Returns an error if the file is no valid drm node or context creation was not
+    /// successful.
     pub fn new_from_file<L>(file: File, logger: L) -> Result<Self, DrmError>
     where
         L: Into<Option<::slog::Logger>>,
@@ -122,6 +282,10 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
         )
     }
 
+    /// Create a new `DrmDevice` from a `File` of an open drm node and given `GlAttributes`
+    ///
+    /// Returns an error if the file is no valid drm node or context creation was not
+    /// successful.
     pub fn new_from_file_with_gl_attr<L>(file: File, attributes: GlAttributes, logger: L)
                                          -> Result<Self, DrmError>
     where
@@ -149,6 +313,7 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
             );
         }
 
+        // Open the gbm device from the drm device and create a context based on that
         Ok(DrmDevice {
             context: Rc::new(Context::try_new(
                 Box::new(Devices::try_new(Box::new(drm), |drm| {
@@ -174,6 +339,11 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
         })
     }
 
+    /// Create a new backend on a given crtc with a given `Mode` for a given amount
+    /// of `connectors` (mirroring).
+    ///
+    /// Errors if initialization fails or the mode is not available on all given
+    /// connectors.
     pub fn create_backend<I>(&mut self, crtc: crtc::Handle, mode: Mode, connectors: I)
                              -> Result<DrmBackend, DrmError>
     where
@@ -183,6 +353,8 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
             .new(o!("drm" => "backend", "crtc" => format!("{:?}", crtc)));
         let own_id = self.backends.len();
 
+        // TODO: Make sure we do not initialize the same crtc multiple times
+        // (check weak pointers and return an error otherwise)
         let backend = Rc::new(RefCell::new(DrmBackendInternal::new(
             self.context.clone(),
             crtc,
@@ -197,18 +369,20 @@ impl<H: DrmHandler + 'static> DrmDevice<H> {
         Ok(DrmBackend::new(backend))
     }
 
+    /// Set a handler for handling finished rendering
     pub fn set_handler(&mut self, handler: H) -> Option<H> {
         let res = self.handler.take();
         self.handler = Some(handler);
         res
     }
 
+    /// Clear the currently set handler
     pub fn clear_handler(&mut self) -> Option<H> {
         self.handler.take()
     }
 }
 
-// for users convinience
+// for users convinience and FdEventSource registering
 impl<H: DrmHandler + 'static> AsRawFd for DrmDevice<H> {
     fn as_raw_fd(&self) -> RawFd {
         self.context.head().head().as_raw_fd()
@@ -217,8 +391,20 @@ impl<H: DrmHandler + 'static> AsRawFd for DrmDevice<H> {
 impl<H: DrmHandler + 'static> BasicDevice for DrmDevice<H> {}
 impl<H: DrmHandler + 'static> ControlDevice for DrmDevice<H> {}
 
+/// Handler for drm node events
+///
+/// See module-level documentation for its use
 pub trait DrmHandler {
+    /// A `DrmBackend` has finished swapping buffers and new frame can now
+    /// (and should be immediately) be rendered.
+    ///
+    /// The `id` argument is the `Id` of the `DrmBackend` that finished rendering,
+    /// check using `DrmBackend::is`.
     fn ready(&mut self, evlh: &mut EventLoopHandle, id: Id, frame: u32, duration: Duration);
+    /// The `DrmDevice` has thrown an error.
+    ///
+    /// The related backends are most likely *not* usable anymore and
+    /// the whole stack has to be recreated.
     fn error(&mut self, evlh: &mut EventLoopHandle, error: IoError);
 }
 
@@ -245,8 +431,10 @@ impl<H: DrmHandler + 'static> FdEventSourceHandler for DrmDevice<H> {
                             userdata: Box<Any>) {
                 let id: Id = *userdata.downcast().unwrap();
                 if let Some(backend) = self.0.backends[id.raw()].upgrade() {
+                    // we can now unlock the buffer
                     backend.borrow().unlock_buffer();
                     if let Some(handler) = self.0.handler.as_mut() {
+                        // and then call the user to render the next frame
                         handler.ready(self.1, id, frame, duration);
                     }
                 }

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -1,0 +1,273 @@
+
+
+use backend::graphics::egl::{EGLContext, GlAttributes, PixelFormatRequirements};
+use drm::Device as BasicDevice;
+use drm::control::{connector, crtc, Mode};
+use drm::control::Device as ControlDevice;
+
+use gbm::Device as GbmDevice;
+
+use nix;
+
+use std::cell::RefCell;
+use std::fs::File;
+use std::io::Error as IoError;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::rc::{Rc, Weak};
+use std::time::Duration;
+
+use wayland_server::{EventLoopHandle};
+use wayland_server::sources::{FdEventSourceHandler, FdInterest};
+
+mod backend;
+mod error;
+
+pub use self::backend::{DrmBackend, Id};
+use self::backend::DrmBackendInternal;
+pub use self::error::{Error as DrmError, ModeError};
+
+#[derive(Debug)]
+pub(crate) struct DrmDev(File);
+
+impl AsRawFd for DrmDev {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+impl BasicDevice for DrmDev {}
+impl ControlDevice for DrmDev {}
+
+impl DrmDev {
+    unsafe fn new_from_fd(fd: RawFd) -> Self {
+        use std::os::unix::io::FromRawFd;
+        DrmDev(File::from_raw_fd(fd))
+    }
+
+    fn new_from_file(file: File) -> Self {
+        DrmDev(file)
+    }
+}
+
+rental! {
+    mod devices {
+        use drm::control::framebuffer;
+        use gbm::{Device as GbmDevice, Surface as GbmSurface};
+
+        use ::backend::graphics::egl::EGLContext;
+        use super::DrmDev;
+
+        #[rental]
+        pub(crate) struct Context {
+            #[subrental(arity = 2)]
+            devices: Box<Devices>,
+            egl: EGLContext<'devices_1, GbmSurface<'devices_1, framebuffer::Info>>,
+        }
+
+        #[rental]
+        pub(crate) struct Devices {
+            drm: Box<DrmDev>,
+            gbm: GbmDevice<'drm>,
+        }
+    }
+}
+use self::devices::{Context, Devices};
+
+
+// odd naming, but makes sense for the user
+pub struct DrmDevice<H: DrmHandler + 'static> {
+    context: Rc<Context>,
+    backends: Vec<Weak<RefCell<DrmBackendInternal>>>,
+    handler: Option<H>,
+    logger: ::slog::Logger,
+}
+
+impl<H: DrmHandler + 'static> DrmDevice<H> {
+    pub unsafe fn new_from_fd<L>(fd: RawFd, logger: L) -> Result<Self, DrmError>
+    where
+        L: Into<Option<::slog::Logger>>,
+    {
+        DrmDevice::new(
+            DrmDev::new_from_fd(fd),
+            GlAttributes {
+                version: None,
+                profile: None,
+                debug: cfg!(debug_assertions),
+                vsync: true,
+            },
+            logger,
+        )
+    }
+
+    pub unsafe fn new_from_fd_with_gl_attr<L>(fd: RawFd, attributes: GlAttributes, logger: L)
+        -> Result<Self, DrmError>
+    where
+        L: Into<Option<::slog::Logger>>,
+    {
+        DrmDevice::new(DrmDev::new_from_fd(fd), attributes, logger)
+    }
+
+    pub fn new_from_file<L>(file: File, logger: L) -> Result<Self, DrmError>
+    where
+        L: Into<Option<::slog::Logger>>,
+    {
+        DrmDevice::new(
+            DrmDev::new_from_file(file),
+            GlAttributes {
+                version: None,
+                profile: None,
+                debug: cfg!(debug_assertions),
+                vsync: true,
+            },
+            logger,
+        )
+    }
+
+    pub fn new_from_file_with_gl_attr<L>(file: File, attributes: GlAttributes, logger: L)
+                                         -> Result<Self, DrmError>
+    where
+        L: Into<Option<::slog::Logger>>,
+    {
+        DrmDevice::new(DrmDev::new_from_file(file), attributes, logger)
+    }
+
+    fn new<L>(drm: DrmDev, attributes: GlAttributes, logger: L) -> Result<Self, DrmError>
+    where
+        L: Into<Option<::slog::Logger>>,
+    {
+        let log = ::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_drm", "drm" => "device"));
+
+        /* GBM will load a dri driver, but even though they need symbols from
+         * libglapi, in some version of Mesa they are not linked to it. Since
+         * only the gl-renderer module links to it,  these symbols won't be globally available,
+         * and loading the DRI driver fails.
+         * Workaround this by dlopen()'ing libglapi with RTLD_GLOBAL.
+         */
+        unsafe {
+            nix::libc::dlopen(
+                "libglapi.so.0".as_ptr() as *const _,
+                nix::libc::RTLD_LAZY | nix::libc::RTLD_GLOBAL,
+            );
+        }
+
+        Ok(DrmDevice {
+            context: Rc::new(Context::try_new(
+                Box::new(Devices::try_new(Box::new(drm), |drm| {
+                    GbmDevice::new_from_drm::<DrmDevice<H>>(drm).map_err(DrmError::from)
+                })?),
+                |devices| {
+                    EGLContext::new_from_gbm(
+                        devices.gbm,
+                        attributes,
+                        PixelFormatRequirements {
+                            hardware_accelerated: Some(true),
+                            color_bits: Some(24),
+                            alpha_bits: Some(8),
+                            ..Default::default()
+                        },
+                        log.clone(),
+                    ).map_err(DrmError::from)
+                },
+            )?),
+            backends: Vec::new(),
+            handler: None,
+            logger: log,
+        })
+    }
+
+    pub fn create_backend<I>(&mut self, crtc: crtc::Handle, mode: Mode, connectors: I)
+                             -> Result<DrmBackend, DrmError>
+    where
+        I: Into<Vec<connector::Handle>>,
+    {
+        let logger = self.logger
+            .new(o!("drm" => "backend", "crtc" => format!("{:?}", crtc)));
+        let own_id = self.backends.len();
+
+        let backend = Rc::new(RefCell::new(DrmBackendInternal::new(
+            self.context.clone(),
+            crtc,
+            mode,
+            connectors,
+            own_id,
+            logger,
+        )?));
+
+        self.backends.push(Rc::downgrade(&backend));
+
+        Ok(DrmBackend::new(backend))
+    }
+
+    pub fn set_handler(&mut self, handler: H) -> Option<H> {
+        let res = self.handler.take();
+        self.handler = Some(handler);
+        res
+    }
+
+    pub fn clear_handler(&mut self) -> Option<H> {
+        self.handler.take()
+    }
+}
+
+// for users convinience
+impl<H: DrmHandler + 'static> AsRawFd for DrmDevice<H> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.context.head().head().as_raw_fd()
+    }
+}
+impl<H: DrmHandler + 'static> BasicDevice for DrmDevice<H> {}
+impl<H: DrmHandler + 'static> ControlDevice for DrmDevice<H> {}
+
+pub trait DrmHandler {
+    fn ready(&mut self, evlh: &mut EventLoopHandle, id: Id, frame: u32, duration: Duration);
+    fn error(&mut self, evlh: &mut EventLoopHandle, error: IoError);
+}
+
+impl<H: DrmHandler + 'static> FdEventSourceHandler for DrmDevice<H> {
+    fn ready(&mut self, evlh: &mut EventLoopHandle, fd: RawFd, _mask: FdInterest) {
+        use std::any::Any;
+
+        struct DrmDeviceRef(RawFd);
+        impl AsRawFd for DrmDeviceRef {
+            fn as_raw_fd(&self) -> RawFd {
+                self.0
+            }
+        }
+        impl BasicDevice for DrmDeviceRef {}
+        impl ControlDevice for DrmDeviceRef {}
+
+        struct PageFlipHandler<'a, 'b, H: DrmHandler + 'static>(
+            &'a mut DrmDevice<H>,
+            &'b mut EventLoopHandle,
+        );
+
+        impl<'a, 'b, H: DrmHandler + 'static> crtc::PageFlipHandler<DrmDeviceRef> for PageFlipHandler<'a, 'b, H> {
+            fn handle_event(&mut self, _device: &DrmDeviceRef, frame: u32, duration: Duration,
+                            userdata: Box<Any>) {
+                let id: Id = *userdata.downcast().unwrap();
+                if let Some(backend) = self.0.backends[id.raw()].upgrade() {
+                    backend.borrow().unlock_buffer();
+                    if let Some(handler) = self.0.handler.as_mut() {
+                        handler.ready(self.1, id, frame, duration);
+                    }
+                }
+            }
+        }
+
+        crtc::handle_event(
+            &DrmDeviceRef(fd),
+            2,
+            None::<&mut ()>,
+            Some(&mut PageFlipHandler(
+                self,
+                evlh,
+            )),
+            None::<&mut ()>,
+        ).unwrap();
+    }
+
+    fn error(&mut self, evlh: &mut EventLoopHandle, _fd: RawFd, error: IoError) {
+        if let Some(handler) = self.handler.as_mut() {
+            handler.error(evlh, error)
+        }
+    }
+}

--- a/src/backend/graphics/glium.rs
+++ b/src/backend/graphics/glium.rs
@@ -7,7 +7,6 @@ use glium::backend::{Backend, Context, Facade};
 use glium::debug::DebugCallbackBehavior;
 use std::ops::Deref;
 use std::os::raw::c_void;
-
 use std::rc::Rc;
 
 impl From<SwapBuffersError> for GliumSwapBuffersError {
@@ -69,15 +68,9 @@ impl<T: EGLGraphicsBackend> Facade for GliumGraphicsBackend<T> {
     }
 }
 
-/// Converter trait to expose `glium` compatibility for all `EGLGraphicsBackend`s
-pub trait IntoGlium: EGLGraphicsBackend + Sized {
-    /// Wrap the given `EGLGraphicsBackend` to a `GliumGraphicBackend`
-    fn into_glium(self) -> GliumGraphicsBackend<Self>;
-}
-
-impl<T: EGLGraphicsBackend + 'static> IntoGlium for T {
-    fn into_glium(self) -> GliumGraphicsBackend<Self> {
-        GliumGraphicsBackend::new(self)
+impl<T: EGLGraphicsBackend + 'static> From<T> for GliumGraphicsBackend<T> {
+    fn from(backend: T) -> Self {
+        GliumGraphicsBackend::new(backend)
     }
 }
 

--- a/src/backend/graphics/glium.rs
+++ b/src/backend/graphics/glium.rs
@@ -34,7 +34,7 @@ impl<T: EGLGraphicsBackend + 'static> GliumGraphicsBackend<T> {
         GliumGraphicsBackend {
             // cannot fail
             context: unsafe {
-                Context::new::<_, ()>(internal.clone(), false, DebugCallbackBehavior::default()).unwrap()
+                Context::new(internal.clone(), true, DebugCallbackBehavior::default()).unwrap()
             },
             backend: internal,
         }
@@ -56,10 +56,10 @@ impl<T: EGLGraphicsBackend + 'static> GliumGraphicsBackend<T> {
 }
 
 impl<T: EGLGraphicsBackend> Deref for GliumGraphicsBackend<T> {
-    type Target = Context;
+    type Target = T;
 
-    fn deref(&self) -> &Context {
-        &self.context
+    fn deref(&self) -> &T {
+        &self.backend.0
     }
 }
 

--- a/src/backend/graphics/mod.rs
+++ b/src/backend/graphics/mod.rs
@@ -8,6 +8,7 @@ pub trait GraphicsBackend {
     /// Format representing the image drawn for the cursor.
     type CursorFormat;
 
+    /// Error the underlying backend throws if operations fail
     type Error;
 
     /// Sets the cursor position and therefor updates the drawn cursors position.

--- a/src/backend/graphics/mod.rs
+++ b/src/backend/graphics/mod.rs
@@ -8,6 +8,8 @@ pub trait GraphicsBackend {
     /// Format representing the image drawn for the cursor.
     type CursorFormat;
 
+    type Error;
+
     /// Sets the cursor position and therefor updates the drawn cursors position.
     /// Useful as well for e.g. pointer wrapping.
     ///
@@ -19,14 +21,15 @@ pub trait GraphicsBackend {
     /// by the higher compositor and not by the backend. It is still good practice to update
     /// the position after every recieved event, but don't rely on pointer wrapping working.
     ///
-    fn set_cursor_position(&mut self, x: u32, y: u32) -> Result<(), ()>;
+    fn set_cursor_position(&self, x: u32, y: u32) -> Result<(), Self::Error>;
 
     /// Set the cursor drawn on the `GraphicsBackend`.
     ///
     /// The format is entirely dictated by the concrete implementation and might range
     /// from raw image buffers over a fixed list of possible cursor types to simply the
     /// void type () to represent no possible customization of the cursor itself.
-    fn set_cursor_representation(&mut self, cursor: Self::CursorFormat);
+    fn set_cursor_representation(&self, cursor: Self::CursorFormat, hotspot: (u32, u32))
+                                 -> Result<(), Self::Error>;
 }
 
 pub mod software;

--- a/src/backend/input.rs
+++ b/src/backend/input.rs
@@ -1,7 +1,6 @@
 //! Common traits for input backends to receive input from.
 
 use backend::{SeatInternal, TouchSlotInternal};
-
 use std::error::Error;
 
 /// A seat describes a group of input devices and at least one

--- a/src/backend/libinput.rs
+++ b/src/backend/libinput.rs
@@ -6,7 +6,6 @@ use input as libinput;
 use input::event;
 use std::collections::hash_map::{DefaultHasher, Entry, HashMap};
 use std::hash::{Hash, Hasher};
-
 use std::io::Error as IoError;
 use std::rc::Rc;
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -18,6 +18,8 @@ pub mod graphics;
 
 #[cfg(feature = "backend_winit")]
 pub mod winit;
+#[cfg(feature = "backend_drm")]
+pub mod drm;
 #[cfg(feature = "backend_libinput")]
 pub mod libinput;
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -7,6 +7,7 @@
 //! Supported graphics backends:
 //!
 //! - winit
+//! - drm
 //!
 //! Supported input backends:
 //!

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -2,8 +2,8 @@
 
 use backend::{SeatInternal, TouchSlotInternal};
 use backend::graphics::GraphicsBackend;
-use backend::graphics::egl::{CreationError, EGLContext, EGLGraphicsBackend, GlAttributes, NativeDisplay,
-                             NativeSurface, PixelFormat, PixelFormatRequirements, SwapBuffersError};
+use backend::graphics::egl::{CreationError, EGLContext, EGLGraphicsBackend, GlAttributes, PixelFormat,
+                             PixelFormatRequirements, SwapBuffersError};
 use backend::input::{Axis, AxisSource, Event as BackendEvent, InputBackend, InputHandler, KeyState,
                      KeyboardKeyEvent, MouseButton, MouseButtonState, PointerAxisEvent, PointerButtonEvent,
                      PointerMotionAbsoluteEvent, Seat, SeatCapabilities, TouchCancelEvent, TouchDownEvent,
@@ -14,31 +14,36 @@ use std::cmp;
 use std::error::Error;
 use std::fmt;
 use std::rc::Rc;
-use wayland_client::egl as wegl;
 use winit::{CreationError as WinitCreationError, ElementState, Event, EventsLoop, KeyboardInput,
-            MouseButton as WinitMouseButton, MouseCursor, MouseScrollDelta, Touch, TouchPhase, Window,
+            MouseButton as WinitMouseButton, MouseCursor, MouseScrollDelta, Touch, TouchPhase,
             WindowBuilder, WindowEvent};
-use winit::os::unix::{WindowExt, get_x11_xconnection};
 
 rental! {
-    mod egl {
+    mod rental {
         use std::boxed::Box;
+        use ::winit::{Window as WinitWindow};
         use ::backend::graphics::egl::{EGLContext, EGLSurface};
 
+        #[rental]
+        pub struct Window {
+            window: Box<WinitWindow>,
+            egl: EGL<'window>,
+        }
 
-        #[rental(deref_suffix)]
-        pub struct RentEGL {
-            context: Box<EGLContext>,
-            surface: EGLSurface<'context>,
+        #[rental]
+        pub struct EGL<'a> {
+            context: Box<EGLContext<'a, WinitWindow>>,
+            surface: EGLSurface<'context, 'a, WinitWindow>,
         }
     }
 }
+
+use self::rental::{Window, EGL};
 
 /// Window with an active EGL Context created by `winit`. Implements the
 /// `EGLGraphicsBackend` graphics backend trait
 pub struct WinitGraphicsBackend {
     window: Rc<Window>,
-    context: egl::RentEGL,
     logger: ::slog::Logger,
 }
 
@@ -48,7 +53,6 @@ pub struct WinitGraphicsBackend {
 pub struct WinitInputBackend {
     events_loop: EventsLoop,
     window: Rc<Window>,
-    surface: Option<wegl::WlEglSurface>,
     time_counter: u32,
     key_counter: u32,
     seat: Seat,
@@ -107,69 +111,46 @@ where
     info!(log, "Initializing a winit backend");
 
     let events_loop = EventsLoop::new();
-    let window = Rc::new(builder.build(&events_loop)?);
+    let winit_window = builder.build(&events_loop)?;
     debug!(log, "Window created");
 
-    let (native_display, native_surface, surface) = if let (Some(conn), Some(window)) =
-        (get_x11_xconnection(), window.get_xlib_window())
-    {
-        debug!(log, "Window is backed by X11");
-        (
-            NativeDisplay::X11(conn.display as *const _),
-            NativeSurface::X11(window),
-            None,
-        )
-    } else if let (Some(display), Some(surface)) =
-        (window.get_wayland_display(), window.get_wayland_surface())
-    {
-        debug!(log, "Window is backed by Wayland");
-        let (w, h) = window.get_inner_size().unwrap();
-        let egl_surface = unsafe { wegl::WlEglSurface::new_from_raw(surface as *mut _, w as i32, h as i32) };
-        (
-            NativeDisplay::Wayland(display),
-            NativeSurface::Wayland(egl_surface.ptr() as *const _),
-            Some(egl_surface),
-        )
-    } else {
-        error!(log, "Window is backed by an unsupported graphics framework");
-        return Err(CreationError::NotSupported);
-    };
-
-    let context = unsafe {
-        match EGLContext::new(
-            native_display,
-            attributes,
-            PixelFormatRequirements {
-                hardware_accelerated: Some(true),
-                color_bits: Some(24),
-                alpha_bits: Some(8),
-                ..Default::default()
-            },
-            log.clone(),
+    let window = match Window::try_new(Box::new(winit_window), |window| {
+        match EGL::try_new(
+            Box::new(match EGLContext::new_from_winit(
+                &*window,
+                attributes,
+                PixelFormatRequirements {
+                    hardware_accelerated: Some(true),
+                    color_bits: Some(24),
+                    alpha_bits: Some(8),
+                    ..Default::default()
+                },
+                log.clone(),
+            ) {
+                Ok(context) => context,
+                Err(err) => {
+                    error!(log, "EGLContext creation failed:\n {}", err);
+                    return Err(err);
+                }
+            }),
+            |context| context.create_surface(window),
         ) {
-            Ok(context) => context,
-            Err(err) => {
-                error!(log, "EGLContext creation failed:\n {}", err);
-                return Err(err);
-            }
+            Ok(x) => Ok(x),
+            Err(::rental::TryNewError(err, _)) => return Err(err),
         }
+    }) {
+        Ok(x) => Rc::new(x),
+        Err(::rental::TryNewError(err, _)) => return Err(err),
     };
 
     Ok((
         WinitGraphicsBackend {
             window: window.clone(),
-            context: match egl::RentEGL::try_new(Box::new(context), move |context| unsafe {
-                context.create_surface(native_surface)
-            }) {
-                Ok(x) => x,
-                Err(::rental::TryNewError(err, _)) => return Err(err),
-            },
             logger: log.new(o!("smithay_winit_component" => "graphics")),
         },
         WinitInputBackend {
-            events_loop: events_loop,
-            window: window,
-            surface: surface,
+            events_loop,
+            window,
             time_counter: 0,
             key_counter: 0,
             seat: Seat::new(
@@ -189,47 +170,52 @@ where
 
 impl GraphicsBackend for WinitGraphicsBackend {
     type CursorFormat = MouseCursor;
+    type Error = ();
 
-    fn set_cursor_position(&mut self, x: u32, y: u32) -> Result<(), ()> {
+    fn set_cursor_position(&self, x: u32, y: u32) -> Result<(), ()> {
         debug!(self.logger, "Setting cursor position to {:?}", (x, y));
-        self.window.set_cursor_position(x as i32, y as i32)
+        self.window.head().set_cursor_position(x as i32, y as i32)
     }
 
-    fn set_cursor_representation(&mut self, cursor: Self::CursorFormat) {
+    fn set_cursor_representation(&self, cursor: Self::CursorFormat, _hotspot: (u32, u32)) -> Result<(), ()> {
         // Cannot log this one, as `CursorFormat` is not `Debug` and should not be
         debug!(self.logger, "Changing cursor representation");
-        self.window.set_cursor(cursor)
+        self.window.head().set_cursor(cursor);
+        Ok(())
     }
 }
 
 impl EGLGraphicsBackend for WinitGraphicsBackend {
     fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
         trace!(self.logger, "Swapping buffers");
-        self.context.rent(|surface| surface.swap_buffers())
+        self.window
+            .rent(|egl| egl.rent(|surface| surface.swap_buffers()))
     }
 
     unsafe fn get_proc_address(&self, symbol: &str) -> *const c_void {
         trace!(self.logger, "Getting symbol for {:?}", symbol);
-        self.context.get_proc_address(symbol)
+        self.window.rent(|egl| egl.head().get_proc_address(symbol))
     }
 
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
         self.window
+            .head()
             .get_inner_size_pixels()
             .expect("Window does not exist anymore")
     }
 
     fn is_current(&self) -> bool {
-        self.context.is_current()
+        self.window.rent(|egl| egl.head().is_current())
     }
 
     unsafe fn make_current(&self) -> Result<(), SwapBuffersError> {
         debug!(self.logger, "Setting EGL context to be the current context");
-        self.context.rent(|surface| surface.make_current())
+        self.window
+            .rent(|egl| egl.rent(|surface| surface.make_current()))
     }
 
     fn get_pixel_format(&self) -> PixelFormat {
-        self.context.get_pixel_format()
+        self.window.rent(|egl| egl.head().get_pixel_format())
     }
 }
 
@@ -310,16 +296,24 @@ impl PointerMotionAbsoluteEvent for WinitMouseMovedEvent {
 
     fn x_transformed(&self, width: u32) -> u32 {
         cmp::min(
-            (self.x * width as f64 / self.window.get_inner_size_points().unwrap_or((width, 0)).0 as f64) as
-                u32,
+            (self.x * width as f64 /
+                self.window
+                    .head()
+                    .get_inner_size_points()
+                    .unwrap_or((width, 0))
+                    .0 as f64) as u32,
             0,
         )
     }
 
     fn y_transformed(&self, height: u32) -> u32 {
         cmp::min(
-            (self.y * height as f64 / self.window.get_inner_size_points().unwrap_or((0, height)).1 as f64) as
-                u32,
+            (self.y * height as f64 /
+                self.window
+                    .head()
+                    .get_inner_size_points()
+                    .unwrap_or((0, height))
+                    .1 as f64) as u32,
             0,
         )
     }
@@ -416,7 +410,11 @@ impl TouchDownEvent for WinitTouchStartedEvent {
     fn x_transformed(&self, width: u32) -> u32 {
         cmp::min(
             self.location.0 as i32 * width as i32 /
-                self.window.get_inner_size_points().unwrap_or((width, 0)).0 as i32,
+                self.window
+                    .head()
+                    .get_inner_size_points()
+                    .unwrap_or((width, 0))
+                    .0 as i32,
             0,
         ) as u32
     }
@@ -424,7 +422,11 @@ impl TouchDownEvent for WinitTouchStartedEvent {
     fn y_transformed(&self, height: u32) -> u32 {
         cmp::min(
             self.location.1 as i32 * height as i32 /
-                self.window.get_inner_size_points().unwrap_or((0, height)).1 as i32,
+                self.window
+                    .head()
+                    .get_inner_size_points()
+                    .unwrap_or((0, height))
+                    .1 as i32,
             0,
         ) as u32
     }
@@ -459,11 +461,21 @@ impl TouchMotionEvent for WinitTouchMovedEvent {
     }
 
     fn x_transformed(&self, width: u32) -> u32 {
-        self.location.0 as u32 * width / self.window.get_inner_size_points().unwrap_or((width, 0)).0
+        self.location.0 as u32 * width /
+            self.window
+                .head()
+                .get_inner_size_points()
+                .unwrap_or((width, 0))
+                .0
     }
 
     fn y_transformed(&self, height: u32) -> u32 {
-        self.location.1 as u32 * height / self.window.get_inner_size_points().unwrap_or((0, height)).1
+        self.location.1 as u32 * height /
+            self.window
+                .head()
+                .get_inner_size_points()
+                .unwrap_or((0, height))
+                .1
     }
 }
 
@@ -578,7 +590,6 @@ impl InputBackend for WinitInputBackend {
             let mut time_counter = &mut self.time_counter;
             let seat = &self.seat;
             let window = &self.window;
-            let surface = &self.surface;
             let mut handler = self.handler.as_mut();
             let logger = &self.logger;
 
@@ -587,10 +598,12 @@ impl InputBackend for WinitInputBackend {
                     match (event, handler.as_mut()) {
                         (WindowEvent::Resized(x, y), _) => {
                             trace!(logger, "Resizing window to {:?}", (x, y));
-                            window.set_inner_size(x, y);
-                            if let Some(wl_egl_surface) = surface.as_ref() {
-                                wl_egl_surface.resize(x as i32, y as i32, 0, 0);
-                            }
+                            window.head().set_inner_size(x, y);
+                            window.rent(|egl| {
+                                egl.rent(|surface| if let Some(wegl_surface) = (**surface).as_ref() {
+                                    wegl_surface.resize(x as i32, y as i32, 0, 0)
+                                })
+                            });
                         }
                         (
                             WindowEvent::KeyboardInput {

--- a/src/compositor/region.rs
+++ b/src/compositor/region.rs
@@ -11,8 +11,9 @@ pub struct RegionData {
 impl RegionData {
     /// Initialize the user_data of a region, must be called right when the surface is created
     pub unsafe fn init(region: &wl_region::WlRegion) {
-        region.set_user_data(Box::into_raw(Box::new(Mutex::new(RegionData::default())))
-            as *mut _)
+        region.set_user_data(
+            Box::into_raw(Box::new(Mutex::new(RegionData::default()))) as *mut _,
+        )
     }
 
     /// Cleans the user_data of that surface, must be called when it is destroyed

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -21,14 +21,10 @@ use backend::input::KeyState;
 use std::io::{Error as IoError, Write};
 use std::os::unix::io::AsRawFd;
 use std::sync::{Arc, Mutex};
-
 use tempfile::tempfile;
-
 use wayland_server::{Liveness, Resource};
 use wayland_server::protocol::{wl_keyboard, wl_surface};
-
 use xkbcommon::xkb;
-
 pub use xkbcommon::xkb::{keysyms, Keysym};
 
 /// Represents the current state of the keyboard modifiers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
+extern crate image;
 extern crate nix;
 #[macro_use]
 extern crate rental;
@@ -15,6 +16,10 @@ extern crate wayland_protocols;
 extern crate wayland_server;
 extern crate xkbcommon;
 
+#[cfg(feature = "backend_drm")]
+extern crate drm;
+#[cfg(feature = "backend_drm")]
+extern crate gbm;
 #[cfg(feature = "backend_libinput")]
 extern crate input;
 #[cfg(feature = "backend_winit")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
+// `error_chain!` can recurse deeply
+#![recursion_limit = "1024"]
 
 extern crate image;
 extern crate nix;
@@ -35,6 +37,9 @@ extern crate glium;
 #[macro_use]
 extern crate slog;
 extern crate slog_stdlog;
+
+#[macro_use]
+extern crate error_chain;
 
 pub mod backend;
 pub mod compositor;

--- a/src/shell/xdg_handlers.rs
+++ b/src/shell/xdg_handlers.rs
@@ -682,8 +682,8 @@ where
         destroy: |evlh, idata, _, popup| {
             let ptr = popup.get_user_data();
             let &(ref surface, _, _) = unsafe {
-                &*(ptr
-                    as *mut (
+                &*(ptr as
+                    *mut (
                         wl_surface::WlSurface,
                         zxdg_shell_v6::ZxdgShellV6,
                         zxdg_surface_v6::ZxdgSurfaceV6,


### PR DESCRIPTION
Rough list of changes:

- new backend rendering via egl via gbm directly on a drm device
- refine EGLContext and EGLSurface dependencies through lifetimes and surface types (super safe now, no unsafe code for initializing is required anymore outside of egl.rs itself).
- add new example using the drm backend instead
- change GliumDrawer to be static for the drm example
- fixup the old winit backend and example to work with these changes

I am sorry this turned out to be one commit (ouch), but I reworked this for so many times and had to rebase this on your re-formatted code, so you might be able to imagine that mess.

This is ready for a first review. ~It is only missing a lot of documentation and more logging.~ It appears to work just fine on my machine and does not seem to have broken anything.