### PR TITLE
Refactor EGL backend

### DIFF
--- a/anvil/src/buffer_utils.rs
+++ b/anvil/src/buffer_utils.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use slog::Logger;
 
 #[cfg(feature = "egl")]
-use smithay::backend::egl::display::WaylandEGLDisplay;
+use smithay::backend::egl::display::EGLBufferReader;
 use smithay::{
     reexports::wayland_server::protocol::wl_buffer::WlBuffer,
     wayland::shm::with_buffer_contents as shm_buffer_contents,
@@ -13,15 +13,18 @@ use smithay::{
 #[derive(Clone)]
 pub struct BufferUtils {
     #[cfg(feature = "egl")]
-    egl_display: Rc<RefCell<Option<WaylandEGLDisplay>>>,
+    egl_buffer_reader: Rc<RefCell<Option<EGLBufferReader>>>,
     log: Logger,
 }
 
 impl BufferUtils {
     /// Creates a new `BufferUtils`.
     #[cfg(feature = "egl")]
-    pub fn new(egl_display: Rc<RefCell<Option<WaylandEGLDisplay>>>, log: Logger) -> Self {
-        Self { egl_display, log }
+    pub fn new(egl_buffer_reader: Rc<RefCell<Option<EGLBufferReader>>>, log: Logger) -> Self {
+        Self {
+            egl_buffer_reader,
+            log,
+        }
     }
 
     /// Creates a new `BufferUtils`.
@@ -34,7 +37,7 @@ impl BufferUtils {
     #[cfg(feature = "egl")]
     pub fn dimensions(&self, buffer: &WlBuffer) -> Option<(i32, i32)> {
         // Try to retrieve the EGL dimensions of this buffer, and, if that fails, the shm dimensions.
-        self.egl_display
+        self.egl_buffer_reader
             .borrow()
             .as_ref()
             .and_then(|display| display.egl_buffer_dimensions(buffer))

--- a/anvil/src/buffer_utils.rs
+++ b/anvil/src/buffer_utils.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use slog::Logger;
 
 #[cfg(feature = "egl")]
-use smithay::backend::egl::EGLDisplay;
+use smithay::backend::egl::display::WaylandEGLDisplay;
 use smithay::{
     reexports::wayland_server::protocol::wl_buffer::WlBuffer,
     wayland::shm::with_buffer_contents as shm_buffer_contents,
@@ -13,14 +13,14 @@ use smithay::{
 #[derive(Clone)]
 pub struct BufferUtils {
     #[cfg(feature = "egl")]
-    egl_display: Rc<RefCell<Option<EGLDisplay>>>,
+    egl_display: Rc<RefCell<Option<WaylandEGLDisplay>>>,
     log: Logger,
 }
 
 impl BufferUtils {
     /// Creates a new `BufferUtils`.
     #[cfg(feature = "egl")]
-    pub fn new(egl_display: Rc<RefCell<Option<EGLDisplay>>>, log: Logger) -> Self {
+    pub fn new(egl_display: Rc<RefCell<Option<WaylandEGLDisplay>>>, log: Logger) -> Self {
         Self { egl_display, log }
     }
 

--- a/anvil/src/glium_drawer.rs
+++ b/anvil/src/glium_drawer.rs
@@ -12,7 +12,7 @@ use glium::{
 use slog::Logger;
 
 #[cfg(feature = "egl")]
-use smithay::backend::egl::EGLDisplay;
+use smithay::backend::egl::display::WaylandEGLDisplay;
 use smithay::{
     backend::{
         egl::{BufferAccessError, EGLImages, Format},
@@ -44,7 +44,7 @@ pub struct GliumDrawer<F: GLGraphicsBackend + 'static> {
     index_buffer: glium::IndexBuffer<u16>,
     programs: [glium::Program; shaders::FRAGMENT_COUNT],
     #[cfg(feature = "egl")]
-    egl_display: Rc<RefCell<Option<EGLDisplay>>>,
+    egl_display: Rc<RefCell<Option<WaylandEGLDisplay>>>,
     log: Logger,
 }
 
@@ -56,7 +56,11 @@ impl<F: GLGraphicsBackend + 'static> GliumDrawer<F> {
 
 impl<T: Into<GliumGraphicsBackend<T>> + GLGraphicsBackend + 'static> GliumDrawer<T> {
     #[cfg(feature = "egl")]
-    pub fn init(backend: T, egl_display: Rc<RefCell<Option<EGLDisplay>>>, log: Logger) -> GliumDrawer<T> {
+    pub fn init(
+        backend: T,
+        egl_display: Rc<RefCell<Option<WaylandEGLDisplay>>>,
+        log: Logger,
+    ) -> GliumDrawer<T> {
         let display = backend.into();
 
         // building the vertex buffer, which contains all the vertices that we will draw

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -15,7 +15,7 @@ use glium::Surface as GliumSurface;
 use slog::Logger;
 
 #[cfg(feature = "egl")]
-use smithay::backend::egl::{display::WaylandEGLDisplay, EGLGraphicsBackend};
+use smithay::backend::egl::{display::EGLBufferReader, EGLGraphicsBackend};
 use smithay::{
     backend::{
         drm::{
@@ -85,10 +85,10 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<AnvilState>, log
     ::std::env::set_var("WAYLAND_DISPLAY", name);
 
     #[cfg(feature = "egl")]
-    let active_egl_context = Rc::new(RefCell::new(None));
+    let egl_buffer_reader = Rc::new(RefCell::new(None));
 
     #[cfg(feature = "egl")]
-    let buffer_utils = BufferUtils::new(active_egl_context.clone(), log.clone());
+    let buffer_utils = BufferUtils::new(egl_buffer_reader.clone(), log.clone());
     #[cfg(not(feature = "egl"))]
     let buffer_utils = BufferUtils::new(log.clone());
 
@@ -127,7 +127,7 @@ pub fn run_udev(mut display: Display, mut event_loop: EventLoop<AnvilState>, log
         UdevHandlerImpl {
             compositor_token,
             #[cfg(feature = "egl")]
-            active_egl_context,
+            egl_buffer_reader,
             session: session.clone(),
             backends: HashMap::new(),
             display: display.clone(),
@@ -294,7 +294,7 @@ struct BackendData<S: SessionNotifier> {
 struct UdevHandlerImpl<S: SessionNotifier, Data: 'static> {
     compositor_token: CompositorToken<Roles>,
     #[cfg(feature = "egl")]
-    active_egl_context: Rc<RefCell<Option<WaylandEGLDisplay>>>,
+    egl_buffer_reader: Rc<RefCell<Option<EGLBufferReader>>>,
     session: AutoSession,
     backends: HashMap<dev_t, BackendData<S>>,
     display: Rc<RefCell<Display>>,
@@ -313,7 +313,7 @@ impl<S: SessionNotifier, Data: 'static> UdevHandlerImpl<S, Data> {
     #[cfg(feature = "egl")]
     pub fn scan_connectors(
         device: &mut RenderDevice,
-        egl_display: Rc<RefCell<Option<WaylandEGLDisplay>>>,
+        egl_buffer_reader: Rc<RefCell<Option<EGLBufferReader>>>,
         logger: &::slog::Logger,
     ) -> HashMap<crtc::Handle, GliumDrawer<RenderSurface>> {
         // Get a set of all modesetting resource handles (excluding planes):
@@ -343,7 +343,7 @@ impl<S: SessionNotifier, Data: 'static> UdevHandlerImpl<S, Data> {
                     if let Entry::Vacant(entry) = backends.entry(crtc) {
                         let renderer = GliumDrawer::init(
                             device.create_surface(crtc).unwrap(),
-                            egl_display.clone(),
+                            egl_buffer_reader.clone(),
                             logger.clone(),
                         );
 
@@ -419,7 +419,7 @@ impl<S: SessionNotifier, Data: 'static> UdevHandler for UdevHandlerImpl<S, Data>
             #[cfg(feature = "egl")]
             {
                 if path.canonicalize().ok() == self.primary_gpu {
-                    *self.active_egl_context.borrow_mut() =
+                    *self.egl_buffer_reader.borrow_mut() =
                         device.bind_wl_display(&*self.display.borrow()).ok();
                 }
             }
@@ -427,7 +427,7 @@ impl<S: SessionNotifier, Data: 'static> UdevHandler for UdevHandlerImpl<S, Data>
             #[cfg(feature = "egl")]
             let backends = Rc::new(RefCell::new(UdevHandlerImpl::<S, Data>::scan_connectors(
                 &mut device,
-                self.active_egl_context.clone(),
+                self.egl_buffer_reader.clone(),
                 &self.logger,
             )));
 
@@ -491,7 +491,7 @@ impl<S: SessionNotifier, Data: 'static> UdevHandler for UdevHandlerImpl<S, Data>
             #[cfg(feature = "egl")]
             let new_backends = UdevHandlerImpl::<S, Data>::scan_connectors(
                 &mut (*evented).0,
-                self.active_egl_context.clone(),
+                self.egl_buffer_reader.clone(),
                 &self.logger,
             );
             #[cfg(not(feature = "egl"))]
@@ -532,7 +532,7 @@ impl<S: SessionNotifier, Data: 'static> UdevHandler for UdevHandlerImpl<S, Data>
             #[cfg(feature = "egl")]
             {
                 if device.dev_path().and_then(|path| path.canonicalize().ok()) == self.primary_gpu {
-                    *self.active_egl_context.borrow_mut() = None;
+                    *self.egl_buffer_reader.borrow_mut() = None;
                 }
             }
 

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -37,10 +37,10 @@ pub fn run_winit(
     let (renderer, mut input) = winit::init(log.clone()).map_err(|_| ())?;
 
     #[cfg(feature = "egl")]
-    let egl_display = Rc::new(RefCell::new(
-        if let Ok(egl_display) = renderer.bind_wl_display(&display) {
+    let egl_buffer_reader = Rc::new(RefCell::new(
+        if let Ok(egl_buffer_reader) = renderer.bind_wl_display(&display) {
             info!(log, "EGL hardware-acceleration enabled");
-            Some(egl_display)
+            Some(egl_buffer_reader)
         } else {
             None
         },
@@ -48,12 +48,12 @@ pub fn run_winit(
 
     let (w, h) = renderer.get_framebuffer_dimensions();
     #[cfg(feature = "egl")]
-    let drawer = GliumDrawer::init(renderer, egl_display.clone(), log.clone());
+    let drawer = GliumDrawer::init(renderer, egl_buffer_reader.clone(), log.clone());
     #[cfg(not(feature = "egl"))]
     let drawer = GliumDrawer::init(renderer, log.clone());
 
     #[cfg(feature = "egl")]
-    let buffer_utils = BufferUtils::new(egl_display, log.clone());
+    let buffer_utils = BufferUtils::new(egl_buffer_reader, log.clone());
     #[cfg(not(feature = "egl"))]
     let buffer_utils = BufferUtils::new(log.clone());
 

--- a/src/backend/drm/egl/mod.rs
+++ b/src/backend/drm/egl/mod.rs
@@ -19,7 +19,7 @@ use super::{Device, DeviceHandler, Surface};
 use crate::backend::egl::native::{Backend, NativeDisplay, NativeSurface};
 use crate::backend::egl::Error as EGLError;
 #[cfg(feature = "use_system_lib")]
-use crate::backend::egl::{display::WaylandEGLDisplay, EGLGraphicsBackend};
+use crate::backend::egl::{display::EGLBufferReader, EGLGraphicsBackend};
 
 mod surface;
 pub use self::surface::*;
@@ -199,7 +199,7 @@ where
     D: Device + NativeDisplay<B, Arguments = crtc::Handle> + 'static,
     <D as Device>::Surface: NativeSurface,
 {
-    fn bind_wl_display(&self, display: &Display) -> Result<WaylandEGLDisplay, EGLError> {
+    fn bind_wl_display(&self, display: &Display) -> Result<EGLBufferReader, EGLError> {
         self.dev.bind_wl_display(display)
     }
 }

--- a/src/backend/drm/egl/mod.rs
+++ b/src/backend/drm/egl/mod.rs
@@ -12,20 +12,19 @@ use drm::control::{connector, crtc, encoder, framebuffer, plane, ResourceHandles
 use drm::SystemError as DrmError;
 use nix::libc::dev_t;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::rc::Rc;
 #[cfg(feature = "use_system_lib")]
 use wayland_server::Display;
 
 use super::{Device, DeviceHandler, Surface};
-use crate::backend::egl::context::GlAttributes;
 use crate::backend::egl::native::{Backend, NativeDisplay, NativeSurface};
-use crate::backend::egl::EGLContext;
 use crate::backend::egl::Error as EGLError;
 #[cfg(feature = "use_system_lib")]
-use crate::backend::egl::{EGLDisplay, EGLGraphicsBackend};
+use crate::backend::egl::{display::WaylandEGLDisplay, EGLGraphicsBackend};
 
 mod surface;
 pub use self::surface::*;
+use crate::backend::egl::context::GlAttributes;
+use crate::backend::egl::display::EGLDisplay;
 
 #[cfg(feature = "backend_session")]
 pub mod session;
@@ -48,7 +47,7 @@ where
     D: Device + NativeDisplay<B, Arguments = crtc::Handle> + 'static,
     <D as Device>::Surface: NativeSurface,
 {
-    dev: Rc<EGLContext<B, D>>,
+    dev: EGLDisplay<B, D>,
     logger: ::slog::Logger,
 }
 
@@ -73,31 +72,7 @@ where
     ///
     /// Returns an error if the file is no valid device or context
     /// creation was not successful.
-    pub fn new<L>(dev: D, logger: L) -> Result<Self, Error<<<D as Device>::Surface as Surface>::Error>>
-    where
-        L: Into<Option<::slog::Logger>>,
-    {
-        EglDevice::new_with_gl_attr(
-            dev,
-            GlAttributes {
-                version: None,
-                profile: None,
-                debug: cfg!(debug_assertions),
-                vsync: true,
-            },
-            logger,
-        )
-    }
-
-    /// Create a new [`EglDevice`] from an open device and given [`GlAttributes`]
-    ///
-    /// Returns an error if the file is no valid device or context
-    /// creation was not successful.
-    pub fn new_with_gl_attr<L>(
-        mut dev: D,
-        attributes: GlAttributes,
-        logger: L,
-    ) -> Result<Self, Error<<<D as Device>::Surface as Surface>::Error>>
+    pub fn new<L>(mut dev: D, logger: L) -> Result<Self, Error<<<D as Device>::Surface as Surface>::Error>>
     where
         L: Into<Option<::slog::Logger>>,
     {
@@ -107,10 +82,7 @@ where
 
         debug!(log, "Creating egl context from device");
         Ok(EglDevice {
-            // Open the gbm device from the drm device and create a context based on that
-            dev: Rc::new(
-                EGLContext::new(dev, attributes, Default::default(), log.clone()).map_err(Error::EGL)?,
-            ),
+            dev: EGLDisplay::new(dev, log.clone()).map_err(Error::EGL)?,
             logger: log,
         })
     }
@@ -147,7 +119,7 @@ where
     D: Device + NativeDisplay<B, Arguments = crtc::Handle> + 'static,
     <D as Device>::Surface: NativeSurface,
 {
-    type Surface = EglSurface<B, D>;
+    type Surface = EglSurface<<D as Device>::Surface>;
 
     fn device_id(&self) -> dev_t {
         self.dev.borrow().device_id()
@@ -166,15 +138,30 @@ where
     fn create_surface(
         &mut self,
         crtc: crtc::Handle,
-    ) -> Result<EglSurface<B, D>, <Self::Surface as Surface>::Error> {
+    ) -> Result<Self::Surface, <Self::Surface as Surface>::Error> {
         info!(self.logger, "Initializing EglSurface");
 
-        let surface = self.dev.create_surface(crtc).map_err(Error::EGL)?;
+        // Device trait is unaware of opengl, so using sensible defaults
+        let attributes = GlAttributes {
+            version: None,
+            profile: None,
+            debug: cfg!(debug_assertions),
+            vsync: true,
+        };
+        let reqs = Default::default();
 
-        Ok(EglSurface {
-            dev: self.dev.clone(),
-            surface,
-        })
+        let context = self.dev.create_context(attributes, reqs).map_err(Error::EGL)?;
+        let surface = self
+            .dev
+            .create_surface(
+                context.get_pixel_format(),
+                reqs.double_buffer,
+                context.get_config_id(),
+                crtc,
+            )
+            .map_err(Error::EGL)?;
+
+        Ok(EglSurface { context, surface })
     }
 
     fn process_events(&mut self) {
@@ -212,7 +199,7 @@ where
     D: Device + NativeDisplay<B, Arguments = crtc::Handle> + 'static,
     <D as Device>::Surface: NativeSurface,
 {
-    fn bind_wl_display(&self, display: &Display) -> Result<EGLDisplay, EGLError> {
+    fn bind_wl_display(&self, display: &Display) -> Result<WaylandEGLDisplay, EGLError> {
         self.dev.bind_wl_display(display)
     }
 }

--- a/src/backend/drm/egl/surface.rs
+++ b/src/backend/drm/egl/surface.rs
@@ -94,7 +94,7 @@ where
         self.surface.swap_buffers()
     }
 
-    unsafe fn get_proc_address(&self, symbol: &str) -> *const c_void {
+    fn get_proc_address(&self, symbol: &str) -> *const c_void {
         get_proc_address(symbol)
     }
 

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -64,7 +64,7 @@ impl EGLContext {
             }
         };
 
-        let (pixel_format, config_id) = unsafe { display.choose_config(version, reqs)? };
+        let (pixel_format, config_id) = display.choose_config(version, reqs)?;
 
         let mut context_attributes = Vec::with_capacity(10);
 

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -63,7 +63,7 @@ impl EGLContext {
             }
         };
 
-        let (pixel_format, config_id) = display.choose_config(version, reqs)?;
+        let (pixel_format, config_id) = display.choose_config(attributes, reqs)?;
 
         let mut context_attributes = Vec::with_capacity(10);
 

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -5,6 +5,7 @@ use crate::backend::egl::display::{EGLDisplay, EGLDisplayHandle};
 use crate::backend::egl::native::NativeSurface;
 use crate::backend::egl::{native, EGLSurface};
 use crate::backend::graphics::{PixelFormat, SwapBuffersError};
+use std::os::raw::c_int;
 use std::ptr;
 use std::sync::Arc;
 
@@ -264,5 +265,72 @@ impl Default for PixelFormatRequirements {
             multisampling: None,
             stereoscopy: false,
         }
+    }
+}
+
+impl PixelFormatRequirements {
+    /// Append the  requirements to the given attribute list
+    pub fn create_attributes(&self, out: &mut Vec<c_int>, logger: &slog::Logger) -> Result<(), Error> {
+        if let Some(hardware_accelerated) = self.hardware_accelerated {
+            out.push(ffi::egl::CONFIG_CAVEAT as c_int);
+            out.push(if hardware_accelerated {
+                trace!(logger, "Setting CONFIG_CAVEAT to NONE");
+                ffi::egl::NONE as c_int
+            } else {
+                trace!(logger, "Setting CONFIG_CAVEAT to SLOW_CONFIG");
+                ffi::egl::SLOW_CONFIG as c_int
+            });
+        }
+
+        if let Some(color) = self.color_bits {
+            trace!(logger, "Setting RED_SIZE to {}", color / 3);
+            out.push(ffi::egl::RED_SIZE as c_int);
+            out.push((color / 3) as c_int);
+            trace!(
+                logger,
+                "Setting GREEN_SIZE to {}",
+                color / 3 + if color % 3 != 0 { 1 } else { 0 }
+            );
+            out.push(ffi::egl::GREEN_SIZE as c_int);
+            out.push((color / 3 + if color % 3 != 0 { 1 } else { 0 }) as c_int);
+            trace!(
+                logger,
+                "Setting BLUE_SIZE to {}",
+                color / 3 + if color % 3 == 2 { 1 } else { 0 }
+            );
+            out.push(ffi::egl::BLUE_SIZE as c_int);
+            out.push((color / 3 + if color % 3 == 2 { 1 } else { 0 }) as c_int);
+        }
+
+        if let Some(alpha) = self.alpha_bits {
+            trace!(logger, "Setting ALPHA_SIZE to {}", alpha);
+            out.push(ffi::egl::ALPHA_SIZE as c_int);
+            out.push(alpha as c_int);
+        }
+
+        if let Some(depth) = self.depth_bits {
+            trace!(logger, "Setting DEPTH_SIZE to {}", depth);
+            out.push(ffi::egl::DEPTH_SIZE as c_int);
+            out.push(depth as c_int);
+        }
+
+        if let Some(stencil) = self.stencil_bits {
+            trace!(logger, "Setting STENCIL_SIZE to {}", stencil);
+            out.push(ffi::egl::STENCIL_SIZE as c_int);
+            out.push(stencil as c_int);
+        }
+
+        if let Some(multisampling) = self.multisampling {
+            trace!(logger, "Setting SAMPLES to {}", multisampling);
+            out.push(ffi::egl::SAMPLES as c_int);
+            out.push(multisampling as c_int);
+        }
+
+        if self.stereoscopy {
+            error!(logger, "Stereoscopy is currently unsupported (sorry!)");
+            return Err(Error::NoAvailablePixelFormat);
+        }
+
+        Ok(())
     }
 }

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -5,7 +5,6 @@ use crate::backend::egl::display::EGLDisplay;
 use crate::backend::egl::native::NativeSurface;
 use crate::backend::egl::{native, EGLSurface};
 use crate::backend::graphics::{PixelFormat, SwapBuffersError};
-use slog;
 use std::ptr;
 use std::sync::{Arc, Weak};
 
@@ -15,7 +14,6 @@ pub struct EGLContext {
     display: Weak<ffi::egl::types::EGLDisplay>,
     config_id: ffi::egl::types::EGLConfig,
     pixel_format: PixelFormat,
-    logger: slog::Logger,
 }
 
 impl EGLContext {
@@ -117,7 +115,6 @@ impl EGLContext {
             display: Arc::downgrade(&display.display),
             config_id,
             pixel_format,
-            logger: log,
         })
     }
 

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -214,65 +214,7 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
                 (_, _) => unreachable!(),
             };
 
-            if let Some(hardware_accelerated) = reqs.hardware_accelerated {
-                out.push(ffi::egl::CONFIG_CAVEAT as c_int);
-                out.push(if hardware_accelerated {
-                    trace!(self.logger, "Setting CONFIG_CAVEAT to NONE");
-                    ffi::egl::NONE as c_int
-                } else {
-                    trace!(self.logger, "Setting CONFIG_CAVEAT to SLOW_CONFIG");
-                    ffi::egl::SLOW_CONFIG as c_int
-                });
-            }
-
-            if let Some(color) = reqs.color_bits {
-                trace!(self.logger, "Setting RED_SIZE to {}", color / 3);
-                out.push(ffi::egl::RED_SIZE as c_int);
-                out.push((color / 3) as c_int);
-                trace!(
-                    self.logger,
-                    "Setting GREEN_SIZE to {}",
-                    color / 3 + if color % 3 != 0 { 1 } else { 0 }
-                );
-                out.push(ffi::egl::GREEN_SIZE as c_int);
-                out.push((color / 3 + if color % 3 != 0 { 1 } else { 0 }) as c_int);
-                trace!(
-                    self.logger,
-                    "Setting BLUE_SIZE to {}",
-                    color / 3 + if color % 3 == 2 { 1 } else { 0 }
-                );
-                out.push(ffi::egl::BLUE_SIZE as c_int);
-                out.push((color / 3 + if color % 3 == 2 { 1 } else { 0 }) as c_int);
-            }
-
-            if let Some(alpha) = reqs.alpha_bits {
-                trace!(self.logger, "Setting ALPHA_SIZE to {}", alpha);
-                out.push(ffi::egl::ALPHA_SIZE as c_int);
-                out.push(alpha as c_int);
-            }
-
-            if let Some(depth) = reqs.depth_bits {
-                trace!(self.logger, "Setting DEPTH_SIZE to {}", depth);
-                out.push(ffi::egl::DEPTH_SIZE as c_int);
-                out.push(depth as c_int);
-            }
-
-            if let Some(stencil) = reqs.stencil_bits {
-                trace!(self.logger, "Setting STENCIL_SIZE to {}", stencil);
-                out.push(ffi::egl::STENCIL_SIZE as c_int);
-                out.push(stencil as c_int);
-            }
-
-            if let Some(multisampling) = reqs.multisampling {
-                trace!(self.logger, "Setting SAMPLES to {}", multisampling);
-                out.push(ffi::egl::SAMPLES as c_int);
-                out.push(multisampling as c_int);
-            }
-
-            if reqs.stereoscopy {
-                error!(self.logger, "Stereoscopy is currently unsupported (sorry!)");
-                return Err(Error::NoAvailablePixelFormat);
-            }
+            reqs.create_attributes(&mut out, &self.logger)?;
 
             out.push(ffi::egl::NONE as c_int);
             out

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -444,7 +444,7 @@ impl WaylandEGLDisplay {
     fn new(
         display: Weak<ffi::egl::types::EGLDisplay>,
         wayland: *mut wl_display,
-        extensions: &Vec<String>,
+        extensions: &[String],
     ) -> Self {
         #[cfg(feature = "renderer_gl")]
         let gl = gl_ffi::Gles2::load_with(|s| get_proc_address(s) as *const _);

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -1,0 +1,618 @@
+//! Type safe native types for safe egl initialisation
+
+#[cfg(feature = "use_system_lib")]
+use crate::backend::egl::EGLGraphicsBackend;
+use crate::backend::egl::{
+    ffi, get_proc_address, native, BufferAccessError, EGLContext, EGLImages, EGLSurface, Error, Format,
+};
+use std::sync::{Arc, Weak};
+
+use std::ptr;
+
+use nix::libc::{c_int, c_void};
+
+#[cfg(feature = "wayland_frontend")]
+use wayland_server::{protocol::wl_buffer::WlBuffer, Display};
+#[cfg(feature = "use_system_lib")]
+use wayland_sys::server::wl_display;
+
+use crate::backend::egl::context::{GlAttributes, PixelFormatRequirements};
+#[cfg(feature = "renderer_gl")]
+use crate::backend::graphics::gl::ffi as gl_ffi;
+use crate::backend::graphics::PixelFormat;
+use std::cell::{Ref, RefCell, RefMut};
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+
+/// [`EGLDisplay`] represents an initialised EGL environment
+pub struct EGLDisplay<B: native::Backend, N: native::NativeDisplay<B>> {
+    native: RefCell<N>,
+    pub(crate) display: Arc<ffi::egl::types::EGLDisplay>,
+    pub(crate) egl_version: (i32, i32),
+    pub(crate) extensions: Vec<String>,
+    logger: slog::Logger,
+    _backend: PhantomData<B>,
+}
+
+impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
+    /// Create a new [`EGLDisplay`] from a given [`NativeDisplay`](native::NativeDisplay)
+    pub fn new<L>(native: N, logger: L) -> Result<EGLDisplay<B, N>, Error>
+    where
+        L: Into<Option<::slog::Logger>>,
+    {
+        let log = crate::slog_or_stdlog(logger.into()).new(o!("smithay_module" => "renderer_egl"));
+        let ptr = native.ptr()?;
+
+        ffi::egl::LOAD.call_once(|| unsafe {
+            fn constrain<F>(f: F) -> F
+            where
+                F: for<'a> Fn(&'a str) -> *const ::std::os::raw::c_void,
+            {
+                f
+            };
+
+            ffi::egl::load_with(|sym| {
+                let name = CString::new(sym).unwrap();
+                let symbol = ffi::egl::LIB.get::<*mut c_void>(name.as_bytes());
+                match symbol {
+                    Ok(x) => *x as *const _,
+                    Err(_) => ptr::null(),
+                }
+            });
+            let proc_address = constrain(|sym| get_proc_address(sym));
+            ffi::egl::load_with(&proc_address);
+            ffi::egl::BindWaylandDisplayWL::load_with(&proc_address);
+            ffi::egl::UnbindWaylandDisplayWL::load_with(&proc_address);
+            ffi::egl::QueryWaylandBufferWL::load_with(&proc_address);
+        });
+
+        // the first step is to query the list of extensions without any display, if supported
+        let dp_extensions = unsafe {
+            let p = ffi::egl::QueryString(ffi::egl::NO_DISPLAY, ffi::egl::EXTENSIONS as i32);
+
+            // this possibility is available only with EGL 1.5 or EGL_EXT_platform_base, otherwise
+            // `eglQueryString` returns an error
+            if p.is_null() {
+                vec![]
+            } else {
+                let p = CStr::from_ptr(p);
+                let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| String::new());
+                list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>()
+            }
+        };
+
+        debug!(log, "EGL No-Display Extensions: {:?}", dp_extensions);
+
+        let display =
+            unsafe { B::get_display(ptr, |e: &str| dp_extensions.iter().any(|s| s == e), log.clone()) };
+        if display == ffi::egl::NO_DISPLAY {
+            error!(log, "EGL Display is not valid");
+            return Err(Error::DisplayNotSupported);
+        }
+
+        let egl_version = {
+            let mut major: MaybeUninit<ffi::egl::types::EGLint> = MaybeUninit::uninit();
+            let mut minor: MaybeUninit<ffi::egl::types::EGLint> = MaybeUninit::uninit();
+
+            if unsafe { ffi::egl::Initialize(display, major.as_mut_ptr(), minor.as_mut_ptr()) } == 0 {
+                return Err(Error::InitFailed);
+            }
+            let major = unsafe { major.assume_init() };
+            let minor = unsafe { minor.assume_init() };
+
+            info!(log, "EGL Initialized");
+            info!(log, "EGL Version: {:?}", (major, minor));
+
+            (major, minor)
+        };
+
+        // the list of extensions supported by the client once initialized is different from the
+        // list of extensions obtained earlier
+        let extensions = if egl_version >= (1, 2) {
+            let p = unsafe { CStr::from_ptr(ffi::egl::QueryString(display, ffi::egl::EXTENSIONS as i32)) };
+            let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| String::new());
+            list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>()
+        } else {
+            vec![]
+        };
+
+        info!(log, "EGL Extensions: {:?}", extensions);
+
+        if egl_version >= (1, 2) && unsafe { ffi::egl::BindAPI(ffi::egl::OPENGL_ES_API) } == 0 {
+            error!(log, "OpenGLES not supported by the underlying EGL implementation");
+            return Err(Error::OpenGlesNotSupported);
+        }
+
+        Ok(EGLDisplay {
+            native: RefCell::new(native),
+            display: Arc::new(display as *const _),
+            egl_version,
+            extensions,
+            logger: log,
+            _backend: PhantomData,
+        })
+    }
+
+    /// Finds a compatible [`EGLConfig`] for a given set of requirements
+    pub unsafe fn choose_config(
+        &self,
+        version: (u8, u8),
+        reqs: PixelFormatRequirements,
+    ) -> Result<(PixelFormat, ffi::egl::types::EGLConfig), Error> {
+        let descriptor = {
+            let mut out: Vec<c_int> = Vec::with_capacity(37);
+
+            if self.egl_version >= (1, 2) {
+                trace!(self.logger, "Setting COLOR_BUFFER_TYPE to RGB_BUFFER");
+                out.push(ffi::egl::COLOR_BUFFER_TYPE as c_int);
+                out.push(ffi::egl::RGB_BUFFER as c_int);
+            }
+
+            trace!(self.logger, "Setting SURFACE_TYPE to WINDOW");
+
+            out.push(ffi::egl::SURFACE_TYPE as c_int);
+            // TODO: Some versions of Mesa report a BAD_ATTRIBUTE error
+            // if we ask for PBUFFER_BIT as well as WINDOW_BIT
+            out.push((ffi::egl::WINDOW_BIT) as c_int);
+
+            match version {
+                (3, _) => {
+                    if self.egl_version < (1, 3) {
+                        error!(
+                            self.logger,
+                            "OpenglES 3.* is not supported on EGL Versions lower then 1.3"
+                        );
+                        return Err(Error::NoAvailablePixelFormat);
+                    }
+                    trace!(self.logger, "Setting RENDERABLE_TYPE to OPENGL_ES3");
+                    out.push(ffi::egl::RENDERABLE_TYPE as c_int);
+                    out.push(ffi::egl::OPENGL_ES3_BIT as c_int);
+                    trace!(self.logger, "Setting CONFORMANT to OPENGL_ES3");
+                    out.push(ffi::egl::CONFORMANT as c_int);
+                    out.push(ffi::egl::OPENGL_ES3_BIT as c_int);
+                }
+                (2, _) => {
+                    if self.egl_version < (1, 3) {
+                        error!(
+                            self.logger,
+                            "OpenglES 2.* is not supported on EGL Versions lower then 1.3"
+                        );
+                        return Err(Error::NoAvailablePixelFormat);
+                    }
+                    trace!(self.logger, "Setting RENDERABLE_TYPE to OPENGL_ES2");
+                    out.push(ffi::egl::RENDERABLE_TYPE as c_int);
+                    out.push(ffi::egl::OPENGL_ES2_BIT as c_int);
+                    trace!(self.logger, "Setting CONFORMANT to OPENGL_ES2");
+                    out.push(ffi::egl::CONFORMANT as c_int);
+                    out.push(ffi::egl::OPENGL_ES2_BIT as c_int);
+                }
+                (_, _) => unreachable!(),
+            };
+
+            if let Some(hardware_accelerated) = reqs.hardware_accelerated {
+                out.push(ffi::egl::CONFIG_CAVEAT as c_int);
+                out.push(if hardware_accelerated {
+                    trace!(self.logger, "Setting CONFIG_CAVEAT to NONE");
+                    ffi::egl::NONE as c_int
+                } else {
+                    trace!(self.logger, "Setting CONFIG_CAVEAT to SLOW_CONFIG");
+                    ffi::egl::SLOW_CONFIG as c_int
+                });
+            }
+
+            if let Some(color) = reqs.color_bits {
+                trace!(self.logger, "Setting RED_SIZE to {}", color / 3);
+                out.push(ffi::egl::RED_SIZE as c_int);
+                out.push((color / 3) as c_int);
+                trace!(
+                    self.logger,
+                    "Setting GREEN_SIZE to {}",
+                    color / 3 + if color % 3 != 0 { 1 } else { 0 }
+                );
+                out.push(ffi::egl::GREEN_SIZE as c_int);
+                out.push((color / 3 + if color % 3 != 0 { 1 } else { 0 }) as c_int);
+                trace!(
+                    self.logger,
+                    "Setting BLUE_SIZE to {}",
+                    color / 3 + if color % 3 == 2 { 1 } else { 0 }
+                );
+                out.push(ffi::egl::BLUE_SIZE as c_int);
+                out.push((color / 3 + if color % 3 == 2 { 1 } else { 0 }) as c_int);
+            }
+
+            if let Some(alpha) = reqs.alpha_bits {
+                trace!(self.logger, "Setting ALPHA_SIZE to {}", alpha);
+                out.push(ffi::egl::ALPHA_SIZE as c_int);
+                out.push(alpha as c_int);
+            }
+
+            if let Some(depth) = reqs.depth_bits {
+                trace!(self.logger, "Setting DEPTH_SIZE to {}", depth);
+                out.push(ffi::egl::DEPTH_SIZE as c_int);
+                out.push(depth as c_int);
+            }
+
+            if let Some(stencil) = reqs.stencil_bits {
+                trace!(self.logger, "Setting STENCIL_SIZE to {}", stencil);
+                out.push(ffi::egl::STENCIL_SIZE as c_int);
+                out.push(stencil as c_int);
+            }
+
+            if let Some(multisampling) = reqs.multisampling {
+                trace!(self.logger, "Setting SAMPLES to {}", multisampling);
+                out.push(ffi::egl::SAMPLES as c_int);
+                out.push(multisampling as c_int);
+            }
+
+            if reqs.stereoscopy {
+                error!(self.logger, "Stereoscopy is currently unsupported (sorry!)");
+                return Err(Error::NoAvailablePixelFormat);
+            }
+
+            out.push(ffi::egl::NONE as c_int);
+            out
+        };
+
+        // calling `eglChooseConfig`
+        let mut config_id = MaybeUninit::uninit();
+        let mut num_configs = MaybeUninit::uninit();
+        if ffi::egl::ChooseConfig(
+            *self.display,
+            descriptor.as_ptr(),
+            config_id.as_mut_ptr(),
+            1,
+            num_configs.as_mut_ptr(),
+        ) == 0
+        {
+            return Err(Error::ConfigFailed);
+        }
+
+        let config_id = config_id.assume_init();
+        let num_configs = num_configs.assume_init();
+
+        if num_configs == 0 {
+            error!(self.logger, "No matching color format found");
+            return Err(Error::NoAvailablePixelFormat);
+        }
+
+        // TODO: Filter configs for matching vsync property
+
+        // analyzing each config
+        macro_rules! attrib {
+            ($display:expr, $config:expr, $attr:expr) => {{
+                let mut value = MaybeUninit::uninit();
+                let res = ffi::egl::GetConfigAttrib(
+                    *$display,
+                    $config,
+                    $attr as ffi::egl::types::EGLint,
+                    value.as_mut_ptr(),
+                );
+                if res == 0 {
+                    return Err(Error::ConfigFailed);
+                }
+                value.assume_init()
+            }};
+        };
+
+        let desc = PixelFormat {
+            hardware_accelerated: attrib!(self.display, config_id, ffi::egl::CONFIG_CAVEAT)
+                != ffi::egl::SLOW_CONFIG as i32,
+            color_bits: attrib!(self.display, config_id, ffi::egl::RED_SIZE) as u8
+                + attrib!(self.display, config_id, ffi::egl::BLUE_SIZE) as u8
+                + attrib!(self.display, config_id, ffi::egl::GREEN_SIZE) as u8,
+            alpha_bits: attrib!(self.display, config_id, ffi::egl::ALPHA_SIZE) as u8,
+            depth_bits: attrib!(self.display, config_id, ffi::egl::DEPTH_SIZE) as u8,
+            stencil_bits: attrib!(self.display, config_id, ffi::egl::STENCIL_SIZE) as u8,
+            stereoscopy: false,
+            multisampling: match attrib!(self.display, config_id, ffi::egl::SAMPLES) {
+                0 | 1 => None,
+                a => Some(a as u16),
+            },
+            srgb: false, // TODO: use EGL_KHR_gl_colorspace to know that
+        };
+
+        info!(self.logger, "Selected color format: {:?}", desc);
+
+        Ok((desc, config_id))
+    }
+
+    /// Create a new [`EGLContext`](::backend::egl::EGLContext)
+    pub fn create_context(
+        &self,
+        attributes: GlAttributes,
+        reqs: PixelFormatRequirements,
+    ) -> Result<EGLContext, Error> {
+        EGLContext::new(&self, attributes, reqs, self.logger.clone())
+    }
+
+    /// Creates a surface for rendering
+    pub fn create_surface(
+        &self,
+        pixel_format: PixelFormat,
+        double_buffer: Option<bool>,
+        config: ffi::egl::types::EGLConfig,
+        args: N::Arguments,
+    ) -> Result<EGLSurface<B::Surface>, Error> {
+        trace!(self.logger, "Creating EGL window surface.");
+        let surface = self.native.borrow_mut().create_surface(args).map_err(|e| {
+            error!(self.logger, "EGL surface creation failed: {}", e);
+            Error::SurfaceCreationFailed
+        })?;
+
+        EGLSurface::new(
+            &self.display,
+            pixel_format,
+            double_buffer,
+            config,
+            surface,
+            self.logger.clone(),
+        )
+        .map(|x| {
+            debug!(self.logger, "EGL surface successfully created");
+            x
+        })
+    }
+
+    /// Returns the runtime egl version of this display
+    pub fn get_egl_version(&self) -> (i32, i32) {
+        self.egl_version
+    }
+
+    /// Returns the supported extensions of this display
+    pub fn get_extensions(&self) -> Vec<String> {
+        self.extensions.clone()
+    }
+
+    /// Borrow the underlying native display.
+    ///
+    /// This follows the same semantics as [`std::cell:RefCell`](std::cell::RefCell).
+    /// Multiple read-only borrows are possible. Borrowing the
+    /// backend while there is a mutable reference will panic.
+    pub fn borrow(&self) -> Ref<'_, N> {
+        self.native.borrow()
+    }
+
+    /// Borrow the underlying native display mutably.
+    ///
+    /// This follows the same semantics as [`std::cell:RefCell`](std::cell::RefCell).
+    /// Holding any other borrow while trying to borrow the backend
+    /// mutably will panic. Note that EGL will borrow the display
+    /// mutably during surface creation.
+    pub fn borrow_mut(&self) -> RefMut<'_, N> {
+        self.native.borrow_mut()
+    }
+}
+
+impl<B: native::Backend, N: native::NativeDisplay<B>> Drop for EGLDisplay<B, N> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::egl::Terminate((*self.display) as *const _);
+        }
+    }
+}
+
+#[cfg(feature = "use_system_lib")]
+impl<B: native::Backend, N: native::NativeDisplay<B>> EGLGraphicsBackend for EGLDisplay<B, N> {
+    /// Binds this EGL display to the given Wayland display.
+    ///
+    /// This will allow clients to utilize EGL to create hardware-accelerated
+    /// surfaces. The server will need to be able to handle EGL-[`WlBuffer`]s.
+    ///
+    /// ## Errors
+    ///
+    /// This might return [`EglExtensionNotSupported`](ErrorKind::EglExtensionNotSupported)
+    /// if binding is not supported by the EGL implementation.
+    ///
+    /// This might return [`OtherEGLDisplayAlreadyBound`](ErrorKind::OtherEGLDisplayAlreadyBound)
+    /// if called for the same [`Display`] multiple times, as only one egl display may be bound at any given time.
+    fn bind_wl_display(&self, display: &Display) -> Result<WaylandEGLDisplay, Error> {
+        if !self.extensions.iter().any(|s| s == "EGL_WL_bind_wayland_display") {
+            return Err(Error::EglExtensionNotSupported(&["EGL_WL_bind_wayland_display"]));
+        }
+        let res = unsafe { ffi::egl::BindWaylandDisplayWL(*self.display, display.c_ptr() as *mut _) };
+        if res == 0 {
+            return Err(Error::OtherEGLDisplayAlreadyBound);
+        }
+        Ok(WaylandEGLDisplay::new(
+            Arc::downgrade(&self.display),
+            display.c_ptr(),
+            &self.extensions,
+        ))
+    }
+}
+
+/// Type to receive [`EGLImages`] for EGL-based [`WlBuffer`]s.
+///
+/// Can be created by using [`EGLGraphicsBackend::bind_wl_display`].
+#[cfg(feature = "use_system_lib")]
+pub struct WaylandEGLDisplay {
+    display: Weak<ffi::egl::types::EGLDisplay>,
+    wayland: *mut wl_display,
+    #[cfg(feature = "renderer_gl")]
+    gl: gl_ffi::Gles2,
+    #[cfg(feature = "renderer_gl")]
+    egl_to_texture_support: bool,
+}
+
+#[cfg(feature = "use_system_lib")]
+impl WaylandEGLDisplay {
+    fn new(
+        display: Weak<ffi::egl::types::EGLDisplay>,
+        wayland: *mut wl_display,
+        extensions: &Vec<String>,
+    ) -> Self {
+        #[cfg(feature = "renderer_gl")]
+        let gl = gl_ffi::Gles2::load_with(|s| unsafe { get_proc_address(s) as *const _ });
+
+        Self {
+            display,
+            wayland,
+            #[cfg(feature = "renderer_gl")]
+            egl_to_texture_support: extensions
+                .iter()
+                .any(|s| s == "GL_OES_EGL_image" || s == "GL_OES_EGL_image_base"),
+            #[cfg(feature = "renderer_gl")]
+            gl,
+        }
+    }
+
+    /// Try to receive [`EGLImages`] from a given [`WlBuffer`].
+    ///
+    /// In case the buffer is not managed by EGL (but e.g. the [`wayland::shm` module](::wayland::shm))
+    /// a [`BufferAccessError::NotManaged`](::backend::egl::BufferAccessError::NotManaged) is returned with the original buffer
+    /// to render it another way.
+    pub fn egl_buffer_contents(
+        &self,
+        buffer: WlBuffer,
+    ) -> ::std::result::Result<EGLImages, BufferAccessError> {
+        if let Some(display) = self.display.upgrade() {
+            let mut format: i32 = 0;
+            if unsafe {
+                ffi::egl::QueryWaylandBufferWL(
+                    *display,
+                    buffer.as_ref().c_ptr() as *mut _,
+                    ffi::egl::EGL_TEXTURE_FORMAT,
+                    &mut format as *mut _,
+                ) == 0
+            } {
+                return Err(BufferAccessError::NotManaged(buffer));
+            }
+            let format = match format {
+                x if x == ffi::egl::TEXTURE_RGB as i32 => Format::RGB,
+                x if x == ffi::egl::TEXTURE_RGBA as i32 => Format::RGBA,
+                ffi::egl::TEXTURE_EXTERNAL_WL => Format::External,
+                ffi::egl::TEXTURE_Y_UV_WL => Format::Y_UV,
+                ffi::egl::TEXTURE_Y_U_V_WL => Format::Y_U_V,
+                ffi::egl::TEXTURE_Y_XUXV_WL => Format::Y_XUXV,
+                _ => panic!("EGL returned invalid texture type"),
+            };
+
+            let mut width: i32 = 0;
+            if unsafe {
+                ffi::egl::QueryWaylandBufferWL(
+                    *display,
+                    buffer.as_ref().c_ptr() as *mut _,
+                    ffi::egl::WIDTH as i32,
+                    &mut width as *mut _,
+                ) == 0
+            } {
+                return Err(BufferAccessError::NotManaged(buffer));
+            }
+
+            let mut height: i32 = 0;
+            if unsafe {
+                ffi::egl::QueryWaylandBufferWL(
+                    *display,
+                    buffer.as_ref().c_ptr() as *mut _,
+                    ffi::egl::HEIGHT as i32,
+                    &mut height as *mut _,
+                ) == 0
+            } {
+                return Err(BufferAccessError::NotManaged(buffer));
+            }
+
+            let mut inverted: i32 = 0;
+            if unsafe {
+                ffi::egl::QueryWaylandBufferWL(
+                    *display,
+                    buffer.as_ref().c_ptr() as *mut _,
+                    ffi::egl::WAYLAND_Y_INVERTED_WL,
+                    &mut inverted as *mut _,
+                ) != 0
+            } {
+                inverted = 1;
+            }
+
+            let mut images = Vec::with_capacity(format.num_planes());
+            for i in 0..format.num_planes() {
+                let mut out = Vec::with_capacity(3);
+                out.push(ffi::egl::WAYLAND_PLANE_WL as i32);
+                out.push(i as i32);
+                out.push(ffi::egl::NONE as i32);
+
+                images.push({
+                    let image = unsafe {
+                        ffi::egl::CreateImageKHR(
+                            *display,
+                            ffi::egl::NO_CONTEXT,
+                            ffi::egl::WAYLAND_BUFFER_WL,
+                            buffer.as_ref().c_ptr() as *mut _,
+                            out.as_ptr(),
+                        )
+                    };
+                    if image == ffi::egl::NO_IMAGE_KHR {
+                        return Err(BufferAccessError::EGLImageCreationFailed);
+                    } else {
+                        image
+                    }
+                });
+            }
+
+            Ok(EGLImages {
+                display: Arc::downgrade(&display),
+                width: width as u32,
+                height: height as u32,
+                y_inverted: inverted != 0,
+                format,
+                images,
+                buffer,
+                #[cfg(feature = "renderer_gl")]
+                gl: self.gl.clone(),
+                #[cfg(feature = "renderer_gl")]
+                egl_to_texture_support: self.egl_to_texture_support,
+            })
+        } else {
+            Err(BufferAccessError::ContextLost)
+        }
+    }
+
+    /// Try to receive the dimensions of a given [`WlBuffer`].
+    ///
+    /// In case the buffer is not managed by EGL (but e.g. the [`wayland::shm` module](::wayland::shm)) or the
+    /// context has been lost, `None` is returned.
+    pub fn egl_buffer_dimensions(&self, buffer: &WlBuffer) -> Option<(i32, i32)> {
+        if let Some(display) = self.display.upgrade() {
+            let mut width: i32 = 0;
+            if unsafe {
+                ffi::egl::QueryWaylandBufferWL(
+                    *display,
+                    buffer.as_ref().c_ptr() as *mut _,
+                    ffi::egl::WIDTH as i32,
+                    &mut width as *mut _,
+                ) == 0
+            } {
+                return None;
+            }
+
+            let mut height: i32 = 0;
+            if unsafe {
+                ffi::egl::QueryWaylandBufferWL(
+                    *display,
+                    buffer.as_ref().c_ptr() as *mut _,
+                    ffi::egl::HEIGHT as i32,
+                    &mut height as *mut _,
+                ) == 0
+            } {
+                return None;
+            }
+
+            Some((width, height))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "use_system_lib")]
+impl Drop for WaylandEGLDisplay {
+    fn drop(&mut self) {
+        if let Some(display) = self.display.upgrade() {
+            if !self.wayland.is_null() {
+                unsafe {
+                    ffi::egl::UnbindWaylandDisplayWL(*display, self.wayland as *mut _);
+                }
+            }
+        }
+    }
+}

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -41,7 +41,7 @@ pub mod native;
 pub mod surface;
 pub use self::surface::EGLSurface;
 #[cfg(feature = "use_system_lib")]
-use crate::backend::egl::display::WaylandEGLDisplay;
+use crate::backend::egl::display::EGLBufferReader;
 use std::ffi::CString;
 use std::sync::Weak;
 
@@ -246,7 +246,7 @@ impl Drop for EGLImages {
 }
 
 /// Trait any backend type may implement that allows binding a [`Display`](wayland_server::Display)
-/// to create an [`WaylandDisplay`](display::WaylandDisplay) for EGL-based [`WlBuffer`]s.
+/// to create an [`EGLBufferReader`](display::EGLBufferReader) for EGL-based [`WlBuffer`]s.
 #[cfg(feature = "use_system_lib")]
 pub trait EGLGraphicsBackend {
     /// Binds this EGL context to the given Wayland display.
@@ -261,5 +261,5 @@ pub trait EGLGraphicsBackend {
     ///
     /// This might return [`OtherEGLDisplayAlreadyBound`](ErrorKind::OtherEGLDisplayAlreadyBound)
     /// if called for the same [`Display`] multiple times, as only one context may be bound at any given time.
-    fn bind_wl_display(&self, display: &Display) -> Result<WaylandEGLDisplay, Error>;
+    fn bind_wl_display(&self, display: &Display) -> Result<EGLBufferReader, Error>;
 }

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -65,10 +65,12 @@ impl ::std::error::Error for EglExtensionNotSupportedError {}
 /// Returns the address of an OpenGL function.
 ///
 /// Result is independent of displays and does not guarantee an extension is actually supported at runtime.
-pub unsafe fn get_proc_address(symbol: &str) -> *const c_void {
-    let addr = CString::new(symbol.as_bytes()).unwrap();
-    let addr = addr.as_ptr();
-    ffi::egl::GetProcAddress(addr) as *const _
+pub fn get_proc_address(symbol: &str) -> *const c_void {
+    unsafe {
+        let addr = CString::new(symbol.as_bytes()).unwrap();
+        let addr = addr.as_ptr();
+        ffi::egl::GetProcAddress(addr) as *const _
+    }
 }
 
 /// Error that can occur when accessing an EGL buffer

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -21,28 +21,29 @@
 #[cfg(feature = "renderer_gl")]
 use crate::backend::graphics::gl::ffi as gl_ffi;
 use nix::libc::c_uint;
-use std::{
-    ffi::CStr,
-    fmt,
-    rc::{Rc, Weak},
-};
+use std::fmt;
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::{protocol::wl_buffer::WlBuffer, Display};
-#[cfg(feature = "use_system_lib")]
-use wayland_sys::server::wl_display;
 
 pub mod context;
 pub use self::context::EGLContext;
 mod error;
 pub use self::error::Error;
 
+use nix::libc::c_void;
+
 #[allow(non_camel_case_types, dead_code, unused_mut, non_upper_case_globals)]
 pub mod ffi;
 use self::ffi::egl::types::EGLImage;
 
+pub mod display;
 pub mod native;
 pub mod surface;
 pub use self::surface::EGLSurface;
+#[cfg(feature = "use_system_lib")]
+use crate::backend::egl::display::WaylandEGLDisplay;
+use std::ffi::CString;
+use std::sync::Weak;
 
 /// Error that can happen on optional EGL features
 #[derive(Debug, Clone, PartialEq)]
@@ -60,6 +61,15 @@ impl fmt::Display for EglExtensionNotSupportedError {
 }
 
 impl ::std::error::Error for EglExtensionNotSupportedError {}
+
+/// Returns the address of an OpenGL function.
+///
+/// Result is independent of displays and does not guarantee an extension is actually supported at runtime.
+pub unsafe fn get_proc_address(symbol: &str) -> *const c_void {
+    let addr = CString::new(symbol.as_bytes()).unwrap();
+    let addr = addr.as_ptr();
+    ffi::egl::GetProcAddress(addr) as *const _
+}
 
 /// Error that can occur when accessing an EGL buffer
 #[cfg(feature = "wayland_frontend")]
@@ -234,7 +244,7 @@ impl Drop for EGLImages {
 }
 
 /// Trait any backend type may implement that allows binding a [`Display`](wayland_server::Display)
-/// to create an [`EGLDisplay`] for EGL-based [`WlBuffer`]s.
+/// to create an [`WaylandDisplay`](display::WaylandDisplay) for EGL-based [`WlBuffer`]s.
 #[cfg(feature = "use_system_lib")]
 pub trait EGLGraphicsBackend {
     /// Binds this EGL context to the given Wayland display.
@@ -249,226 +259,5 @@ pub trait EGLGraphicsBackend {
     ///
     /// This might return [`OtherEGLDisplayAlreadyBound`](ErrorKind::OtherEGLDisplayAlreadyBound)
     /// if called for the same [`Display`] multiple times, as only one context may be bound at any given time.
-    fn bind_wl_display(&self, display: &Display) -> Result<EGLDisplay, Error>;
-}
-
-/// Type to receive [`EGLImages`] for EGL-based [`WlBuffer`]s.
-///
-/// Can be created by using [`EGLGraphicsBackend::bind_wl_display`].
-#[cfg(feature = "use_system_lib")]
-pub struct EGLDisplay {
-    egl: Weak<ffi::egl::types::EGLDisplay>,
-    wayland: *mut wl_display,
-    #[cfg(feature = "renderer_gl")]
-    gl: gl_ffi::Gles2,
-    #[cfg(feature = "renderer_gl")]
-    egl_to_texture_support: bool,
-}
-
-#[cfg(feature = "use_system_lib")]
-impl EGLDisplay {
-    fn new<B: native::Backend, N: native::NativeDisplay<B>>(
-        context: &EGLContext<B, N>,
-        display: *mut wl_display,
-    ) -> EGLDisplay {
-        #[cfg(feature = "renderer_gl")]
-        let gl = gl_ffi::Gles2::load_with(|s| unsafe { context.get_proc_address(s) as *const _ });
-
-        EGLDisplay {
-            egl: Rc::downgrade(&context.display),
-            wayland: display,
-            #[cfg(feature = "renderer_gl")]
-            egl_to_texture_support: {
-                // the list of gl extensions supported by the context
-                let data = unsafe { CStr::from_ptr(gl.GetString(gl_ffi::EXTENSIONS) as *const _) }
-                    .to_bytes()
-                    .to_vec();
-                let list = String::from_utf8(data).unwrap();
-                list.split(' ')
-                    .any(|s| s == "GL_OES_EGL_image" || s == "GL_OES_EGL_image_base")
-            },
-            #[cfg(feature = "renderer_gl")]
-            gl,
-        }
-    }
-
-    /// Try to receive [`EGLImages`] from a given [`WlBuffer`].
-    ///
-    /// In case the buffer is not managed by EGL (but e.g. the [`wayland::shm` module](::wayland::shm))
-    /// a [`BufferAccessError::NotManaged`](::backend::egl::BufferAccessError::NotManaged) is returned with the original buffer
-    /// to render it another way.
-    pub fn egl_buffer_contents(
-        &self,
-        buffer: WlBuffer,
-    ) -> ::std::result::Result<EGLImages, BufferAccessError> {
-        if let Some(display) = self.egl.upgrade() {
-            let mut format: i32 = 0;
-            if unsafe {
-                ffi::egl::QueryWaylandBufferWL(
-                    *display,
-                    buffer.as_ref().c_ptr() as *mut _,
-                    ffi::egl::EGL_TEXTURE_FORMAT,
-                    &mut format as *mut _,
-                ) == 0
-            } {
-                return Err(BufferAccessError::NotManaged(buffer));
-            }
-            let format = match format {
-                x if x == ffi::egl::TEXTURE_RGB as i32 => Format::RGB,
-                x if x == ffi::egl::TEXTURE_RGBA as i32 => Format::RGBA,
-                ffi::egl::TEXTURE_EXTERNAL_WL => Format::External,
-                ffi::egl::TEXTURE_Y_UV_WL => Format::Y_UV,
-                ffi::egl::TEXTURE_Y_U_V_WL => Format::Y_U_V,
-                ffi::egl::TEXTURE_Y_XUXV_WL => Format::Y_XUXV,
-                _ => panic!("EGL returned invalid texture type"),
-            };
-
-            let mut width: i32 = 0;
-            if unsafe {
-                ffi::egl::QueryWaylandBufferWL(
-                    *display,
-                    buffer.as_ref().c_ptr() as *mut _,
-                    ffi::egl::WIDTH as i32,
-                    &mut width as *mut _,
-                ) == 0
-            } {
-                return Err(BufferAccessError::NotManaged(buffer));
-            }
-
-            let mut height: i32 = 0;
-            if unsafe {
-                ffi::egl::QueryWaylandBufferWL(
-                    *display,
-                    buffer.as_ref().c_ptr() as *mut _,
-                    ffi::egl::HEIGHT as i32,
-                    &mut height as *mut _,
-                ) == 0
-            } {
-                return Err(BufferAccessError::NotManaged(buffer));
-            }
-
-            let mut inverted: i32 = 0;
-            if unsafe {
-                ffi::egl::QueryWaylandBufferWL(
-                    *display,
-                    buffer.as_ref().c_ptr() as *mut _,
-                    ffi::egl::WAYLAND_Y_INVERTED_WL,
-                    &mut inverted as *mut _,
-                ) != 0
-            } {
-                inverted = 1;
-            }
-
-            let mut images = Vec::with_capacity(format.num_planes());
-            for i in 0..format.num_planes() {
-                let mut out = Vec::with_capacity(3);
-                out.push(ffi::egl::WAYLAND_PLANE_WL as i32);
-                out.push(i as i32);
-                out.push(ffi::egl::NONE as i32);
-
-                images.push({
-                    let image = unsafe {
-                        ffi::egl::CreateImageKHR(
-                            *display,
-                            ffi::egl::NO_CONTEXT,
-                            ffi::egl::WAYLAND_BUFFER_WL,
-                            buffer.as_ref().c_ptr() as *mut _,
-                            out.as_ptr(),
-                        )
-                    };
-                    if image == ffi::egl::NO_IMAGE_KHR {
-                        return Err(BufferAccessError::EGLImageCreationFailed);
-                    } else {
-                        image
-                    }
-                });
-            }
-
-            Ok(EGLImages {
-                display: Rc::downgrade(&display),
-                width: width as u32,
-                height: height as u32,
-                y_inverted: inverted != 0,
-                format,
-                images,
-                buffer,
-                #[cfg(feature = "renderer_gl")]
-                gl: self.gl.clone(),
-                #[cfg(feature = "renderer_gl")]
-                egl_to_texture_support: self.egl_to_texture_support,
-            })
-        } else {
-            Err(BufferAccessError::ContextLost)
-        }
-    }
-
-    /// Try to receive the dimensions of a given [`WlBuffer`].
-    ///
-    /// In case the buffer is not managed by EGL (but e.g. the [`wayland::shm` module](::wayland::shm)) or the
-    /// context has been lost, `None` is returned.
-    pub fn egl_buffer_dimensions(&self, buffer: &WlBuffer) -> Option<(i32, i32)> {
-        if let Some(display) = self.egl.upgrade() {
-            let mut width: i32 = 0;
-            if unsafe {
-                ffi::egl::QueryWaylandBufferWL(
-                    *display,
-                    buffer.as_ref().c_ptr() as *mut _,
-                    ffi::egl::WIDTH as i32,
-                    &mut width as *mut _,
-                ) == 0
-            } {
-                return None;
-            }
-
-            let mut height: i32 = 0;
-            if unsafe {
-                ffi::egl::QueryWaylandBufferWL(
-                    *display,
-                    buffer.as_ref().c_ptr() as *mut _,
-                    ffi::egl::HEIGHT as i32,
-                    &mut height as *mut _,
-                ) == 0
-            } {
-                return None;
-            }
-
-            Some((width, height))
-        } else {
-            None
-        }
-    }
-}
-
-#[cfg(feature = "use_system_lib")]
-impl Drop for EGLDisplay {
-    fn drop(&mut self) {
-        if let Some(display) = self.egl.upgrade() {
-            if !self.wayland.is_null() {
-                unsafe {
-                    ffi::egl::UnbindWaylandDisplayWL(*display, self.wayland as *mut _);
-                }
-            }
-        }
-    }
-}
-
-#[cfg(feature = "use_system_lib")]
-impl<E: EGLGraphicsBackend> EGLGraphicsBackend for Rc<E> {
-    fn bind_wl_display(&self, display: &Display) -> Result<EGLDisplay, Error> {
-        (**self).bind_wl_display(display)
-    }
-}
-
-#[cfg(feature = "use_system_lib")]
-impl<B: native::Backend, N: native::NativeDisplay<B>> EGLGraphicsBackend for EGLContext<B, N> {
-    fn bind_wl_display(&self, display: &Display) -> Result<EGLDisplay, Error> {
-        if !self.wl_drm_support {
-            return Err(Error::EglExtensionNotSupported(&["EGL_WL_bind_wayland_display"]));
-        }
-        let res = unsafe { ffi::egl::BindWaylandDisplayWL(*self.display, display.c_ptr() as *mut _) };
-        if res == 0 {
-            return Err(Error::OtherEGLDisplayAlreadyBound);
-        }
-        Ok(EGLDisplay::new(self, display.c_ptr()))
-    }
+    fn bind_wl_display(&self, display: &Display) -> Result<WaylandEGLDisplay, Error>;
 }

--- a/src/backend/graphics/format.rs
+++ b/src/backend/graphics/format.rs
@@ -13,8 +13,6 @@ pub struct PixelFormat {
     pub stencil_bits: u8,
     /// is stereoscopy enabled
     pub stereoscopy: bool,
-    /// is double buffering enabled
-    pub double_buffer: bool,
     /// number of samples used for multisampling if enabled
     pub multisampling: Option<u16>,
     /// is srgb enabled

--- a/src/backend/graphics/gl.rs
+++ b/src/backend/graphics/gl.rs
@@ -18,11 +18,7 @@ pub trait GLGraphicsBackend {
     fn swap_buffers(&self) -> Result<(), SwapBuffersError>;
 
     /// Returns the address of an OpenGL function.
-    ///
-    /// # Safety
-    ///
-    /// The context must have been made current before this function is called.
-    unsafe fn get_proc_address(&self, symbol: &str) -> *const c_void;
+    fn get_proc_address(&self, symbol: &str) -> *const c_void;
 
     /// Returns the dimensions of the window, or screen, etc in points.
     ///
@@ -51,5 +47,5 @@ pub trait GLGraphicsBackend {
 /// and may only be used in combination with the backend. Using this with any
 /// other gl context or after the backend was dropped *may* cause undefined behavior.
 pub fn load_raw_gl<B: GLGraphicsBackend>(backend: &B) -> Gles2 {
-    Gles2::load_with(|s| unsafe { backend.get_proc_address(s) as *const _ })
+    Gles2::load_with(|s| { backend.get_proc_address(s) as *const _ })
 }

--- a/src/backend/graphics/gl.rs
+++ b/src/backend/graphics/gl.rs
@@ -47,5 +47,5 @@ pub trait GLGraphicsBackend {
 /// and may only be used in combination with the backend. Using this with any
 /// other gl context or after the backend was dropped *may* cause undefined behavior.
 pub fn load_raw_gl<B: GLGraphicsBackend>(backend: &B) -> Gles2 {
-    Gles2::load_with(|s| { backend.get_proc_address(s) as *const _ })
+    Gles2::load_with(|s| backend.get_proc_address(s) as *const _)
 }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -33,7 +33,7 @@ use winit::{
 };
 
 #[cfg(feature = "use_system_lib")]
-use crate::backend::egl::{display::WaylandEGLDisplay, EGLGraphicsBackend};
+use crate::backend::egl::{display::EGLBufferReader, EGLGraphicsBackend};
 
 /// Errors thrown by the `winit` backends
 #[derive(thiserror::Error, Debug)]
@@ -336,7 +336,7 @@ impl GLGraphicsBackend for WinitGraphicsBackend {
 
 #[cfg(feature = "use_system_lib")]
 impl EGLGraphicsBackend for WinitGraphicsBackend {
-    fn bind_wl_display(&self, wl_display: &Display) -> Result<WaylandEGLDisplay, EGLError> {
+    fn bind_wl_display(&self, wl_display: &Display) -> Result<EGLBufferReader, EGLError> {
         match *self.window {
             Window::Wayland { ref display, .. } => display.bind_wl_display(wl_display),
             Window::X11 { ref display, .. } => display.bind_wl_display(wl_display),

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -1,10 +1,9 @@
 //! Implementation of backend traits for types provided by `winit`
 
+use crate::backend::egl::display::EGLDisplay;
+use crate::backend::egl::get_proc_address;
 use crate::backend::{
-    egl::{
-        context::GlAttributes, native, EGLContext, EGLDisplay, EGLGraphicsBackend, EGLSurface,
-        Error as EGLError,
-    },
+    egl::{context::GlAttributes, native, EGLContext, EGLSurface, Error as EGLError},
     graphics::{gl::GLGraphicsBackend, CursorBackend, PixelFormat, SwapBuffersError},
     input::{
         Axis, AxisSource, Event as BackendEvent, InputBackend, InputHandler, KeyState, KeyboardKeyEvent,
@@ -33,6 +32,9 @@ use winit::{
     window::{CursorIcon, Window as WinitWindow, WindowBuilder},
 };
 
+#[cfg(feature = "use_system_lib")]
+use crate::backend::egl::{display::WaylandEGLDisplay, EGLGraphicsBackend};
+
 /// Errors thrown by the `winit` backends
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -49,11 +51,13 @@ pub enum Error {
 
 enum Window {
     Wayland {
-        context: EGLContext<native::Wayland, WinitWindow>,
+        display: EGLDisplay<native::Wayland, WinitWindow>,
+        context: EGLContext,
         surface: EGLSurface<wegl::WlEglSurface>,
     },
     X11 {
-        context: EGLContext<native::X11, WinitWindow>,
+        display: EGLDisplay<native::X11, WinitWindow>,
+        context: EGLContext,
         surface: EGLSurface<native::XlibWindow>,
     },
 }
@@ -61,8 +65,8 @@ enum Window {
 impl Window {
     fn window(&self) -> Ref<'_, WinitWindow> {
         match *self {
-            Window::Wayland { ref context, .. } => context.borrow(),
-            Window::X11 { ref context, .. } => context.borrow(),
+            Window::Wayland { ref display, .. } => display.borrow(),
+            Window::X11 { ref display, .. } => display.borrow(),
         }
     }
 }
@@ -158,15 +162,33 @@ where
     let reqs = Default::default();
     let window = Rc::new(
         if native::NativeDisplay::<native::Wayland>::is_backend(&winit_window) {
-            let context =
-                EGLContext::<native::Wayland, WinitWindow>::new(winit_window, attributes, reqs, log.clone())?;
-            let surface = context.create_surface(())?;
-            Window::Wayland { context, surface }
+            let display = EGLDisplay::<native::Wayland, WinitWindow>::new(winit_window, log.clone())?;
+            let context = display.create_context(attributes, reqs)?;
+            let surface = display.create_surface(
+                context.get_pixel_format(),
+                reqs.double_buffer,
+                context.get_config_id(),
+                (),
+            )?;
+            Window::Wayland {
+                display,
+                context,
+                surface,
+            }
         } else if native::NativeDisplay::<native::X11>::is_backend(&winit_window) {
-            let context =
-                EGLContext::<native::X11, WinitWindow>::new(winit_window, attributes, reqs, log.clone())?;
-            let surface = context.create_surface(())?;
-            Window::X11 { context, surface }
+            let display = EGLDisplay::<native::X11, WinitWindow>::new(winit_window, log.clone())?;
+            let context = display.create_context(attributes, reqs)?;
+            let surface = display.create_surface(
+                context.get_pixel_format(),
+                reqs.double_buffer,
+                context.get_config_id(),
+                (),
+            )?;
+            Window::X11 {
+                display,
+                context,
+                surface,
+            }
         } else {
             return Err(Error::NotSupported);
         },
@@ -265,10 +287,7 @@ impl GLGraphicsBackend for WinitGraphicsBackend {
 
     unsafe fn get_proc_address(&self, symbol: &str) -> *const c_void {
         trace!(self.logger, "Getting symbol for {:?}", symbol);
-        match *self.window {
-            Window::Wayland { ref context, .. } => context.get_proc_address(symbol),
-            Window::X11 { ref context, .. } => context.get_proc_address(symbol),
-        }
+        get_proc_address(symbol)
     }
 
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
@@ -281,10 +300,12 @@ impl GLGraphicsBackend for WinitGraphicsBackend {
             Window::Wayland {
                 ref context,
                 ref surface,
+                ..
             } => context.is_current() && surface.is_current(),
             Window::X11 {
                 ref context,
                 ref surface,
+                ..
             } => context.is_current() && surface.is_current(),
         }
     }
@@ -292,24 +313,33 @@ impl GLGraphicsBackend for WinitGraphicsBackend {
     unsafe fn make_current(&self) -> ::std::result::Result<(), SwapBuffersError> {
         trace!(self.logger, "Setting EGL context to be the current context");
         match *self.window {
-            Window::Wayland { ref surface, .. } => surface.make_current(),
-            Window::X11 { ref surface, .. } => surface.make_current(),
+            Window::Wayland {
+                ref surface,
+                ref context,
+                ..
+            } => context.make_current_with_surface(surface),
+            Window::X11 {
+                ref surface,
+                ref context,
+                ..
+            } => context.make_current_with_surface(surface),
         }
     }
 
     fn get_pixel_format(&self) -> PixelFormat {
         match *self.window {
-            Window::Wayland { ref context, .. } => context.get_pixel_format(),
-            Window::X11 { ref context, .. } => context.get_pixel_format(),
+            Window::Wayland { ref surface, .. } => surface.get_pixel_format(),
+            Window::X11 { ref surface, .. } => surface.get_pixel_format(),
         }
     }
 }
 
+#[cfg(feature = "use_system_lib")]
 impl EGLGraphicsBackend for WinitGraphicsBackend {
-    fn bind_wl_display(&self, display: &Display) -> Result<EGLDisplay, EGLError> {
+    fn bind_wl_display(&self, wl_display: &Display) -> Result<WaylandEGLDisplay, EGLError> {
         match *self.window {
-            Window::Wayland { ref context, .. } => context.bind_wl_display(display),
-            Window::X11 { ref context, .. } => context.bind_wl_display(display),
+            Window::Wayland { ref display, .. } => display.bind_wl_display(wl_display),
+            Window::X11 { ref display, .. } => display.bind_wl_display(wl_display),
         }
     }
 }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -285,7 +285,7 @@ impl GLGraphicsBackend for WinitGraphicsBackend {
         }
     }
 
-    unsafe fn get_proc_address(&self, symbol: &str) -> *const c_void {
+    fn get_proc_address(&self, symbol: &str) -> *const c_void {
         trace!(self.logger, "Getting symbol for {:?}", symbol);
         get_proc_address(symbol)
     }


### PR DESCRIPTION
Refactors the `backend:egl` to more closely represent how EGL works under the hood.

I have kept the exposed `EglSurface` api the same, Now it represents a `EGLContext` and `EGLSurface` pair. Allowing the `GLBackend` to still be implemented without the creation of a new type. Similar has happened for `winit`.

The old `EGLDisplay` has now became `WaylandEGLDisplay`, which can be created from either a `EglDevice`, `EGLDisplay, or `WinitGraphicsBackend`.

These changes should then make exposing shared contexts, and improving thread safety in the future a lot easier.
