### PR TITLE
Winit handler

### DIFF
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -178,6 +178,13 @@ where
     ))
 }
 
+impl WinitGraphicsBackend {
+    /// Get a reference to the internally used `winit::Window`
+    pub fn winit_window(&self) -> &WinitWindow {
+        self.window.window()
+    }
+}
+
 impl GraphicsBackend for WinitGraphicsBackend {
     type CursorFormat = MouseCursor;
     type Error = ();


### PR DESCRIPTION
This adds an additional `WinitEventsHandler` to our `WinitBackend`. This allows a real compositor to receive additional window events not available in the more restricted `InputHandler`, that it might be interested in.

This also exposes the underlying `winit::Window` object to allow further customization like the window title or to receive properties of the window, like its hidpi factor, if the compositor wants to take that into account.

I figured giving the user more control is way easier then adding a bunch of functions to the backend for that purpose and follows smithay's philosophy.