### PR TITLE
Make wayland support optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ env:
     - FEATURES="backend_session_logind"
     - FEATURES="renderer_gl"
     - FEATURES="renderer_glium"
+    - FEATURES="wayland_frontend"
     - FEATURES="xwayland"
       # test default features
     - FEATURES="default"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ edition = "2018"
 members = [ "anvil" ]
 
 [dependencies]
-wayland-server = "0.21.6"
-wayland-commons = "0.21.1"
+wayland-server = { version = "0.21.6", optional = true }
+wayland-commons = { version = "0.21.1", optional = true }
 wayland-sys = { version = "0.21.6", optional = true }
+calloop = "0.4.2"
 nix = "0.11"
 xkbcommon = "0.2.1"
 tempfile = "2.1.5"
@@ -29,8 +30,8 @@ input = { version = "0.4.1", optional = true }
 udev = { version = "0.2.0", optional = true }
 dbus = { version = "0.6.1", optional = true }
 systemd = { version = "^0.2.0", optional = true }
-wayland-protocols = { version = "0.21.3", features = ["unstable_protocols", "server"] }
-image = "0.17.0"
+wayland-protocols = { version = "0.21.3", features = ["unstable_protocols", "server"], optional = true }
+image = { version = "0.17.0", optional = true }
 error-chain = "0.11.0"
 lazy_static = "1.0.0"
 
@@ -41,11 +42,11 @@ slog-term = "2.3"
 gl_generator = { version = "0.9", optional = true }
 
 [features]
-default = ["backend_winit", "backend_drm_legacy", "backend_drm_gbm", "backend_drm_egl", "backend_libinput", "backend_udev", "backend_session", "renderer_glium", "xwayland"]
+default = ["backend_winit", "backend_drm_legacy", "backend_drm_gbm", "backend_drm_egl", "backend_libinput", "backend_udev", "backend_session", "renderer_glium", "xwayland", "wayland_frontend"]
 backend_winit = ["winit", "wayland-server/dlopen", "wayland-client/dlopen", "backend_egl", "renderer_gl", "native_lib"]
 backend_drm = ["drm"]
 backend_drm_legacy = ["backend_drm"]
-backend_drm_gbm = ["backend_drm", "gbm"]
+backend_drm_gbm = ["backend_drm", "gbm", "image"]
 backend_drm_egl = ["backend_drm", "backend_egl"]
 backend_egl = ["gl_generator"]
 backend_libinput = ["input"]
@@ -54,8 +55,9 @@ backend_udev = ["udev"]
 backend_session_logind = ["dbus", "systemd", "backend_session"]
 renderer_gl = ["gl_generator"]
 renderer_glium = ["renderer_gl", "glium"]
-native_lib = ["wayland-sys", "wayland-server/native_lib", "wayland-protocols/native_server"]
-xwayland = []
+native_lib = ["wayland_frontend", "wayland-sys", "wayland-server/native_lib", "wayland-protocols/native_server"]
+wayland_frontend = ["wayland-server", "wayland-commons", "wayland-protocols"]
+xwayland = ["wayland_frontend"]
 
 [[example]]
 name = "raw_drm"

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -18,7 +18,7 @@ xkbcommon = "0.2.1"
 [dependencies.smithay]
 path = ".."
 default-features = false
-features = [ "renderer_glium", "backend_egl" ]
+features = [ "renderer_glium", "backend_egl", "wayland_frontend" ]
 
 [build-dependencies]
 gl_generator = "0.9"

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -8,7 +8,7 @@ extern crate slog;
 extern crate smithay;
 
 use slog::Drain;
-use smithay::reexports::wayland_server::{calloop::EventLoop, Display};
+use smithay::reexports::{calloop::EventLoop, wayland_server::Display};
 
 #[macro_use]
 mod shaders;

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -6,7 +6,10 @@ use std::{
 
 use smithay::{
     backend::{egl::EGLGraphicsBackend, graphics::gl::GLGraphicsBackend, input::InputBackend, winit},
-    reexports::wayland_server::{calloop::EventLoop, protocol::wl_output, Display},
+    reexports::{
+        calloop::EventLoop,
+        wayland_server::{protocol::wl_output, Display},
+    },
     wayland::{
         data_device::{default_action_chooser, init_data_device, set_data_device_focus, DataDeviceEvent},
         output::{Mode, Output, PhysicalProperties},

--- a/examples/raw_drm.rs
+++ b/examples/raw_drm.rs
@@ -11,6 +11,7 @@ use smithay::{
         Device, DeviceHandler, RawSurface, Surface,
     },
     reexports::{
+        calloop::EventLoop,
         drm::{
             buffer::PixelFormat,
             control::{
@@ -20,7 +21,6 @@ use smithay::{
                 encoder, framebuffer, Device as ControlDevice, ResourceInfo,
             },
         },
-        wayland_server::calloop::EventLoop,
     },
 };
 use std::{

--- a/src/backend/drm/egl/mod.rs
+++ b/src/backend/drm/egl/mod.rs
@@ -12,6 +12,7 @@ use drm::control::{crtc, ResourceHandles, ResourceInfo};
 use nix::libc::dev_t;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::rc::Rc;
+#[cfg(feature = "native_lib")]
 use wayland_server::Display;
 
 use super::{Device, DeviceHandler, Surface};

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -46,10 +46,10 @@ use std::iter::IntoIterator;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 
-use wayland_server::calloop::generic::{EventedFd, Generic};
-use wayland_server::calloop::mio::Ready;
-use wayland_server::calloop::InsertError;
-use wayland_server::calloop::{LoopHandle, Source};
+use calloop::generic::{EventedFd, Generic};
+use calloop::mio::Ready;
+use calloop::InsertError;
+use calloop::{LoopHandle, Source};
 
 use super::graphics::SwapBuffersError;
 
@@ -106,7 +106,7 @@ pub trait Device: AsRawFd + DevPath {
     ///
     /// You should not call this function manually, but rather use
     /// [`device_bind`] to register the device
-    /// to an [`EventLoop`](wayland_server::calloop::EventLoop)
+    /// to an [`EventLoop`](calloop::EventLoop)
     /// to synchronize your rendering to the vblank events of the open crtc's
     fn process_events(&mut self);
 
@@ -222,7 +222,7 @@ impl<A: AsRawFd> DevPath for A {
     }
 }
 
-/// Bind a `Device` to an [`EventLoop`](wayland_server::calloop::EventLoop),
+/// Bind a `Device` to an [`EventLoop`](calloop::EventLoop),
 ///
 /// This will cause it to recieve events and feed them into a previously
 /// set [`DeviceHandler`](DeviceHandler).

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -26,6 +26,7 @@ use std::{
     fmt,
     rc::{Rc, Weak},
 };
+#[cfg(feature = "wayland_frontend")]
 use wayland_server::{
     protocol::wl_buffer::{self, WlBuffer},
     Display, Resource,
@@ -72,6 +73,7 @@ impl ::std::error::Error for EglExtensionNotSupportedError {
 }
 
 /// Error that can occur when accessing an EGL buffer
+#[cfg(feature = "wayland_frontend")]
 pub enum BufferAccessError {
     /// The corresponding Context is not alive anymore
     ContextLost,
@@ -83,6 +85,7 @@ pub enum BufferAccessError {
     EglExtensionNotSupported(EglExtensionNotSupportedError),
 }
 
+#[cfg(feature = "wayland_frontend")]
 impl fmt::Debug for BufferAccessError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         match *self {
@@ -96,6 +99,7 @@ impl fmt::Debug for BufferAccessError {
     }
 }
 
+#[cfg(feature = "wayland_frontend")]
 impl fmt::Display for BufferAccessError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         use std::error::Error;
@@ -108,6 +112,7 @@ impl fmt::Display for BufferAccessError {
     }
 }
 
+#[cfg(feature = "wayland_frontend")]
 impl ::std::error::Error for BufferAccessError {
     fn description(&self) -> &str {
         match *self {
@@ -126,6 +131,7 @@ impl ::std::error::Error for BufferAccessError {
     }
 }
 
+#[cfg(feature = "wayland_frontend")]
 impl From<EglExtensionNotSupportedError> for BufferAccessError {
     fn from(error: EglExtensionNotSupportedError) -> Self {
         BufferAccessError::EglExtensionNotSupported(error)
@@ -221,6 +227,7 @@ impl Format {
 }
 
 /// Images of the EGL-based [`WlBuffer`].
+#[cfg(feature = "wayland_frontend")]
 pub struct EGLImages {
     display: Weak<ffi::egl::types::EGLDisplay>,
     /// Width in pixels
@@ -239,6 +246,7 @@ pub struct EGLImages {
     egl_to_texture_support: bool,
 }
 
+#[cfg(feature = "wayland_frontend")]
 impl EGLImages {
     /// Amount of planes of these `EGLImages`
     pub fn num_planes(&self) -> usize {
@@ -285,6 +293,7 @@ impl EGLImages {
     }
 }
 
+#[cfg(feature = "wayland_frontend")]
 impl Drop for EGLImages {
     fn drop(&mut self) {
         if let Some(display) = self.display.upgrade() {

--- a/src/backend/libinput.rs
+++ b/src/backend/libinput.rs
@@ -15,7 +15,7 @@ use std::{
     os::unix::io::{AsRawFd, RawFd},
 };
 
-use wayland_server::calloop::{
+use calloop::{
     generic::{EventedFd, Generic},
     mio::Ready,
     InsertError, LoopHandle, Source,

--- a/src/backend/session/auto.rs
+++ b/src/backend/session/auto.rs
@@ -37,7 +37,7 @@ use super::{
 use nix::fcntl::OFlag;
 use std::{cell::RefCell, io::Error as IoError, os::unix::io::RawFd, path::Path, rc::Rc};
 
-use wayland_server::calloop::LoopHandle;
+use calloop::LoopHandle;
 
 /// [`Session`] using the best available interface
 #[derive(Clone)]
@@ -58,7 +58,7 @@ pub enum AutoSessionNotifier {
     Direct(DirectSessionNotifier),
 }
 
-/// Bound session that is driven by a [`EventLoop`](wayland_server::calloop::EventLoop).
+/// Bound session that is driven by a [`EventLoop`](calloop::EventLoop).
 ///
 /// See [`auto_session_bind`] for details.
 ///
@@ -139,7 +139,7 @@ impl AutoSession {
     }
 }
 
-/// Bind an [`AutoSessionNotifier`] to an [`EventLoop`](wayland_server::calloop::EventLoop).
+/// Bind an [`AutoSessionNotifier`] to an [`EventLoop`](calloop::EventLoop).
 ///
 /// Allows the [`AutoSessionNotifier`] to listen for incoming signals signalling the session state.
 /// If you don't use this function [`AutoSessionNotifier`] will not correctly tell you the
@@ -233,7 +233,7 @@ impl SessionNotifier for AutoSessionNotifier {
 }
 
 impl BoundAutoSession {
-    /// Unbind the session from the [`EventLoop`](wayland_server::calloop::EventLoop) again
+    /// Unbind the session from the [`EventLoop`](calloop::EventLoop) again
     pub fn unbind(self) -> AutoSessionNotifier {
         match self {
             #[cfg(feature = "backend_session_logind")]

--- a/src/backend/session/dbus/logind.rs
+++ b/src/backend/session/dbus/logind.rs
@@ -50,7 +50,7 @@ use std::{
 };
 use systemd::login;
 
-use wayland_server::calloop::{
+use calloop::{
     generic::{Event, EventedRawFd, Generic},
     mio::Ready,
     InsertError, LoopHandle, Source,
@@ -418,7 +418,7 @@ impl SessionNotifier for LogindSessionNotifier {
     }
 }
 
-/// Bound logind session that is driven by the [`EventLoop`](wayland_server::calloop::EventLoop).
+/// Bound logind session that is driven by the [`EventLoop`](calloop::EventLoop).
 ///
 /// See [`logind_session_bind`] for details.
 ///
@@ -429,7 +429,7 @@ pub struct BoundLogindSession {
     sources: Vec<Source<Generic<EventedRawFd>>>,
 }
 
-/// Bind a [`LogindSessionNotifier`] to an [`EventLoop`](wayland_server::calloop::EventLoop).
+/// Bind a [`LogindSessionNotifier`] to an [`EventLoop`](calloop::EventLoop).
 ///
 /// Allows the [`LogindSessionNotifier`] to listen for incoming signals signalling the session state.
 /// If you don't use this function [`LogindSessionNotifier`] will not correctly tell you the logind
@@ -472,7 +472,7 @@ pub fn logind_session_bind<Data: 'static>(
 }
 
 impl BoundLogindSession {
-    /// Unbind the logind session from the [`EventLoop`](wayland_server::calloop::EventLoop)
+    /// Unbind the logind session from the [`EventLoop`](calloop::EventLoop)
     pub fn unbind(self) -> LogindSessionNotifier {
         for source in self.sources {
             source.remove();

--- a/src/backend/session/direct.rs
+++ b/src/backend/session/direct.rs
@@ -45,6 +45,7 @@
 //! for notifications are the [`Libinput`](input::Libinput) context or the [`Device`](::backend::drm::Device).
 
 use super::{AsErrno, Session, SessionNotifier, SessionObserver};
+use calloop::{signals::Signals, LoopHandle, Source};
 use nix::{
     fcntl::{self, open, OFlag},
     libc::c_int,
@@ -68,7 +69,6 @@ use std::{
 };
 #[cfg(feature = "backend_udev")]
 use udev::Context;
-use wayland_server::calloop::{signals::Signals, LoopHandle, Source};
 
 #[allow(dead_code)]
 mod tty {
@@ -390,7 +390,7 @@ impl DirectSessionNotifier {
     }
 }
 
-/// Bound logind session that is driven by the [`EventLoop`](wayland_server::calloop::EventLoop).
+/// Bound logind session that is driven by the [`EventLoop`](calloop::EventLoop).
 ///
 /// See [`direct_session_bind`] for details.
 pub struct BoundDirectSession {
@@ -399,7 +399,7 @@ pub struct BoundDirectSession {
 }
 
 impl BoundDirectSession {
-    /// Unbind the direct session from the [`EventLoop`](wayland_server::calloop::EventLoop)
+    /// Unbind the direct session from the [`EventLoop`](calloop::EventLoop)
     pub fn unbind(self) -> DirectSessionNotifier {
         let BoundDirectSession { source, notifier } = self;
         source.remove();
@@ -410,7 +410,7 @@ impl BoundDirectSession {
     }
 }
 
-/// Bind a [`DirectSessionNotifier`] to an [`EventLoop`](wayland_server::calloop::EventLoop).
+/// Bind a [`DirectSessionNotifier`] to an [`EventLoop`](calloop::EventLoop).
 ///
 /// Allows the [`DirectSessionNotifier`] to listen for incoming signals signalling the session state.
 /// If you don't use this function [`DirectSessionNotifier`] will not correctly tell you the current

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -18,7 +18,7 @@ use std::{
 };
 use udev::{Context, Enumerator, EventType, MonitorBuilder, MonitorSocket, Result as UdevResult};
 
-use wayland_server::calloop::{
+use calloop::{
     generic::{EventedFd, Generic},
     mio::Ready,
     InsertError, LoopHandle, Source,
@@ -97,7 +97,7 @@ impl<T: UdevHandler + 'static> Drop for UdevBackend<T> {
     }
 }
 
-/// Binds a [`UdevBackend`] to a given [`EventLoop`](wayland_server::calloop::EventLoop).
+/// Binds a [`UdevBackend`] to a given [`EventLoop`](calloop::EventLoop).
 ///
 /// Allows the backend to receive kernel events and thus to drive the [`UdevHandler`].
 /// No runtime functionality can be provided without using this function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate lazy_static;
 
 pub mod backend;
 pub mod utils;
+#[cfg(feature = "wayland_frontend")]
 pub mod wayland;
 
 #[cfg(feature = "xwayland")]

--- a/src/reexports.rs
+++ b/src/reexports.rs
@@ -1,5 +1,6 @@
 //! Reexports of crates, that are part of the public api, for convenience
 
+pub use calloop;
 #[cfg(feature = "dbus")]
 pub use dbus;
 #[cfg(feature = "backend_drm")]
@@ -16,6 +17,9 @@ pub use nix;
 pub use systemd;
 #[cfg(feature = "backend_udev")]
 pub use udev;
+#[cfg(feature = "wayland_frontend")]
 pub use wayland_commons;
+#[cfg(feature = "wayland_frontend")]
 pub use wayland_protocols;
+#[cfg(feature = "wayland_frontend")]
 pub use wayland_server;


### PR DESCRIPTION
All is in the title, hide all wayland-related stuff behind a feature-gate, so that it is possible to use smithay's backends for standalone tty applications without depending on wayland.