### PR TITLE
anvil: implement the Resize request

### DIFF
--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -14,6 +14,7 @@ rand = "0.6"
 glium = { version = "0.23.0", default-features = false }
 wayland-server = "0.23"
 xkbcommon = "0.4.0"
+bitflags = "1.2.1"
 
 [dependencies.smithay]
 path = ".."

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -270,6 +270,7 @@ pub struct SurfaceData {
     pub buffer: Option<wl_buffer::WlBuffer>,
     pub texture: Option<crate::glium_drawer::TextureMetadata>,
     pub dimensions: Option<(i32, i32)>,
+    pub geometry: Option<Rectangle>,
     pub input_region: Option<RegionAttributes>,
 }
 
@@ -315,10 +316,15 @@ fn surface_commit(
     token: CompositorToken<Roles>,
     buffer_utils: &BufferUtils,
 ) {
+    let geometry = token
+        .with_role_data(surface, |role: &mut XdgSurfaceRole| role.window_geometry)
+        .unwrap_or(None);
+
     token.with_surface_data(surface, |attributes| {
         attributes.user_data.insert_if_missing(SurfaceData::default);
         let data = attributes.user_data.get_mut::<SurfaceData>().unwrap();
 
+        data.geometry = geometry;
         data.input_region = attributes.input_region.clone();
 
         // we retrieve the contents of the associated buffer and copy it

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -122,21 +122,17 @@ where
                             x += subdata.location.0;
                             y += subdata.location.1;
                         }
-                        // update the bounding box
-                        if x < min_x {
-                            min_x = x;
-                        }
-                        if y < min_y {
-                            min_y = y;
-                        }
-                        if x + w > max_x {
-                            max_x = x + w;
-                        }
-                        if y + h > max_y {
-                            max_y = y + w;
-                        }
+
+                        // Update the bounding box.
+                        min_x = min_x.min(x);
+                        min_y = min_y.min(y);
+                        max_x = max_x.max(x + w);
+                        max_y = max_y.max(y + h);
+
                         TraversalAction::DoChildren((x, y))
                     } else {
+                        // If the parent surface is unmapped, then the child surfaces are hidden as
+                        // well, no need to consider them here.
                         TraversalAction::SkipChildren
                     }
                 },

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -19,6 +19,16 @@ pub enum Kind<R> {
     Wl(ShellSurface<R>),
 }
 
+// We implement Clone manually because #[derive(..)] would require R: Clone.
+impl<R> Clone for Kind<R> {
+    fn clone(&self) -> Self {
+        match self {
+            Kind::Xdg(xdg) => Kind::Xdg(xdg.clone()),
+            Kind::Wl(wl) => Kind::Wl(wl.clone()),
+        }
+    }
+}
+
 impl<R> Kind<R>
 where
     R: Role<SubsurfaceRole> + Role<XdgSurfaceRole> + Role<ShellSurfaceRole> + 'static,

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -241,6 +241,21 @@ where
         self.windows.clear();
     }
 
+    /// Finds the toplevel corresponding to the given `WlSurface`.
+    pub fn find(&self, surface: &wl_surface::WlSurface) -> Option<Kind<R>> {
+        self.windows.iter().find_map(|w| {
+            if w.toplevel
+                .get_surface()
+                .map(|s| s.as_ref().equals(surface.as_ref()))
+                .unwrap_or(false)
+            {
+                Some(w.toplevel.clone())
+            } else {
+                None
+            }
+        })
+    }
+
     /// Returns the location of the toplevel, if it exists.
     pub fn location(&self, toplevel: &Kind<R>) -> Option<(i32, i32)> {
         self.windows

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -144,6 +144,16 @@ where
             height: max_y - min_y,
         };
     }
+
+    /// Returns the geometry of this window.
+    pub fn geometry(&self, ctoken: CompositorToken<R>) -> Rectangle {
+        // It's the set geometry with the full bounding box as the fallback.
+        ctoken
+            .with_surface_data(self.toplevel.get_surface().unwrap(), |attributes| {
+                attributes.user_data.get::<SurfaceData>().unwrap().geometry
+            })
+            .unwrap_or(self.bbox)
+    }
 }
 
 pub struct WindowMap<R> {
@@ -235,5 +245,13 @@ where
             w.location = location;
             w.self_update(self.ctoken);
         }
+    }
+
+    /// Returns the geometry of the toplevel, if it exists.
+    pub fn geometry(&self, toplevel: &Kind<R>) -> Option<Rectangle> {
+        self.windows
+            .iter()
+            .find(|w| w.toplevel.equals(toplevel))
+            .map(|w| w.geometry(self.ctoken))
     }
 }

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -237,6 +237,13 @@ where
         }
     }
 
+    /// Refreshes the state of the toplevel, if it exists.
+    pub fn refresh_toplevel(&mut self, toplevel: &Kind<R>) {
+        if let Some(w) = self.windows.iter_mut().find(|w| w.toplevel.equals(toplevel)) {
+            w.self_update(self.ctoken);
+        }
+    }
+
     pub fn clear(&mut self) {
         self.windows.clear();
     }

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -46,10 +46,11 @@ where
 
 struct Window<R> {
     location: (i32, i32),
-    /// A bounding box over the input areas of this window and its children.
+    /// A bounding box over this window and its children.
     ///
-    /// Used for the fast path of the check in `matching`.
-    input_bbox: Rectangle,
+    /// Used for the fast path of the check in `matching`, and as the fall-back for the window
+    /// geometry if that's not set explicitly.
+    bbox: Rectangle,
     toplevel: Kind<R>,
 }
 
@@ -71,7 +72,7 @@ where
     where
         F: Fn(&SurfaceAttributes, (f64, f64)) -> bool,
     {
-        if !self.input_bbox.contains((point.0 as i32, point.1 as i32)) {
+        if !self.bbox.contains((point.0 as i32, point.1 as i32)) {
             return None;
         }
         // need to check more carefully
@@ -143,7 +144,7 @@ where
                 |_, _, _, _| true,
             );
         }
-        self.input_bbox = Rectangle {
+        self.bbox = Rectangle {
             x: min_x,
             y: min_y,
             width: max_x - min_x,
@@ -179,7 +180,7 @@ where
     pub fn insert(&mut self, toplevel: Kind<R>, location: (i32, i32)) {
         let mut window = Window {
             location,
-            input_bbox: Rectangle::default(),
+            bbox: Rectangle::default(),
             toplevel,
         };
         window.self_update(self.ctoken, &self.get_size);

--- a/src/wayland/shell/legacy/mod.rs
+++ b/src/wayland/shell/legacy/mod.rs
@@ -92,6 +92,17 @@ pub struct ShellSurface<R> {
     token: CompositorToken<R>,
 }
 
+// We implement Clone manually because #[derive(..)] would require R: Clone.
+impl<R> Clone for ShellSurface<R> {
+    fn clone(&self) -> Self {
+        Self {
+            wl_surface: self.wl_surface.clone(),
+            shell_surface: self.shell_surface.clone(),
+            token: self.token.clone(),
+        }
+    }
+}
+
 impl<R> ShellSurface<R>
 where
     R: Role<ShellSurfaceRole> + 'static,

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -472,6 +472,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub(crate) enum ToplevelKind {
     Xdg(xdg_toplevel::XdgToplevel),
     ZxdgV6(zxdg_toplevel_v6::ZxdgToplevelV6),
@@ -482,6 +483,17 @@ pub struct ToplevelSurface<R> {
     wl_surface: wl_surface::WlSurface,
     shell_surface: ToplevelKind,
     token: CompositorToken<R>,
+}
+
+// We implement Clone manually because #[derive(..)] would require R: Clone.
+impl<R> Clone for ToplevelSurface<R> {
+    fn clone(&self) -> Self {
+        Self {
+            wl_surface: self.wl_surface.clone(),
+            shell_surface: self.shell_surface.clone(),
+            token: self.token.clone(),
+        }
+    }
 }
 
 impl<R> ToplevelSurface<R>

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -941,4 +941,11 @@ pub enum XdgRequest<R> {
         /// location of the menu request
         location: (i32, i32),
     },
+    /// A surface has acknowledged a configure serial.
+    AckConfigure {
+        /// The surface.
+        surface: wl_surface::WlSurface,
+        /// The configure serial.
+        serial: u32,
+    },
 }

--- a/src/wayland/shell/xdg/xdg_handlers.rs
+++ b/src/wayland/shell/xdg/xdg_handlers.rs
@@ -333,6 +333,12 @@ where
                     role_data.configured = true;
                 })
                 .expect("xdg_surface exists but surface has not shell_surface role?!");
+
+            let mut user_impl = data.shell_data.user_impl.borrow_mut();
+            (&mut *user_impl)(XdgRequest::AckConfigure {
+                surface: data.wl_surface.clone(),
+                serial,
+            });
         }
         _ => unreachable!(),
     }

--- a/src/wayland/shell/xdg/xdg_handlers.rs
+++ b/src/wayland/shell/xdg/xdg_handlers.rs
@@ -473,7 +473,7 @@ where
         }
         xdg_toplevel::Request::SetMinSize { width, height } => {
             with_surface_toplevel_data(&data.shell_data, &toplevel, |toplevel_data| {
-                toplevel_data.max_size = (width, height);
+                toplevel_data.min_size = (width, height);
             });
         }
         xdg_toplevel::Request::SetMaximized => {

--- a/src/wayland/shell/xdg/zxdgv6_handlers.rs
+++ b/src/wayland/shell/xdg/zxdgv6_handlers.rs
@@ -491,7 +491,7 @@ where
         }
         zxdg_toplevel_v6::Request::SetMinSize { width, height } => {
             with_surface_toplevel_data::<R, _>(&toplevel, |toplevel_data| {
-                toplevel_data.max_size = (width, height);
+                toplevel_data.min_size = (width, height);
             });
         }
         zxdg_toplevel_v6::Request::SetMaximized => {

--- a/src/wayland/shell/xdg/zxdgv6_handlers.rs
+++ b/src/wayland/shell/xdg/zxdgv6_handlers.rs
@@ -349,6 +349,12 @@ fn xdg_surface_implementation<R>(
                     role_data.configured = true;
                 })
                 .expect("xdg_surface exists but surface has not shell_surface role?!");
+
+            let mut user_impl = data.shell_data.user_impl.borrow_mut();
+            (&mut *user_impl)(XdgRequest::AckConfigure {
+                surface: data.wl_surface.clone(),
+                serial,
+            });
         }
         _ => unreachable!(),
     }


### PR DESCRIPTION
Everything works, the geometry is computed as in Weston.

[Video!](https://streamable.com/52jd8) (the graphical glitches during gnome-calculator resizing are some OBS issue with capturing OpenGL that I've been seeing in other applications too)

Closes #94 

I tested the xdg-shell resizing on weston-terminal, alacritty and evince. I tested the wl-shell resize on the old weston-terminal ([this](https://gitlab.freedesktop.org/wayland/weston/commit/c0f17aba5e007821bf08e58b5033e7e545f6ab10) is the last commit before the xdg-shell switch) and on the sctk clients with xdg-shell disabled in anvil; the sctk clients seem to be computing the initial size incorrectly so the size jumps a little, but otherwise work fine.

The alacritty decorations being off-sync during a left resize seems like a bug in alacritty because it's not present in sctk clients and also it's not present when alacritty is running some program like `evince` and waiting for its output.