### PR TITLE
Reexport ModifiersState to make it publically accessible

### DIFF
--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -57,7 +57,7 @@
 mod keyboard;
 mod pointer;
 
-pub use self::keyboard::{Error as KeyboardError, KeyboardHandle};
+pub use self::keyboard::{Error as KeyboardError, KeyboardHandle, ModifiersState};
 pub use self::pointer::PointerHandle;
 use wayland_server::{Client, EventLoopHandle, Global, Liveness, Resource, StateToken};
 use wayland_server::protocol::{wl_keyboard, wl_pointer, wl_seat};


### PR DESCRIPTION
I don't know why this even compiles without the reexport, probably because it is only passed into a closure (I still think this should be a hard error, and I should probably think about reporting that to rustc).

Anyways I noticed, that `ModifiersState` is greyed out in [our documentation](https://docs.rs/smithay/0.1.0/smithay/wayland/seat/struct.KeyboardHandle.html#method.input) and there is no way to import the type. This PR fixes this.

Btw I think we should think about how we use types of other crates. Right now we expect the user to depend on the same library version of crates like libxkbcommon as we do to get things like `Keysym`. I am guilty of that as well in the backend code (there is no way to write a real compositor without depending on drm.rs), maybe we should re-export these as well?