### PR TITLE
Fix Anvil build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,14 +44,13 @@ slog-term = "2.3"
 gl_generator = { version = "0.10", optional = true }
 
 [features]
-default = ["backend_winit", "backend_drm_legacy", "backend_drm_gbm", "backend_drm_egl", "backend_libinput_udev", "backend_session_logind", "renderer_glium", "xwayland", "wayland_frontend"]
+default = ["backend_winit", "backend_drm_legacy", "backend_drm_gbm", "backend_drm_egl", "backend_libinput", "backend_udev", "backend_session_logind", "renderer_glium", "xwayland", "wayland_frontend"]
 backend_winit = ["winit", "wayland-server/dlopen", "wayland-client/dlopen", "backend_egl", "renderer_gl", "use_system_lib"]
 backend_drm = ["drm", "failure"]
 backend_drm_legacy = ["backend_drm"]
 backend_drm_gbm = ["backend_drm", "gbm", "image"]
 backend_drm_egl = ["backend_drm", "backend_egl"]
 backend_egl = ["gl_generator"]
-backend_libinput_udev = ["backend_libinput", "backend_udev", "input/udev"]
 backend_libinput = ["input"]
 backend_session = []
 backend_udev = ["udev"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,13 +44,14 @@ slog-term = "2.3"
 gl_generator = { version = "0.10", optional = true }
 
 [features]
-default = ["backend_winit", "backend_drm_legacy", "backend_drm_gbm", "backend_drm_egl", "backend_libinput", "backend_udev", "backend_session_logind", "renderer_glium", "xwayland", "wayland_frontend"]
+default = ["backend_winit", "backend_drm_legacy", "backend_drm_gbm", "backend_drm_egl", "backend_libinput_udev", "backend_session_logind", "renderer_glium", "xwayland", "wayland_frontend"]
 backend_winit = ["winit", "wayland-server/dlopen", "wayland-client/dlopen", "backend_egl", "renderer_gl", "use_system_lib"]
 backend_drm = ["drm", "failure"]
 backend_drm_legacy = ["backend_drm"]
 backend_drm_gbm = ["backend_drm", "gbm", "image"]
 backend_drm_egl = ["backend_drm", "backend_egl"]
 backend_egl = ["gl_generator"]
+backend_libinput_udev = ["backend_libinput", "backend_udev", "input/udev"]
 backend_libinput = ["input"]
 backend_session = []
 backend_udev = ["udev"]

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -28,5 +28,5 @@ gl_generator = "0.10"
 default = [ "winit", "egl", "udev", "logind" ]
 egl = [ "smithay/use_system_lib" ]
 winit = [ "smithay/backend_winit" ]
-udev = [ "smithay/backend_libinput", "smithay/backend_drm_legacy", "smithay/backend_drm_gbm", "smithay/backend_drm_egl", "smithay/backend_udev", "smithay/backend_session" ]
+udev = [ "smithay/backend_libinput_udev", "smithay/backend_drm_legacy", "smithay/backend_drm_gbm", "smithay/backend_drm_egl", "smithay/backend_session" ]
 logind = [ "smithay/backend_session_logind" ]

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -15,6 +15,7 @@ glium = { version = "0.23.0", default-features = false }
 wayland-server = "0.25.0"
 xkbcommon = "0.4.0"
 bitflags = "1.2.1"
+input = { version = "0.5.0", features = ["udev"] }
 
 [dependencies.smithay]
 path = ".."
@@ -28,5 +29,5 @@ gl_generator = "0.10"
 default = [ "winit", "egl", "udev", "logind" ]
 egl = [ "smithay/use_system_lib" ]
 winit = [ "smithay/backend_winit" ]
-udev = [ "smithay/backend_libinput_udev", "smithay/backend_drm_legacy", "smithay/backend_drm_gbm", "smithay/backend_drm_egl", "smithay/backend_session" ]
+udev = [ "smithay/backend_libinput", "smithay/backend_udev", "smithay/backend_drm_legacy", "smithay/backend_drm_gbm", "smithay/backend_drm_egl", "smithay/backend_session" ]
 logind = [ "smithay/backend_session_logind" ]


### PR DESCRIPTION
Add `backend_libinput_udev` feature to Smithay
This feature enables backend_libinput, backend_udev and input/udev features.
Use `backend_libinput_udev` feature in Anvil to fix build