### PR TITLE
Fix clippy warnings with cargo fix

### DIFF
--- a/src/backend/drm/gbm/mod.rs
+++ b/src/backend/drm/gbm/mod.rs
@@ -19,7 +19,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::rc::{Rc, Weak};
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 pub mod error;
 use self::error::*;
@@ -34,7 +34,7 @@ pub mod egl;
 #[cfg(feature = "backend_session")]
 pub mod session;
 
-static LOAD: Once = ONCE_INIT;
+static LOAD: Once = Once::new();
 
 /// Representation of an open gbm device to create rendering surfaces
 pub struct GbmDevice<D: RawDevice + ControlDevice + 'static> {

--- a/src/backend/drm/legacy/surface.rs
+++ b/src/backend/drm/legacy/surface.rs
@@ -199,7 +199,7 @@ impl<A: AsRawFd + 'static> RawSurface for LegacyDrmSurfaceInternal<A> {
             &pending
                 .connectors
                 .iter()
-                .map(|x| *x)
+                .copied()
                 .collect::<Vec<connector::Handle>>(),
             (0, 0),
             pending.mode,

--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -17,13 +17,13 @@ pub type NativeWindowType = *const c_void;
 pub mod egl {
     use super::*;
     use libloading::Library;
-    use std::sync::{Once, ONCE_INIT};
+    use std::sync::Once;
 
     lazy_static! {
         pub static ref LIB: Library = { Library::new("libEGL.so.1").expect("Failed to load LibEGL") };
     }
 
-    pub static LOAD: Once = ONCE_INIT;
+    pub static LOAD: Once = Once::new();
 
     include!(concat!(env!("OUT_DIR"), "/egl_bindings.rs"));
 

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -67,9 +67,7 @@ where
     fn receive_surface_request(&mut self, req: wl_surface::Request, surface: wl_surface::WlSurface) {
         match req {
             wl_surface::Request::Attach { buffer, x, y } => {
-                SurfaceData::<R>::with_data(&surface, |d| {
-                    d.buffer = Some(buffer.map(|b| (b.clone(), (x, y))))
-                });
+                SurfaceData::<R>::with_data(&surface, |d| d.buffer = Some(buffer.map(|b| (b, (x, y)))));
             }
             wl_surface::Request::Damage { x, y, width, height } => {
                 SurfaceData::<R>::with_data(&surface, |d| {
@@ -189,7 +187,7 @@ where
                     );
                     return;
                 }
-                implement_subsurface::<R>(id, surface.clone());
+                implement_subsurface::<R>(id, surface);
             }
             wl_subcompositor::Request::Destroy => {}
             _ => unreachable!(),

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -56,7 +56,7 @@ where
     pub fn init(surface: &WlSurface) {
         let my_data_mutex = surface.as_ref().user_data::<Mutex<SurfaceData<R>>>().unwrap();
         let mut my_data = my_data_mutex.lock().unwrap();
-        debug_assert!(my_data.children.len() == 0);
+        debug_assert!(my_data.children.is_empty());
         my_data.children.push(surface.clone());
     }
 
@@ -164,12 +164,12 @@ impl<R: RoleType + Role<SubsurfaceRole> + 'static> SurfaceData<R> {
         let b_guard = b_mutex.lock().unwrap();
         if let Some(ref parent) = b_guard.parent {
             if parent.as_ref().equals(a.as_ref()) {
-                return true;
+                true
             } else {
-                return Self::is_ancestor(a, parent);
+                Self::is_ancestor(a, parent)
             }
         } else {
-            return false;
+            false
         }
     }
 

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -165,7 +165,7 @@ impl<R: Role<DnDIconRole> + 'static> PointerGrab for DnDGrab<R> {
         serial: u32,
         time: u32,
     ) {
-        if handle.current_pressed().len() == 0 {
+        if handle.current_pressed().is_empty() {
             // the user dropped, proceed to the drop
             let seat_data = self
                 .seat

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -475,7 +475,7 @@ where
                                 source,
                                 origin,
                                 seat.clone(),
-                                icon.clone(),
+                                icon,
                                 token.clone(),
                                 callback.clone(),
                             ),

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -164,7 +164,7 @@ where
         serial: u32,
         time: u32,
     ) {
-        if handle.current_pressed().len() == 0 {
+        if handle.current_pressed().is_empty() {
             // the user dropped, proceed to the drop
             let seat_data = self
                 .seat

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -402,7 +402,7 @@ fn buffer_basic_checks(
                 ParamError::InvalidFormat as u32,
                 format!("Format {:x} is not supported.", format),
             );
-            return false;;
+            return false;
         }
     };
     // The number of planes set must match what the format expects
@@ -473,5 +473,5 @@ fn buffer_basic_checks(
             }
         }
     }
-    return true;
+    true
 }

--- a/src/wayland/explicit_synchronization/mod.rs
+++ b/src/wayland/explicit_synchronization/mod.rs
@@ -201,11 +201,11 @@ where
     L: Into<Option<::slog::Logger>>,
     R: 'static,
 {
-    let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "wayland_explicit_synchronization"));
+    let _log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "wayland_explicit_synchronization"));
 
     display.create_global::<zwp_linux_explicit_synchronization_v1::ZwpLinuxExplicitSynchronizationV1, _>(
         2,
-        move |new_sync, version| {
+        move |new_sync, _version| {
             new_sync.implement_closure(
                 move |req, explicit_sync| match req {
                     zwp_linux_explicit_synchronization_v1::Request::GetSynchronization { id, surface } => {

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -346,7 +346,7 @@ impl<'a> PointerInnerHandle<'a> {
             let entered = self.inner.focus.is_none();
             // in all cases, update the focus, the coordinates of the surface
             // might have changed
-            self.inner.focus = Some((surface.clone(), (sx, sy)));
+            self.inner.focus = Some((surface, (sx, sy)));
             if entered {
                 self.inner.with_focused_pointers(|pointer, surface| {
                     pointer.enter(serial, &surface, x - sx, y - sy);
@@ -672,7 +672,7 @@ impl PointerGrab for ClickGrab {
         time: u32,
     ) {
         handle.button(button, state, serial, time);
-        if handle.current_pressed().len() == 0 {
+        if handle.current_pressed().is_empty() {
             // no more buttons are pressed, release the grab
             handle.unset_grab(serial, time);
         }

--- a/src/wayland/shell/xdg/zxdgv6_handlers.rs
+++ b/src/wayland/shell/xdg/zxdgv6_handlers.rs
@@ -94,7 +94,7 @@ where
                 Some(destroy_surface::<R>),
                 XdgSurfaceUserData {
                     shell_data: data.shell_data.clone(),
-                    wl_surface: surface.clone(),
+                    wl_surface: surface,
                     shell: shell.clone(),
                 },
             );

--- a/src/wayland/shm/pool.rs
+++ b/src/wayland/shm/pool.rs
@@ -10,12 +10,12 @@ use std::{
     cell::Cell,
     os::unix::io::RawFd,
     ptr,
-    sync::{Once, RwLock, ONCE_INIT},
+    sync::{Once, RwLock},
 };
 
 thread_local!(static SIGBUS_GUARD: Cell<(*const MemMap, bool)> = Cell::new((ptr::null_mut(), false)));
 
-static SIGBUS_INIT: Once = ONCE_INIT;
+static SIGBUS_INIT: Once = Once::new();
 static mut OLD_SIGBUS_HANDLER: *mut SigAction = 0 as *mut SigAction;
 
 pub struct Pool {
@@ -147,7 +147,7 @@ impl MemMap {
     }
 
     fn contains(&self, ptr: *mut u8) -> bool {
-        ptr >= self.ptr && ptr < unsafe { self.ptr.offset(self.size as isize) }
+        ptr >= self.ptr && ptr < unsafe { self.ptr.add(self.size) }
     }
 
     fn nullify(&self) -> Result<(), ()> {


### PR DESCRIPTION
Simply ran:
```
rustup run nightly  cargo fix --clippy -Z unstable-options
```

No manual change in this commit.

Partially addresses https://github.com/Smithay/smithay/issues/45