### PR TITLE
Refactor Seat::add_keyboard

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -29,7 +29,7 @@ use smithay::drm::result::Error as DrmError;
 use smithay::input::Libinput;
 use smithay::wayland::compositor::CompositorToken;
 use smithay::wayland::output::{Mode, Output, PhysicalProperties};
-use smithay::wayland::seat::Seat;
+use smithay::wayland::seat::{Seat, XkbConfig};
 use smithay::wayland::shm::init_shm_global;
 use smithay::wayland_server::calloop::EventLoop;
 use smithay::wayland_server::protocol::wl_output;
@@ -97,7 +97,7 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<()>, log: Logger
 
     let pointer = w_seat.add_pointer();
     let keyboard = w_seat
-        .add_keyboard("", "", "", None, 1000, 500)
+        .add_keyboard(XkbConfig::default(), 1000, 500)
         .expect("Failed to initialize the keyboard");
 
     let (output, _output_global) = Output::new(

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -8,7 +8,7 @@ use smithay::backend::graphics::egl::EGLGraphicsBackend;
 use smithay::backend::input::InputBackend;
 use smithay::backend::winit;
 use smithay::wayland::output::{Mode, Output, PhysicalProperties};
-use smithay::wayland::seat::Seat;
+use smithay::wayland::seat::{Seat, XkbConfig};
 use smithay::wayland::shm::init_shm_global;
 use smithay::wayland_server::calloop::EventLoop;
 use smithay::wayland_server::protocol::wl_output;
@@ -53,7 +53,7 @@ pub fn run_winit(display: &mut Display, event_loop: &mut EventLoop<()>, log: Log
 
     let pointer = seat.add_pointer();
     let keyboard = seat
-        .add_keyboard("", "fr", "oss", None, 1000, 500)
+        .add_keyboard(XkbConfig::default(), 1000, 500)
         .expect("Failed to initialize the keyboard");
 
     let (output, _) = Output::new(


### PR DESCRIPTION
With the new XkbConfig struct, it is now easier to just use xkbcommon's
default configuration, by moving the xkbcommon specific options into a
struct with according documentation.

Additionally, anvil now uses xkbcommon's defaults with all backends
(previously, the winit backend had a hardcoded french keyboard layout).