### PR TITLE
Upgrade to dbus 0.7, change imports to match.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ gbm = { version = "^0.5.0", optional = true, default-features = false, features 
 glium = { version = "0.23.0", optional = true, default-features = false }
 input = { version = "0.4.1", optional = true }
 udev = { version = "0.2.0", optional = true }
-dbus = { version = "0.6.1", optional = true }
+dbus = { version = "0.8", optional = true }
 systemd = { version = "0.4.0", optional = true }
 wayland-protocols = { version = "0.23.4", features = ["unstable_protocols", "server"], optional = true }
 image = { version = "0.21.0", optional = true }

--- a/src/backend/session/dbus/logind.rs
+++ b/src/backend/session/dbus/logind.rs
@@ -33,8 +33,10 @@
 
 use crate::backend::session::{AsErrno, Session, SessionNotifier, SessionObserver};
 use dbus::{
-    BusName, BusType, Connection, ConnectionItem, ConnectionItems, Interface, Member, Message, MessageItem,
-    OwnedFd, Path as DbusPath, Watch, WatchEvent,
+    arg::{messageitem::MessageItem, OwnedFd},
+    ffidisp::{BusType, Connection, ConnectionItem, Watch, WatchEvent},
+    strings::{BusName, Interface, Member, Path as DbusPath},
+    Message,
 };
 use nix::{
     fcntl::OFlag,
@@ -246,7 +248,10 @@ impl LogindSessionImpl {
         }
     }
 
-    fn handle_signals(&self, signals: ConnectionItems<'_>) -> Result<()> {
+    fn handle_signals<I>(&self, signals: I) -> Result<()>
+    where
+        I: IntoIterator<Item = ConnectionItem>,
+    {
         for item in signals {
             let message = if let ConnectionItem::Signal(ref s) = item {
                 s
@@ -521,7 +526,7 @@ impl LogindSessionNotifier {
 
 /// Errors related to logind sessions
 pub mod errors {
-    use dbus::{BusName, Interface, Member, Path as DbusPath};
+    use dbus::strings::{BusName, Interface, Member, Path as DbusPath};
 
     error_chain! {
         errors {


### PR DESCRIPTION
This is step one of upgrading: no real code changes, still using the old API.
Will follow this up with an actual upgrade to the recommended new way of doing things.