### PR TITLE
Pin slog version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ wayland-sys = "0.14.0"
 nix = "0.9.0"
 xkbcommon = "0.2.1"
 tempfile = "2.1.5"
-slog = { version = "2.1.1" }
+slog = { version = "=2.1.1" }
 slog-stdlog = "3.0.2"
 libloading = "0.4.0"
 wayland-client = { version = "0.12.5", optional = true }


### PR DESCRIPTION
Slog 2.2.1 breaks smithay due to https://github.com/slog-rs/slog/issues/164

Lets pin the latest working version for now.