### PR TITLE
added scroll events to pointer and winit demo

### DIFF
--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -16,7 +16,7 @@ use helpers::{init_shell, GliumDrawer, MyWindowMap};
 use slog::{Drain, Logger};
 use smithay::backend::graphics::egl::EGLGraphicsBackend;
 use smithay::backend::input::{self, Event, InputBackend, InputHandler, KeyboardKeyEvent, PointerButtonEvent,
-                              PointerMotionAbsoluteEvent};
+                              PointerMotionAbsoluteEvent, PointerAxisEvent};
 use smithay::backend::winit;
 use smithay::wayland::compositor::{SubsurfaceRole, TraversalAction};
 use smithay::wayland::compositor::roles::Role;
@@ -97,8 +97,12 @@ impl InputHandler<winit::WinitInputBackend> for WinitInputHandler {
         };
         self.pointer.button(button, state, serial, evt.time());
     }
-    fn on_pointer_axis(&mut self, _: &input::Seat, _: winit::WinitMouseWheelEvent) {
-        /* not done in this example */
+    fn on_pointer_axis(&mut self, _: &input::Seat, evt: winit::WinitMouseWheelEvent) {
+        let axis = match evt.axis() {
+            input::Axis::Vertical => wayland_server::protocol::wl_pointer::Axis::VerticalScroll,
+            input::Axis::Horizontal => wayland_server::protocol::wl_pointer::Axis::HorizontalScroll,
+        };
+        self.pointer.axis(axis, evt.amount(), evt.time());
     }
     fn on_touch_down(&mut self, _: &input::Seat, _: winit::WinitTouchStartedEvent) {
         /* not done in this example */

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -104,7 +104,13 @@ impl PointerHandle {
         })
     }
 
-    // TODO: handle axis
+    /// send axis events
+    pub fn axis(&self, axis: wl_pointer::Axis, value: f64, time: u32) {
+        let guard = self.inner.lock().unwrap();
+        guard.with_focused_pointers(|pointer, _| {
+            pointer.axis(time, axis, value);
+        })
+    }
 
     pub(crate) fn cleanup_old_pointers(&self) {
         let mut guard = self.inner.lock().unwrap();


### PR DESCRIPTION
My first PR here (and in Rust anywhere). I'm not sure the correct way to pass around the axis enum (input::Axis, wl_pointer::Axis, or something else). I went with wl_pointer::Axis. I tested with weston-eventdemo and weston-terminal and everything seems to work. Merge, edit or ignore as you wish.