### PR TITLE
Update gl_generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ error-chain = "0.11.0"
 lazy_static = "1.0.0"
 
 [build-dependencies]
-gl_generator = "0.7"
+gl_generator = "0.9"
 
 [dev-dependencies]
 slog-term = "2.3"


### PR DESCRIPTION
We are getting some build errors on nightly and now on beta related to comments in the generated gl code.
Updating the gl_generator seems to fix this.