### PR TITLE
Upgrade winit backend to 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **[Breaking]** WinitBackend: Upgrade to winit 0.17
+
 ## version 0.1.0 (2017-10-01)
 
 ### Protocol handling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ slog = "2.1.1"
 slog-stdlog = "3.0.2"
 libloading = "0.4.0"
 wayland-client = { version = "0.20.5", optional = true }
-winit = { version = "0.14.0", optional = true }
+winit = { version = "0.17.0", optional = true }
 drm = { version = "^0.3.1", optional = true }
 gbm = { version = "^0.4.0", optional = true, default-features = false, features = ["drm-support"] }
 glium = { version = "0.19.0", optional = true, default-features = false }

--- a/src/backend/graphics/egl/native.rs
+++ b/src/backend/graphics/egl/native.rs
@@ -187,8 +187,10 @@ unsafe impl NativeDisplay<Wayland> for WinitWindow {
 
     fn create_surface(&self, _args: ()) -> Result<wegl::WlEglSurface> {
         if let Some(surface) = self.get_wayland_surface() {
-            let (w, h) = self.get_inner_size().unwrap();
-            Ok(unsafe { wegl::WlEglSurface::new_from_raw(surface as *mut _, w as i32, h as i32) })
+            let size = self.get_inner_size().unwrap();
+            Ok(unsafe {
+                wegl::WlEglSurface::new_from_raw(surface as *mut _, size.width as i32, size.height as i32)
+            })
         } else {
             bail!(ErrorKind::NonMatchingBackend("Wayland"))
         }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -195,7 +195,7 @@ pub trait WinitEventsHandler {
     /// The window was resized, can be used to adjust the associated `wayland::output::Output`s mode.
     fn resized(&mut self, size: LogicalSize);
     /// The window was moved
-    fn moved(&mut self, x: i32, h: i32);
+    fn moved(&mut self, position: LogicalPosition);
     /// The window gained or lost focus
     fn focus_changed(&mut self, focused: bool);
     /// The window needs to be redrawn
@@ -714,7 +714,7 @@ impl InputBackend for WinitInputBackend {
                             }
                         }
                         (WindowEvent::Moved(position), _, Some(events_handler)) => {
-                            events_handler.moved(position.x as i32, position.y as i32)
+                            events_handler.moved(position)
                         }
                         (WindowEvent::Focused(focus), _, Some(events_handler)) => {
                             events_handler.focus_changed(focus)


### PR DESCRIPTION
This PR upgrades the winit backend to 0.17. I couldn't test this in detail since I can't open applications in anvil because of an error about seat manager support but I would assume none of these changes would have much affect.