### PR TITLE
Remove user data type parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [ "anvil" ]
 
 [dependencies]
 wayland-server = { version = "0.23.2", optional = true }
-wayland-commons = { version = "0.23", optional = true }
+wayland-commons = { version = "0.23.3", optional = true }
 wayland-sys = { version = "0.23", optional = true }
 calloop = "0.4.2"
 nix = "0.13"

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -31,12 +31,12 @@ use crate::window_map::{Kind as SurfaceKind, WindowMap};
 
 define_roles!(Roles =>
     [ XdgSurface, XdgSurfaceRole ]
-    [ ShellSurface, ShellSurfaceRole<()>]
+    [ ShellSurface, ShellSurfaceRole]
     [ DnDIcon, DnDIconRole ]
     [ CursorImage, CursorImageRole ]
 );
 
-pub type MyWindowMap = WindowMap<Roles, (), (), fn(&SurfaceAttributes) -> Option<(i32, i32)>>;
+pub type MyWindowMap = WindowMap<Roles, fn(&SurfaceAttributes) -> Option<(i32, i32)>>;
 
 pub type MyCompositorToken = CompositorToken<Roles>;
 
@@ -45,8 +45,8 @@ pub fn init_shell(
     log: ::slog::Logger,
 ) -> (
     CompositorToken<Roles>,
-    Arc<Mutex<XdgShellState<Roles, ()>>>,
-    Arc<Mutex<WlShellState<Roles, ()>>>,
+    Arc<Mutex<XdgShellState<Roles>>>,
+    Arc<Mutex<WlShellState<Roles>>>,
     Rc<RefCell<MyWindowMap>>,
 ) {
     // Create the compositor
@@ -62,7 +62,7 @@ pub fn init_shell(
     );
 
     // Init a window map, to track the location of our windows
-    let window_map = Rc::new(RefCell::new(WindowMap::<_, (), (), _>::new(
+    let window_map = Rc::new(RefCell::new(WindowMap::<_, _>::new(
         compositor_token,
         get_size as _,
     )));
@@ -104,7 +104,7 @@ pub fn init_shell(
     let (wl_shell_state, _) = wl_shell_init(
         display,
         compositor_token,
-        move |req: ShellRequest<_, ()>| {
+        move |req: ShellRequest<_>| {
             if let ShellRequest::SetKind {
                 surface,
                 kind: ShellSurfaceKind::Toplevel,

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -63,7 +63,7 @@ use smithay::{
 
 use crate::glium_drawer::GliumDrawer;
 use crate::input_handler::AnvilInputHandler;
-use crate::shell::{init_shell, MyWindowMap, Roles, SurfaceData};
+use crate::shell::{init_shell, MyWindowMap, Roles};
 
 pub struct SessionFd(RawFd);
 impl AsRawFd for SessionFd {
@@ -272,7 +272,7 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<()>, log: Logger
 }
 
 struct UdevHandlerImpl<S: SessionNotifier, Data: 'static> {
-    compositor_token: CompositorToken<SurfaceData, Roles>,
+    compositor_token: CompositorToken<Roles>,
     #[cfg(feature = "egl")]
     active_egl_context: Rc<RefCell<Option<EGLDisplay>>>,
     session: AutoSession,
@@ -522,7 +522,7 @@ impl<S: SessionNotifier, Data: 'static> UdevHandler for UdevHandlerImpl<S, Data>
 }
 
 pub struct DrmHandlerImpl {
-    compositor_token: CompositorToken<SurfaceData, Roles>,
+    compositor_token: CompositorToken<Roles>,
     backends: Rc<RefCell<HashMap<crtc::Handle, GliumDrawer<RenderSurface>>>>,
     window_map: Rc<RefCell<MyWindowMap>>,
     pointer_location: Rc<RefCell<(f64, f64)>>,

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -12,16 +12,14 @@ use smithay::{
     },
 };
 
-pub enum Kind<R, SD, D> {
-    Xdg(ToplevelSurface<R, SD>),
-    Wl(ShellSurface<R, D>),
+pub enum Kind<R> {
+    Xdg(ToplevelSurface<R>),
+    Wl(ShellSurface<R>),
 }
 
-impl<R, SD, D> Kind<R, SD, D>
+impl<R> Kind<R>
 where
-    R: Role<SubsurfaceRole> + Role<XdgSurfaceRole> + Role<ShellSurfaceRole<D>> + 'static,
-    SD: 'static,
-    D: 'static,
+    R: Role<SubsurfaceRole> + Role<XdgSurfaceRole> + Role<ShellSurfaceRole> + 'static,
 {
     pub fn alive(&self) -> bool {
         match *self {
@@ -37,17 +35,15 @@ where
     }
 }
 
-struct Window<R, SD, D> {
+struct Window<R> {
     location: (i32, i32),
     surface: Rectangle,
-    toplevel: Kind<R, SD, D>,
+    toplevel: Kind<R>,
 }
 
-impl<R, SD, D> Window<R, SD, D>
+impl<R> Window<R>
 where
-    R: Role<SubsurfaceRole> + Role<XdgSurfaceRole> + Role<ShellSurfaceRole<D>> + 'static,
-    SD: 'static,
-    D: 'static,
+    R: Role<SubsurfaceRole> + Role<XdgSurfaceRole> + Role<ShellSurfaceRole> + 'static,
 {
     // Find the topmost surface under this point if any and the location of this surface
     fn matching<F>(
@@ -146,20 +142,18 @@ where
     }
 }
 
-pub struct WindowMap<R, SD, D, F> {
+pub struct WindowMap<R, F> {
     ctoken: CompositorToken<R>,
-    windows: Vec<Window<R, SD, D>>,
+    windows: Vec<Window<R>>,
     get_size: F,
 }
 
-impl<R, SD, D, F> WindowMap<R, SD, D, F>
+impl<R, F> WindowMap<R, F>
 where
     F: Fn(&SurfaceAttributes) -> Option<(i32, i32)>,
-    R: Role<SubsurfaceRole> + Role<XdgSurfaceRole> + Role<ShellSurfaceRole<D>> + 'static,
-    SD: 'static,
-    D: 'static,
+    R: Role<SubsurfaceRole> + Role<XdgSurfaceRole> + Role<ShellSurfaceRole> + 'static,
 {
-    pub fn new(ctoken: CompositorToken<R>, get_size: F) -> WindowMap<R, D, SD, F> {
+    pub fn new(ctoken: CompositorToken<R>, get_size: F) -> WindowMap<R, F> {
         WindowMap {
             ctoken,
             windows: Vec::new(),
@@ -167,7 +161,7 @@ where
         }
     }
 
-    pub fn insert(&mut self, toplevel: Kind<R, SD, D>, location: (i32, i32)) {
+    pub fn insert(&mut self, toplevel: Kind<R>, location: (i32, i32)) {
         let mut window = Window {
             location,
             surface: Rectangle {
@@ -213,7 +207,7 @@ where
 
     pub fn with_windows_from_bottom_to_top<Func>(&self, mut f: Func)
     where
-        Func: FnMut(&Kind<R, SD, D>, (i32, i32)),
+        Func: FnMut(&Kind<R>, (i32, i32)),
     {
         for w in self.windows.iter().rev() {
             f(&w.toplevel, w.location)

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -300,7 +300,6 @@ impl Drop for EGLImages {
                 }
             }
         }
-        println!("RELEASING EGL BUFFER");
         self.buffer.release();
     }
 }

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -32,14 +32,6 @@
 //! # #[macro_use] extern crate smithay;
 //! use smithay::wayland::compositor::compositor_init;
 //!
-//! // Define some user data to be associated with the surfaces.
-//! // It must implement the Default trait, which will represent the state of a surface which
-//! // has just been created.
-//! #[derive(Default)]
-//! struct MyData {
-//!     // whatever you need here
-//! }
-//!
 //! // Declare the roles enum
 //! define_roles!(MyRoles);
 //!
@@ -47,7 +39,7 @@
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
 //! // Call the init function:
-//! let (token, _, _) = compositor_init::<MyData, MyRoles, _, _>(
+//! let (token, _, _) = compositor_init::<MyRoles, _, _>(
 //!     &mut display,
 //!     |request, surface, compositor_token| {
 //!         /*
@@ -112,8 +104,7 @@ pub enum Damage {
 }
 
 #[derive(Copy, Clone, Default)]
-struct Marker<U, R> {
-    _u: ::std::marker::PhantomData<U>,
+struct Marker<R> {
     _r: ::std::marker::PhantomData<R>,
 }
 
@@ -125,7 +116,7 @@ struct Marker<U, R> {
 ///
 /// You are responsible for setting those values as you see fit to avoid
 /// processing them two times.
-pub struct SurfaceAttributes<U> {
+pub struct SurfaceAttributes {
     /// Buffer defining the contents of the surface
     ///
     /// The tuple represent the coordinates of this buffer
@@ -164,11 +155,11 @@ pub struct SurfaceAttributes<U> {
     /// User-controlled data
     ///
     /// This is your field to host whatever you need.
-    pub user_data: U,
+    pub user_data: ::wayland_commons::utils::UserDataMap,
 }
 
-impl<U: Default> Default for SurfaceAttributes<U> {
-    fn default() -> SurfaceAttributes<U> {
+impl Default for SurfaceAttributes {
+    fn default() -> SurfaceAttributes {
         SurfaceAttributes {
             buffer: None,
             buffer_scale: 1,
@@ -176,7 +167,7 @@ impl<U: Default> Default for SurfaceAttributes<U> {
             opaque_region: None,
             input_region: None,
             damage: Damage::Full,
-            user_data: Default::default(),
+            user_data: ::wayland_commons::utils::UserDataMap::new(),
         }
     }
 }
@@ -239,33 +230,30 @@ impl Default for RegionAttributes {
 /// access data associated with the [`wl_surface`](wayland_server::protocol::wl_surface)
 /// and [`wl_region`](wayland_server::protocol::wl_region) managed
 /// by the `CompositorGlobal` that provided it.
-pub struct CompositorToken<U, R> {
-    _data: ::std::marker::PhantomData<*mut U>,
+pub struct CompositorToken<R> {
     _role: ::std::marker::PhantomData<*mut R>,
 }
 
-// we implement them manually because #[derive(..)] would require
-// U: Clone and R: Clone
-impl<U, R> Copy for CompositorToken<U, R> {}
-impl<U, R> Clone for CompositorToken<U, R> {
-    fn clone(&self) -> CompositorToken<U, R> {
+// we implement them manually because #[derive(..)] would require R: Clone
+impl<R> Copy for CompositorToken<R> {}
+impl<R> Clone for CompositorToken<R> {
+    fn clone(&self) -> CompositorToken<R> {
         *self
     }
 }
 
-unsafe impl<U, R> Send for CompositorToken<U, R> {}
-unsafe impl<U, R> Sync for CompositorToken<U, R> {}
+unsafe impl<R> Send for CompositorToken<R> {}
+unsafe impl<R> Sync for CompositorToken<R> {}
 
-impl<U, R> CompositorToken<U, R> {
-    pub(crate) fn make() -> CompositorToken<U, R> {
+impl<R> CompositorToken<R> {
+    pub(crate) fn make() -> CompositorToken<R> {
         CompositorToken {
-            _data: ::std::marker::PhantomData,
             _role: ::std::marker::PhantomData,
         }
     }
 }
 
-impl<U: 'static, R: 'static> CompositorToken<U, R> {
+impl<R: 'static> CompositorToken<R> {
     /// Access the data of a surface
     ///
     /// The closure will be called with the contents of the data associated with this surface.
@@ -274,15 +262,14 @@ impl<U: 'static, R: 'static> CompositorToken<U, R> {
     /// will panic (having more than one compositor is not supported).
     pub fn with_surface_data<F, T>(&self, surface: &WlSurface, f: F) -> T
     where
-        F: FnOnce(&mut SurfaceAttributes<U>) -> T,
+        F: FnOnce(&mut SurfaceAttributes) -> T,
     {
-        SurfaceData::<U, R>::with_data(surface, f)
+        SurfaceData::<R>::with_data(surface, f)
     }
 }
 
-impl<U, R> CompositorToken<U, R>
+impl<R> CompositorToken<R>
 where
-    U: 'static,
     R: RoleType + Role<SubsurfaceRole> + 'static,
 {
     /// Access the data of a surface tree from bottom to top
@@ -319,11 +306,11 @@ where
         processor: F2,
         post_filter: F3,
     ) where
-        F1: FnMut(&WlSurface, &mut SurfaceAttributes<U>, &mut R, &T) -> TraversalAction<T>,
-        F2: FnMut(&WlSurface, &mut SurfaceAttributes<U>, &mut R, &T),
-        F3: FnMut(&WlSurface, &mut SurfaceAttributes<U>, &mut R, &T) -> bool,
+        F1: FnMut(&WlSurface, &mut SurfaceAttributes, &mut R, &T) -> TraversalAction<T>,
+        F2: FnMut(&WlSurface, &mut SurfaceAttributes, &mut R, &T),
+        F3: FnMut(&WlSurface, &mut SurfaceAttributes, &mut R, &T) -> bool,
     {
-        SurfaceData::<U, R>::map_tree(surface, &initial, filter, processor, post_filter, false);
+        SurfaceData::<R>::map_tree(surface, &initial, filter, processor, post_filter, false);
     }
 
     /// Access the data of a surface tree from top to bottom
@@ -340,11 +327,11 @@ where
         processor: F2,
         post_filter: F3,
     ) where
-        F1: FnMut(&WlSurface, &mut SurfaceAttributes<U>, &mut R, &T) -> TraversalAction<T>,
-        F2: FnMut(&WlSurface, &mut SurfaceAttributes<U>, &mut R, &T),
-        F3: FnMut(&WlSurface, &mut SurfaceAttributes<U>, &mut R, &T) -> bool,
+        F1: FnMut(&WlSurface, &mut SurfaceAttributes, &mut R, &T) -> TraversalAction<T>,
+        F2: FnMut(&WlSurface, &mut SurfaceAttributes, &mut R, &T),
+        F3: FnMut(&WlSurface, &mut SurfaceAttributes, &mut R, &T) -> bool,
     {
-        SurfaceData::<U, R>::map_tree(surface, &initial, filter, processor, post_filter, true);
+        SurfaceData::<R>::map_tree(surface, &initial, filter, processor, post_filter, true);
     }
 
     /// Retrieve the parent of this surface
@@ -354,7 +341,7 @@ where
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn get_parent(&self, surface: &WlSurface) -> Option<WlSurface> {
-        SurfaceData::<U, R>::get_parent(surface)
+        SurfaceData::<R>::get_parent(surface)
     }
 
     /// Retrieve the children of this surface
@@ -362,17 +349,17 @@ where
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn get_children(&self, surface: &WlSurface) -> Vec<WlSurface> {
-        SurfaceData::<U, R>::get_children(surface)
+        SurfaceData::<R>::get_children(surface)
     }
 }
 
-impl<U: 'static, R: RoleType + 'static> CompositorToken<U, R> {
+impl<R: RoleType + 'static> CompositorToken<R> {
     /// Check whether this surface as a role or not
     ///
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn has_a_role(&self, surface: &WlSurface) -> bool {
-        SurfaceData::<U, R>::has_a_role(surface)
+        SurfaceData::<R>::has_a_role(surface)
     }
 
     /// Check whether this surface as a specific role
@@ -383,7 +370,7 @@ impl<U: 'static, R: RoleType + 'static> CompositorToken<U, R> {
     where
         R: Role<RoleData>,
     {
-        SurfaceData::<U, R>::has_role::<RoleData>(surface)
+        SurfaceData::<R>::has_role::<RoleData>(surface)
     }
 
     /// Register that this surface has given role with default data
@@ -397,7 +384,7 @@ impl<U: 'static, R: RoleType + 'static> CompositorToken<U, R> {
         R: Role<RoleData>,
         RoleData: Default,
     {
-        SurfaceData::<U, R>::give_role::<RoleData>(surface)
+        SurfaceData::<R>::give_role::<RoleData>(surface)
     }
 
     /// Register that this surface has given role with given data
@@ -410,7 +397,7 @@ impl<U: 'static, R: RoleType + 'static> CompositorToken<U, R> {
     where
         R: Role<RoleData>,
     {
-        SurfaceData::<U, R>::give_role_with::<RoleData>(surface, data)
+        SurfaceData::<R>::give_role_with::<RoleData>(surface, data)
     }
 
     /// Access the role data of a surface
@@ -424,7 +411,7 @@ impl<U: 'static, R: RoleType + 'static> CompositorToken<U, R> {
         R: Role<RoleData>,
         F: FnOnce(&mut RoleData) -> T,
     {
-        SurfaceData::<U, R>::with_role_data::<RoleData, _, _>(surface, f)
+        SurfaceData::<R>::with_role_data::<RoleData, _, _>(surface, f)
     }
 
     /// Register that this surface does not have a role any longer and retrieve the data
@@ -437,7 +424,7 @@ impl<U: 'static, R: RoleType + 'static> CompositorToken<U, R> {
     where
         R: Role<RoleData>,
     {
-        SurfaceData::<U, R>::remove_role::<RoleData>(surface)
+        SurfaceData::<R>::remove_role::<RoleData>(surface)
     }
 
     /// Retrieve the metadata associated with a `wl_region`
@@ -461,30 +448,29 @@ impl<U: 'static, R: RoleType + 'static> CompositorToken<U, R> {
 ///
 /// It also returns the two global handles, in case you wish to remove these
 /// globals from the event loop in the future.
-pub fn compositor_init<U, R, Impl, L>(
+pub fn compositor_init<R, Impl, L>(
     display: &mut Display,
     implem: Impl,
     logger: L,
 ) -> (
-    CompositorToken<U, R>,
+    CompositorToken<R>,
     Global<wl_compositor::WlCompositor>,
     Global<wl_subcompositor::WlSubcompositor>,
 )
 where
     L: Into<Option<::slog::Logger>>,
-    U: Default + 'static,
     R: Default + RoleType + Role<SubsurfaceRole> + 'static,
-    Impl: FnMut(SurfaceEvent, WlSurface, CompositorToken<U, R>) + 'static,
+    Impl: FnMut(SurfaceEvent, WlSurface, CompositorToken<R>) + 'static,
 {
     let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "compositor_handler"));
     let implem = Rc::new(RefCell::new(implem));
 
     let compositor = display.create_global(4, move |new_compositor, _version| {
-        self::handlers::implement_compositor::<U, R, Impl>(new_compositor, log.clone(), implem.clone());
+        self::handlers::implement_compositor::<R, Impl>(new_compositor, log.clone(), implem.clone());
     });
 
     let subcompositor = display.create_global(1, move |new_subcompositor, _version| {
-        self::handlers::implement_subcompositor::<U, R>(new_subcompositor);
+        self::handlers::implement_subcompositor::<R>(new_subcompositor);
     });
 
     (CompositorToken::make(), compositor, subcompositor)

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -13,7 +13,7 @@ use crate::wayland::{
 
 use super::{with_source_metadata, DataDeviceData, DnDIconRole, SeatData};
 
-pub(crate) struct DnDGrab<U, R> {
+pub(crate) struct DnDGrab<R> {
     data_source: Option<wl_data_source::WlDataSource>,
     current_focus: Option<wl_surface::WlSurface>,
     pending_offers: Vec<wl_data_offer::WlDataOffer>,
@@ -21,19 +21,19 @@ pub(crate) struct DnDGrab<U, R> {
     icon: Option<wl_surface::WlSurface>,
     origin: wl_surface::WlSurface,
     callback: Rc<RefCell<dyn FnMut(super::DataDeviceEvent)>>,
-    token: CompositorToken<U, R>,
+    token: CompositorToken<R>,
     seat: Seat,
 }
 
-impl<U: 'static, R: Role<DnDIconRole> + 'static> DnDGrab<U, R> {
+impl<R: Role<DnDIconRole> + 'static> DnDGrab<R> {
     pub(crate) fn new(
         source: Option<wl_data_source::WlDataSource>,
         origin: wl_surface::WlSurface,
         seat: Seat,
         icon: Option<wl_surface::WlSurface>,
-        token: CompositorToken<U, R>,
+        token: CompositorToken<R>,
         callback: Rc<RefCell<dyn FnMut(super::DataDeviceEvent)>>,
-    ) -> DnDGrab<U, R> {
+    ) -> DnDGrab<R> {
         DnDGrab {
             data_source: source,
             current_focus: None,
@@ -48,7 +48,7 @@ impl<U: 'static, R: Role<DnDIconRole> + 'static> DnDGrab<U, R> {
     }
 }
 
-impl<U: 'static, R: Role<DnDIconRole> + 'static> PointerGrab for DnDGrab<U, R> {
+impl<R: Role<DnDIconRole> + 'static> PointerGrab for DnDGrab<R> {
     fn motion(
         &mut self,
         _handle: &mut PointerInnerHandle<'_>,

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -43,7 +43,7 @@
 //! # fn main(){
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
-//! # let (compositor_token, _, _) = compositor_init::<(), Roles, _, _>(&mut display, |_, _, _| {}, None);
+//! # let (compositor_token, _, _) = compositor_init::<Roles, _, _>(&mut display, |_, _, _| {}, None);
 //! // init the data device:
 //! init_data_device(
 //!     &mut display,            // the display
@@ -286,18 +286,17 @@ impl SeatData {
 /// and the second argument is the preferred action reported by the target. If no action should be
 /// chosen (and thus the drag'n'drop should abort on drop), return
 /// [`DndAction::empty()`](wayland_server::protocol::wl_data_device_manager::DndAction::empty).
-pub fn init_data_device<F, C, U, R, L>(
+pub fn init_data_device<F, C, R, L>(
     display: &mut Display,
     callback: C,
     action_choice: F,
-    token: CompositorToken<U, R>,
+    token: CompositorToken<R>,
     logger: L,
 ) -> Global<wl_data_device_manager::WlDataDeviceManager>
 where
     F: FnMut(DndAction, DndAction) -> DndAction + 'static,
     C: FnMut(DataDeviceEvent) + 'static,
     R: Role<DnDIconRole> + 'static,
-    U: 'static,
     L: Into<Option<::slog::Logger>>,
 {
     let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "data_device_mgr"));
@@ -378,18 +377,17 @@ where
     }
 }
 
-fn implement_ddm<F, C, U, R>(
+fn implement_ddm<F, C, R>(
     new_ddm: NewResource<wl_data_device_manager::WlDataDeviceManager>,
     callback: Rc<RefCell<C>>,
     action_choice: Rc<RefCell<F>>,
-    token: CompositorToken<U, R>,
+    token: CompositorToken<R>,
     log: ::slog::Logger,
 ) -> wl_data_device_manager::WlDataDeviceManager
 where
     F: FnMut(DndAction, DndAction) -> DndAction + 'static,
     C: FnMut(DataDeviceEvent) + 'static,
     R: Role<DnDIconRole> + 'static,
-    U: 'static,
 {
     use self::wl_data_device_manager::Request;
     new_ddm.implement_closure(
@@ -429,19 +427,18 @@ struct DataDeviceData {
     action_choice: Rc<RefCell<dyn FnMut(DndAction, DndAction) -> DndAction + 'static>>,
 }
 
-fn implement_data_device<F, C, U, R>(
+fn implement_data_device<F, C, R>(
     new_dd: NewResource<wl_data_device::WlDataDevice>,
     seat: Seat,
     callback: Rc<RefCell<C>>,
     action_choice: Rc<RefCell<F>>,
-    token: CompositorToken<U, R>,
+    token: CompositorToken<R>,
     log: ::slog::Logger,
 ) -> wl_data_device::WlDataDevice
 where
     F: FnMut(DndAction, DndAction) -> DndAction + 'static,
     C: FnMut(DataDeviceEvent) + 'static,
     R: Role<DnDIconRole> + 'static,
-    U: 'static,
 {
     use self::wl_data_device::Request;
     let dd_data = DataDeviceData {

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -20,7 +20,7 @@
 //! # fn main(){
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
-//! # let (compositor_token, _, _) = compositor_init::<(), Roles, _, _>(&mut display, |_, _, _| {}, None);
+//! # let (compositor_token, _, _) = compositor_init::<Roles, _, _>(&mut display, |_, _, _| {}, None);
 //! // insert the seat:
 //! let (seat, seat_global) = Seat::new(
 //!     &mut display,             // the display
@@ -121,14 +121,13 @@ impl Seat {
     /// You are provided with the state token to retrieve it (allowing
     /// you to add or remove capabilities from it), and the global handle,
     /// in case you want to remove it.
-    pub fn new<U, R, L>(
+    pub fn new<R, L>(
         display: &mut Display,
         name: String,
-        token: CompositorToken<U, R>,
+        token: CompositorToken<R>,
         logger: L,
     ) -> (Seat, Global<wl_seat::WlSeat>)
     where
-        U: 'static,
         R: Role<CursorImageRole> + 'static,
         L: Into<Option<::slog::Logger>>,
     {
@@ -194,7 +193,7 @@ impl Seat {
     /// # fn main(){
     /// # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
     /// # let mut display = wayland_server::Display::new(event_loop.handle());
-    /// # let (compositor_token, _, _) = compositor_init::<(), Roles, _, _>(&mut display, |_, _, _| {}, None);
+    /// # let (compositor_token, _, _) = compositor_init::<Roles, _, _>(&mut display, |_, _, _| {}, None);
     /// # let (mut seat, seat_global) = Seat::new(
     /// #     &mut display,
     /// #     "seat-0".into(),
@@ -207,9 +206,8 @@ impl Seat {
     /// );
     /// # }
     /// ```
-    pub fn add_pointer<U, R, F>(&mut self, token: CompositorToken<U, R>, cb: F) -> PointerHandle
+    pub fn add_pointer<R, F>(&mut self, token: CompositorToken<R>, cb: F) -> PointerHandle
     where
-        U: 'static,
         R: Role<CursorImageRole> + 'static,
         F: FnMut(CursorImageStatus) + 'static,
     {
@@ -336,14 +334,13 @@ impl ::std::cmp::PartialEq for Seat {
     }
 }
 
-fn implement_seat<U, R>(
+fn implement_seat<R>(
     new_seat: NewResource<wl_seat::WlSeat>,
     arc: Rc<SeatRc>,
-    token: CompositorToken<U, R>,
+    token: CompositorToken<R>,
 ) -> wl_seat::WlSeat
 where
     R: Role<CursorImageRole> + 'static,
-    U: 'static,
 {
     let dest_arc = arc.clone();
     new_seat.implement_closure(

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -46,9 +46,8 @@ struct PointerInternal {
 }
 
 impl PointerInternal {
-    fn new<F, U, R>(token: CompositorToken<U, R>, mut cb: F) -> PointerInternal
+    fn new<F, R>(token: CompositorToken<R>, mut cb: F) -> PointerInternal
     where
-        U: 'static,
         R: Role<CursorImageRole> + 'static,
         F: FnMut(CursorImageStatus) + 'static,
     {
@@ -514,10 +513,9 @@ impl AxisFrame {
     }
 }
 
-pub(crate) fn create_pointer_handler<F, U, R>(token: CompositorToken<U, R>, cb: F) -> PointerHandle
+pub(crate) fn create_pointer_handler<F, R>(token: CompositorToken<R>, cb: F) -> PointerHandle
 where
     R: Role<CursorImageRole> + 'static,
-    U: 'static,
     F: FnMut(CursorImageStatus) + 'static,
 {
     PointerHandle {
@@ -525,14 +523,13 @@ where
     }
 }
 
-pub(crate) fn implement_pointer<U, R>(
+pub(crate) fn implement_pointer<R>(
     new_pointer: NewResource<WlPointer>,
     handle: Option<&PointerHandle>,
-    token: CompositorToken<U, R>,
+    token: CompositorToken<R>,
 ) -> WlPointer
 where
     R: Role<CursorImageRole> + 'static,
-    U: 'static,
 {
     let inner = handle.map(|h| h.inner.clone());
     let destructor = match inner.clone() {

--- a/src/wayland/shell/legacy/mod.rs
+++ b/src/wayland/shell/legacy/mod.rs
@@ -36,17 +36,10 @@
 //! use smithay::wayland::compositor::CompositorToken;
 //! use smithay::wayland::shell::legacy::{wl_shell_init, ShellSurfaceRole, ShellRequest};
 //! # use wayland_server::protocol::{wl_seat, wl_output};
-//! # #[derive(Default)] struct MySurfaceData;
-//!
-//! // define the metadata you want associated with the shell surfaces
-//! #[derive(Default)]
-//! pub struct MyShellSurfaceData {
-//!     /* ... */
-//! }
 //!
 //! // define the roles type. You need to integrate the XdgSurface role:
 //! define_roles!(MyRoles =>
-//!     [ShellSurface, ShellSurfaceRole<MyShellSurfaceData>]
+//!     [ShellSurface, ShellSurfaceRole]
 //! );
 //!
 //! # fn main() {
@@ -62,7 +55,7 @@
 //!     // token from the compositor implementation
 //!     compositor_token,
 //!     // your implementation
-//!     |event: ShellRequest<_, MyShellSurfaceData>| { /* ... */ },
+//!     |event: ShellRequest<_>| { /* ... */ },
 //!     None  // put a logger if you want
 //! );
 //!
@@ -86,28 +79,24 @@ use wayland_server::{
 mod wl_handlers;
 
 /// Metadata associated with the `wl_surface` role
-pub struct ShellSurfaceRole<D: 'static> {
+pub struct ShellSurfaceRole {
     /// Title of the surface
     pub title: String,
     /// Class of the surface
     pub class: String,
     pending_ping: u32,
-    /// Some user data you may want to associate with the surface
-    pub user_data: D,
 }
 
 /// A handle to a shell surface
-pub struct ShellSurface<R, D> {
+pub struct ShellSurface<R> {
     wl_surface: wl_surface::WlSurface,
     shell_surface: wl_shell_surface::WlShellSurface,
     token: CompositorToken<R>,
-    _d: ::std::marker::PhantomData<D>,
 }
 
-impl<R, D> ShellSurface<R, D>
+impl<R> ShellSurface<R>
 where
-    R: Role<ShellSurfaceRole<D>> + 'static,
-    D: 'static,
+    R: Role<ShellSurfaceRole> + 'static,
 {
     /// Is the shell surface referred by this handle still alive?
     pub fn alive(&self) -> bool {
@@ -168,16 +157,6 @@ where
     pub fn send_popup_done(&self) {
         self.shell_surface.popup_done()
     }
-
-    /// Access the user data you associated to this surface
-    pub fn with_user_data<F, T>(&self, f: F) -> Result<T, ()>
-    where
-        F: FnOnce(&mut D) -> T,
-    {
-        self.token
-            .with_role_data(&self.wl_surface, |data| f(&mut data.user_data))
-            .map_err(|_| ())
-    }
 }
 
 /// Possible kinds of shell surface of the `wl_shell` protocol
@@ -234,13 +213,13 @@ pub enum ShellSurfaceKind {
 }
 
 /// A request triggered by a `wl_shell_surface`
-pub enum ShellRequest<R, D> {
+pub enum ShellRequest<R> {
     /// A new shell surface was created
     ///
     /// by default it has no kind and this should not be displayed
     NewShellSurface {
         /// The created surface
-        surface: ShellSurface<R, D>,
+        surface: ShellSurface<R>,
     },
     /// A pong event
     ///
@@ -248,14 +227,14 @@ pub enum ShellRequest<R, D> {
     /// event, smithay has already checked that the responded serial was valid.
     Pong {
         /// The surface that sent the pong
-        surface: ShellSurface<R, D>,
+        surface: ShellSurface<R>,
     },
     /// Start of an interactive move
     ///
     /// The surface requests that an interactive move is started on it
     Move {
         /// The surface requesting the move
-        surface: ShellSurface<R, D>,
+        surface: ShellSurface<R>,
         /// Serial of the implicit grab that initiated the move
         serial: u32,
         /// Seat associated with the move
@@ -266,7 +245,7 @@ pub enum ShellRequest<R, D> {
     /// The surface requests that an interactive resize is started on it
     Resize {
         /// The surface requesting the resize
-        surface: ShellSurface<R, D>,
+        surface: ShellSurface<R>,
         /// Serial of the implicit grab that initiated the resize
         serial: u32,
         /// Seat associated with the resize
@@ -277,7 +256,7 @@ pub enum ShellRequest<R, D> {
     /// The surface changed its kind
     SetKind {
         /// The surface
-        surface: ShellSurface<R, D>,
+        surface: ShellSurface<R>,
         /// Its new kind
         kind: ShellSurfaceKind,
     },
@@ -287,14 +266,13 @@ pub enum ShellRequest<R, D> {
 ///
 /// This state allows you to retrieve a list of surfaces
 /// currently known to the shell global.
-pub struct ShellState<R, D> {
-    known_surfaces: Vec<ShellSurface<R, D>>,
+pub struct ShellState<R> {
+    known_surfaces: Vec<ShellSurface<R>>,
 }
 
-impl<R, D> ShellState<R, D>
+impl<R> ShellState<R>
 where
-    R: Role<ShellSurfaceRole<D>> + 'static,
-    D: 'static,
+    R: Role<ShellSurfaceRole> + 'static,
 {
     /// Cleans the internal surface storage by removing all dead surfaces
     pub(crate) fn cleanup_surfaces(&mut self) {
@@ -302,23 +280,22 @@ where
     }
 
     /// Access all the shell surfaces known by this handler
-    pub fn surfaces(&self) -> &[ShellSurface<R, D>] {
+    pub fn surfaces(&self) -> &[ShellSurface<R>] {
         &self.known_surfaces[..]
     }
 }
 
 /// Create a new `wl_shell` global
-pub fn wl_shell_init<R, D, L, Impl>(
+pub fn wl_shell_init<R, L, Impl>(
     display: &mut Display,
     ctoken: CompositorToken<R>,
     implementation: Impl,
     logger: L,
-) -> (Arc<Mutex<ShellState<R, D>>>, Global<wl_shell::WlShell>)
+) -> (Arc<Mutex<ShellState<R>>>, Global<wl_shell::WlShell>)
 where
-    D: Default + 'static,
-    R: Role<ShellSurfaceRole<D>> + 'static,
+    R: Role<ShellSurfaceRole> + 'static,
     L: Into<Option<::slog::Logger>>,
-    Impl: FnMut(ShellRequest<R, D>) + 'static,
+    Impl: FnMut(ShellRequest<R>) + 'static,
 {
     let _log = crate::slog_or_stdlog(logger);
 


### PR DESCRIPTION
Currently the compositor global handler has a `U` type parameter to allow the association of arbitrary associated data to a `wl_surface` in a general way.

However other protocols (like `wp_viewporter` or `linux-explicit-synchronization`) also need to associate arbitrary data to a surface.

Do avoid type parameter complication creep, this replaces this type parameter with a `UserDataMap`, a type-map-like abstraction that we are already using for `Client`-wide user data. This allows other modules to associate any data to a surface without the user needing to deal with it.

This also uses `UserDataMap` to store the shell-wide data in the `xdg_shell` abstraction.

I expect the runtime cost of this change to be pretty negligible except in very pathological cases maybe.