### PR TITLE
anvil: Fix udev build without egl

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -371,9 +371,9 @@ impl<S: SessionNotifier, Data: 'static> UdevHandlerImpl<S, Data> {
         let connector_infos: Vec<ConnectorInfo> = res_handles
             .connectors()
             .iter()
-            .map(|conn| device.resource_info::<ConnectorInfo>(*conn).unwrap())
-            .filter(|conn| conn.connection_state() == ConnectorState::Connected)
-            .inspect(|conn| info!(logger, "Connected: {:?}", conn.connector_type()))
+            .map(|conn| device.get_connector_info(*conn).unwrap())
+            .filter(|conn| conn.state() == ConnectorState::Connected)
+            .inspect(|conn| info!(logger, "Connected: {:?}", conn.interface()))
             .collect();
 
         let mut backends = HashMap::new();
@@ -383,7 +383,8 @@ impl<S: SessionNotifier, Data: 'static> UdevHandlerImpl<S, Data> {
             let encoder_infos = connector_info
                 .encoders()
                 .iter()
-                .flat_map(|encoder_handle| device.resource_info::<EncoderInfo>(*encoder_handle))
+                .filter_map(|e| *e)
+                .flat_map(|encoder_handle| device.get_encoder_info(encoder_handle))
                 .collect::<Vec<EncoderInfo>>();
             for encoder_info in encoder_infos {
                 for crtc in res_handles.filter_crtcs(encoder_info.possible_crtcs()) {


### PR DESCRIPTION
I think exactly this feature combination lead to the introduction of `ANVIL_FEATURES` in Travis.
A good thing CI is up and running again, because when updating anvil for drm 0.4, I somehow forgot this again...

(Should fix anvil builds with `udev` but without `egl`.)