### PR TITLE
anvil: retrieve buffer dimensions on commit

### DIFF
--- a/anvil/src/buffer_utils.rs
+++ b/anvil/src/buffer_utils.rs
@@ -1,0 +1,59 @@
+use std::{cell::RefCell, rc::Rc};
+
+use slog::Logger;
+
+#[cfg(feature = "egl")]
+use smithay::backend::egl::{BufferAccessError, EGLDisplay};
+use smithay::{
+    reexports::wayland_server::protocol::wl_buffer::WlBuffer,
+    wayland::shm::with_buffer_contents as shm_buffer_contents,
+};
+
+/// Utilities for working with `WlBuffer`s.
+#[derive(Clone)]
+pub struct BufferUtils {
+    #[cfg(feature = "egl")]
+    egl_display: Rc<RefCell<Option<EGLDisplay>>>,
+    log: Logger,
+}
+
+impl BufferUtils {
+    /// Creates a new `BufferUtils`.
+    #[cfg(feature = "egl")]
+    pub fn new(egl_display: Rc<RefCell<Option<EGLDisplay>>>, log: Logger) -> Self {
+        Self { egl_display, log }
+    }
+
+    /// Creates a new `BufferUtils`.
+    #[cfg(not(feature = "egl"))]
+    pub fn new(log: Logger) -> Self {
+        Self { log }
+    }
+
+    /// Returns the dimensions of an image stored in the buffer.
+    #[cfg(feature = "egl")]
+    pub fn dimensions(&self, buffer: &WlBuffer) -> Option<(i32, i32)> {
+        // Try to retrieve the EGL dimensions of this buffer, and, if that fails, the shm dimensions.
+        self.egl_display
+            .borrow()
+            .as_ref()
+            .and_then(|display| display.egl_buffer_dimensions(buffer))
+            .or_else(|| self.shm_buffer_dimensions(buffer))
+    }
+
+    /// Returns the dimensions of an image stored in the buffer.
+    #[cfg(not(feature = "egl"))]
+    pub fn dimensions(&self, buffer: &WlBuffer) -> Option<(i32, i32)> {
+        self.shm_buffer_dimensions(buffer)
+    }
+
+    /// Returns the dimensions of an image stored in the shm buffer.
+    fn shm_buffer_dimensions(&self, buffer: &WlBuffer) -> Option<(i32, i32)> {
+        shm_buffer_contents(buffer, |_, data| (data.width, data.height))
+            .map_err(|err| {
+                warn!(self.log, "Unable to load buffer contents"; "err" => format!("{:?}", err));
+                err
+            })
+            .ok()
+    }
+}

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -12,6 +12,7 @@ use smithay::reexports::{calloop::EventLoop, wayland_server::Display};
 
 #[macro_use]
 mod shaders;
+mod buffer_utils;
 mod glium_drawer;
 mod input_handler;
 mod shell;

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -61,6 +61,7 @@ use smithay::{
     },
 };
 
+use crate::buffer_utils::BufferUtils;
 use crate::glium_drawer::GliumDrawer;
 use crate::input_handler::AnvilInputHandler;
 use crate::shell::{init_shell, MyWindowMap, Roles};
@@ -85,6 +86,11 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<()>, log: Logger
     #[cfg(feature = "egl")]
     let active_egl_context = Rc::new(RefCell::new(None));
 
+    #[cfg(feature = "egl")]
+    let buffer_utils = BufferUtils::new(active_egl_context.clone(), log.clone());
+    #[cfg(not(feature = "egl"))]
+    let buffer_utils = BufferUtils::new(log.clone());
+
     let display = Rc::new(RefCell::new(display));
 
     /*
@@ -92,7 +98,8 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<()>, log: Logger
      */
     init_shm_global(&mut display.borrow_mut(), vec![], log.clone());
 
-    let (compositor_token, _, _, window_map) = init_shell(&mut display.borrow_mut(), log.clone());
+    let (compositor_token, _, _, window_map) =
+        init_shell(&mut display.borrow_mut(), buffer_utils, log.clone());
 
     /*
      * Initialize session


### PR DESCRIPTION
This fixes the issue outlined in the IRC where moving the pointer around the surface would frequently result in the surface behind it getting focus. The problem was that when the buffer is committed, the texture (used for size calculations) gets set to None, and is updated only on the next draw, which can happen after `self_update`. `self_update` would thus think the surface was zero-sized.

An easy way to test this is to open something with sctk decorations and mouse over the buttons. Before the patch the buttons randomly lose color (because they become unfocused due to this bug), after the patch they work correctly.