### PR TITLE
Introduce SessionObserver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,9 @@ backend_session_udev = ["udev", "backend_session"]
 backend_session_logind = ["dbus", "systemd", "backend_session"]
 backend_udev = ["udev", "backend_drm", "backend_session_udev"]
 renderer_glium = ["glium"]
+
+[patch.crates-io]
+wayland-server = { git = "https://github.com/Drakulix/wayland-rs.git", branch = "feature/with_idata" }
+wayland-protocols = { git = "https://github.com/Drakulix/wayland-rs.git", branch = "feature/with_idata" }
+wayland-client = { git = "https://github.com/Drakulix/wayland-rs.git", branch = "feature/with_idata" }
+wayland-sys = { git = "https://github.com/Drakulix/wayland-rs.git", branch = "feature/with_idata" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ description = "Smithay is a library for writing wayland compositors."
 repository = "https://github.com/Smithay/smithay"
 
 [dependencies]
-wayland-server = "0.13.0"
-wayland-sys = "0.13.0"
+wayland-server = "0.14.0"
+wayland-sys = "0.14.0"
 nix = "0.9.0"
 xkbcommon = "0.2.1"
 tempfile = "2.1.5"
@@ -24,7 +24,7 @@ input = { version = "0.4.0", optional = true }
 udev = { version = "0.2.0", optional = true }
 dbus = { version = "0.6.1", optional = true }
 systemd = { version = "^0.2.0", optional = true }
-wayland-protocols = { version = "0.13.0", features = ["unstable_protocols", "server"] }
+wayland-protocols = { version = "0.14.0", features = ["unstable_protocols", "server"] }
 image = "0.17.0"
 error-chain = "0.11.0"
 lazy_static = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ description = "Smithay is a library for writing wayland compositors."
 repository = "https://github.com/Smithay/smithay"
 
 [dependencies]
-wayland-server = "0.12.5"
-wayland-sys = "0.12.5"
+wayland-server = "0.13.0"
+wayland-sys = "0.13.0"
 nix = "0.9.0"
 xkbcommon = "0.2.1"
 tempfile = "2.1.5"
@@ -24,7 +24,7 @@ input = { version = "0.4.0", optional = true }
 udev = { version = "0.2.0", optional = true }
 dbus = { version = "0.6.1", optional = true }
 systemd = { version = "^0.2.0", optional = true }
-wayland-protocols = { version = "0.12.5", features = ["unstable_protocols", "server"] }
+wayland-protocols = { version = "0.13.0", features = ["unstable_protocols", "server"] }
 image = "0.17.0"
 error-chain = "0.11.0"
 lazy_static = "1.0.0"
@@ -47,9 +47,3 @@ backend_session_udev = ["udev", "backend_session"]
 backend_session_logind = ["dbus", "systemd", "backend_session"]
 backend_udev = ["udev", "backend_drm", "backend_session_udev"]
 renderer_glium = ["glium"]
-
-[patch.crates-io]
-wayland-server = { git = "https://github.com/Drakulix/wayland-rs.git", branch = "feature/with_idata" }
-wayland-protocols = { git = "https://github.com/Drakulix/wayland-rs.git", branch = "feature/with_idata" }
-wayland-client = { git = "https://github.com/Drakulix/wayland-rs.git", branch = "feature/with_idata" }
-wayland-sys = { git = "https://github.com/Drakulix/wayland-rs.git", branch = "feature/with_idata" }

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -34,6 +34,7 @@ use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
 use std::rc::Rc;
 use std::time::Duration;
+use wayland_server::EventLoopHandle;
 
 #[derive(Debug)]
 pub struct Card(File);
@@ -165,7 +166,7 @@ pub struct DrmHandlerImpl {
 
 impl DrmHandler<Card> for DrmHandlerImpl {
     fn ready(
-        &mut self, _device: &mut DrmDevice<Card>, _crtc: crtc::Handle, _frame: u32, _duration: Duration
+        &mut self, _evlh: &mut EventLoopHandle, _device: &mut DrmDevice<Card>, _crtc: crtc::Handle, _frame: u32, _duration: Duration
     ) {
         let mut frame = self.drawer.draw();
         frame.clear_color(0.8, 0.8, 0.9, 1.0);
@@ -245,7 +246,7 @@ impl DrmHandler<Card> for DrmHandlerImpl {
         frame.finish().unwrap();
     }
 
-    fn error(&mut self, _device: &mut DrmDevice<Card>, error: DrmError) {
+    fn error(&mut self, _evlh: &mut EventLoopHandle, _device: &mut DrmDevice<Card>, error: DrmError) {
         panic!("{:?}", error);
     }
 }

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -147,7 +147,8 @@ fn main() {
             drawer: renderer,
             logger: log,
         },
-    ).unwrap();
+    ).map_err(|(err, _)| err)
+        .unwrap();
 
     loop {
         event_loop.dispatch(Some(16)).unwrap();
@@ -166,7 +167,8 @@ pub struct DrmHandlerImpl {
 
 impl DrmHandler<Card> for DrmHandlerImpl {
     fn ready(
-        &mut self, _evlh: &mut EventLoopHandle, _device: &mut DrmDevice<Card>, _crtc: crtc::Handle, _frame: u32, _duration: Duration
+        &mut self, _evlh: &mut EventLoopHandle, _device: &mut DrmDevice<Card>, _crtc: crtc::Handle,
+        _frame: u32, _duration: Duration,
     ) {
         let mut frame = self.drawer.draw();
         frame.clear_color(0.8, 0.8, 0.9, 1.0);

--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -137,10 +137,9 @@ fn main() {
     /*
      * Register the DrmDevice on the EventLoop
      */
-    let device_token = event_loop.state().insert(device);
     let _source = drm_device_bind(
         &mut event_loop,
-        device_token,
+        device,
         DrmHandlerImpl {
             compositor_token,
             window_map: window_map.clone(),

--- a/examples/udev.rs
+++ b/examples/udev.rs
@@ -55,8 +55,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use wayland_server::{Display, EventLoopHandle};
-use wayland_server::sources::EventSource;
 use wayland_server::protocol::{wl_output, wl_pointer};
+use wayland_server::sources::EventSource;
 use xkbcommon::xkb::keysyms as xkb;
 
 struct LibinputInputHandler {
@@ -475,17 +475,13 @@ impl UdevHandler<DrmHandlerImpl> for UdevHandlerImpl {
         })
     }
 
-    fn device_changed(
-        &mut self, _evlh: &mut EventLoopHandle, device: &mut DrmDevice<SessionFdDrmDevice>
-    ) {
+    fn device_changed(&mut self, _evlh: &mut EventLoopHandle, device: &mut DrmDevice<SessionFdDrmDevice>) {
         //quick and dirt, just re-init all backends
         let backends = self.backends.get(&device.device_id()).unwrap();
         *backends.borrow_mut() = self.scan_connectors(device);
     }
 
-    fn device_removed(
-        &mut self, _evlh: &mut EventLoopHandle, device: &mut DrmDevice<SessionFdDrmDevice>
-    ) {
+    fn device_removed(&mut self, _evlh: &mut EventLoopHandle, device: &mut DrmDevice<SessionFdDrmDevice>) {
         // drop the backends on this side
         self.backends.remove(&device.device_id());
 

--- a/examples/udev.rs
+++ b/examples/udev.rs
@@ -506,7 +506,7 @@ pub struct DrmHandlerImpl {
 
 impl DrmHandler<SessionFdDrmDevice> for DrmHandlerImpl {
     fn ready(
-        &mut self, _device: &mut DrmDevice<SessionFdDrmDevice>, crtc: crtc::Handle, _frame: u32,
+        &mut self, _evlh: &mut EventLoopHandle, _device: &mut DrmDevice<SessionFdDrmDevice>, crtc: crtc::Handle, _frame: u32,
         _duration: Duration,
     ) {
         if let Some(drawer) = self.backends.borrow().get(&crtc) {
@@ -597,7 +597,7 @@ impl DrmHandler<SessionFdDrmDevice> for DrmHandlerImpl {
         }
     }
 
-    fn error(&mut self, _device: &mut DrmDevice<SessionFdDrmDevice>, error: DrmError) {
+    fn error(&mut self, _evlh: &mut EventLoopHandle, _device: &mut DrmDevice<SessionFdDrmDevice>, error: DrmError) {
         error!(self.logger, "{:?}", error);
     }
 }

--- a/examples/udev.rs
+++ b/examples/udev.rs
@@ -357,10 +357,16 @@ fn main() {
             running: running.clone(),
         },
     );
-    let libinput_event_source = libinput_bind(libinput_backend, &mut event_loop).unwrap();
+    let libinput_event_source = libinput_bind(libinput_backend, &mut event_loop)
+        .map_err(|(err, _)| err)
+        .unwrap();
 
-    let session_event_source = auto_session_bind(notifier, &mut event_loop).unwrap();
-    let udev_event_source = udev_backend_bind(&mut event_loop, udev_backend).unwrap();
+    let session_event_source = auto_session_bind(notifier, &mut event_loop)
+        .map_err(|(err, _)| err)
+        .unwrap();
+    let udev_event_source = udev_backend_bind(&mut event_loop, udev_backend)
+        .map_err(|(err, _)| err)
+        .unwrap();
 
     while running.load(Ordering::SeqCst) {
         if let Err(_) = event_loop.dispatch(Some(16)) {
@@ -506,8 +512,8 @@ pub struct DrmHandlerImpl {
 
 impl DrmHandler<SessionFdDrmDevice> for DrmHandlerImpl {
     fn ready(
-        &mut self, _evlh: &mut EventLoopHandle, _device: &mut DrmDevice<SessionFdDrmDevice>, crtc: crtc::Handle, _frame: u32,
-        _duration: Duration,
+        &mut self, _evlh: &mut EventLoopHandle, _device: &mut DrmDevice<SessionFdDrmDevice>,
+        crtc: crtc::Handle, _frame: u32, _duration: Duration,
     ) {
         if let Some(drawer) = self.backends.borrow().get(&crtc) {
             {
@@ -597,7 +603,9 @@ impl DrmHandler<SessionFdDrmDevice> for DrmHandlerImpl {
         }
     }
 
-    fn error(&mut self, _evlh: &mut EventLoopHandle, _device: &mut DrmDevice<SessionFdDrmDevice>, error: DrmError) {
+    fn error(
+        &mut self, _evlh: &mut EventLoopHandle, _device: &mut DrmDevice<SessionFdDrmDevice>, error: DrmError
+    ) {
         error!(self.logger, "{:?}", error);
     }
 }

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -139,6 +139,7 @@
 //! # use std::time::Duration;
 //! use smithay::backend::drm::{DrmDevice, DrmBackend, DrmHandler, drm_device_bind};
 //! use smithay::backend::graphics::egl::EGLGraphicsBackend;
+//! use wayland_server::EventLoopHandle;
 //! #
 //! # #[derive(Debug)]
 //! # pub struct Card(File);
@@ -180,6 +181,7 @@
 //! impl DrmHandler<Card> for MyDrmHandler {
 //!     fn ready(
 //!         &mut self,
+//!         _evlh: &mut EventLoopHandle,
 //!         _device: &mut DrmDevice<Card>,
 //!         _crtc: CrtcHandle,
 //!         _frame: u32,
@@ -190,6 +192,7 @@
 //!     }
 //!     fn error(
 //!         &mut self,
+//!         _evlh: &mut EventLoopHandle,
 //!         device: &mut DrmDevice<Card>,
 //!         error: DrmError)
 //!     {

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -52,7 +52,6 @@
 //! use std::os::unix::io::RawFd;
 //! use std::os::unix::io::AsRawFd;
 //! use smithay::backend::drm::{DrmDevice, DrmBackend};
-//! use wayland_server::StateToken;
 //!
 //! #[derive(Debug)]
 //! pub struct Card(File);
@@ -201,8 +200,7 @@
 //! // render something (like clear_color)
 //! backend.swap_buffers().unwrap();
 //!
-//! let device_token = event_loop.state().insert(device);
-//! let _source = drm_device_bind(&mut event_loop, device_token, MyDrmHandler(backend)).unwrap();
+//! let _source = drm_device_bind(&mut event_loop, device, MyDrmHandler(backend)).unwrap();
 //!
 //! event_loop.run().unwrap();
 //! # }
@@ -213,7 +211,7 @@ use backend::graphics::egl::error::Result as EGLResult;
 use backend::graphics::egl::native::Gbm;
 use backend::graphics::egl::wayland::{EGLDisplay, EGLWaylandExtensions};
 #[cfg(feature = "backend_session")]
-use backend::session::SessionObserver;
+use backend::session::{AsSessionObserver, SessionObserver};
 use drm::Device as BasicDevice;
 use drm::control::{connector, crtc, encoder, Mode, ResourceInfo};
 use drm::control::Device as ControlDevice;
@@ -222,17 +220,17 @@ use drm::result::Error as DrmError;
 use gbm::{BufferObject, Device as GbmDevice};
 use nix;
 use nix::sys::stat::{self, dev_t, fstat};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::io::Result as IoResult;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
 use std::rc::{Rc, Weak};
-use std::sync::{Once, ONCE_INIT};
+use std::sync::{Arc, Once, ONCE_INIT};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
-use wayland_server::{Display, EventLoopHandle, StateToken};
-#[cfg(feature = "backend_session")]
-use wayland_server::StateProxy;
+use wayland_server::{Display, EventLoopHandle};
 use wayland_server::sources::{FdEventSource, FdEventSourceImpl, FdInterest};
 
 mod backend;
@@ -249,8 +247,8 @@ pub struct DrmDevice<A: ControlDevice + 'static> {
     context: Rc<EGLContext<Gbm<framebuffer::Info>, GbmDevice<A>>>,
     old_state: HashMap<crtc::Handle, (crtc::Info, Vec<connector::Handle>)>,
     device_id: dev_t,
-    backends: HashMap<crtc::Handle, Weak<DrmBackendInternal<A>>>,
-    active: bool,
+    backends: Rc<RefCell<HashMap<crtc::Handle, Weak<DrmBackendInternal<A>>>>>,
+    active: Arc<AtomicBool>,
     priviledged: bool,
     logger: ::slog::Logger,
 }
@@ -316,10 +314,10 @@ impl<A: ControlDevice + 'static> DrmDevice<A> {
                 Default::default(),
                 log.clone(),
             ).map_err(Error::from)?),
-            backends: HashMap::new(),
+            backends: Rc::new(RefCell::new(HashMap::new())),
             device_id,
             old_state: HashMap::new(),
-            active: true,
+            active: Arc::new(AtomicBool::new(true)),
             priviledged: true,
             logger: log.clone(),
         };
@@ -382,11 +380,11 @@ impl<A: ControlDevice + 'static> DrmDevice<A> {
     where
         I: Into<Vec<connector::Handle>>,
     {
-        if self.backends.contains_key(&crtc) {
+        if self.backends.borrow().contains_key(&crtc) {
             bail!(ErrorKind::CrtcAlreadyInUse(crtc));
         }
 
-        if !self.active {
+        if !self.active.load(Ordering::SeqCst) {
             bail!(ErrorKind::DeviceInactive);
         }
 
@@ -441,7 +439,7 @@ impl<A: ControlDevice + 'static> DrmDevice<A> {
 
         let logger = self.logger.new(o!("crtc" => format!("{:?}", crtc)));
         let backend = DrmBackend::new(self.context.clone(), crtc, mode, connectors, logger)?;
-        self.backends.insert(crtc, backend.weak());
+        self.backends.borrow_mut().insert(crtc, backend.weak());
         Ok(backend)
     }
 
@@ -543,13 +541,13 @@ pub trait DrmHandler<A: ControlDevice + 'static> {
 ///
 /// This will cause it to recieve events and feed them into an `DrmHandler`
 pub fn drm_device_bind<A, H>(
-    evlh: &mut EventLoopHandle, device: StateToken<DrmDevice<A>>, handler: H
-) -> IoResult<FdEventSource<(StateToken<DrmDevice<A>>, H)>>
+    evlh: &mut EventLoopHandle, device: DrmDevice<A>, handler: H
+) -> IoResult<FdEventSource<(DrmDevice<A>, H)>>
 where
     A: ControlDevice + 'static,
     H: DrmHandler<A> + 'static,
 {
-    let fd = evlh.state().get(&device).as_raw_fd();
+    let fd = device.as_raw_fd();
     evlh.add_fd_event_source(
         fd,
         fd_event_source_implementation(),
@@ -558,26 +556,19 @@ where
     )
 }
 
-fn fd_event_source_implementation<A, H>() -> FdEventSourceImpl<(StateToken<DrmDevice<A>>, H)>
+fn fd_event_source_implementation<A, H>() -> FdEventSourceImpl<(DrmDevice<A>, H)>
 where
     A: ControlDevice + 'static,
     H: DrmHandler<A> + 'static,
 {
     FdEventSourceImpl {
-        ready: |evlh, &mut (ref mut dev_token, ref mut handler), _, _| {
-            let (events, logger) = {
-                let dev = evlh.state().get(dev_token);
-                let events = crtc::receive_events(dev);
-                let logger = dev.logger.clone();
-                (events, logger)
-            };
-
-            match events {
+        ready: |_evlh, &mut (ref mut device, ref mut handler), _, _| {
+            match crtc::receive_events(device) {
                 Ok(events) => for event in events {
                     if let crtc::Event::PageFlip(event) = event {
-                        let dev = evlh.state().get_mut(dev_token);
-                        if dev.active {
-                            if let Some(backend) = dev.backends
+                        if device.active.load(Ordering::SeqCst) {
+                            let backends = device.backends.borrow().clone();
+                            if let Some(backend) = backends
                                 .get(&event.crtc)
                                 .iter()
                                 .flat_map(|x| x.upgrade())
@@ -585,39 +576,60 @@ where
                             {
                                 // we can now unlock the buffer
                                 backend.unlock_buffer();
-                                trace!(logger, "Handling event for backend {:?}", event.crtc);
+                                trace!(device.logger, "Handling event for backend {:?}", event.crtc);
                                 // and then call the user to render the next frame
-                                handler.ready(dev, event.crtc, event.frame, event.duration);
+                                handler.ready(device, event.crtc, event.frame, event.duration);
                             } else {
-                                dev.backends.remove(&event.crtc);
+                                device.backends.borrow_mut().remove(&event.crtc);
                             }
                         }
                     }
                 },
-                Err(err) => handler.error(evlh.state().get_mut(dev_token), err),
+                Err(err) => handler.error(device, err),
             };
         },
-        error: |evlh, &mut (ref mut dev_token, ref mut handler), _, error| {
-            let mut dev = evlh.state().get_mut(dev_token);
-            warn!(dev.logger, "DrmDevice errored: {}", error);
-            handler.error(&mut dev, error.into());
+        error: |_evlh, &mut (ref mut device, ref mut handler), _, error| {
+            warn!(device.logger, "DrmDevice errored: {}", error);
+            handler.error(device, error.into());
         },
     }
 }
 
+/// `SessionObserver` linked to the `DrmDevice` it was created from.
+pub struct DrmDeviceObserver<A: ControlDevice + 'static> {
+    context: Weak<EGLContext<Gbm<framebuffer::Info>, GbmDevice<A>>>,
+    device_id: dev_t,
+    backends: Rc<RefCell<HashMap<crtc::Handle, Weak<DrmBackendInternal<A>>>>>,
+    active: Arc<AtomicBool>,
+    priviledged: bool,
+    logger: ::slog::Logger,
+}
+
+impl<A: ControlDevice + 'static> AsSessionObserver<DrmDeviceObserver<A>> for DrmDevice<A> {
+    fn observer(&mut self) -> DrmDeviceObserver<A> {
+        DrmDeviceObserver {
+            context: Rc::downgrade(&self.context),
+            device_id: self.device_id.clone(),
+            backends: self.backends.clone(),
+            active: self.active.clone(),
+            priviledged: self.priviledged,
+            logger: self.logger.clone(),
+        }
+    }
+}
+
 #[cfg(feature = "backend_session")]
-impl<A: ControlDevice + 'static> SessionObserver for StateToken<DrmDevice<A>> {
-    fn pause<'a>(&mut self, state: &mut StateProxy<'a>, devnum: Option<(u32, u32)>) {
-        let device = state.get_mut(self);
+impl<A: ControlDevice + 'static> SessionObserver for DrmDeviceObserver<A> {
+    fn pause(&mut self, _evlh: &mut EventLoopHandle, devnum: Option<(u32, u32)>) {
         if let Some((major, minor)) = devnum {
-            if major as u64 != stat::major(device.device_id) || minor as u64 != stat::minor(device.device_id)
+            if major as u64 != stat::major(self.device_id) || minor as u64 != stat::minor(self.device_id)
             {
                 return;
             }
         }
-        for (handle, &(ref info, ref connectors)) in device.old_state.iter() {
+        for (handle, &(ref info, ref connectors)) in self.old_state.iter() {
             if let Err(err) = crtc::set(
-                &*device.context,
+                &*self.context,
                 *handle,
                 info.fb(),
                 connectors,
@@ -625,51 +637,56 @@ impl<A: ControlDevice + 'static> SessionObserver for StateToken<DrmDevice<A>> {
                 info.mode(),
             ) {
                 error!(
-                    device.logger,
+                    self.logger,
                     "Failed to reset crtc ({:?}). Error: {}", handle, err
                 );
             }
         }
-        device.active = false;
-        if device.priviledged {
-            if let Err(err) = device.drop_master() {
-                error!(
-                    device.logger,
-                    "Failed to drop drm master state. Error: {}", err
-                );
+        self.active.store(false, Ordering::SeqCst);
+        if self.priviledged {
+            if let Some(device) = self.context.upgrade() {
+                if let Err(err) = device.drop_master() {
+                    error!(
+                        self.logger,
+                        "Failed to drop drm master state. Error: {}", err
+                    );
+                }
             }
         }
     }
 
-    fn activate<'a>(&mut self, state: &mut StateProxy<'a>, devnum: Option<(u32, u32, Option<RawFd>)>) {
-        let device = state.get_mut(self);
+    fn activate(&mut self, _evlh: &mut EventLoopHandle, devnum: Option<(u32, u32, Option<RawFd>)>) {
         if let Some((major, minor, fd)) = devnum {
-            if major as u64 != stat::major(device.device_id) || minor as u64 != stat::minor(device.device_id)
+            if major as u64 != stat::major(self.device_id) || minor as u64 != stat::minor(self.device_id)
             {
                 return;
             } else if let Some(fd) = fd {
-                info!(device.logger, "Replacing fd");
-                nix::unistd::dup2(device.as_raw_fd(), fd)
-                    .expect("Failed to replace file descriptor of drm device");
+                info!(self.logger, "Replacing fd");
+                if let Some(device) = self.context.upgrade() {
+                    nix::unistd::dup2(device.as_raw_fd(), fd)
+                        .expect("Failed to replace file descriptor of drm device");
+                }
             }
         }
-        device.active = true;
-        if device.priviledged {
-            if let Err(err) = device.set_master() {
-                crit!(
-                    device.logger,
-                    "Failed to acquire drm master again. Error: {}",
-                    err
-                );
+        self.active.store(true, Ordering::SeqCst);
+        if self.priviledged {
+            if let Some(device) = self.context.upgrade() {
+                if let Err(err) = device.set_master() {
+                    crit!(
+                        self.logger,
+                        "Failed to acquire drm master again. Error: {}",
+                        err
+                    );
+                }
             }
         }
         let mut crtcs = Vec::new();
-        for (crtc, backend) in device.backends.iter() {
+        for (crtc, backend) in self.backends.borrow().iter() {
             if let Some(backend) = backend.upgrade() {
                 backend.unlock_buffer();
                 if let Err(err) = backend.page_flip(None) {
                     error!(
-                        device.logger,
+                        self.logger,
                         "Failed to activate crtc ({:?}) again. Error: {}", crtc, err
                     );
                 }
@@ -685,7 +702,7 @@ impl<A: ControlDevice + 'static> SessionObserver for StateToken<DrmDevice<A>> {
                     ).is_err()
                     {
                         if let Err(err) = crtc::set_cursor(&*backend.context, *crtc, cursor) {
-                            error!(device.logger, "Failed to reset cursor. Error: {}", err);
+                            error!(self.logger, "Failed to reset cursor. Error: {}", err);
                         }
                     }
                 }
@@ -694,7 +711,7 @@ impl<A: ControlDevice + 'static> SessionObserver for StateToken<DrmDevice<A>> {
             }
         }
         for crtc in crtcs {
-            device.backends.remove(&crtc);
+            self.backends.borrow_mut().remove(&crtc);
         }
     }
 }

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -529,12 +529,15 @@ impl<A: ControlDevice + 'static> Drop for DrmDevice<A> {
 pub trait DrmHandler<A: ControlDevice + 'static> {
     /// The `DrmBackend` of crtc has finished swapping buffers and new frame can now
     /// (and should be immediately) be rendered.
-    fn ready(&mut self, evlh: &mut EventLoopHandle, device: &mut DrmDevice<A>, crtc: crtc::Handle, frame: u32, duration: Duration);
+    fn ready(
+        &mut self, evlh: &mut EventLoopHandle, device: &mut DrmDevice<A>, crtc: crtc::Handle, frame: u32,
+        duration: Duration,
+    );
     /// The `DrmDevice` has thrown an error.
     ///
     /// The related backends are most likely *not* usable anymore and
     /// the whole stack has to be recreated..
-    fn error(&mut self,  evlh: &mut EventLoopHandle, device: &mut DrmDevice<A>, error: DrmError);
+    fn error(&mut self, evlh: &mut EventLoopHandle, device: &mut DrmDevice<A>, error: DrmError);
 }
 
 /// Bind a `DrmDevice` to an `EventLoop`,
@@ -622,8 +625,7 @@ impl<A: ControlDevice + 'static> AsSessionObserver<DrmDeviceObserver<A>> for Drm
 impl<A: ControlDevice + 'static> SessionObserver for DrmDeviceObserver<A> {
     fn pause(&mut self, _evlh: &mut EventLoopHandle, devnum: Option<(u32, u32)>) {
         if let Some((major, minor)) = devnum {
-            if major as u64 != stat::major(self.device_id) || minor as u64 != stat::minor(self.device_id)
-            {
+            if major as u64 != stat::major(self.device_id) || minor as u64 != stat::minor(self.device_id) {
                 return;
             }
         }
@@ -657,8 +659,7 @@ impl<A: ControlDevice + 'static> SessionObserver for DrmDeviceObserver<A> {
 
     fn activate(&mut self, _evlh: &mut EventLoopHandle, devnum: Option<(u32, u32, Option<RawFd>)>) {
         if let Some((major, minor, fd)) = devnum {
-            if major as u64 != stat::major(self.device_id) || minor as u64 != stat::minor(self.device_id)
-            {
+            if major as u64 != stat::major(self.device_id) || minor as u64 != stat::minor(self.device_id) {
                 return;
             } else if let Some(fd) = fd {
                 info!(self.logger, "Replacing fd");

--- a/src/backend/libinput.rs
+++ b/src/backend/libinput.rs
@@ -11,7 +11,7 @@ use std::io::{Error as IoError, Result as IoResult};
 use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::rc::Rc;
-use wayland_server::{EventLoopHandle, StateProxy};
+use wayland_server::EventLoopHandle;
 use wayland_server::sources::{FdEventSource, FdEventSourceImpl, FdInterest};
 
 // No idea if this is the same across unix platforms
@@ -586,7 +586,7 @@ impl From<event::pointer::ButtonState> for backend::MouseButtonState {
 
 #[cfg(feature = "backend_session")]
 impl SessionObserver for libinput::Libinput {
-    fn pause<'a>(&mut self, _state: &mut StateProxy<'a>, device: Option<(u32, u32)>) {
+    fn pause(&mut self, _state: &mut EventLoopHandle, device: Option<(u32, u32)>) {
         if let Some((major, _)) = device {
             if major != INPUT_MAJOR {
                 return;
@@ -596,7 +596,7 @@ impl SessionObserver for libinput::Libinput {
         self.suspend()
     }
 
-    fn activate<'a>(&mut self, _state: &mut StateProxy<'a>, _device: Option<(u32, u32, Option<RawFd>)>) {
+    fn activate(&mut self, _state: &mut EventLoopHandle, _device: Option<(u32, u32, Option<RawFd>)>) {
         // libinput closes the devices on suspend, so we should not get any INPUT_MAJOR calls
         // also lets hope multiple resumes are okay in case of logind
         self.resume().expect("Unable to resume libinput context");

--- a/src/backend/libinput.rs
+++ b/src/backend/libinput.rs
@@ -7,7 +7,7 @@ use input as libinput;
 use input::event;
 use std::collections::hash_map::{DefaultHasher, Entry, HashMap};
 use std::hash::{Hash, Hasher};
-use std::io::{Error as IoError, Result as IoResult};
+use std::io::Error as IoError;
 use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::rc::Rc;
@@ -635,7 +635,7 @@ impl<S: Session> libinput::LibinputInterface for LibinputSessionInterface<S> {
 /// `dispatch_new_events`. Should be used to achieve the smallest possible latency.
 pub fn libinput_bind(
     backend: LibinputInputBackend, evlh: &mut EventLoopHandle
-) -> IoResult<FdEventSource<LibinputInputBackend>> {
+) -> ::std::result::Result<FdEventSource<LibinputInputBackend>, (IoError, LibinputInputBackend)> {
     let fd = unsafe { backend.context.fd() };
     evlh.add_fd_event_source(
         fd,

--- a/src/backend/session/auto.rs
+++ b/src/backend/session/auto.rs
@@ -29,7 +29,7 @@
 //! automatically by the `UdevBackend`, if not done manually).
 //! ```
 
-use super::{AsErrno, Session, SessionNotifier, SessionObserver};
+use super::{AsErrno, Session, SessionNotifier, SessionObserver, AsSessionObserver};
 use super::direct::{self, direct_session_bind, DirectSession, DirectSessionNotifier};
 #[cfg(feature = "backend_session_logind")]
 use super::logind::{self, logind_session_bind, BoundLogindSession, LogindSession, LogindSessionNotifier};
@@ -40,7 +40,7 @@ use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::rc::Rc;
 use wayland_server::EventLoopHandle;
-use wayland_server::sources::SignalEventSource;
+use wayland_server::sources::{EventSource, SignalEventSource};
 
 /// `Session` using the best available inteface
 #[derive(Clone)]
@@ -207,7 +207,9 @@ impl Session for AutoSession {
 impl SessionNotifier for AutoSessionNotifier {
     type Id = AutoId;
 
-    fn register<S: SessionObserver + 'static>(&mut self, signal: S) -> Self::Id {
+    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(&mut self, signal: &mut A)
+        -> Self::Id
+    {
         match self {
             #[cfg(feature = "backend_session_logind")]
             &mut AutoSessionNotifier::Logind(ref mut logind) => {

--- a/src/backend/session/auto.rs
+++ b/src/backend/session/auto.rs
@@ -35,7 +35,7 @@ use super::direct::{self, direct_session_bind, DirectSession, DirectSessionNotif
 use super::logind::{self, logind_session_bind, BoundLogindSession, LogindSession, LogindSessionNotifier};
 use nix::fcntl::OFlag;
 use std::cell::RefCell;
-use std::io::Result as IoResult;
+use std::io::Error as IoError;
 use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::rc::Rc;
@@ -154,11 +154,13 @@ impl AutoSession {
 /// session state and call it's `SessionObservers`.
 pub fn auto_session_bind(
     notifier: AutoSessionNotifier, evlh: &mut EventLoopHandle
-) -> IoResult<BoundAutoSession> {
+) -> ::std::result::Result<BoundAutoSession, (IoError, AutoSessionNotifier)> {
     Ok(match notifier {
         #[cfg(feature = "backend_session_logind")]
-        AutoSessionNotifier::Logind(logind) => BoundAutoSession::Logind(logind_session_bind(logind, evlh)?),
-        AutoSessionNotifier::Direct(direct) => BoundAutoSession::Direct(direct_session_bind(direct, evlh)?),
+        AutoSessionNotifier::Logind(logind) => BoundAutoSession::Logind(logind_session_bind(logind, evlh)
+            .map_err(|(error, notifier)| (error, AutoSessionNotifier::Logind(notifier)))?),
+        AutoSessionNotifier::Direct(direct) => BoundAutoSession::Direct(direct_session_bind(direct, evlh)
+            .map_err(|(error, notifier)| (error, AutoSessionNotifier::Direct(notifier)))?),
     })
 }
 

--- a/src/backend/session/auto.rs
+++ b/src/backend/session/auto.rs
@@ -29,7 +29,7 @@
 //! automatically by the `UdevBackend`, if not done manually).
 //! ```
 
-use super::{AsErrno, Session, SessionNotifier, SessionObserver, AsSessionObserver};
+use super::{AsErrno, AsSessionObserver, Session, SessionNotifier, SessionObserver};
 use super::direct::{self, direct_session_bind, DirectSession, DirectSessionNotifier};
 #[cfg(feature = "backend_session_logind")]
 use super::logind::{self, logind_session_bind, BoundLogindSession, LogindSession, LogindSessionNotifier};
@@ -207,9 +207,9 @@ impl Session for AutoSession {
 impl SessionNotifier for AutoSessionNotifier {
     type Id = AutoId;
 
-    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(&mut self, signal: &mut A)
-        -> Self::Id
-    {
+    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(
+        &mut self, signal: &mut A
+    ) -> Self::Id {
         match self {
             #[cfg(feature = "backend_session_logind")]
             &mut AutoSessionNotifier::Logind(ref mut logind) => {

--- a/src/backend/session/dbus/logind.rs
+++ b/src/backend/session/dbus/logind.rs
@@ -30,7 +30,7 @@
 //! automatically by the `UdevBackend`, if not done manually).
 //! ```
 
-use backend::session::{AsErrno, Session, SessionNotifier, SessionObserver};
+use backend::session::{AsErrno, Session, SessionNotifier, SessionObserver, AsSessionObserver};
 use dbus::{BusName, BusType, Connection, ConnectionItem, ConnectionItems, Interface, Member, Message,
            MessageItem, OwnedFd, Path as DbusPath, Watch, WatchEvent};
 use nix::fcntl::OFlag;
@@ -43,7 +43,7 @@ use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
 use systemd::login;
 use wayland_server::EventLoopHandle;
-use wayland_server::sources::{FdEventSource, FdEventSourceImpl, FdInterest};
+use wayland_server::sources::{EventSource, FdEventSource, FdEventSourceImpl, FdInterest};
 
 struct LogindSessionImpl {
     conn: RefCell<Connection>,
@@ -246,7 +246,7 @@ impl LogindSessionImpl {
                 //So lets just put it to sleep.. forever
                 for signal in &mut *self.signals.borrow_mut() {
                     if let &mut Some(ref mut signal) = signal {
-                        signal.pause(&mut evlh.state().as_proxy(), None);
+                        signal.pause(evlh, None);
                     }
                 }
                 self.active.store(false, Ordering::SeqCst);
@@ -263,7 +263,7 @@ impl LogindSessionImpl {
                     );
                     for signal in &mut *self.signals.borrow_mut() {
                         if let &mut Some(ref mut signal) = signal {
-                            signal.pause(&mut evlh.state().as_proxy(), Some((major, minor)));
+                            signal.pause(evlh, Some((major, minor)));
                         }
                     }
                     // the other possible types are "force" or "gone" (unplugged),
@@ -289,7 +289,7 @@ impl LogindSessionImpl {
                     debug!(self.logger, "Reactivating device ({},{})", major, minor);
                     for signal in &mut *self.signals.borrow_mut() {
                         if let &mut Some(ref mut signal) = signal {
-                            signal.activate(&mut evlh.state().as_proxy(), Some((major, minor, Some(fd))));
+                            signal.activate(evlh, Some((major, minor, Some(fd))));
                         }
                     }
                 }
@@ -392,11 +392,13 @@ pub struct Id(usize);
 impl SessionNotifier for LogindSessionNotifier {
     type Id = Id;
 
-    fn register<S: SessionObserver + 'static>(&mut self, signal: S) -> Id {
+    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(&mut self, signal: &mut A)
+        -> Self::Id
+    {
         self.internal
             .signals
             .borrow_mut()
-            .push(Some(Box::new(signal)));
+            .push(Some(Box::new(signal.observer())));
         Id(self.internal.signals.borrow().len() - 1)
     }
     fn unregister(&mut self, signal: Id) {

--- a/src/backend/session/dbus/logind.rs
+++ b/src/backend/session/dbus/logind.rs
@@ -30,7 +30,7 @@
 //! automatically by the `UdevBackend`, if not done manually).
 //! ```
 
-use backend::session::{AsErrno, Session, SessionNotifier, SessionObserver, AsSessionObserver};
+use backend::session::{AsErrno, AsSessionObserver, Session, SessionNotifier, SessionObserver};
 use dbus::{BusName, BusType, Connection, ConnectionItem, ConnectionItems, Interface, Member, Message,
            MessageItem, OwnedFd, Path as DbusPath, Watch, WatchEvent};
 use nix::fcntl::OFlag;
@@ -392,9 +392,9 @@ pub struct Id(usize);
 impl SessionNotifier for LogindSessionNotifier {
     type Id = Id;
 
-    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(&mut self, signal: &mut A)
-        -> Self::Id
-    {
+    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(
+        &mut self, signal: &mut A
+    ) -> Self::Id {
         self.internal
             .signals
             .borrow_mut()

--- a/src/backend/session/direct.rs
+++ b/src/backend/session/direct.rs
@@ -52,7 +52,7 @@ use nix::libc::c_int;
 use nix::sys::signal::{self, Signal};
 use nix::sys::stat::{dev_t, fstat, major, minor, Mode};
 use nix::unistd::{close, dup};
-use std::io::Result as IoResult;
+use std::io::Error as IoError;
 use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::sync::Arc;
@@ -369,7 +369,7 @@ impl SessionNotifier for DirectSessionNotifier {
 /// session state and call it's `SessionObservers`.
 pub fn direct_session_bind(
     notifier: DirectSessionNotifier, evlh: &mut EventLoopHandle
-) -> IoResult<SignalEventSource<DirectSessionNotifier>> {
+) -> ::std::result::Result<SignalEventSource<DirectSessionNotifier>, (IoError, DirectSessionNotifier)> {
     let signal = notifier.signal;
 
     evlh.add_signal_event_source(

--- a/src/backend/session/direct.rs
+++ b/src/backend/session/direct.rs
@@ -45,7 +45,7 @@
 //! for notifications are the `Libinput` context, the `UdevBackend` or a `DrmDevice` (handled
 //! automatically by the `UdevBackend`, if not done manually).
 
-use super::{AsErrno, Session, SessionNotifier, SessionObserver, AsSessionObserver};
+use super::{AsErrno, AsSessionObserver, Session, SessionNotifier, SessionObserver};
 use nix::{Error as NixError, Result as NixResult};
 use nix::fcntl::{self, open, OFlag};
 use nix::libc::c_int;
@@ -344,9 +344,9 @@ pub struct Id(usize);
 impl SessionNotifier for DirectSessionNotifier {
     type Id = Id;
 
-    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(&mut self, signal: &mut A)
-        -> Self::Id
-    {
+    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(
+        &mut self, signal: &mut A
+    ) -> Self::Id {
         self.signals.push(Some(Box::new(signal.observer())));
         Id(self.signals.len() - 1)
     }

--- a/src/backend/session/direct.rs
+++ b/src/backend/session/direct.rs
@@ -45,7 +45,7 @@
 //! for notifications are the `Libinput` context, the `UdevBackend` or a `DrmDevice` (handled
 //! automatically by the `UdevBackend`, if not done manually).
 
-use super::{AsErrno, Session, SessionNotifier, SessionObserver};
+use super::{AsErrno, Session, SessionNotifier, SessionObserver, AsSessionObserver};
 use nix::{Error as NixError, Result as NixResult};
 use nix::fcntl::{self, open, OFlag};
 use nix::libc::c_int;
@@ -344,8 +344,10 @@ pub struct Id(usize);
 impl SessionNotifier for DirectSessionNotifier {
     type Id = Id;
 
-    fn register<S: SessionObserver + 'static>(&mut self, signal: S) -> Id {
-        self.signals.push(Some(Box::new(signal)));
+    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(&mut self, signal: &mut A)
+        -> Self::Id
+    {
+        self.signals.push(Some(Box::new(signal.observer())));
         Id(self.signals.len() - 1)
     }
     fn unregister(&mut self, signal: Id) {
@@ -376,7 +378,7 @@ pub fn direct_session_bind(
                 info!(notifier.logger, "Session shall become inactive");
                 for signal in &mut notifier.signals {
                     if let &mut Some(ref mut signal) = signal {
-                        signal.pause(&mut evlh.state().as_proxy(), None);
+                        signal.pause(evlh, None);
                     }
                 }
                 notifier.active.store(false, Ordering::SeqCst);
@@ -391,7 +393,7 @@ pub fn direct_session_bind(
                 }
                 for signal in &mut notifier.signals {
                     if let &mut Some(ref mut signal) = signal {
-                        signal.activate(&mut evlh.state().as_proxy(), None);
+                        signal.activate(evlh, None);
                     }
                 }
                 notifier.active.store(true, Ordering::SeqCst);

--- a/src/backend/session/mod.rs
+++ b/src/backend/session/mod.rs
@@ -53,7 +53,8 @@ pub trait SessionNotifier {
     /// Registers a given `SessionObserver`.
     ///
     /// Returns an id of the inserted observer, can be used to remove it again.
-    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(&mut self, signal: &mut A) -> Self::Id;
+    fn register<S: SessionObserver + 'static, A: AsSessionObserver<S>>(&mut self, signal: &mut A)
+        -> Self::Id;
     /// Removes an observer by its given id from `SessionNotifier::register`.
     fn unregister(&mut self, signal: Self::Id);
 

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -10,7 +10,7 @@
 //! backend.
 
 use backend::drm::{drm_device_bind, DrmDevice, DrmHandler};
-use backend::session::{Session, SessionObserver, AsSessionObserver};
+use backend::session::{AsSessionObserver, Session, SessionObserver};
 use drm::Device as BasicDevice;
 use drm::control::Device as ControlDevice;
 use nix::fcntl;
@@ -171,7 +171,8 @@ impl<
     H: DrmHandler<SessionFdDrmDevice> + 'static,
     S: Session + 'static,
     T: UdevHandler<H> + 'static,
-> AsSessionObserver<UdevBackendObserver<H>> for UdevBackend<H, S, T> {
+> AsSessionObserver<UdevBackendObserver<H>> for UdevBackend<H, S, T>
+{
     fn observer(&mut self) -> UdevBackendObserver<H> {
         UdevBackendObserver {
             devices: Rc::downgrade(&self.devices),
@@ -180,8 +181,7 @@ impl<
     }
 }
 
-impl<H: DrmHandler<SessionFdDrmDevice> + 'static> SessionObserver for UdevBackendObserver<H>
-{
+impl<H: DrmHandler<SessionFdDrmDevice> + 'static> SessionObserver for UdevBackendObserver<H> {
     fn pause<'a>(&mut self, evlh: &mut EventLoopHandle, devnum: Option<(u32, u32)>) {
         if let Some(devices) = self.devices.upgrade() {
             for fd_event_source in devices.borrow_mut().values_mut() {
@@ -285,8 +285,7 @@ where
                                         if let Err(err) = udev.session.close(fd) {
                                             warn!(
                                                 udev.logger,
-                                                "Failed to close dropped device. Error: {:?}. Ignoring",
-                                                err
+                                                "Failed to close dropped device. Error: {:?}. Ignoring", err
                                             );
                                         };
                                     }
@@ -322,7 +321,7 @@ where
                                 };
                             }
                         }
-                    },
+                    }
                     // New connector
                     EventType::Change => {
                         info!(udev.logger, "Device Changed");
@@ -341,14 +340,12 @@ where
                         } else {
                             info!(udev.logger, "changed, but no devnum");
                         }
-                    },
+                    }
                     _ => {}
                 }
             }
         },
-        error: |evlh, udev, _, err| {
-            udev.handler.error(evlh, err)
-        },
+        error: |evlh, udev, _, err| udev.handler.error(evlh, err),
     }
 }
 
@@ -370,9 +367,7 @@ pub trait UdevHandler<H: DrmHandler<SessionFdDrmDevice> + 'static> {
     ///
     /// ## Panics
     /// Panics if you try to borrow the token of the belonging `UdevBackend` using this `StateProxy`.
-    fn device_changed(
-        &mut self, evlh: &mut EventLoopHandle, device: &mut DrmDevice<SessionFdDrmDevice>
-    );
+    fn device_changed(&mut self, evlh: &mut EventLoopHandle, device: &mut DrmDevice<SessionFdDrmDevice>);
     /// Called when a device was removed.
     ///
     /// The device will not accept any operations anymore and its file descriptor will be closed once
@@ -380,9 +375,7 @@ pub trait UdevHandler<H: DrmHandler<SessionFdDrmDevice> + 'static> {
     ///
     /// ## Panics
     /// Panics if you try to borrow the token of the belonging `UdevBackend` using this `StateProxy`.
-    fn device_removed(
-        &mut self, evlh: &mut EventLoopHandle, device: &mut DrmDevice<SessionFdDrmDevice>
-    );
+    fn device_removed(&mut self, evlh: &mut EventLoopHandle, device: &mut DrmDevice<SessionFdDrmDevice>);
     /// Called when the udev context has encountered and error.
     ///
     /// ## Panics


### PR DESCRIPTION
`DrmDevice` and `UdevBackend` now do not need to be wrapped into `StateToken`s anymore, but can return a separate `SessionObserver` object using the new `AsSessionObserver` trait.

This change was motivated by allowing the `UdevHandler` to obtain a mutable reference to an `EventLoopHandle` to create a wayland object, e.g. a `wl_output` object.

Previously this was not possible.

Depends on https://github.com/Smithay/wayland-rs/pull/164

~### TODO:~
- [x] Merge #63 
- [x] Crates.io release including: https://github.com/Smithay/wayland-rs/pull/164