### PR TITLE
Rework dpi scaling in the winit backend

### DIFF
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -213,8 +213,6 @@ pub trait WinitEventsHandler {
     ///
     /// Here are provided the new size (in physical pixels) and the new scale factor provided by winit.
     fn resized(&mut self, size: (f64, f64), scale: f64);
-    /// The window was moved
-    fn moved(&mut self, position: LogicalPosition);
     /// The window gained or lost focus
     fn focus_changed(&mut self, focused: bool);
     /// The window needs to be redrawn
@@ -704,9 +702,6 @@ impl InputBackend for WinitInputBackend {
                             if let Some(events_handler) = events_handler {
                                 events_handler.resized(physical_size.into(), wsize.dpi_factor);
                             }
-                        }
-                        (WindowEvent::Moved(position), _, Some(events_handler)) => {
-                            events_handler.moved(position)
                         }
                         (WindowEvent::Focused(focus), _, Some(events_handler)) => {
                             events_handler.focus_changed(focus)


### PR DESCRIPTION
This reworks dpi handling in the winit backend to only expose physical pixel values to the user, while still exposing the winit dpi factor as an information.

This brings the winit backend in par to the framebuffer one: all is done in physical pixels by default and the compositor using smithay is responsible for choosing the dpi factor it wants to use.

This also makes anvil run correctly again on hidpi screens under winit even though not being hidpi aware.