### PR TITLE
[travis] Only do cargo check for incomplete feature-sets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ script:
             vagga cargo-$TRAVIS_RUST_VERSION test -p anvil --all-features
         ;;
         *)
-            vagga cargo-$TRAVIS_RUST_VERSION test --no-default-features --features "$FEATURES" &&
+            vagga cargo-$TRAVIS_RUST_VERSION check --tests --no-default-features --features "$FEATURES" &&
             vagga cargo-$TRAVIS_RUST_VERSION doc --no-deps --no-default-features --features "$FEATURES"
       esac
 


### PR DESCRIPTION
As discussed on matrix, this is a try to speed up travis builds.

The reasoning is, that we just want to make sure all features do build independently,
but testing is only required once, so as long as tests are run for the "all" target, this should be enough.