### PR TITLE
Rework the udev backend as a calloop event source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ systemd = { version = "0.4.0", optional = true }
 tempfile = "3.0"
 thiserror = "1"
 udev = { version = "0.4", optional = true }
-wayland-commons = { version = "0.25.0", optional = true }
-wayland-egl = { version = "0.25.0", optional = true }
-wayland-protocols = { version = "0.25.0", features = ["unstable_protocols", "server"], optional = true }
-wayland-server = { version = "0.25.0", optional = true }
-wayland-sys = { version = "0.25.0", optional = true }
+wayland-commons = { version = "0.26", optional = true }
+wayland-egl = { version = "0.26", optional = true }
+wayland-protocols = { version = "0.26", features = ["unstable_protocols", "server"], optional = true }
+wayland-server = { version = "0.26", optional = true }
+wayland-sys = { version = "0.26", optional = true }
 winit = { version = "0.22.0", optional = true }
 xkbcommon = "0.4.0"
 # TODO: remove as soon as drm-rs provides an error implementing Error

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [ "anvil" ]
 
 [dependencies]
 bitflags = "1"
-calloop = "0.5.1"
+calloop = "0.6.2"
 dbus = { version = "0.8", optional = true }
 drm = { version = "^0.4.0", git = "https://github.com/drakulix/drm-rs", branch = "develop", optional = true }
 gbm = { version = "^0.6.0", git = "https://github.com/drakulix/gbm.rs", branch = "develop", optional = true, default-features = false, features = ["drm-support"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,30 +11,30 @@ edition = "2018"
 members = [ "anvil" ]
 
 [dependencies]
-wayland-server = { version = "0.25.0", optional = true }
-wayland-commons = { version = "0.25.0", optional = true }
-wayland-sys = { version = "0.25.0", optional = true }
-calloop = "0.5.1"
 bitflags = "1"
-nix = "0.17"
-xkbcommon = "0.4.0"
-tempfile = "3.0"
-slog = "2"
-slog-stdlog = "4"
-libloading = "0.6.0"
-wayland-egl = { version = "0.25.0", optional = true }
-winit = { version = "0.22.0", optional = true }
+calloop = "0.5.1"
+dbus = { version = "0.8", optional = true }
 drm = { version = "^0.4.0", git = "https://github.com/drakulix/drm-rs", branch = "develop", optional = true }
 gbm = { version = "^0.6.0", git = "https://github.com/drakulix/gbm.rs", branch = "develop", optional = true, default-features = false, features = ["drm-support"] }
 glium = { version = "0.27.0", optional = true, default-features = false }
-input = { version = "0.5", default-features = false, optional = true }
-udev = { version = "0.4", optional = true }
-dbus = { version = "0.8", optional = true }
-systemd = { version = "0.4.0", optional = true }
-wayland-protocols = { version = "0.25.0", features = ["unstable_protocols", "server"], optional = true }
 image = { version = "0.23.0", optional = true }
-lazy_static = "1.0.0"
+input = { version = "0.5", default-features = false, optional = true }
+lazy_static = "1"
+libloading = "0.6.0"
+nix = "0.17"
+slog = "2"
+slog-stdlog = "4"
+systemd = { version = "0.4.0", optional = true }
+tempfile = "3.0"
 thiserror = "1"
+udev = { version = "0.4", optional = true }
+wayland-commons = { version = "0.25.0", optional = true }
+wayland-egl = { version = "0.25.0", optional = true }
+wayland-protocols = { version = "0.25.0", features = ["unstable_protocols", "server"], optional = true }
+wayland-server = { version = "0.25.0", optional = true }
+wayland-sys = { version = "0.25.0", optional = true }
+winit = { version = "0.22.0", optional = true }
+xkbcommon = "0.4.0"
 # TODO: remove as soon as drm-rs provides an error implementing Error
 failure = { version = "0.1", optional = true }
 

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.7"
 slog = { version = "2.1.1" }
 slog-term = "2.3"
 slog-async = "2.2"
-wayland-server = "0.25.0"
+wayland-server = "0.26"
 xkbcommon = "0.4.0"
 
 [dependencies.smithay]

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -7,15 +7,15 @@ publish = false
 edition = "2018"
 
 [dependencies]
+bitflags = "1.2.1"
+glium = { version = "0.27.0", default-features = false }
+input = { version = "0.5.0", features = ["udev"], optional = true }
+rand = "0.7"
 slog = { version = "2.1.1" }
 slog-term = "2.3"
 slog-async = "2.2"
-rand = "0.7"
-glium = { version = "0.27.0", default-features = false }
 wayland-server = "0.25.0"
 xkbcommon = "0.4.0"
-bitflags = "1.2.1"
-input = { version = "0.5.0", features = ["udev"], optional = true }
 
 [dependencies.smithay]
 path = ".."

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -697,13 +697,12 @@ impl SurfaceData {
     //
     // returns true if the texture cache should be invalidated
     fn merge_state(into: &mut CommitedState, next: CommitedState) -> bool {
-        let mut new_buffer = false;
         // release the previous buffer if relevant
-        if into.buffer != next.buffer {
+        let new_buffer = into.buffer != next.buffer;
+        if new_buffer {
             if let Some(buffer) = into.buffer.take() {
                 buffer.release();
             }
-            new_buffer = true;
         }
         // ping the previous callback if relevant
         if into.frame_callback != next.frame_callback {
@@ -780,7 +779,7 @@ fn surface_commit(
     });
 
     let sub_data = token
-        .with_role_data(surface, |role: &mut SubsurfaceRole| role.clone())
+        .with_role_data(surface, |&mut role: &mut SubsurfaceRole| role)
         .ok();
 
     let mut next_state = CommitedState::default();

--- a/src/backend/session/auto.rs
+++ b/src/backend/session/auto.rs
@@ -146,7 +146,7 @@ impl AutoSession {
 /// session state and call its [`SessionObserver`]s.
 pub fn auto_session_bind<Data: 'static>(
     notifier: AutoSessionNotifier,
-    handle: &LoopHandle<Data>,
+    handle: LoopHandle<Data>,
 ) -> ::std::result::Result<BoundAutoSession, (IoError, AutoSessionNotifier)> {
     Ok(match notifier {
         #[cfg(feature = "backend_session_logind")]


### PR DESCRIPTION
depends on #202 
cc #203 

This only reworks the Smithay part, anvil is simply minimally modified to adapt by keeping the `UdevHandler` and just making a plumbing closure. Final goal would be to fuse the `UdevHandler` into the main `AnvilState`, but I'd like feedback on the Smithay API before attacking that.