### PR TITLE
Update to udev 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ winit = { version = "0.22.0", optional = true }
 drm = { version = "^0.4.0", git = "https://github.com/drakulix/drm-rs", branch = "develop", optional = true }
 gbm = { version = "^0.6.0", git = "https://github.com/drakulix/gbm.rs", branch = "develop", optional = true, default-features = false, features = ["drm-support"] }
 glium = { version = "0.23.0", optional = true, default-features = false }
-input = { version = "0.4.1", optional = true }
-udev = { version = "0.2.0", optional = true }
+input = { version = "0.5", default-features = false, optional = true }
+udev = { version = "0.4", optional = true }
 dbus = { version = "0.8", optional = true }
 systemd = { version = "0.4.0", optional = true }
 wayland-protocols = { version = "0.25.0", features = ["unstable_protocols", "server"], optional = true }
@@ -37,7 +37,7 @@ image = { version = "0.21.0", optional = true }
 lazy_static = "1.0.0"
 thiserror = "1"
 # TODO: remove as soon as drm-rs provides an error implementing Error
-failure = "0.1"
+failure = { version = "0.1", optional = true }
 
 [dev-dependencies]
 slog-term = "2.3"
@@ -47,8 +47,8 @@ gl_generator = { version = "0.10", optional = true }
 
 [features]
 default = ["backend_winit", "backend_drm_legacy", "backend_drm_gbm", "backend_drm_egl", "backend_libinput", "backend_udev", "backend_session_logind", "renderer_glium", "xwayland", "wayland_frontend"]
-backend_winit = ["winit", "wayland-server/dlopen", "wayland-client/dlopen", "wayland-egl", "backend_egl", "renderer_gl", "use_system_lib"]
-backend_drm = ["drm"]
+backend_winit = ["winit", "wayland-server/dlopen", "wayland-client/dlopen", "backend_egl", "wayland-egl", "renderer_gl", "use_system_lib"]
+backend_drm = ["drm", "failure"]
 backend_drm_legacy = ["backend_drm"]
 backend_drm_gbm = ["backend_drm", "gbm", "image"]
 backend_drm_egl = ["backend_drm", "backend_egl"]

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -15,6 +15,7 @@ glium = { version = "0.23.0", default-features = false }
 wayland-server = "0.25.0"
 xkbcommon = "0.4.0"
 bitflags = "1.2.1"
+input = { version = "0.5.0", features = ["udev"], optional = true }
 
 [dependencies.smithay]
 path = ".."
@@ -28,5 +29,5 @@ gl_generator = "0.10"
 default = [ "winit", "egl", "udev", "logind" ]
 egl = [ "smithay/use_system_lib" ]
 winit = [ "smithay/backend_winit" ]
-udev = [ "smithay/backend_libinput", "smithay/backend_drm_legacy", "smithay/backend_drm_gbm", "smithay/backend_drm_egl", "smithay/backend_udev", "smithay/backend_session" ]
+udev = [ "smithay/backend_libinput", "smithay/backend_udev", "smithay/backend_drm_legacy", "smithay/backend_drm_gbm", "smithay/backend_drm_egl", "smithay/backend_session", "input" ]
 logind = [ "smithay/backend_session_logind" ]

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -118,14 +118,12 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<AnvilState>, log
     /*
      * Initialize the udev backend
      */
-    let context = ::smithay::reexports::udev::Context::new().map_err(|_| ())?;
     let seat = session.seat();
 
-    let primary_gpu = primary_gpu(&context, &seat).unwrap_or_default();
+    let primary_gpu = primary_gpu(&seat).unwrap_or_default();
 
     let bytes = include_bytes!("../resources/cursor2.rgba");
     let udev_backend = UdevBackend::new(
-        &context,
         UdevHandlerImpl {
             compositor_token,
             #[cfg(feature = "egl")]
@@ -223,7 +221,7 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<AnvilState>, log
      * Initialize libinput backend
      */
     let mut libinput_context =
-        Libinput::new_from_udev::<LibinputSessionInterface<AutoSession>>(session.clone().into(), &context);
+        Libinput::new_with_udev::<LibinputSessionInterface<AutoSession>>(session.clone().into());
     let libinput_session_id = notifier.register(libinput_context.observer());
     libinput_context.udev_assign_seat(&seat).unwrap();
     let mut libinput_backend = LibinputInputBackend::new(libinput_context, log.clone());

--- a/src/backend/session/direct.rs
+++ b/src/backend/session/direct.rs
@@ -66,7 +66,7 @@ use std::{
     },
 };
 #[cfg(feature = "backend_udev")]
-use udev::Context;
+use udev::Device as UdevDevice;
 
 #[allow(dead_code)]
 mod tty {
@@ -126,12 +126,7 @@ fn is_tty_device(dev: dev_t, _path: Option<&Path>) -> bool {
 fn is_tty_device(dev: dev_t, path: Option<&Path>) -> bool {
     match path {
         Some(path) => {
-            let udev = match Context::new() {
-                Ok(context) => context,
-                Err(_) => return major(dev) == TTY_MAJOR || minor(dev) != 0,
-            };
-
-            let device = match udev.device_from_syspath(path) {
+            let device = match UdevDevice::from_syspath(path) {
                 Ok(device) => device,
                 Err(_) => return major(dev) == TTY_MAJOR || minor(dev) != 0,
             };


### PR DESCRIPTION
This upgrades our udev dependency to 0.4, which does not require a context anymore, therefor simplifying our code.

This also updates input-rs in one go, as it also depends on udev and the old version still expects a context, which we are now unable to provide.

The new input-rs version also enables us to use functions introduced in newer libinput versions. But because we are not doing so now, I have for now disabled its features.

But we are re-exporing libinput and users might have use-cases for the later versions, so we should likely make this configurable in the future (through more features....).