### PR TITLE
fix some clippy warnings

### DIFF
--- a/anvil/build.rs
+++ b/anvil/build.rs
@@ -1,7 +1,7 @@
 use std::env::var;
 
 fn main() {
-    if !var("CARGO_FEATURE_LOGIND").ok().is_some() {
+    if var("CARGO_FEATURE_LOGIND").ok().is_none() {
         println!("cargo:warning=You are compiling anvil without logind support.");
         println!("cargo:warning=This means that you'll likely need to run it as root if you want to launch it from a tty.");
         println!("cargo:warning=To enable logind support add `--feature logind` to your cargo invocation:");

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -113,7 +113,7 @@ impl<B: InputBackend> InputHandler<B> for AnvilInputHandler {
                     "mods" => format!("{:?}", modifiers),
                     "keysym" => ::xkbcommon::xkb::keysym_get_name(keysym)
                 );
-                action = process_keyboard_shortcut(modifiers, keysym);
+                action = process_keyboard_shortcut(*modifiers, keysym);
                 // forward to client only if action == KeyAction::Forward
                 // both for pressed and released, to avoid inconsistencies
                 if let KeyAction::Forward = action {
@@ -293,7 +293,7 @@ enum KeyAction {
     None,
 }
 
-fn process_keyboard_shortcut(modifiers: &ModifiersState, keysym: Keysym) -> KeyAction {
+fn process_keyboard_shortcut(modifiers: ModifiersState, keysym: Keysym) -> KeyAction {
     if modifiers.ctrl && modifiers.alt && keysym == xkb::KEY_BackSpace
         || modifiers.logo && keysym == xkb::KEY_q
     {

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -229,13 +229,13 @@ impl<B: InputBackend> InputHandler<B> for AnvilInputHandler {
             input::AxisSource::Wheel | input::AxisSource::WheelTilt => wl_pointer::AxisSource::Wheel,
         };
         let horizontal_amount = evt
-            .amount(&input::Axis::Horizontal)
-            .unwrap_or_else(|| evt.amount_discrete(&input::Axis::Horizontal).unwrap() * 3.0);
+            .amount(input::Axis::Horizontal)
+            .unwrap_or_else(|| evt.amount_discrete(input::Axis::Horizontal).unwrap() * 3.0);
         let vertical_amount = evt
-            .amount(&input::Axis::Vertical)
-            .unwrap_or_else(|| evt.amount_discrete(&input::Axis::Vertical).unwrap() * 3.0);
-        let horizontal_amount_discrete = evt.amount_discrete(&input::Axis::Horizontal);
-        let vertical_amount_discrete = evt.amount_discrete(&input::Axis::Vertical);
+            .amount(input::Axis::Vertical)
+            .unwrap_or_else(|| evt.amount_discrete(input::Axis::Vertical).unwrap() * 3.0);
+        let horizontal_amount_discrete = evt.amount_discrete(input::Axis::Horizontal);
+        let vertical_amount_discrete = evt.amount_discrete(input::Axis::Vertical);
 
         {
             let mut frame = AxisFrame::new(evt.time()).source(source);

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -22,7 +22,7 @@ mod window_map;
 #[cfg(feature = "winit")]
 mod winit;
 
-static POSSIBLE_BACKENDS: &'static [&'static str] = &[
+static POSSIBLE_BACKENDS: &[&str] = &[
     #[cfg(feature = "winit")]
     "--winit : Run anvil as a X11 or Wayland client using winit.",
     #[cfg(feature = "udev")]

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -137,7 +137,7 @@ pub struct SurfaceData {
 fn surface_commit(surface: &wl_surface::WlSurface, token: CompositorToken<Roles>) {
     // we retrieve the contents of the associated buffer and copy it
     token.with_surface_data(surface, |attributes| {
-        attributes.user_data.insert_if_missing(|| SurfaceData::default());
+        attributes.user_data.insert_if_missing(SurfaceData::default);
         match attributes.buffer.take() {
             Some(Some((buffer, (_x, _y)))) => {
                 // new contents

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -156,7 +156,7 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<()>, log: Logger
             _ => {}
         },
         default_action_chooser,
-        compositor_token.clone(),
+        compositor_token,
         log.clone(),
     );
 
@@ -166,7 +166,7 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<()>, log: Logger
     let (mut w_seat, _) = Seat::new(
         &mut display.borrow_mut(),
         session.seat(),
-        compositor_token.clone(),
+        compositor_token,
         log.clone(),
     );
 

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -61,7 +61,7 @@ where
         // need to check more carefully
         let found = RefCell::new(None);
         if let Some(wl_surface) = self.toplevel.get_surface() {
-            let _ = ctoken.with_surface_tree_downward(
+            ctoken.with_surface_tree_downward(
                 wl_surface,
                 self.location,
                 |wl_surface, attributes, role, &(mut x, mut y)| {
@@ -102,7 +102,7 @@ where
         let (base_x, base_y) = self.location;
         let (mut min_x, mut min_y, mut max_x, mut max_y) = (base_x, base_y, base_x, base_y);
         if let Some(wl_surface) = self.toplevel.get_surface() {
-            let _ = ctoken.with_surface_tree_downward(
+            ctoken.with_surface_tree_downward(
                 wl_surface,
                 (base_x, base_y),
                 |_, attributes, role, &(mut x, mut y)| {

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -75,11 +75,11 @@ pub fn run_winit(display: &mut Display, event_loop: &mut EventLoop<()>, log: Log
             _ => {}
         },
         default_action_chooser,
-        compositor_token.clone(),
+        compositor_token,
         log.clone(),
     );
 
-    let (mut seat, _) = Seat::new(display, "winit".into(), compositor_token.clone(), log.clone());
+    let (mut seat, _) = Seat::new(display, "winit".into(), compositor_token, log.clone());
 
     let cursor_status = Arc::new(Mutex::new(CursorImageStatus::Default));
 

--- a/src/backend/drm/legacy/surface.rs
+++ b/src/backend/drm/legacy/surface.rs
@@ -132,13 +132,13 @@ impl<A: AsRawFd + 'static> Surface for LegacyDrmSurfaceInternal<A> {
     fn use_mode(&self, mode: Option<Mode>) -> Result<()> {
         let mut pending = self.pending.write().unwrap();
 
+        let error = || ErrorKind::DrmDev(format!("Error loading connector info on {:?}", self.dev_path()));
+
         // check the connectors to see if this mode is supported
         if let Some(mode) = mode {
             for connector in &pending.connectors {
                 if !connector::Info::load_from_device(self, *connector)
-                    .chain_err(|| {
-                        ErrorKind::DrmDev(format!("Error loading connector info on {:?}", self.dev_path()))
-                    })?
+                    .chain_err(error)?
                     .modes()
                     .contains(&mode)
                 {

--- a/src/backend/drm/legacy/surface.rs
+++ b/src/backend/drm/legacy/surface.rs
@@ -132,16 +132,14 @@ impl<A: AsRawFd + 'static> Surface for LegacyDrmSurfaceInternal<A> {
     fn use_mode(&self, mode: Option<Mode>) -> Result<()> {
         let mut pending = self.pending.write().unwrap();
 
-        let error = || ErrorKind::DrmDev(format!("Error loading connector info on {:?}", self.dev_path()));
-
         // check the connectors to see if this mode is supported
         if let Some(mode) = mode {
             for connector in &pending.connectors {
-                if !connector::Info::load_from_device(self, *connector)
-                    .chain_err(error)?
-                    .modes()
-                    .contains(&mode)
-                {
+                let info = connector::Info::load_from_device(self, *connector).chain_err(|| {
+                    ErrorKind::DrmDev(format!("Error loading connector info on {:?}", self.dev_path()))
+                })?;
+
+                if !info.modes().contains(&mode) {
                     bail!(ErrorKind::ModeNotSuitable(mode));
                 }
             }

--- a/src/backend/drm/legacy/surface.rs
+++ b/src/backend/drm/legacy/surface.rs
@@ -78,11 +78,11 @@ impl<A: AsRawFd + 'static> Surface for LegacyDrmSurfaceInternal<A> {
     }
 
     fn current_mode(&self) -> Option<Mode> {
-        self.state.read().unwrap().mode.clone()
+        self.state.read().unwrap().mode
     }
 
     fn pending_mode(&self) -> Option<Mode> {
-        self.pending.read().unwrap().mode.clone()
+        self.pending.read().unwrap().mode
     }
 
     fn add_connector(&self, connector: connector::Handle) -> Result<()> {

--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -1,11 +1,11 @@
 #![allow(missing_docs)]
 
-use nix::libc::{c_long, c_uint, c_void, int32_t, uint64_t};
+use nix::libc::{c_long, c_uint, c_void};
 
 pub type khronos_utime_nanoseconds_t = khronos_uint64_t;
-pub type khronos_uint64_t = uint64_t;
+pub type khronos_uint64_t = u64;
 pub type khronos_ssize_t = c_long;
-pub type EGLint = int32_t;
+pub type EGLint = i32;
 pub type EGLNativeDisplayType = NativeDisplayType;
 pub type EGLNativePixmapType = NativePixmapType;
 pub type EGLNativeWindowType = NativeWindowType;
@@ -162,11 +162,11 @@ pub mod egl {
     // Accepted in the <attrib_list> parameter of eglCreateImageKHR:
     pub const WAYLAND_PLANE_WL: c_uint = 0x31D6;
     // Possible values for EGL_TEXTURE_FORMAT:
-    pub const TEXTURE_Y_U_V_WL: int32_t = 0x31D7;
-    pub const TEXTURE_Y_UV_WL: int32_t = 0x31D8;
-    pub const TEXTURE_Y_XUXV_WL: int32_t = 0x31D9;
-    pub const TEXTURE_EXTERNAL_WL: int32_t = 0x31DA;
+    pub const TEXTURE_Y_U_V_WL: i32 = 0x31D7;
+    pub const TEXTURE_Y_UV_WL: i32 = 0x31D8;
+    pub const TEXTURE_Y_XUXV_WL: i32 = 0x31D9;
+    pub const TEXTURE_EXTERNAL_WL: i32 = 0x31DA;
     // Accepted in the <attribute> parameter of eglQueryWaylandBufferWL:
-    pub const EGL_TEXTURE_FORMAT: int32_t = 0x3080;
-    pub const WAYLAND_Y_INVERTED_WL: int32_t = 0x31DB;
+    pub const EGL_TEXTURE_FORMAT: i32 = 0x3080;
+    pub const WAYLAND_Y_INVERTED_WL: i32 = 0x31DB;
 }

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -122,13 +122,13 @@ unsafe impl NativeDisplay<X11> for WinitWindow {
     fn ptr(&self) -> Result<ffi::NativeDisplayType> {
         self.get_xlib_display()
             .map(|ptr| ptr as *const _)
-            .ok_or(ErrorKind::NonMatchingBackend("X11").into())
+            .ok_or_else(|| ErrorKind::NonMatchingBackend("X11").into())
     }
 
     fn create_surface(&mut self, _args: ()) -> Result<XlibWindow> {
         self.get_xlib_window()
             .map(XlibWindow)
-            .ok_or(ErrorKind::NonMatchingBackend("X11").into())
+            .ok_or_else(|| ErrorKind::NonMatchingBackend("X11").into())
     }
 }
 
@@ -144,7 +144,7 @@ unsafe impl NativeDisplay<Wayland> for WinitWindow {
     fn ptr(&self) -> Result<ffi::NativeDisplayType> {
         self.get_wayland_display()
             .map(|ptr| ptr as *const _)
-            .ok_or(ErrorKind::NonMatchingBackend("Wayland").into())
+            .ok_or_else(|| ErrorKind::NonMatchingBackend("Wayland").into())
     }
 
     fn create_surface(&mut self, _args: ()) -> Result<wegl::WlEglSurface> {

--- a/src/backend/graphics/errors.rs
+++ b/src/backend/graphics/errors.rs
@@ -23,7 +23,6 @@ pub enum SwapBuffersError {
 
 impl fmt::Display for SwapBuffersError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        use std::error::Error;
         write!(formatter, "{}", self.description())
     }
 }

--- a/src/backend/input.rs
+++ b/src/backend/input.rs
@@ -215,23 +215,23 @@ pub trait PointerAxisEvent: Event {
     /// Amount of scrolling in pixels on the given [`Axis`].
     ///
     /// Guaranteed to be `Some` when source returns either [`AxisSource::Finger`] or [`AxisSource::Continuous`].
-    fn amount(&self, axis: &Axis) -> Option<f64>;
+    fn amount(&self, axis: Axis) -> Option<f64>;
 
     /// Amount of scrolling in discrete steps on the given [`Axis`].
     ///
     /// Guaranteed to be `Some` when source returns either [`AxisSource::Wheel`] or [`AxisSource::WheelTilt`].
-    fn amount_discrete(&self, axis: &Axis) -> Option<f64>;
+    fn amount_discrete(&self, axis: Axis) -> Option<f64>;
 
     /// Source of the scroll event.
     fn source(&self) -> AxisSource;
 }
 
 impl PointerAxisEvent for UnusedEvent {
-    fn amount(&self, _axis: &Axis) -> Option<f64> {
+    fn amount(&self, _axis: Axis) -> Option<f64> {
         match *self {}
     }
 
-    fn amount_discrete(&self, _axis: &Axis) -> Option<f64> {
+    fn amount_discrete(&self, _axis: Axis) -> Option<f64> {
         match *self {}
     }
 

--- a/src/backend/libinput.rs
+++ b/src/backend/libinput.rs
@@ -87,12 +87,12 @@ impl<'a> backend::Event for event::pointer::PointerAxisEvent {
 }
 
 impl backend::PointerAxisEvent for event::pointer::PointerAxisEvent {
-    fn amount(&self, axis: &Axis) -> Option<f64> {
-        Some(self.axis_value((*axis).into()))
+    fn amount(&self, axis: Axis) -> Option<f64> {
+        Some(self.axis_value(axis.into()))
     }
 
-    fn amount_discrete(&self, axis: &Axis) -> Option<f64> {
-        self.axis_value_discrete((*axis).into())
+    fn amount_discrete(&self, axis: Axis) -> Option<f64> {
+        self.axis_value_discrete(axis.into())
     }
 
     fn source(&self) -> backend::AxisSource {
@@ -612,8 +612,6 @@ pub fn libinput_bind<Data: 'static>(
     source.set_interest(Ready::readable());
 
     handle.insert_source(source, move |evt, _| {
-        use crate::backend::input::InputBackend;
-
         let mut backend = evt.source.borrow_mut();
         if let Err(error) = backend.0.dispatch_new_events() {
             warn!(backend.0.logger, "Libinput errored: {}", error);

--- a/src/backend/session/direct.rs
+++ b/src/backend/session/direct.rs
@@ -19,9 +19,7 @@
 //!
 //! use smithay::backend::session::direct::DirectSession;
 //!
-//! # fn main() {
 //! let (session, mut notifier) = DirectSession::new(None, None).unwrap();
-//! # }
 //! ```
 //!
 //! ### Usage of the session

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -183,7 +183,7 @@ pub fn primary_gpu<S: AsRef<str>>(context: &Context, seat: S) -> UdevResult<Opti
         if device
             .property_value("ID_SEAT")
             .map(|x| x.to_os_string())
-            .unwrap_or(OsString::from("seat0"))
+            .unwrap_or_else(|| OsString::from("seat0"))
             == *seat.as_ref()
         {
             if let Some(pci) = device.parent_with_subsystem(Path::new("pci"))? {
@@ -214,7 +214,7 @@ pub fn all_gpus<S: AsRef<str>>(context: &Context, seat: S) -> UdevResult<Vec<Pat
             device
                 .property_value("ID_SEAT")
                 .map(|x| x.to_os_string())
-                .unwrap_or(OsString::from("seat0"))
+                .unwrap_or_else(|| OsString::from("seat0"))
                 == *seat.as_ref()
         })
         .flat_map(|device| device.devnode().map(PathBuf::from))

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -431,18 +431,18 @@ impl PointerAxisEvent for WinitMouseWheelEvent {
         }
     }
 
-    fn amount(&self, axis: &Axis) -> Option<f64> {
+    fn amount(&self, axis: Axis) -> Option<f64> {
         match (axis, self.delta) {
-            (&Axis::Horizontal, MouseScrollDelta::PixelDelta(delta)) => Some(delta.x),
-            (&Axis::Vertical, MouseScrollDelta::PixelDelta(delta)) => Some(delta.y),
+            (Axis::Horizontal, MouseScrollDelta::PixelDelta(delta)) => Some(delta.x),
+            (Axis::Vertical, MouseScrollDelta::PixelDelta(delta)) => Some(delta.y),
             (_, MouseScrollDelta::LineDelta(_, _)) => None,
         }
     }
 
-    fn amount_discrete(&self, axis: &Axis) -> Option<f64> {
+    fn amount_discrete(&self, axis: Axis) -> Option<f64> {
         match (axis, self.delta) {
-            (&Axis::Horizontal, MouseScrollDelta::LineDelta(x, _)) => Some(x as f64),
-            (&Axis::Vertical, MouseScrollDelta::LineDelta(_, y)) => Some(y as f64),
+            (Axis::Horizontal, MouseScrollDelta::LineDelta(x, _)) => Some(x as f64),
+            (Axis::Vertical, MouseScrollDelta::LineDelta(_, y)) => Some(y as f64),
             (_, MouseScrollDelta::PixelDelta(_)) => None,
         }
     }

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -35,7 +35,6 @@
 //! // Declare the roles enum
 //! define_roles!(MyRoles);
 //!
-//! # fn main() {
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
 //! // Call the init function:
@@ -52,7 +51,6 @@
 //! // this `token` is what you'll use to access the surface associated data
 //!
 //! // You're now ready to go!
-//! # }
 //! ```
 //!
 //! ### Use the surface metadata
@@ -260,7 +258,7 @@ impl<R: 'static> CompositorToken<R> {
     ///
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
-    pub fn with_surface_data<F, T>(&self, surface: &WlSurface, f: F) -> T
+    pub fn with_surface_data<F, T>(self, surface: &WlSurface, f: F) -> T
     where
         F: FnOnce(&mut SurfaceAttributes) -> T,
     {
@@ -299,7 +297,7 @@ where
     /// If the surface not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
     pub fn with_surface_tree_upward<F1, F2, F3, T>(
-        &self,
+        self,
         surface: &WlSurface,
         initial: T,
         filter: F1,
@@ -320,7 +318,7 @@ where
     ///
     /// This would typically be used to find out which surface of a subsurface tree has been clicked for example.
     pub fn with_surface_tree_downward<F1, F2, F3, T>(
-        &self,
+        self,
         surface: &WlSurface,
         initial: T,
         filter: F1,
@@ -340,7 +338,7 @@ where
     ///
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
-    pub fn get_parent(&self, surface: &WlSurface) -> Option<WlSurface> {
+    pub fn get_parent(self, surface: &WlSurface) -> Option<WlSurface> {
         SurfaceData::<R>::get_parent(surface)
     }
 
@@ -348,7 +346,7 @@ where
     ///
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
-    pub fn get_children(&self, surface: &WlSurface) -> Vec<WlSurface> {
+    pub fn get_children(self, surface: &WlSurface) -> Vec<WlSurface> {
         SurfaceData::<R>::get_children(surface)
     }
 }
@@ -358,7 +356,7 @@ impl<R: RoleType + 'static> CompositorToken<R> {
     ///
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
-    pub fn has_a_role(&self, surface: &WlSurface) -> bool {
+    pub fn has_a_role(self, surface: &WlSurface) -> bool {
         SurfaceData::<R>::has_a_role(surface)
     }
 
@@ -366,7 +364,7 @@ impl<R: RoleType + 'static> CompositorToken<R> {
     ///
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
-    pub fn has_role<RoleData>(&self, surface: &WlSurface) -> bool
+    pub fn has_role<RoleData>(self, surface: &WlSurface) -> bool
     where
         R: Role<RoleData>,
     {
@@ -379,7 +377,7 @@ impl<R: RoleType + 'static> CompositorToken<R> {
     ///
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
-    pub fn give_role<RoleData>(&self, surface: &WlSurface) -> Result<(), ()>
+    pub fn give_role<RoleData>(self, surface: &WlSurface) -> Result<(), ()>
     where
         R: Role<RoleData>,
         RoleData: Default,
@@ -393,7 +391,7 @@ impl<R: RoleType + 'static> CompositorToken<R> {
     ///
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
-    pub fn give_role_with<RoleData>(&self, surface: &WlSurface, data: RoleData) -> Result<(), RoleData>
+    pub fn give_role_with<RoleData>(self, surface: &WlSurface, data: RoleData) -> Result<(), RoleData>
     where
         R: Role<RoleData>,
     {
@@ -406,7 +404,7 @@ impl<R: RoleType + 'static> CompositorToken<R> {
     ///
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
-    pub fn with_role_data<RoleData, F, T>(&self, surface: &WlSurface, f: F) -> Result<T, WrongRole>
+    pub fn with_role_data<RoleData, F, T>(self, surface: &WlSurface, f: F) -> Result<T, WrongRole>
     where
         R: Role<RoleData>,
         F: FnOnce(&mut RoleData) -> T,
@@ -420,7 +418,7 @@ impl<R: RoleType + 'static> CompositorToken<R> {
     ///
     /// If the surface is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
-    pub fn remove_role<RoleData>(&self, surface: &WlSurface) -> Result<RoleData, WrongRole>
+    pub fn remove_role<RoleData>(self, surface: &WlSurface) -> Result<RoleData, WrongRole>
     where
         R: Role<RoleData>,
     {
@@ -431,7 +429,7 @@ impl<R: RoleType + 'static> CompositorToken<R> {
     ///
     /// If the region is not managed by the `CompositorGlobal` that provided this token, this
     /// will panic (having more than one compositor is not supported).
-    pub fn get_region_attributes(&self, region: &wl_region::WlRegion) -> RegionAttributes {
+    pub fn get_region_attributes(self, region: &wl_region::WlRegion) -> RegionAttributes {
         match region.as_ref().user_data::<Mutex<RegionAttributes>>() {
             Some(mutex) => mutex.lock().unwrap().clone(),
             None => panic!("Accessing the data of foreign regions is not supported."),

--- a/src/wayland/compositor/roles.rs
+++ b/src/wayland/compositor/roles.rs
@@ -32,9 +32,7 @@
 //! type. You can call it like this:
 //!
 //! ```
-//! # #[macro_use]
-//! # extern crate smithay;
-//! #
+//! # use smithay::define_roles;
 //! // Metadata for a first role
 //! #[derive(Default)]
 //! pub struct MyRoleMetadata {
@@ -55,7 +53,6 @@
 //!     /* ... */
 //! );
 //!
-//! # fn main() {}
 //! ```
 //!
 //! And this will expand to an enum like this:

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -242,7 +242,7 @@ fn implement_dnd_data_offer(
         move |req, offer| {
             let mut data = offer_data.borrow_mut();
             match req {
-                Request::Accept { serial: _, mime_type } => {
+                Request::Accept { mime_type, .. } => {
                     if let Some(mtype) = mime_type {
                         if let Err(()) = with_source_metadata(&source, |meta| {
                             data.accepted = meta.mime_types.contains(&mtype);
@@ -304,8 +304,8 @@ fn implement_dnd_data_offer(
                             "Invalid preferred action.".into(),
                         );
                     }
-                    let source_actions =
-                        with_source_metadata(&source, |meta| meta.dnd_action).unwrap_or(DndAction::empty());
+                    let source_actions = with_source_metadata(&source, |meta| meta.dnd_action)
+                        .unwrap_or_else(|_| DndAction::empty());
                     let possible_actions = source_actions & DndAction::from_bits_truncate(dnd_actions);
                     data.chosen_action =
                         (&mut *action_choice.borrow_mut())(possible_actions, preferred_action);

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -236,7 +236,7 @@ where
         move |req, offer| {
             let mut data = offer_data.borrow_mut();
             match req {
-                Request::Accept { serial: _, mime_type } => {
+                Request::Accept { mime_type, .. } => {
                     if let Some(mtype) = mime_type {
                         data.accepted = metadata.mime_types.contains(&mtype);
                     } else {

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -51,7 +51,6 @@
 //!
 //! // Once this is defined, you can in your setup initialize the dmabuf global:
 //!
-//! # fn main() {
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
 //! // define your supported formats
@@ -64,7 +63,6 @@
 //!     MyDmabufHandler,
 //!     None // we don't provide a logger in this example
 //! );
-//! # }
 //! ```
 
 use std::{cell::RefCell, os::unix::io::RawFd, rc::Rc};
@@ -108,11 +106,11 @@ pub struct Plane {
 bitflags! {
     pub struct BufferFlags: u32 {
         /// The buffer content is Y-inverted
-        const YInvert = 1;
+        const Y_INVERT = 1;
         /// The buffer content is interlaced
-        const Interlaced = 2;
+        const INTERLACED = 2;
         /// The buffer content if interlaced is bottom-field first
-        const BottomFirst = 4;
+        const BOTTOM_FIRST = 4;
     }
 }
 
@@ -200,8 +198,8 @@ where
         let dma_handler = handler.clone();
         let dma_log = log.clone();
         let dmabuf: zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1 = new_dmabuf.implement_closure(
-            move |req, _| match req {
-                zwp_linux_dmabuf_v1::Request::CreateParams { params_id } => {
+            move |req, _| {
+                if let zwp_linux_dmabuf_v1::Request::CreateParams { params_id } = req {
                     params_id.implement(
                         ParamsHandler {
                             pending_planes: Vec::new(),
@@ -215,7 +213,6 @@ where
                         (),
                     );
                 }
-                _ => (),
             },
             None::<fn(_)>,
             (),

--- a/src/wayland/explicit_synchronization/mod.rs
+++ b/src/wayland/explicit_synchronization/mod.rs
@@ -28,7 +28,6 @@
 //! use smithay::wayland::explicit_synchronization::*;
 //! # define_roles!(MyRoles);
 //! #
-//! # fn main() {
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
 //! # let (compositor_token, _, _) = smithay::wayland::compositor::compositor_init::<MyRoles, _, _>(
@@ -41,7 +40,6 @@
 //!     compositor_token,
 //!     None /* You can insert a logger here */
 //! );
-//! # }
 //! ```
 //!
 //! Then when handling a surface commit, you can retrieve the synchronization information for the surface
@@ -207,8 +205,12 @@ where
         2,
         move |new_sync, _version| {
             new_sync.implement_closure(
-                move |req, explicit_sync| match req {
-                    zwp_linux_explicit_synchronization_v1::Request::GetSynchronization { id, surface } => {
+                move |req, explicit_sync| {
+                    if let zwp_linux_explicit_synchronization_v1::Request::GetSynchronization {
+                        id,
+                        surface,
+                    } = req
+                    {
                         let exists = compositor.with_surface_data(&surface, |attrs| {
                             attrs.user_data.insert_if_missing(|| ESUserData { state: None });
                             attrs
@@ -236,7 +238,6 @@ where
                             });
                         });
                     }
-                    _ => {}
                 },
                 None::<fn(_)>,
                 (),

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -21,7 +21,6 @@
 //! use smithay::wayland::output::{Output, PhysicalProperties, Mode};
 //! use wayland_server::protocol::wl_output;
 //!
-//! # fn main() {
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
 //! // Create the Output with given name and physical properties
@@ -48,7 +47,6 @@
 //! // add other supported modes
 //! output.add_mode(Mode { width: 800, height: 600, refresh: 60000 });
 //! output.add_mode(Mode { width: 1024, height: 768, refresh: 60000 });
-//! # }
 //! ```
 
 use std::sync::{Arc, Mutex};

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -17,7 +17,6 @@
 //! // to set a surface as a cursor image
 //! define_roles!(Roles => [CursorImage, CursorImageRole]);
 //!
-//! # fn main(){
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
 //! # let (compositor_token, _, _) = compositor_init::<Roles, _, _>(&mut display, |_, _, _| {}, None);
@@ -28,7 +27,6 @@
 //!     compositor_token.clone(), // the compositor token
 //!     None                      // insert a logger here
 //! );
-//! # }
 //! ```
 //!
 //! ### Run usage
@@ -144,7 +142,7 @@ impl Seat {
         });
         let seat = Seat { arc: arc.clone() };
         let global = display.create_global(5, move |new_seat, _version| {
-            let seat = implement_seat(new_seat, arc.clone(), token.clone());
+            let seat = implement_seat(new_seat, arc.clone(), token);
             let mut inner = arc.inner.borrow_mut();
             if seat.as_ref().version() >= 2 {
                 seat.name(arc.name.clone());
@@ -190,7 +188,6 @@ impl Seat {
     /// #
     /// # define_roles!(Roles => [CursorImage, CursorImageRole]);
     /// #
-    /// # fn main(){
     /// # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
     /// # let mut display = wayland_server::Display::new(event_loop.handle());
     /// # let (compositor_token, _, _) = compositor_init::<Roles, _, _>(&mut display, |_, _, _| {}, None);
@@ -204,7 +201,6 @@ impl Seat {
     ///     compositor_token.clone(),
     ///     |new_status| { /* a closure handling requests from clients tot change the cursor icon */ }
     /// );
-    /// # }
     /// ```
     pub fn add_pointer<R, F>(&mut self, token: CompositorToken<R>, cb: F) -> PointerHandle
     where
@@ -349,7 +345,7 @@ where
             let inner = arc.inner.borrow_mut();
             match request {
                 wl_seat::Request::GetPointer { id } => {
-                    let pointer = self::pointer::implement_pointer(id, inner.pointer.as_ref(), token.clone());
+                    let pointer = self::pointer::implement_pointer(id, inner.pointer.as_ref(), token);
                     if let Some(ref ptr_handle) = inner.pointer {
                         ptr_handle.new_pointer(pointer);
                     } else {

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -545,10 +545,10 @@ where
         move |request, pointer: WlPointer| {
             match request {
                 Request::SetCursor {
-                    serial: _,
                     surface,
                     hotspot_x,
                     hotspot_y,
+                    ..
                 } => {
                     if let Some(ref inner) = inner {
                         let mut guard = inner.borrow_mut();

--- a/src/wayland/shell/legacy/mod.rs
+++ b/src/wayland/shell/legacy/mod.rs
@@ -42,7 +42,6 @@
 //!     [ShellSurface, ShellSurfaceRole]
 //! );
 //!
-//! # fn main() {
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
 //! # let (compositor_token, _, _) = smithay::wayland::compositor::compositor_init::<MyRoles, _, _>(
@@ -60,7 +59,6 @@
 //! );
 //!
 //! // You're now ready to go!
-//! # }
 //! ```
 
 use std::{

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -47,7 +47,6 @@
 //!     /* ... */
 //! }
 //!
-//! # fn main() {
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
 //! # let (compositor_token, _, _) = smithay::wayland::compositor::compositor_init::<MyRoles, _, _>(
@@ -65,7 +64,6 @@
 //! );
 //!
 //! // You're now ready to go!
-//! # }
 //! ```
 //!
 //! ### Access to shell surface and clients data

--- a/src/wayland/shm/mod.rs
+++ b/src/wayland/shm/mod.rs
@@ -22,7 +22,6 @@
 //! use smithay::wayland::shm::init_shm_global;
 //! use wayland_server::protocol::wl_shm::Format;
 //!
-//! # fn main() {
 //! # let mut event_loop = wayland_server::calloop::EventLoop::<()>::new().unwrap();
 //! # let mut display = wayland_server::Display::new(event_loop.handle());
 //! // Insert the ShmGlobal into your event loop
@@ -33,7 +32,6 @@
 //!     vec![Format::Yuyv, Format::C8],
 //!     None // we don't provide a logger here
 //! );
-//! # }
 //! ```
 //!
 //! Then, when you have a [`WlBuffer`](wayland_server::protocol::wl_buffer::WlBuffer)
@@ -67,7 +65,6 @@
 //!     }
 //! }
 //! # }
-//! # fn main() {}
 //! ```
 //!
 //! **Note**


### PR DESCRIPTION
This commit removes some clippy warnings (to advance #45) by doing the following:
- replace usage of `mem::uninitialized()` with `MaybeUninit`
- replace usage of `nix::libc::{uint64_t, int32_t}` with `{u64, i32}`
- replace functions inside of `Option::ok_or` with `Option::ok_or_else`
- replace functions inside of `Result::unwrap_or` with `Result::unwrap_or_else`
- replace occurrences of pass-by-reference with pass-by-value when
  appropriate
- replace unused variables in pattern-matching with wildcards
- replace `match` expressions that only have one case with `if let`
  expressions
- replace UpperCamelCase names of consts with SCREAMING_SNAKE_CASE
- replace negated `is_some` with `is_none`
- remove `clone()` on types that implement Copy
- remove redundant imports
- remove `fn main()` from doctests
- remove let binding for variables that are returned afterwards
- remove unused `let _`
- move closure out of if condition to simplify reading the condition

I didn't fix the warnings for missing documentation and complex types because I don't think that my comprehension of the codebase is sufficient to do that by now.