### PR TITLE
wayland.compositor: CompositorToken is threadsafe

### DIFF
--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -248,6 +248,9 @@ impl<U, R> Clone for CompositorToken<U, R> {
     }
 }
 
+unsafe impl<U, R> Send for CompositorToken<U, R> {}
+unsafe impl<U, R> Sync for CompositorToken<U, R> {}
+
 impl<U, R> CompositorToken<U, R> {
     pub(crate) fn make() -> CompositorToken<U, R> {
         CompositorToken {


### PR DESCRIPTION
Thanks to the refactor of wayland-rs, the CompositorToken can
be make Send/Sync again.

Fixes #66.