### PR TITLE
Fix anvil event loop

### DIFF
--- a/anvil/src/glium_drawer.rs
+++ b/anvil/src/glium_drawer.rs
@@ -24,6 +24,7 @@ use smithay::{
         data_device::DnDIconRole,
         seat::CursorImageRole,
         shm::with_buffer_contents as shm_buffer_contents,
+        SERIAL_COUNTER as SCOUNTER,
     },
 };
 
@@ -379,6 +380,11 @@ impl<F: GLGraphicsBackend + 'static> GliumDrawer<F> {
                                 ..Default::default()
                             },
                         );
+                    }
+
+                    // send a frame event to the surface if applicable
+                    if let Some(callback) = data.borrow_mut().frame_callback.take() {
+                        callback.done(SCOUNTER.next_serial());
                     }
                 }
             },

--- a/anvil/src/glium_drawer.rs
+++ b/anvil/src/glium_drawer.rs
@@ -24,7 +24,6 @@ use smithay::{
         data_device::DnDIconRole,
         seat::CursorImageRole,
         shm::with_buffer_contents as shm_buffer_contents,
-        SERIAL_COUNTER as SCOUNTER,
     },
 };
 
@@ -380,11 +379,6 @@ impl<F: GLGraphicsBackend + 'static> GliumDrawer<F> {
                                 ..Default::default()
                             },
                         );
-                    }
-
-                    // send a frame event to the surface if applicable
-                    if let Some(callback) = data.borrow_mut().frame_callback.take() {
-                        callback.done(SCOUNTER.next_serial());
                     }
                 }
             },

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -7,20 +7,10 @@ extern crate slog;
 #[macro_use(define_roles)]
 extern crate smithay;
 
-use std::{
-    cell::RefCell,
-    rc::Rc,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::{cell::RefCell, rc::Rc};
 
 use slog::Drain;
-use smithay::reexports::{
-    calloop::{generic::Generic, mio::Interest, EventLoop},
-    wayland_server::Display,
-};
+use smithay::reexports::{calloop::EventLoop, wayland_server::Display};
 
 #[macro_use]
 mod shaders;
@@ -29,11 +19,14 @@ mod glium_drawer;
 mod input_handler;
 mod shell;
 mod shm_load;
+mod state;
 #[cfg(feature = "udev")]
 mod udev;
 mod window_map;
 #[cfg(feature = "winit")]
 mod winit;
+
+use state::AnvilState;
 
 static POSSIBLE_BACKENDS: &[&str] = &[
     #[cfg(feature = "winit")]
@@ -42,18 +35,6 @@ static POSSIBLE_BACKENDS: &[&str] = &[
     "--tty-udev : Run anvil as a tty udev client (requires root if without logind).",
 ];
 
-pub struct AnvilState {
-    pub running: Arc<AtomicBool>,
-}
-
-impl Default for AnvilState {
-    fn default() -> AnvilState {
-        AnvilState {
-            running: Arc::new(AtomicBool::new(true)),
-        }
-    }
-}
-
 fn main() {
     // A logger facility, here we use the terminal here
     let log = slog::Logger::root(
@@ -61,40 +42,22 @@ fn main() {
         o!(),
     );
 
-    let event_loop = EventLoop::<AnvilState>::new().unwrap();
+    let mut event_loop = EventLoop::<AnvilState>::new().unwrap();
     let display = Rc::new(RefCell::new(Display::new()));
-
-    // Glue for event dispatching
-    let mut wayland_event_source = Generic::from_raw_fd(display.borrow().get_poll_fd());
-    wayland_event_source.set_interest(Interest::READABLE);
-    let _wayland_source = event_loop.handle().insert_source(wayland_event_source, {
-        let display = display.clone();
-        let log = log.clone();
-        move |_, state: &mut AnvilState| {
-            let mut display = display.borrow_mut();
-            match display.dispatch(std::time::Duration::from_millis(0), state) {
-                Ok(_) => {}
-                Err(e) => {
-                    error!(log, "I/O error on the Wayland display: {}", e);
-                    state.running.store(false, Ordering::SeqCst);
-                }
-            }
-        }
-    });
 
     let arg = ::std::env::args().nth(1);
     match arg.as_ref().map(|s| &s[..]) {
         #[cfg(feature = "winit")]
         Some("--winit") => {
             info!(log, "Starting anvil with winit backend");
-            if let Err(()) = winit::run_winit(display, event_loop, log.clone()) {
+            if let Err(()) = winit::run_winit(display, &mut event_loop, log.clone()) {
                 crit!(log, "Failed to initialize winit backend.");
             }
         }
         #[cfg(feature = "udev")]
         Some("--tty-udev") => {
             info!(log, "Starting anvil on a tty using udev");
-            if let Err(()) = udev::run_udev(display, event_loop, log.clone()) {
+            if let Err(()) = udev::run_udev(display, &mut event_loop, log.clone()) {
                 crit!(log, "Failed to initialize tty backend.");
             }
         }

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -694,6 +694,13 @@ impl SurfaceData {
 
         self.input_region.as_ref().unwrap().contains(point)
     }
+
+    /// Send the frame callback if it had been requested
+    pub fn send_frame(&mut self, serial: u32) {
+        if let Some(callback) = self.frame_callback.take() {
+            callback.done(serial);
+        }
+    }
 }
 
 fn surface_commit(

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -70,6 +70,8 @@ impl AnvilState {
             )
             .expect("Failed to init the wayland event source.");
 
+        // Init the basic compositor globals
+
         init_shm_global(&mut display.borrow_mut(), vec![], log.clone());
 
         let (ctoken, _, _, window_map) = init_shell(&mut display.borrow_mut(), buffer_utils, log.clone());
@@ -82,6 +84,8 @@ impl AnvilState {
             .unwrap();
         info!(log, "Listening on wayland socket"; "name" => socket_name.clone());
         ::std::env::set_var("WAYLAND_DISPLAY", &socket_name);
+
+        // init data device
 
         let dnd_icon = Arc::new(Mutex::new(None));
 

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -1,0 +1,117 @@
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use smithay::{
+    reexports::{
+        calloop::{
+            generic::{Generic, SourceRawFd},
+            mio::Interest,
+            LoopHandle, Source,
+        },
+        wayland_server::{protocol::wl_surface::WlSurface, Display},
+    },
+    wayland::{
+        compositor::CompositorToken,
+        data_device::{default_action_chooser, init_data_device, DataDeviceEvent},
+        shm::init_shm_global,
+    },
+};
+
+use crate::{buffer_utils::BufferUtils, shell::init_shell};
+
+pub struct AnvilState {
+    pub socket_name: String,
+    pub running: Arc<AtomicBool>,
+    pub display: Rc<RefCell<Display>>,
+    pub handle: LoopHandle<AnvilState>,
+    pub ctoken: CompositorToken<crate::shell::Roles>,
+    pub window_map: Rc<RefCell<crate::window_map::WindowMap<crate::shell::Roles>>>,
+    pub dnd_icon: Arc<Mutex<Option<WlSurface>>>,
+    pub log: slog::Logger,
+    // things we must keep alive
+    _wayland_event_source: Source<Generic<SourceRawFd>>,
+}
+
+impl AnvilState {
+    pub fn init(
+        display: Rc<RefCell<Display>>,
+        handle: LoopHandle<AnvilState>,
+        buffer_utils: BufferUtils,
+        log: slog::Logger,
+    ) -> AnvilState {
+        // init the wayland connection
+        let _wayland_event_source = handle
+            .insert_source(
+                {
+                    let mut source = Generic::from_raw_fd(display.borrow().get_poll_fd());
+                    source.set_interest(Interest::READABLE);
+                    source
+                },
+                {
+                    let display = display.clone();
+                    let log = log.clone();
+                    move |_, state: &mut AnvilState| {
+                        let mut display = display.borrow_mut();
+                        match display.dispatch(std::time::Duration::from_millis(0), state) {
+                            Ok(_) => {}
+                            Err(e) => {
+                                error!(log, "I/O error on the Wayland display: {}", e);
+                                state.running.store(false, Ordering::SeqCst);
+                            }
+                        }
+                    }
+                },
+            )
+            .expect("Failed to init the wayland event source.");
+
+        init_shm_global(&mut display.borrow_mut(), vec![], log.clone());
+
+        let (ctoken, _, _, window_map) = init_shell(&mut display.borrow_mut(), buffer_utils, log.clone());
+
+        let socket_name = display
+            .borrow_mut()
+            .add_socket_auto()
+            .unwrap()
+            .into_string()
+            .unwrap();
+        info!(log, "Listening on wayland socket"; "name" => socket_name.clone());
+        ::std::env::set_var("WAYLAND_DISPLAY", &socket_name);
+
+        let dnd_icon = Arc::new(Mutex::new(None));
+
+        let dnd_icon2 = dnd_icon.clone();
+        init_data_device(
+            &mut display.borrow_mut(),
+            move |event| match event {
+                DataDeviceEvent::DnDStarted { icon, .. } => {
+                    *dnd_icon2.lock().unwrap() = icon;
+                }
+                DataDeviceEvent::DnDDropped => {
+                    *dnd_icon2.lock().unwrap() = None;
+                }
+                _ => {}
+            },
+            default_action_chooser,
+            ctoken,
+            log.clone(),
+        );
+
+        AnvilState {
+            running: Arc::new(AtomicBool::new(true)),
+            display,
+            handle,
+            ctoken,
+            window_map,
+            dnd_icon,
+            log,
+            socket_name,
+            _wayland_event_source,
+        }
+    }
+}

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -82,9 +82,9 @@ where
                 });
             }
             wl_surface::Request::Frame { callback } => {
-                let mut user_impl = self.implem.borrow_mut();
-                trace!(self.log, "Calling user implementation for wl_surface.frame");
-                (&mut *user_impl)(SurfaceEvent::Frame { callback }, surface, CompositorToken::make());
+                SurfaceData::<R>::with_data(&surface, move |d| {
+                    d.frame_callback = Some((*callback).clone());
+                });
             }
             wl_surface::Request::SetOpaqueRegion { region } => {
                 let attributes = region.map(|r| {

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -84,7 +84,7 @@ use wayland_server::{
     protocol::{
         wl_buffer, wl_callback, wl_compositor, wl_output, wl_region, wl_subcompositor, wl_surface::WlSurface,
     },
-    Display, Filter, Global, Main, UserDataMap,
+    Display, Filter, Global, UserDataMap,
 };
 
 /// Description of which part of a surface
@@ -156,6 +156,14 @@ pub struct SurfaceAttributes {
     /// Hint provided by the client to suggest that only this part
     /// of the surface was changed and needs to be redrawn
     pub damage: Damage,
+    /// The frame callback associated with this surface for the commit
+    ///
+    /// The be triggered to notify the client about when it would be a
+    /// good time to start drawing its next frame.
+    ///
+    /// An example possibility would be to trigger it once the frame
+    /// associated with this commit has been displayed on the screen.
+    pub frame_callback: Option<wl_callback::WlCallback>,
     /// User-controlled data
     ///
     /// This is your field to host whatever you need.
@@ -171,6 +179,7 @@ impl Default for SurfaceAttributes {
             opaque_region: None,
             input_region: None,
             damage: Damage::Full,
+            frame_callback: None,
             user_data: UserDataMap::new(),
         }
     }
@@ -511,22 +520,8 @@ pub enum SurfaceEvent {
     /// The double-buffered state has been validated by the client
     ///
     /// At this point, the pending state that has been accumulated in the [`SurfaceAttributes`] associated
-    /// to this surface should be integrated into the current state of the surface.
-    ///
-    /// See [`wayland_server::protocol::wl_surface::Implementation::commit`](https://docs.rs/wayland-server/0.10.1/wayland_server/protocol/wl_surface/struct.Implementation.html#structfield.commit)
-    /// for more details
+    /// to this surface should be atomically integrated into the current state of the surface.
     Commit,
-    /// The client asks to be notified when would be a good time to update the contents of this surface
-    ///
-    /// You must keep the provided [`WlCallback`](wayland_server::protocol::wl_callback::WlCallback)
-    /// and trigger it at the appropriate time by calling its `done()` method.
-    ///
-    /// See [`wayland_server::protocol::wl_surface::Implementation::frame`](https://docs.rs/wayland-server/0.10.1/wayland_server/protocol/wl_surface/struct.Implementation.html#structfield.frame)
-    /// for more details
-    Frame {
-        /// The created `WlCallback`
-        callback: Main<wl_callback::WlCallback>,
-    },
 }
 
 #[cfg(test)]


### PR DESCRIPTION
A few anvil changes to make things work better overall

- commit 1: introduce a correct handling of frame callbacks
- commit 2: restore the behavior of Wayland dispatching to dispatch the clients in the calloop callback
- commit 3: refactor common portions of anvil into the `AnvilState`
- commit 4: send frame events in bulk to all clients that requested it just after each page flip
- commit 5: implement correct state caching for sync subsurfaces