### PR TITLE
wayland.shell: fix memory corruption in wl_shell

### DIFF
--- a/src/wayland/shell/wl_handlers.rs
+++ b/src/wayland/shell/wl_handlers.rs
@@ -84,7 +84,7 @@ where
                 return;
             }
             shell_surface
-                .set_user_data(Box::into_raw(Box::new(unsafe { surface.clone_unchecked() })) as *mut _);
+                .set_user_data(Box::into_raw(Box::new(unsafe { (surface.clone_unchecked(), shell.clone_unchecked()) })) as *mut _);
             evlh.register(
                 &shell_surface,
                 shell_surface_implementation(),


### PR DESCRIPTION
Invalid data was set as user data for wl_shell_surface, causing
access to invalid memory at drop time.

Fixes #60