### PR TITLE
winit: Don't resize in resize handler

### DIFF
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -701,7 +701,6 @@ impl InputBackend for WinitInputBackend {
                     match (event, handler.as_mut(), events_handler.as_mut()) {
                         (WindowEvent::Resized(size), _, events_handler) => {
                             trace!(logger, "Resizing window to {:?}", size);
-                            window.window().set_inner_size(size);
                             let mut wsize = window_size.borrow_mut();
                             wsize.logical_size = size;
                             let physical_size = size.to_physical(wsize.dpi_factor);


### PR DESCRIPTION
The resize handler with a window resize request causes oscillations between two window sizes (presumably the inner and the outer). While it's not clear what part of the stack causes it, checking `window.get_inner_size()` already presents the correct size.

Either way, changing the same property in its change handler is a recipe for feedback loops as this one and should be avoided whenever possible, and then carefully fortified too.