### PR TITLE
wayland: fix deadlock in SurfaceData::cleanup

### DIFF
--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -74,11 +74,12 @@ where
         }
         // orphan all our children
         for child in &my_data.children {
-            // don't do anything if this child is ourselves
-            if child.as_ref().equals(surface.as_ref()) {
+            let child_mutex = child.as_ref().user_data::<Mutex<SurfaceData<R>>>().unwrap();
+            if child_mutex as *const _ == my_data_mutex as *const _ {
+                // This child is ourselves, don't do anything.
                 continue;
             }
-            let child_mutex = child.as_ref().user_data::<Mutex<SurfaceData<R>>>().unwrap();
+
             let mut child_guard = child_mutex.lock().unwrap();
             child_guard.parent = None;
         }

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -75,7 +75,7 @@ where
         // orphan all our children
         for child in &my_data.children {
             let child_mutex = child.as_ref().user_data::<Mutex<SurfaceData<R>>>().unwrap();
-            if child_mutex as *const _ == my_data_mutex as *const _ {
+            if std::ptr::eq(child_mutex, my_data_mutex) {
                 // This child is ourselves, don't do anything.
                 continue;
             }


### PR DESCRIPTION
If the surface is not alive and is present among its own children, the code would deadlock.