### PR TITLE
Update winit dependency to version 22.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ slog = "2.1.1"
 slog-stdlog = "3.0.2"
 libloading = "0.5.0"
 wayland-client = { version = "0.23.4", features = ["egl"], optional = true }
-winit = { version = "0.18.0", optional = true }
+winit = { version = "0.22.0", optional = true }
 drm = { version = "^0.3.4", optional = true }
 gbm = { version = "^0.5.0", optional = true, default-features = false, features = ["drm-support"] }
 glium = { version = "0.23.0", optional = true, default-features = false }

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -9,9 +9,9 @@ use std::ptr;
 #[cfg(feature = "backend_winit")]
 use wayland_client::egl as wegl;
 #[cfg(feature = "backend_winit")]
-use winit::os::unix::WindowExt;
+use winit::platform::unix::WindowExtUnix;
 #[cfg(feature = "backend_winit")]
-use winit::Window as WinitWindow;
+use winit::window::Window as WinitWindow;
 
 /// Trait for typed backend variants (X11/Wayland/GBM)
 pub trait Backend {
@@ -116,17 +116,17 @@ unsafe impl NativeDisplay<X11> for WinitWindow {
     type Error = Error;
 
     fn is_backend(&self) -> bool {
-        self.get_xlib_display().is_some()
+        self.xlib_display().is_some()
     }
 
     fn ptr(&self) -> Result<ffi::NativeDisplayType> {
-        self.get_xlib_display()
+        self.xlib_display()
             .map(|ptr| ptr as *const _)
             .ok_or_else(|| ErrorKind::NonMatchingBackend("X11").into())
     }
 
     fn create_surface(&mut self, _args: ()) -> Result<XlibWindow> {
-        self.get_xlib_window()
+        self.xlib_window()
             .map(XlibWindow)
             .ok_or_else(|| ErrorKind::NonMatchingBackend("X11").into())
     }
@@ -138,18 +138,18 @@ unsafe impl NativeDisplay<Wayland> for WinitWindow {
     type Error = Error;
 
     fn is_backend(&self) -> bool {
-        self.get_wayland_display().is_some()
+        self.wayland_display().is_some()
     }
 
     fn ptr(&self) -> Result<ffi::NativeDisplayType> {
-        self.get_wayland_display()
+        self.wayland_display()
             .map(|ptr| ptr as *const _)
             .ok_or_else(|| ErrorKind::NonMatchingBackend("Wayland").into())
     }
 
     fn create_surface(&mut self, _args: ()) -> Result<wegl::WlEglSurface> {
-        if let Some(surface) = self.get_wayland_surface() {
-            let size = self.get_inner_size().unwrap();
+        if let Some(surface) = self.wayland_surface() {
+            let size = self.inner_size();
             Ok(unsafe {
                 wegl::WlEglSurface::new_from_raw(surface as *mut _, size.width as i32, size.height as i32)
             })

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -718,7 +718,6 @@ impl InputBackend for WinitInputBackend {
                         match (event, handler.as_mut(), events_handler.as_mut()) {
                             (WindowEvent::Resized(psize), _, events_handler) => {
                                 trace!(logger, "Resizing window to {:?}", psize);
-                                window.window().set_inner_size(psize);
                                 let scale_factor = window.window().scale_factor();
                                 let mut wsize = window_size.borrow_mut();
                                 wsize.physical_size = psize;

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -162,7 +162,6 @@ where
 
     let events_loop = EventLoop::new();
     let winit_window = builder.build(&events_loop).chain_err(|| ErrorKind::InitFailed)?;
-    winit_window.set_cursor_visible(false);
 
     debug!(log, "Window created");
 
@@ -183,10 +182,9 @@ where
         },
     );
 
-    let scale_factor = window.window().scale_factor();
     let size = Rc::new(RefCell::new(WindowSize {
         physical_size: window.window().inner_size(), // TODO: original code check if window is alive or not using inner_size().expect()
-        scale_factor,
+        scale_factor: window.window().scale_factor(),
     }));
 
     Ok((

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -509,18 +509,18 @@ impl TouchDownEvent for WinitTouchStartedEvent {
 
     fn x_transformed(&self, width: u32) -> u32 {
         let wsize = self.size.borrow();
-        let w_width = wsize.physical_size.to_logical::<f64>(wsize.scale_factor).width;
+        let w_width = wsize.physical_size.to_logical::<i32>(wsize.scale_factor).width;
         cmp::min(
-            self.location.0 as i32 * width as i32 / w_width as i32,
+            self.location.0 as i32 * width as i32 / w_width,
             0,
         ) as u32
     }
 
     fn y_transformed(&self, height: u32) -> u32 {
         let wsize = self.size.borrow();
-        let w_height = wsize.physical_size.to_logical::<f64>(wsize.scale_factor).height;
+        let w_height = wsize.physical_size.to_logical::<i32>(wsize.scale_factor).height;
         cmp::min(
-            self.location.1 as i32 * height as i32 / w_height as i32,
+            self.location.1 as i32 * height as i32 / w_height,
             0,
         ) as u32
     }
@@ -558,14 +558,14 @@ impl TouchMotionEvent for WinitTouchMovedEvent {
 
     fn x_transformed(&self, width: u32) -> u32 {
         let wsize = self.size.borrow();
-        let w_width = wsize.physical_size.to_logical::<f64>(wsize.scale_factor).width;
-        self.location.0 as u32 * width / w_width as u32
+        let w_width = wsize.physical_size.to_logical::<u32>(wsize.scale_factor).width;
+        self.location.0 as u32 * width / w_width
     }
 
     fn y_transformed(&self, height: u32) -> u32 {
         let wsize = self.size.borrow();
-        let w_height = wsize.physical_size.to_logical::<f64>(wsize.scale_factor).height;
-        self.location.1 as u32 * height / w_height as u32
+        let w_height = wsize.physical_size.to_logical::<u32>(wsize.scale_factor).height;
+        self.location.1 as u32 * height / w_height
     }
 }
 


### PR DESCRIPTION
Summary:
* use PhysicalSize as winit seems to prefer it to LogicalSize everywhere
* run_return instead of poll_events, explicit ControlFlow synchronization
* other changes are mostly related to naming and changes in winit's internal structure