### PR TITLE
anvil.shell: don't send first configure to WlShell

### DIFF
--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -218,7 +218,6 @@ pub fn init_shell(
                     let mut rng = rand::thread_rng();
                     let x = range.sample(&mut rng);
                     let y = range.sample(&mut rng);
-                    surface.send_configure((0, 0), wl_shell_surface::Resize::None);
                     shell_window_map
                         .borrow_mut()
                         .insert(SurfaceKind::Wl(surface), (x, y));


### PR DESCRIPTION
It doesn't need it, and it also takes the (0, 0) size literally, which makes everything try to be the smallest size possible initially.

Notably fixes sctk clients being one pixel wide initially if wl_shell is used.