### PR TITLE
Update glium integration to allow mutable borrowing

### DIFF
--- a/examples/drm.rs
+++ b/examples/drm.rs
@@ -174,7 +174,7 @@ impl DrmHandler<Card> for DrmHandlerImpl {
         frame.clear_color(0.8, 0.8, 0.9, 1.0);
         // redraw the frame, in a simple but inneficient way
         {
-            let screen_dimensions = self.drawer.get_framebuffer_dimensions();
+            let screen_dimensions = self.drawer.borrow().get_framebuffer_dimensions();
             self.window_map
                 .borrow()
                 .with_windows_from_bottom_to_top(|toplevel_surface, initial_place| {

--- a/examples/helpers/glium.rs
+++ b/examples/helpers/glium.rs
@@ -6,7 +6,7 @@ use smithay::backend::graphics::egl::EGLGraphicsBackend;
 use smithay::backend::graphics::egl::error::Result as EGLResult;
 use smithay::backend::graphics::egl::wayland::{EGLDisplay, EGLImages, EGLWaylandExtensions, Format};
 use smithay::backend::graphics::glium::GliumGraphicsBackend;
-use std::borrow::Borrow;
+use std::cell::Ref;
 use std::ops::Deref;
 use wayland_server::Display;
 
@@ -25,16 +25,8 @@ pub struct GliumDrawer<F: EGLGraphicsBackend + 'static> {
     program: glium::Program,
 }
 
-impl<F: EGLGraphicsBackend + 'static> Deref for GliumDrawer<F> {
-    type Target = F;
-
-    fn deref(&self) -> &F {
-        self.borrow()
-    }
-}
-
-impl<F: EGLGraphicsBackend + 'static> Borrow<F> for GliumDrawer<F> {
-    fn borrow(&self) -> &F {
+impl<F: EGLGraphicsBackend + 'static> GliumDrawer<F> {
+    pub fn borrow(&self) -> Ref<F> {
         self.display.borrow()
     }
 }

--- a/examples/udev.rs
+++ b/examples/udev.rs
@@ -439,6 +439,7 @@ impl UdevHandlerImpl {
 
                         // create cursor
                         renderer
+                            .borrow()
                             .set_cursor_representation(&self.pointer_image, (2, 2))
                             .unwrap();
 
@@ -518,13 +519,15 @@ impl DrmHandler<SessionFdDrmDevice> for DrmHandlerImpl {
         if let Some(drawer) = self.backends.borrow().get(&crtc) {
             {
                 let (x, y) = *self.pointer_location.borrow();
-                let _ = drawer.set_cursor_position(x.trunc().abs() as u32, y.trunc().abs() as u32);
+                let _ = drawer
+                    .borrow()
+                    .set_cursor_position(x.trunc().abs() as u32, y.trunc().abs() as u32);
             }
             let mut frame = drawer.draw();
             frame.clear_color(0.8, 0.8, 0.9, 1.0);
             // redraw the frame, in a simple but inneficient way
             {
-                let screen_dimensions = drawer.get_framebuffer_dimensions();
+                let screen_dimensions = drawer.borrow().get_framebuffer_dimensions();
                 self.window_map.borrow().with_windows_from_bottom_to_top(
                     |toplevel_surface, initial_place| {
                         if let Some(wl_surface) = toplevel_surface.get_surface() {

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -241,7 +241,7 @@ fn main() {
         frame.clear(None, Some((0.8, 0.8, 0.9, 1.0)), false, Some(1.0), None);
         // redraw the frame, in a simple but inneficient way
         {
-            let screen_dimensions = drawer.get_framebuffer_dimensions();
+            let screen_dimensions = drawer.borrow().get_framebuffer_dimensions();
             window_map
                 .borrow()
                 .with_windows_from_bottom_to_top(|toplevel_surface, initial_place| {


### PR DESCRIPTION
This is kinda ugly, but I cannot think of a better way to allow mutable access, which is needed for many operations on the drm backend at least. e.g. mode setting.

@vberger if you have a better idea, please tell me.