### PR TITLE
wayland.shell: Fix a leak of surfaces

### DIFF
--- a/src/wayland/shell/xdg/xdg_handlers.rs
+++ b/src/wayland/shell/xdg/xdg_handlers.rs
@@ -533,7 +533,6 @@ where
         // the wl_surface is destroyed, this means the client is not
         // trying to change the role but it's a cleanup (possibly a
         // disconnecting client), ignore the protocol check.
-        return;
     } else {
         data.shell_data
             .compositor_token
@@ -622,7 +621,6 @@ where
         // the wl_surface is destroyed, this means the client is not
         // trying to change the role but it's a cleanup (possibly a
         // disconnecting client), ignore the protocol check.
-        return;
     } else {
         data.shell_data
             .compositor_token

--- a/src/wayland/shell/xdg/zxdgv6_handlers.rs
+++ b/src/wayland/shell/xdg/zxdgv6_handlers.rs
@@ -547,7 +547,6 @@ where
         // the wl_surface is destroyed, this means the client is not
         // trying to change the role but it's a cleanup (possibly a
         // disconnecting client), ignore the protocol check.
-        return;
     } else {
         data.shell_data
             .compositor_token
@@ -639,7 +638,6 @@ where
         // the wl_surface is destroyed, this means the client is not
         // trying to change the role but it's a cleanup (possibly a
         // disconnecting client), ignore the protocol check.
-        return;
     } else {
         data.shell_data
             .compositor_token

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -4,7 +4,7 @@ containers:
     base:
         auto-clean: true
         setup:
-            - !UbuntuRelease { codename: artful }
+            - !UbuntuRelease { codename: cosmic }
             - !UbuntuUniverse
             - !Install [build-essential, wget, curl, pkg-config, file, openssl, sudo, ca-certificates, libssl-dev, cmake, libudev-dev, libgbm-dev, libxkbcommon-dev, libegl1-mesa-dev, libwayland-dev, libinput-dev, libsystemd-dev, libdbus-1-dev]
 


### PR DESCRIPTION
As the comment in the code states, the role check should be skipped for toplevels linked to dead surfaces.

The current code however not only skipped the check, but also the cleanup of the global toplevel list. Which is obviously wrong. This PR fixes that.