### PR TITLE
Derive PartialEq,Eq,Hash for ModifiersState

### DIFF
--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -14,7 +14,7 @@ pub use xkbcommon::xkb::{keysyms, Keysym};
 ///
 /// For some modifiers, this means that the key is currently pressed, others are toggled
 /// (like caps lock).
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ModifiersState {
     /// The "control" key
     pub ctrl: bool,


### PR DESCRIPTION
This is very useful to implement serializable key bindings, e.g. in config files.