### PR TITLE
[WIP] Integration tests for Anvil

### DIFF
--- a/anvil/src/lib.rs
+++ b/anvil/src/lib.rs
@@ -1,0 +1,21 @@
+#![warn(rust_2018_idioms)]
+
+#[macro_use]
+extern crate glium;
+#[macro_use]
+extern crate slog;
+#[macro_use(define_roles)]
+extern crate smithay;
+
+#[macro_use]
+pub mod shaders;
+pub mod buffer_utils;
+pub mod glium_drawer;
+pub mod input_handler;
+pub mod shell;
+pub mod shm_load;
+#[cfg(feature = "udev")]
+pub mod udev;
+pub mod window_map;
+#[cfg(feature = "winit")]
+pub mod winit;

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -1,27 +1,15 @@
 #![warn(rust_2018_idioms)]
 
 #[macro_use]
-extern crate glium;
-#[macro_use]
 extern crate slog;
-#[macro_use(define_roles)]
-extern crate smithay;
 
 use slog::Drain;
 use smithay::reexports::{calloop::EventLoop, wayland_server::Display};
 
-#[macro_use]
-mod shaders;
-mod buffer_utils;
-mod glium_drawer;
-mod input_handler;
-mod shell;
-mod shm_load;
 #[cfg(feature = "udev")]
-mod udev;
-mod window_map;
+use anvil::udev;
 #[cfg(feature = "winit")]
-mod winit;
+use anvil::winit;
 
 static POSSIBLE_BACKENDS: &[&str] = &[
     #[cfg(feature = "winit")]

--- a/anvil/tests/common/input.rs
+++ b/anvil/tests/common/input.rs
@@ -1,0 +1,151 @@
+use std::{error::Error, fmt};
+
+use smithay::backend::input::*;
+
+pub struct TestInputBackend {
+    handler: Option<Box<dyn InputHandler<Self> + 'static>>,
+    input_config: (),
+    seat: Seat,
+    pending_events: Vec<TestEvent>,
+}
+
+#[derive(Debug)]
+pub enum TestInputBackendError {}
+
+pub enum TestEvent {
+    PointerButton(TestPointerButtonEvent),
+    PointerMotionAbsolute(TestPointerMotionAbsoluteEvent),
+}
+
+pub struct TestPointerButtonEvent {
+    pub time: u32,
+    pub button: MouseButton,
+    pub state: MouseButtonState,
+}
+
+pub struct TestPointerMotionAbsoluteEvent {
+    pub time: u32,
+    pub x: f64,
+    pub y: f64,
+}
+
+impl TestInputBackend {
+    pub fn new() -> Self {
+        Self {
+            handler: None,
+            input_config: (),
+            seat: Seat::new(
+                0,
+                "test",
+                SeatCapabilities {
+                    pointer: true,
+                    keyboard: true,
+                    touch: false,
+                },
+            ),
+            pending_events: Vec::new(),
+        }
+    }
+
+    pub fn push_event(&mut self, event: TestEvent) {
+        self.pending_events.push(event);
+    }
+}
+
+impl InputBackend for TestInputBackend {
+    type InputConfig = ();
+    type EventError = TestInputBackendError;
+    type KeyboardKeyEvent = UnusedEvent;
+    type PointerAxisEvent = UnusedEvent;
+    type PointerButtonEvent = TestPointerButtonEvent;
+    type PointerMotionEvent = UnusedEvent;
+    type PointerMotionAbsoluteEvent = TestPointerMotionAbsoluteEvent;
+    type TouchDownEvent = UnusedEvent;
+    type TouchUpEvent = UnusedEvent;
+    type TouchMotionEvent = UnusedEvent;
+    type TouchCancelEvent = UnusedEvent;
+    type TouchFrameEvent = UnusedEvent;
+
+    fn set_handler<H: InputHandler<Self> + 'static>(&mut self, mut handler: H) {
+        self.clear_handler();
+
+        handler.on_seat_created(&self.seat);
+        self.handler = Some(Box::new(handler));
+    }
+
+    fn get_handler(&mut self) -> Option<&mut dyn InputHandler<Self>> {
+        self.handler.as_deref_mut().map(|x| x as _)
+    }
+
+    fn clear_handler(&mut self) {
+        if let Some(mut handler) = self.handler.take() {
+            handler.on_seat_destroyed(&self.seat);
+        }
+    }
+
+    fn input_config(&mut self) -> &mut <Self as InputBackend>::InputConfig {
+        &mut self.input_config
+    }
+
+    fn dispatch_new_events(&mut self) -> Result<(), <Self as InputBackend>::EventError> {
+        let handler = self.handler.as_deref_mut().unwrap();
+
+        for event in self.pending_events.drain(..) {
+            use TestEvent::*;
+            match event {
+                PointerButton(e) => handler.on_pointer_button(&self.seat, e),
+                PointerMotionAbsolute(e) => handler.on_pointer_move_absolute(&self.seat, e),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for TestInputBackendError {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unreachable!()
+    }
+}
+
+impl Error for TestInputBackendError {}
+
+impl Event for TestPointerButtonEvent {
+    fn time(&self) -> u32 {
+        self.time
+    }
+}
+
+impl PointerButtonEvent for TestPointerButtonEvent {
+    fn button(&self) -> MouseButton {
+        self.button
+    }
+
+    fn state(&self) -> MouseButtonState {
+        self.state
+    }
+}
+
+impl Event for TestPointerMotionAbsoluteEvent {
+    fn time(&self) -> u32 {
+        self.time
+    }
+}
+
+impl PointerMotionAbsoluteEvent for TestPointerMotionAbsoluteEvent {
+    fn x(&self) -> f64 {
+        self.x
+    }
+
+    fn y(&self) -> f64 {
+        self.y
+    }
+
+    fn x_transformed(&self, _: u32) -> u32 {
+        self.x as u32
+    }
+
+    fn y_transformed(&self, _: u32) -> u32 {
+        self.y as u32
+    }
+}

--- a/anvil/tests/common/mod.rs
+++ b/anvil/tests/common/mod.rs
@@ -1,0 +1,277 @@
+use std::{
+    cell::RefCell,
+    process::Command,
+    rc::Rc,
+    sync::{atomic::AtomicBool, Arc, Mutex},
+};
+
+use slog::{info, o, Drain, Logger};
+use smithay::{
+    backend::input::{InputBackend, MouseButton, MouseButtonState},
+    reexports::{
+        calloop::EventLoop,
+        wayland_server::{protocol::wl_output, Display},
+    },
+    wayland::{
+        data_device::{default_action_chooser, init_data_device, set_data_device_focus, DataDeviceEvent},
+        output::{Mode, Output, PhysicalProperties},
+        seat::{CursorImageStatus, Seat, XkbConfig},
+        shm::init_shm_global,
+    },
+    utils::Rectangle,
+};
+
+use anvil::{
+    buffer_utils::BufferUtils,
+    input_handler::AnvilInputHandler,
+    shell::{init_shell, MyCompositorToken, MyWindowMap, SurfaceData},
+};
+
+pub mod input;
+use input::*;
+
+pub struct Anvil {
+    log: Logger,
+    event_loop: EventLoop<()>,
+    display: Display,
+    socket: String,
+    token: MyCompositorToken,
+    window_map: Rc<RefCell<MyWindowMap>>,
+    input: TestInputBackend,
+    event_time_counter: u32,
+}
+
+impl Anvil {
+    pub fn start() -> Self {
+        let decorator = slog_term::TermDecorator::new().build();
+        let drain = slog_term::FullFormat::new(decorator).build();
+        let log = Logger::root(Mutex::new(drain).fuse(), o!());
+
+        let event_loop = EventLoop::<()>::new().unwrap();
+        let mut display = Display::new(event_loop.handle());
+
+        // TODO: headless EGL?
+
+        let buffer_utils = BufferUtils::new(log.clone());
+
+        let name = display.add_socket_auto().unwrap().into_string().unwrap();
+        info!(log, "Listening on wayland socket"; "name" => name.clone());
+
+        let running = Arc::new(AtomicBool::new(true));
+
+        init_shm_global(&mut display, vec![], log.clone());
+
+        let (token, _, _, window_map) = init_shell(&mut display, buffer_utils, log.clone());
+
+        let dnd_icon = Arc::new(Mutex::new(None));
+        let dnd_icon2 = dnd_icon.clone();
+        init_data_device(
+            &mut display,
+            move |event| match event {
+                DataDeviceEvent::DnDStarted { icon, .. } => {
+                    *dnd_icon2.lock().unwrap() = icon;
+                }
+                DataDeviceEvent::DnDDropped => {
+                    *dnd_icon2.lock().unwrap() = None;
+                }
+                _ => {}
+            },
+            default_action_chooser,
+            token,
+            log.clone(),
+        );
+
+        let (mut seat, _) = Seat::new(&mut display, "test".into(), token, log.clone());
+
+        let cursor_status = Arc::new(Mutex::new(CursorImageStatus::Default));
+        let cursor_status2 = cursor_status.clone();
+        let pointer = seat.add_pointer(token.clone(), move |new_status| {
+            *cursor_status2.lock().unwrap() = new_status
+        });
+
+        let keyboard = seat
+            .add_keyboard(XkbConfig::default(), 1000, 500, |seat, focus| {
+                set_data_device_focus(seat, focus.and_then(|s| s.as_ref().client()))
+            })
+            .expect("Failed to initialize the keyboard");
+
+        let (output, _) = Output::new(
+            &mut display,
+            "Test".into(),
+            PhysicalProperties {
+                width: 0,
+                height: 0,
+                subpixel: wl_output::Subpixel::Unknown,
+                make: "Smithay".into(),
+                model: "Test".into(),
+            },
+            log.clone(),
+        );
+
+        let (w, h) = (1280, 720);
+        output.change_current_state(
+            Some(Mode {
+                width: w as i32,
+                height: h as i32,
+                refresh: 60_000,
+            }),
+            None,
+            None,
+        );
+        output.set_preferred(Mode {
+            width: w as i32,
+            height: h as i32,
+            refresh: 60_000,
+        });
+
+        let pointer_location = Rc::new(RefCell::new((0.0, 0.0)));
+
+        let mut input = TestInputBackend::new();
+        input.set_handler(AnvilInputHandler::new(
+            log.clone(),
+            pointer,
+            keyboard,
+            window_map.clone(),
+            (0, 0),
+            running.clone(),
+            pointer_location.clone(),
+        ));
+
+        info!(log, "Initialization completed.");
+
+        Self {
+            log,
+            event_loop,
+            display,
+            socket: name,
+            token,
+            window_map,
+            input,
+            // Certain clients, particularly the Weston test clients, start up with their "last click time"
+            // zeroed, so if we start from zero and click once they will assume it's the second click of a
+            // double-click sequence, which is not what we want.
+            event_time_counter: 100_000,
+        }
+    }
+
+    pub fn socket(&self) -> &str {
+        &self.socket
+    }
+
+    pub fn log(&self) -> Logger {
+        self.log.clone()
+    }
+
+    pub fn spawn_client(&self, command: &str) {
+        info!(self.log, "Spawning client"; "command" => command);
+
+        Command::new(command)
+            .env("WAYLAND_DISPLAY", self.socket())
+            .spawn()
+            .unwrap();
+    }
+
+    pub fn wait_for_surface_map(&mut self) {
+        info!(self.log, "Waiting for surface map...");
+
+        loop {
+            self.display.flush_clients();
+            self.event_loop.dispatch(None, &mut ()).unwrap();
+
+            let mut found = false;
+            self.window_map
+                .borrow()
+                .with_windows_from_bottom_to_top(|toplevel, _| {
+                    self.token
+                        .with_surface_data(toplevel.get_surface().unwrap(), |attributes| {
+                            let data = attributes.user_data.get_mut::<SurfaceData>().unwrap();
+                            if data.buffer.is_some() {
+                                found = true;
+                            }
+                        });
+                });
+
+            if found {
+                info!(self.log, "Found a mapped surface, breaking");
+                break;
+            }
+        }
+    }
+
+    pub fn wait_for_move(&mut self) {
+        info!(self.log, "Waiting for move...");
+
+        // TODO: how to best check this properly?
+        // Ideally this should wait until an xdg or wl Move request is received and processed, and
+        // then return so as to not depend on any implementation details.
+        let mut i = 0;
+        loop {
+            self.display.flush_clients();
+            self.event_loop.dispatch(None, &mut ()).unwrap();
+
+            i += 1;
+            if i == 5 {
+                break;
+            }
+        }
+    }
+
+    pub fn window_location(&self) -> (i32, i32) {
+        let mut location = None;
+        self.window_map.borrow().with_windows_from_bottom_to_top(|_, l| {
+            if location.is_some() {
+                panic!("more than one window");
+            }
+
+            location = Some(l);
+        });
+        location.expect("there are no windows")
+    }
+
+    pub fn window_geometry(&self) -> Rectangle {
+        let mut toplevel = None;
+        self.window_map.borrow().with_windows_from_bottom_to_top(|t, _| {
+            if toplevel.is_some() {
+                panic!("more than one window");
+            }
+
+            toplevel = Some(t.clone());
+        });
+        let toplevel = toplevel.expect("there are no windows");
+        self.window_map.borrow().geometry(&toplevel).unwrap()
+    }
+
+    pub fn push_event(&mut self, event: TestEvent) {
+        self.input.push_event(event);
+    }
+
+    pub fn dispatch_events(&mut self) {
+        self.input.dispatch_new_events().unwrap();
+    }
+
+    pub fn event_time(&mut self) -> u32 {
+        let time = self.event_time_counter;
+        self.event_time_counter += 1;
+        time
+    }
+
+    pub fn pointer_move(&mut self, x: i32, y: i32) {
+        let time = self.event_time();
+        self.push_event(TestEvent::PointerMotionAbsolute(TestPointerMotionAbsoluteEvent {
+            time,
+            x: x as f64,
+            y: y as f64,
+        }));
+        self.dispatch_events();
+    }
+
+    pub fn pointer_press(&mut self, button: MouseButton) {
+        let time = self.event_time();
+        self.push_event(TestEvent::PointerButton(TestPointerButtonEvent {
+            time,
+            button,
+            state: MouseButtonState::Pressed,
+        }));
+        self.dispatch_events();
+    }
+}

--- a/anvil/tests/move.rs
+++ b/anvil/tests/move.rs
@@ -1,0 +1,30 @@
+#![cfg(not(feature = "egl"))] // TODO: headless EGL support in Anvil::start().
+
+extern crate anvil;
+
+use slog::info;
+use smithay::backend::input::MouseButton;
+
+mod common;
+use common::*;
+
+#[test]
+fn move_test() {
+    let mut anvil = Anvil::start();
+    let log = anvil.log();
+
+    anvil.spawn_client("weston-terminal");
+    anvil.wait_for_surface_map();
+
+    let (x, y) = anvil.window_location();
+    let geometry = anvil.window_geometry();
+    info!(log, "Window"; "location" => ?(x, y), "geometry" => ?geometry);
+
+    // There should be draggable window frame area there.
+    anvil.pointer_move(x + geometry.x + 10, y + geometry.y + 10);
+    anvil.pointer_press(MouseButton::Left);
+    anvil.wait_for_move();
+    anvil.pointer_move(x + geometry.x, y + geometry.y);
+
+    assert_eq!(anvil.window_location(), (x - 10, y - 10));
+}

--- a/src/backend/input.rs
+++ b/src/backend/input.rs
@@ -21,7 +21,8 @@ pub struct Seat {
 }
 
 impl Seat {
-    pub(crate) fn new<S: ToString>(id: u64, name: S, capabilities: SeatCapabilities) -> Seat {
+    /// Creates a new [`Seat`].
+    pub fn new<S: ToString>(id: u64, name: S, capabilities: SeatCapabilities) -> Seat {
         Seat {
             id,
             name: name.to_string(),


### PR DESCRIPTION
This PR adds some basic infrastructure for Anvil integration tests, namely helper methods for launching Anvil and feeding it simulated input. It also adds a basic Move test.

TODO:
- How do I do headless EGL?
- How do I properly wait for requests, in this case the Move request? For this particular test ideally I only need to wait for the Move request, but for a Resize test I'll need to wait for a Resize request, then potentially for an Ack, and then for a surface commit or something, and I'm not sure how to handle all of this. Maybe just dispatch with a 100 ms timeout lol.
- Do the logging in such a way that it's only visible when the test fails or something, so there's no spam.
- It would be nice to spawn SCTK clients right in the test, but requires more effort.