### PR TITLE
anvil: add input region support

### DIFF
--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -188,5 +188,19 @@ fn contains_point(attrs: &SurfaceAttributes, point: (f64, f64)) -> bool {
         width: w,
         height: h,
     };
-    rect.contains((point.0 as i32, point.1 as i32))
+
+    let point = (point.0 as i32, point.1 as i32);
+
+    // The input region is always within the surface itself, so if the surface itself doesn't contain the
+    // point we can return false.
+    if !rect.contains(point) {
+        return false;
+    }
+
+    // If there's no input region, we're done.
+    if attrs.input_region.is_none() {
+        return true;
+    }
+
+    attrs.input_region.as_ref().unwrap().contains(point)
 }

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -170,12 +170,7 @@ where
     pub fn insert(&mut self, toplevel: Kind<R>, location: (i32, i32)) {
         let mut window = Window {
             location,
-            input_bbox: Rectangle {
-                x: 0,
-                y: 0,
-                width: 0,
-                height: 0,
-            },
+            input_bbox: Rectangle::default(),
             toplevel,
         };
         window.self_update(self.ctoken, &self.get_size);

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -37,7 +37,10 @@ where
 
 struct Window<R> {
     location: (i32, i32),
-    surface: Rectangle,
+    /// A bounding box over the input areas of this window and its children.
+    ///
+    /// Used for the fast path of the check in `matching`.
+    input_bbox: Rectangle,
     toplevel: Kind<R>,
 }
 
@@ -55,7 +58,7 @@ where
     where
         F: Fn(&SurfaceAttributes) -> Option<(i32, i32)>,
     {
-        if !self.surface.contains((point.0 as i32, point.1 as i32)) {
+        if !self.input_bbox.contains((point.0 as i32, point.1 as i32)) {
             return None;
         }
         // need to check more carefully
@@ -133,7 +136,7 @@ where
                 |_, _, _, _| true,
             );
         }
-        self.surface = Rectangle {
+        self.input_bbox = Rectangle {
             x: min_x,
             y: min_y,
             width: max_x - min_x,
@@ -164,7 +167,7 @@ where
     pub fn insert(&mut self, toplevel: Kind<R>, location: (i32, i32)) {
         let mut window = Window {
             location,
-            surface: Rectangle {
+            input_bbox: Rectangle {
                 x: 0,
                 y: 0,
                 width: 0,

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -48,7 +48,8 @@ impl<R> Window<R>
 where
     R: Role<SubsurfaceRole> + Role<XdgSurfaceRole> + Role<ShellSurfaceRole> + 'static,
 {
-    // Find the topmost surface under this point if any and the location of this surface
+    /// Finds the topmost surface under this point if any and returns it together with the location of this
+    /// surface.
     fn matching<F>(
         &self,
         point: (f64, f64),
@@ -109,6 +110,8 @@ where
                 wl_surface,
                 (base_x, base_y),
                 |_, attributes, role, &(mut x, mut y)| {
+                    // The input region is intersected with the surface size, so the surface size
+                    // can serve as an approximation for the input bounding box.
                     if let Some((w, h)) = get_size(attributes) {
                         if let Ok(subdata) = Role::<SubsurfaceRole>::data(role) {
                             x += subdata.location.0;
@@ -148,6 +151,7 @@ where
 pub struct WindowMap<R, F> {
     ctoken: CompositorToken<R>,
     windows: Vec<Window<R>>,
+    /// A function returning the surface size.
     get_size: F,
 }
 

--- a/src/utils/rectangle.rs
+++ b/src/utils/rectangle.rs
@@ -1,5 +1,5 @@
 /// A rectangle defined by its top-left corner and dimensions
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct Rectangle {
     /// horizontal position of the top-left corner of the rectangle, in surface coordinates
     pub x: i32,


### PR DESCRIPTION
This makes things like CSD shadows on weston clients and others clickable-through as they should be.