### PR TITLE
Protocol support for client-provided cursor surfaces

### DIFF
--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -9,6 +9,7 @@ use rand;
 use smithay::{
     wayland::{
         compositor::{compositor_init, CompositorToken, SurfaceAttributes, SurfaceEvent},
+        data_device::DnDIconRole,
         seat::CursorImageRole,
         shell::{
             legacy::{
@@ -31,6 +32,7 @@ use window_map::{Kind as SurfaceKind, WindowMap};
 define_roles!(Roles =>
     [ XdgSurface, XdgSurfaceRole ]
     [ ShellSurface, ShellSurfaceRole<()>]
+    [ DnDIcon, DnDIconRole ]
     [ CursorImage, CursorImageRole ]
 );
 

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -9,6 +9,7 @@ use rand;
 use smithay::{
     wayland::{
         compositor::{compositor_init, CompositorToken, SurfaceAttributes, SurfaceEvent},
+        seat::CursorImageRole,
         shell::{
             legacy::{
                 wl_shell_init, ShellRequest, ShellState as WlShellState, ShellSurfaceKind, ShellSurfaceRole,
@@ -27,7 +28,11 @@ use smithay::{
 
 use window_map::{Kind as SurfaceKind, WindowMap};
 
-define_roles!(Roles => [ XdgSurface, XdgSurfaceRole ] [ ShellSurface, ShellSurfaceRole<()>] );
+define_roles!(Roles =>
+    [ XdgSurface, XdgSurfaceRole ]
+    [ ShellSurface, ShellSurfaceRole<()>]
+    [ CursorImage, CursorImageRole ]
+);
 
 pub type MyWindowMap =
     WindowMap<SurfaceData, Roles, (), (), fn(&SurfaceAttributes<SurfaceData>) -> Option<(i32, i32)>>;

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -140,6 +140,7 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<()>, log: Logger
         &mut display.borrow_mut(),
         |_| {},
         default_action_chooser,
+        compositor_token.clone(),
         log.clone(),
     );
 

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -146,9 +146,14 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<()>, log: Logger
     /*
      * Initialize wayland input object
      */
-    let (mut w_seat, _) = Seat::new(&mut display.borrow_mut(), session.seat(), log.clone());
+    let (mut w_seat, _) = Seat::new(
+        &mut display.borrow_mut(),
+        session.seat(),
+        compositor_token.clone(),
+        log.clone(),
+    );
 
-    let pointer = w_seat.add_pointer();
+    let pointer = w_seat.add_pointer(compositor_token.clone(), |_| {});
     let keyboard = w_seat
         .add_keyboard(XkbConfig::default(), 1000, 500, |seat, focus| {
             set_data_device_focus(seat, focus.and_then(|s| s.client()))

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -50,7 +50,13 @@ pub fn run_winit(display: &mut Display, event_loop: &mut EventLoop<()>, log: Log
 
     let (compositor_token, _, _, window_map) = init_shell(display, log.clone());
 
-    init_data_device(display, |_| {}, default_action_chooser, log.clone());
+    init_data_device(
+        display,
+        |_| {},
+        default_action_chooser,
+        compositor_token.clone(),
+        log.clone(),
+    );
 
     let (mut seat, _) = Seat::new(display, "winit".into(), compositor_token.clone(), log.clone());
 

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -1,15 +1,15 @@
 use std::{
     cell::RefCell,
     rc::Rc,
-    sync::{atomic::AtomicBool, Arc},
+    sync::{atomic::AtomicBool, Arc, Mutex},
 };
 
 use smithay::{
     backend::{egl::EGLGraphicsBackend, graphics::gl::GLGraphicsBackend, input::InputBackend, winit},
     wayland::{
-        data_device::{default_action_chooser, init_data_device, set_data_device_focus},
+        data_device::{default_action_chooser, init_data_device, set_data_device_focus, DataDeviceEvent},
         output::{Mode, Output, PhysicalProperties},
-        seat::{Seat, XkbConfig},
+        seat::{CursorImageStatus, Seat, XkbConfig},
         shm::init_shm_global,
     },
     wayland_server::{calloop::EventLoop, protocol::wl_output, Display},
@@ -50,9 +50,20 @@ pub fn run_winit(display: &mut Display, event_loop: &mut EventLoop<()>, log: Log
 
     let (compositor_token, _, _, window_map) = init_shell(display, log.clone());
 
+    let dnd_icon = Arc::new(Mutex::new(None));
+
+    let dnd_icon2 = dnd_icon.clone();
     init_data_device(
         display,
-        |_| {},
+        move |event| match event {
+            DataDeviceEvent::DnDStarted { icon, .. } => {
+                *dnd_icon2.lock().unwrap() = icon;
+            }
+            DataDeviceEvent::DnDDropped => {
+                *dnd_icon2.lock().unwrap() = None;
+            }
+            _ => {}
+        },
         default_action_chooser,
         compositor_token.clone(),
         log.clone(),
@@ -60,7 +71,13 @@ pub fn run_winit(display: &mut Display, event_loop: &mut EventLoop<()>, log: Log
 
     let (mut seat, _) = Seat::new(display, "winit".into(), compositor_token.clone(), log.clone());
 
-    let pointer = seat.add_pointer(compositor_token.clone(), |_| {});
+    let cursor_status = Arc::new(Mutex::new(CursorImageStatus::Default));
+
+    let cursor_status2 = cursor_status.clone();
+    let pointer = seat.add_pointer(compositor_token.clone(), move |new_status| {
+        // TODO: hide winit system cursor when relevant
+        *cursor_status2.lock().unwrap() = new_status
+    });
 
     let keyboard = seat
         .add_keyboard(XkbConfig::default(), 1000, 500, |seat, focus| {
@@ -96,6 +113,8 @@ pub fn run_winit(display: &mut Display, event_loop: &mut EventLoop<()>, log: Log
         refresh: 60_000,
     });
 
+    let pointer_location = Rc::new(RefCell::new((0.0, 0.0)));
+
     input.set_handler(AnvilInputHandler::new(
         log.clone(),
         pointer,
@@ -103,7 +122,7 @@ pub fn run_winit(display: &mut Display, event_loop: &mut EventLoop<()>, log: Log
         window_map.clone(),
         (0, 0),
         running.clone(),
-        Rc::new(RefCell::new((0.0, 0.0))),
+        pointer_location.clone(),
     ));
 
     info!(log, "Initialization completed, starting the main loop.");
@@ -111,7 +130,46 @@ pub fn run_winit(display: &mut Display, event_loop: &mut EventLoop<()>, log: Log
     loop {
         input.dispatch_new_events().unwrap();
 
-        drawer.draw_windows(&*window_map.borrow(), compositor_token, &log);
+        // drawing logic
+        {
+            use glium::Surface;
+            let mut frame = drawer.draw();
+            frame.clear(None, Some((0.8, 0.8, 0.9, 1.0)), false, Some(1.0), None);
+
+            // draw the windows
+            drawer.draw_windows(&mut frame, &*window_map.borrow(), compositor_token);
+
+            let (x, y) = *pointer_location.borrow();
+            // draw the dnd icon if any
+            {
+                let guard = dnd_icon.lock().unwrap();
+                if let Some(ref surface) = *guard {
+                    if surface.is_alive() {
+                        drawer.draw_dnd_icon(&mut frame, surface, (x as i32, y as i32), compositor_token);
+                    }
+                }
+            }
+            // draw the cursor as relevant
+            {
+                let mut guard = cursor_status.lock().unwrap();
+                // reset the cursor if the surface is no longer alive
+                let mut reset = false;
+                if let CursorImageStatus::Image(ref surface) = *guard {
+                    reset = !surface.is_alive();
+                }
+                if reset {
+                    *guard = CursorImageStatus::Default;
+                }
+                // draw as relevant
+                if let CursorImageStatus::Image(ref surface) = *guard {
+                    drawer.draw_cursor(&mut frame, surface, (x as i32, y as i32), compositor_token);
+                }
+            }
+
+            if let Err(err) = frame.finish() {
+                error!(log, "Error during rendering: {:?}", err);
+            }
+        }
 
         event_loop
             .dispatch(Some(::std::time::Duration::from_millis(16)), &mut ())

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -52,9 +52,9 @@ pub fn run_winit(display: &mut Display, event_loop: &mut EventLoop<()>, log: Log
 
     init_data_device(display, |_| {}, default_action_chooser, log.clone());
 
-    let (mut seat, _) = Seat::new(display, "winit".into(), log.clone());
+    let (mut seat, _) = Seat::new(display, "winit".into(), compositor_token.clone(), log.clone());
 
-    let pointer = seat.add_pointer();
+    let pointer = seat.add_pointer(compositor_token.clone(), |_| {});
 
     let keyboard = seat
         .add_keyboard(XkbConfig::default(), 1000, 500, |seat, focus| {

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -17,7 +17,7 @@ pub struct CursorImageRole {
 }
 
 /// Possible status of a cursor as requested by clients
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum CursorImageStatus {
     /// The cursor should be hidden
     Hidden,


### PR DESCRIPTION
depends on #115 

fixes #49 

This introduces the necessary code in the wayland protocol handlers to correctly process requests from clients to set custom cursor images, both in general and in a DnD context.

This does *not* implement any of the necessary logic in anvil to actually display them.