### PR TITLE
Subsurface rework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 members = [ "anvil" ]
 
 [dependencies]
-wayland-server = { version = "0.23", optional = true }
+wayland-server = { version = "0.23.2", optional = true }
 wayland-commons = { version = "0.23", optional = true }
 wayland-sys = { version = "0.23", optional = true }
 calloop = "0.4.2"

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -300,6 +300,7 @@ impl Drop for EGLImages {
                 }
             }
         }
+        println!("RELEASING EGL BUFFER");
         self.buffer.release();
     }
 }

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -139,6 +139,7 @@ where
         Some(|surface| SurfaceData::<U, R>::cleanup(&surface)),
         SurfaceData::<U, R>::new(),
     );
+    SurfaceData::<U, R>::init(&surface);
     surface
 }
 


### PR DESCRIPTION
Rework the subsurface tree by:

- forbidding subsurface loops
- storing the relative depth of a parent to its children,
  finally respecting the wl_subsurface specification.

closes #23

Also contains a small bugfix of anvil, which would attempt to release the same EGL buffer several times, causing segfaults when trying to release an already-destroyed buffer (as it comes from mesa we don't benefit of the liveness-tracking of wayland-server...)