### PR TITLE
Fix drm mode and connector handling

### DIFF
--- a/anvil/src/glium_drawer.rs
+++ b/anvil/src/glium_drawer.rs
@@ -16,7 +16,10 @@ use smithay::backend::egl::display::EGLBufferReader;
 use smithay::{
     backend::{
         egl::{BufferAccessError, EGLImages, Format},
-        graphics::{gl::GLGraphicsBackend, glium::{GliumGraphicsBackend, Frame}},
+        graphics::{
+            gl::GLGraphicsBackend,
+            glium::{Frame, GliumGraphicsBackend},
+        },
     },
     reexports::wayland_server::protocol::{wl_buffer, wl_surface},
     wayland::{
@@ -159,7 +162,10 @@ impl<F: GLGraphicsBackend + 'static> GliumDrawer<F> {
         let images = if let Some(display) = &self.egl_buffer_reader.borrow().as_ref() {
             display.egl_buffer_contents(buffer)
         } else {
-            Err(BufferAccessError::NotManaged(buffer, smithay::backend::egl::EGLError::BadDisplay))
+            Err(BufferAccessError::NotManaged(
+                buffer,
+                smithay::backend::egl::EGLError::BadDisplay,
+            ))
         };
         match images {
             Ok(images) => {

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -389,7 +389,7 @@ impl<S: SessionNotifier, Data: 'static> UdevHandler for UdevHandlerImpl<S, Data>
             )
             .ok()
             .and_then(
-                |fd| match FallbackDevice::new(SessionFd(fd), self.logger.clone()) {
+                |fd| match FallbackDevice::new(SessionFd(fd), true, self.logger.clone()) {
                     Ok(drm) => Some(drm),
                     Err(err) => {
                         error!(self.logger, "Skipping drm device, because of error: {}", err);

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -319,7 +319,7 @@ impl<S: SessionNotifier, Data: 'static> UdevHandlerImpl<S, Data> {
                 for crtc in res_handles.filter_crtcs(encoder_info.possible_crtcs()) {
                     if let Entry::Vacant(entry) = backends.entry(crtc) {
                         let renderer = GliumDrawer::init(
-                            device.create_surface(crtc).unwrap(),
+                            device.create_surface(crtc, connector_info.modes()[0], &[connector_info.handle()]).unwrap(),
                             egl_buffer_reader.clone(),
                             logger.clone(),
                         );

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -319,7 +319,9 @@ impl<S: SessionNotifier, Data: 'static> UdevHandlerImpl<S, Data> {
                 for crtc in res_handles.filter_crtcs(encoder_info.possible_crtcs()) {
                     if let Entry::Vacant(entry) = backends.entry(crtc) {
                         let renderer = GliumDrawer::init(
-                            device.create_surface(crtc, connector_info.modes()[0], &[connector_info.handle()]).unwrap(),
+                            device
+                                .create_surface(crtc, connector_info.modes()[0], &[connector_info.handle()])
+                                .unwrap(),
                             egl_buffer_reader.clone(),
                             logger.clone(),
                         );

--- a/examples/raw_atomic_drm.rs
+++ b/examples/raw_atomic_drm.rs
@@ -56,7 +56,7 @@ fn main() {
     let mut options = OpenOptions::new();
     options.read(true);
     options.write(true);
-    let mut device = AtomicDrmDevice::new(options.open("/dev/dri/card0").unwrap(), log.clone()).unwrap();
+    let mut device = AtomicDrmDevice::new(options.open("/dev/dri/card0").unwrap(), true, log.clone()).unwrap();
 
     // Get a set of all modesetting resource handles (excluding planes):
     let res_handles = Device::resource_handles(&device).unwrap();

--- a/examples/raw_atomic_drm.rs
+++ b/examples/raw_atomic_drm.rs
@@ -56,7 +56,8 @@ fn main() {
     let mut options = OpenOptions::new();
     options.read(true);
     options.write(true);
-    let mut device = AtomicDrmDevice::new(options.open("/dev/dri/card0").unwrap(), true, log.clone()).unwrap();
+    let mut device =
+        AtomicDrmDevice::new(options.open("/dev/dri/card0").unwrap(), true, log.clone()).unwrap();
 
     // Get a set of all modesetting resource handles (excluding planes):
     let res_handles = Device::resource_handles(&device).unwrap();
@@ -96,7 +97,11 @@ fn main() {
     let mode = connector_info.modes()[0]; // Use first mode (usually highest resoltion, but in reality you should filter and sort and check and match with other connectors, if you use more then one.)
 
     // Initialize the hardware backend
-    let surface = Rc::new(device.create_surface(crtc, mode, &[connector_info.handle()]).unwrap());
+    let surface = Rc::new(
+        device
+            .create_surface(crtc, mode, &[connector_info.handle()])
+            .unwrap(),
+    );
 
     for conn in surface.current_connectors().into_iter() {
         if conn != connector_info.handle() {

--- a/examples/raw_atomic_drm.rs
+++ b/examples/raw_atomic_drm.rs
@@ -96,9 +96,7 @@ fn main() {
     let mode = connector_info.modes()[0]; // Use first mode (usually highest resoltion, but in reality you should filter and sort and check and match with other connectors, if you use more then one.)
 
     // Initialize the hardware backend
-    let surface = Rc::new(device.create_surface(crtc).unwrap());
-    surface.set_connectors(&[connector_info.handle()]).unwrap();
-    surface.use_mode(Some(mode)).unwrap();
+    let surface = Rc::new(device.create_surface(crtc, mode, &[connector_info.handle()]).unwrap());
 
     for conn in surface.current_connectors().into_iter() {
         if conn != connector_info.handle() {

--- a/examples/raw_legacy_drm.rs
+++ b/examples/raw_legacy_drm.rs
@@ -40,7 +40,7 @@ fn main() {
     let mut options = OpenOptions::new();
     options.read(true);
     options.write(true);
-    let mut device = LegacyDrmDevice::new(options.open("/dev/dri/card0").unwrap(), log.clone()).unwrap();
+    let mut device = LegacyDrmDevice::new(options.open("/dev/dri/card0").unwrap(), true, log.clone()).unwrap();
 
     // Get a set of all modesetting resource handles (excluding planes):
     let res_handles = Device::resource_handles(&device).unwrap();

--- a/examples/raw_legacy_drm.rs
+++ b/examples/raw_legacy_drm.rs
@@ -9,7 +9,7 @@ use smithay::{
         common::Error,
         device_bind,
         legacy::{LegacyDrmDevice, LegacyDrmSurface},
-        Device, DeviceHandler, RawSurface, Surface,
+        Device, DeviceHandler, RawSurface,
     },
     reexports::{
         calloop::EventLoop,

--- a/examples/raw_legacy_drm.rs
+++ b/examples/raw_legacy_drm.rs
@@ -40,7 +40,8 @@ fn main() {
     let mut options = OpenOptions::new();
     options.read(true);
     options.write(true);
-    let mut device = LegacyDrmDevice::new(options.open("/dev/dri/card0").unwrap(), true, log.clone()).unwrap();
+    let mut device =
+        LegacyDrmDevice::new(options.open("/dev/dri/card0").unwrap(), true, log.clone()).unwrap();
 
     // Get a set of all modesetting resource handles (excluding planes):
     let res_handles = Device::resource_handles(&device).unwrap();
@@ -78,7 +79,11 @@ fn main() {
     let mode = connector_info.modes()[0]; // Use first mode (usually highest resoltion, but in reality you should filter and sort and check and match with other connectors, if you use more then one.)
 
     // Initialize the hardware backend
-    let surface = Rc::new(device.create_surface(crtc, mode, &[connector_info.handle()]).unwrap());
+    let surface = Rc::new(
+        device
+            .create_surface(crtc, mode, &[connector_info.handle()])
+            .unwrap(),
+    );
 
     /*
      * Lets create buffers and framebuffers.

--- a/examples/raw_legacy_drm.rs
+++ b/examples/raw_legacy_drm.rs
@@ -78,10 +78,8 @@ fn main() {
     let mode = connector_info.modes()[0]; // Use first mode (usually highest resoltion, but in reality you should filter and sort and check and match with other connectors, if you use more then one.)
 
     // Initialize the hardware backend
-    let surface = Rc::new(device.create_surface(crtc).unwrap());
+    let surface = Rc::new(device.create_surface(crtc, mode, &[connector_info.handle()]).unwrap());
 
-    surface.use_mode(Some(mode)).unwrap();
-    surface.set_connectors(&[connector_info.handle()]).unwrap();
     /*
      * Lets create buffers and framebuffers.
      * We use drm-rs DumbBuffers, because they always work and require little to no setup.

--- a/src/backend/drm/atomic/mod.rs
+++ b/src/backend/drm/atomic/mod.rs
@@ -273,7 +273,7 @@ impl<A: AsRawFd + 'static> AtomicDrmDevice<A> {
 
         dev.old_state = old_state;
         dev.prop_mapping = mapping;
-        debug!(log, "Mapping: {:#?}", dev.prop_mapping);
+        trace!(log, "Mapping: {:#?}", dev.prop_mapping);
 
         if disable_connectors {
             // Disable all connectors as initial state

--- a/src/backend/drm/atomic/session.rs
+++ b/src/backend/drm/atomic/session.rs
@@ -59,7 +59,7 @@ impl<A: AsRawFd + 'static> SessionObserver for AtomicDrmDeviceObserver<A> {
                 if let Err(err) = surface.clear_plane(surface.planes.cursor) {
                     warn!(
                         self.logger,
-                        "Failed to clear cursor on {:?}: {}", surface.crtc, err
+                        "Failed to clear cursor on {:?}: {}", surface.planes.cursor, err
                     );
                 }
             }

--- a/src/backend/drm/atomic/surface.rs
+++ b/src/backend/drm/atomic/surface.rs
@@ -488,7 +488,7 @@ impl<A: AsRawFd + 'static> RawSurface for AtomicDrmSurfaceInternal<A> {
             }
         };
 
-        debug!(self.logger, "Setting screen: {:#?}", req);
+        debug!(self.logger, "Setting screen: {:?}", req);
         self.atomic_commit(
             &[
                 AtomicCommitFlags::PageFlipEvent,

--- a/src/backend/drm/atomic/surface.rs
+++ b/src/backend/drm/atomic/surface.rs
@@ -144,7 +144,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurfaceInternal<A> {
         let pending = State {
             mode,
             blob,
-            connectors: connectors.into_iter().copied().collect(),
+            connectors: connectors.iter().copied().collect(),
         };
 
         let (primary, cursor) =

--- a/src/backend/drm/atomic/surface.rs
+++ b/src/backend/drm/atomic/surface.rs
@@ -44,7 +44,7 @@ pub(super) struct AtomicDrmSurfaceInternal<A: AsRawFd + 'static> {
     pub(super) state: RwLock<State>,
     pub(super) pending: RwLock<State>,
     pub(super) logger: ::slog::Logger,
-    init_buffer: Cell<Option<(DumbBuffer, framebuffer::Handle)>>,
+    pub(super) init_buffer: Cell<Option<(DumbBuffer, framebuffer::Handle)>>,
 }
 
 impl<A: AsRawFd + 'static> AsRawFd for AtomicDrmSurfaceInternal<A> {

--- a/src/backend/drm/common/fallback.rs
+++ b/src/backend/drm/common/fallback.rs
@@ -244,10 +244,10 @@ where
         }
     }
     fallback_device_impl!(clear_handler, &mut Self);
-    fn create_surface(&mut self, crtc: crtc::Handle) -> Result<Self::Surface, E> {
+    fn create_surface(&mut self, crtc: crtc::Handle, mode: Mode, connectors: &[connector::Handle]) -> Result<Self::Surface, E> {
         match self {
-            FallbackDevice::Preference(dev) => Ok(FallbackSurface::Preference(dev.create_surface(crtc)?)),
-            FallbackDevice::Fallback(dev) => Ok(FallbackSurface::Fallback(dev.create_surface(crtc)?)),
+            FallbackDevice::Preference(dev) => Ok(FallbackSurface::Preference(dev.create_surface(crtc, mode, connectors)?)),
+            FallbackDevice::Fallback(dev) => Ok(FallbackSurface::Fallback(dev.create_surface(crtc, mode, connectors)?)),
         }
     }
     fallback_device_impl!(process_events, &mut Self);
@@ -297,9 +297,9 @@ where
     fallback_surface_impl!(add_connector, &Self, Result<(), E>, conn: connector::Handle);
     fallback_surface_impl!(remove_connector, &Self, Result<(), E>, conn: connector::Handle);
     fallback_surface_impl!(set_connectors, &Self, Result<(), E>, conns: &[connector::Handle]);
-    fallback_surface_impl!(current_mode, &Self, Option<Mode>);
-    fallback_surface_impl!(pending_mode, &Self, Option<Mode>);
-    fallback_surface_impl!(use_mode, &Self, Result<(), E>, mode: Option<Mode>);
+    fallback_surface_impl!(current_mode, &Self, Mode);
+    fallback_surface_impl!(pending_mode, &Self, Mode);
+    fallback_surface_impl!(use_mode, &Self, Result<(), E>, mode: Mode);
 }
 
 impl<E, C, S1, S2> RawSurface for FallbackSurface<S1, S2>

--- a/src/backend/drm/common/fallback.rs
+++ b/src/backend/drm/common/fallback.rs
@@ -311,7 +311,7 @@ where
 {
     fallback_surface_impl!(commit_pending, &Self, bool);
     fallback_surface_impl!(commit, &Self, Result<(), E>, fb: framebuffer::Handle);
-    fn page_flip(&self, framebuffer: framebuffer::Handle) -> Result<(), SwapBuffersError> {
+    fn page_flip(&self, framebuffer: framebuffer::Handle) -> Result<(), E> {
         match self {
             FallbackSurface::Preference(dev) => RawSurface::page_flip(dev, framebuffer),
             FallbackSurface::Fallback(dev) => RawSurface::page_flip(dev, framebuffer),

--- a/src/backend/drm/common/fallback.rs
+++ b/src/backend/drm/common/fallback.rs
@@ -174,12 +174,12 @@ impl<A: AsRawFd + Clone + 'static> FallbackDevice<AtomicDrmDevice<A>, LegacyDrmD
         let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_drm_fallback"));
         info!(log, "Trying to initialize AtomicDrmDevice");
 
-        if env::var("SMITHAY_USE_LEGACY")
+        let force_legacy = env::var("SMITHAY_USE_LEGACY")
             .map(|x| {
                 x == "1" || x.to_lowercase() == "true" || x.to_lowercase() == "yes" || x.to_lowercase() == "y"
             })
-            .unwrap_or(false)
-        {
+            .unwrap_or(false);
+        if force_legacy {
             info!(log, "SMITHAY_USE_LEGACY is set. Forcing LegacyDrmDevice.");
             return Ok(FallbackDevice::Fallback(LegacyDrmDevice::new(
                 fd,

--- a/src/backend/drm/common/mod.rs
+++ b/src/backend/drm/common/mod.rs
@@ -40,6 +40,9 @@ pub enum Error {
     /// The given crtc is already in use by another backend
     #[error("Crtc `{0:?}` is already in use by another backend")]
     CrtcAlreadyInUse(crtc::Handle),
+    /// This operation would result in a surface without connectors.
+    #[error("Surface of crtc `{0:?}` would have no connectors, which is not accepted")]
+    SurfaceWithoutConnectors(crtc::Handle),
     /// No encoder was found for a given connector on the set crtc
     #[error("No encoder found for the given connector '{connector:?}' on crtc `{crtc:?}`")]
     NoSuitableEncoder {

--- a/src/backend/drm/common/mod.rs
+++ b/src/backend/drm/common/mod.rs
@@ -3,9 +3,9 @@
 //! and [`Surface`](::backend::drm::Surface) implementations of the `backend::drm` module.
 //!
 
+use crate::backend::graphics::SwapBuffersError;
 use drm::control::{connector, crtc, Mode, RawResourceHandle};
 use std::path::PathBuf;
-use crate::backend::graphics::SwapBuffersError;
 
 pub mod fallback;
 
@@ -81,10 +81,17 @@ impl Into<SwapBuffersError> for Error {
                 dev: _,
                 source,
             } if match source.get_ref() {
-                drm::SystemError::Unknown { errno: nix::errno::Errno::EBUSY } => true,
-                drm::SystemError::Unknown { errno: nix::errno::Errno::EINTR } => true,
+                drm::SystemError::Unknown {
+                    errno: nix::errno::Errno::EBUSY,
+                } => true,
+                drm::SystemError::Unknown {
+                    errno: nix::errno::Errno::EINTR,
+                } => true,
                 _ => false,
-            } => SwapBuffersError::TemporaryFailure(Box::new(source)),
+            } =>
+            {
+                SwapBuffersError::TemporaryFailure(Box::new(source))
+            }
             x => SwapBuffersError::ContextLost(Box::new(x)),
         }
     }

--- a/src/backend/drm/common/mod.rs
+++ b/src/backend/drm/common/mod.rs
@@ -76,19 +76,16 @@ impl Into<SwapBuffersError> for Error {
     fn into(self) -> SwapBuffersError {
         match self {
             x @ Error::DeviceInactive => SwapBuffersError::TemporaryFailure(Box::new(x)),
-            Error::Access {
-                errmsg: _,
-                dev: _,
-                source,
-            } if match source.get_ref() {
-                drm::SystemError::Unknown {
-                    errno: nix::errno::Errno::EBUSY,
-                } => true,
-                drm::SystemError::Unknown {
-                    errno: nix::errno::Errno::EINTR,
-                } => true,
-                _ => false,
-            } =>
+            Error::Access { source, .. }
+                if match source.get_ref() {
+                    drm::SystemError::Unknown {
+                        errno: nix::errno::Errno::EBUSY,
+                    } => true,
+                    drm::SystemError::Unknown {
+                        errno: nix::errno::Errno::EINTR,
+                    } => true,
+                    _ => false,
+                } =>
             {
                 SwapBuffersError::TemporaryFailure(Box::new(source))
             }

--- a/src/backend/drm/common/mod.rs
+++ b/src/backend/drm/common/mod.rs
@@ -19,7 +19,7 @@ pub enum Error {
     #[error("Failed to aquire DRM master")]
     DrmMasterFailed,
     /// The `DrmDevice` encountered an access error
-    #[error("DRM access error: {errmsg} on device `{dev:?}`")]
+    #[error("DRM access error: {errmsg} on device `{dev:?}` ({source:})")]
     Access {
         /// Error message associated to the access error
         errmsg: &'static str,

--- a/src/backend/drm/egl/mod.rs
+++ b/src/backend/drm/egl/mod.rs
@@ -17,9 +17,9 @@ use wayland_server::Display;
 
 use super::{Device, DeviceHandler, Surface};
 use crate::backend::egl::native::{Backend, NativeDisplay, NativeSurface};
-use crate::backend::egl::{Error as EGLError, EGLError as RawEGLError, SurfaceCreationError};
 #[cfg(feature = "use_system_lib")]
 use crate::backend::egl::{display::EGLBufferReader, EGLGraphicsBackend};
+use crate::backend::egl::{EGLError as RawEGLError, Error as EGLError, SurfaceCreationError};
 
 mod surface;
 pub use self::surface::*;
@@ -49,7 +49,9 @@ type Arguments = (crtc::Handle, Mode, Vec<connector::Handle>);
 pub struct EglDevice<B, D>
 where
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = Arguments, Error=<<D as Device>::Surface as Surface>::Error> + 'static,
+    D: Device
+        + NativeDisplay<B, Arguments = Arguments, Error = <<D as Device>::Surface as Surface>::Error>
+        + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     dev: EGLDisplay<B, D>,
@@ -61,7 +63,9 @@ where
 impl<B, D> AsRawFd for EglDevice<B, D>
 where
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = Arguments, Error=<<D as Device>::Surface as Surface>::Error> + 'static,
+    D: Device
+        + NativeDisplay<B, Arguments = Arguments, Error = <<D as Device>::Surface as Surface>::Error>
+        + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     fn as_raw_fd(&self) -> RawFd {
@@ -72,7 +76,9 @@ where
 impl<B, D> EglDevice<B, D>
 where
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = Arguments, Error=<<D as Device>::Surface as Surface>::Error> + 'static,
+    D: Device
+        + NativeDisplay<B, Arguments = Arguments, Error = <<D as Device>::Surface as Surface>::Error>
+        + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     /// Try to create a new [`EglDevice`] from an open device.
@@ -127,7 +133,9 @@ where
 struct InternalDeviceHandler<B, D>
 where
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = Arguments, Error=<<D as Device>::Surface as Surface>::Error> + 'static,
+    D: Device
+        + NativeDisplay<B, Arguments = Arguments, Error = <<D as Device>::Surface as Surface>::Error>
+        + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     handler: Box<dyn DeviceHandler<Device = EglDevice<B, D>> + 'static>,
@@ -136,7 +144,9 @@ where
 impl<B, D> DeviceHandler for InternalDeviceHandler<B, D>
 where
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = Arguments, Error=<<D as Device>::Surface as Surface>::Error> + 'static,
+    D: Device
+        + NativeDisplay<B, Arguments = Arguments, Error = <<D as Device>::Surface as Surface>::Error>
+        + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     type Device = D;
@@ -152,7 +162,9 @@ where
 impl<B, D> Device for EglDevice<B, D>
 where
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = Arguments, Error=<<D as Device>::Surface as Surface>::Error> + 'static,
+    D: Device
+        + NativeDisplay<B, Arguments = Arguments, Error = <<D as Device>::Surface as Surface>::Error>
+        + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     type Surface = EglSurface<<D as Device>::Surface>;
@@ -231,7 +243,9 @@ where
 impl<B, D> EGLGraphicsBackend for EglDevice<B, D>
 where
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = Arguments, Error=<<D as Device>::Surface as Surface>::Error> + 'static,
+    D: Device
+        + NativeDisplay<B, Arguments = Arguments, Error = <<D as Device>::Surface as Surface>::Error>
+        + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     fn bind_wl_display(&self, display: &Display) -> Result<EGLBufferReader, EGLError> {
@@ -242,7 +256,9 @@ where
 impl<B, D> Drop for EglDevice<B, D>
 where
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = Arguments, Error=<<D as Device>::Surface as Surface>::Error> + 'static,
+    D: Device
+        + NativeDisplay<B, Arguments = Arguments, Error = <<D as Device>::Surface as Surface>::Error>
+        + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     fn drop(&mut self) {

--- a/src/backend/drm/egl/session.rs
+++ b/src/backend/drm/egl/session.rs
@@ -3,7 +3,7 @@
 //! to an open [`Session`](::backend::session::Session).
 //!
 
-use drm::control::{crtc, connector, Mode};
+use drm::control::{connector, crtc, Mode};
 use std::os::unix::io::RawFd;
 
 use super::EglDevice;
@@ -22,7 +22,13 @@ impl<S, B, D> AsSessionObserver<EglDeviceObserver<S>> for EglDevice<B, D>
 where
     S: SessionObserver + 'static,
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = (crtc::Handle, Mode, Vec<connector::Handle>), Error=<<D as Device>::Surface as Surface>::Error> + AsSessionObserver<S> + 'static,
+    D: Device
+        + NativeDisplay<
+            B,
+            Arguments = (crtc::Handle, Mode, Vec<connector::Handle>),
+            Error = <<D as Device>::Surface as Surface>::Error,
+        > + AsSessionObserver<S>
+        + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     fn observer(&mut self) -> EglDeviceObserver<S> {

--- a/src/backend/drm/egl/session.rs
+++ b/src/backend/drm/egl/session.rs
@@ -7,7 +7,7 @@ use drm::control::{crtc, connector, Mode};
 use std::os::unix::io::RawFd;
 
 use super::EglDevice;
-use crate::backend::drm::Device;
+use crate::backend::drm::{Device, Surface};
 use crate::backend::egl::native::{Backend, NativeDisplay, NativeSurface};
 use crate::backend::session::{AsSessionObserver, SessionObserver};
 
@@ -22,7 +22,7 @@ impl<S, B, D> AsSessionObserver<EglDeviceObserver<S>> for EglDevice<B, D>
 where
     S: SessionObserver + 'static,
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = (crtc::Handle, Mode, Vec<connector::Handle>)> + AsSessionObserver<S> + 'static,
+    D: Device + NativeDisplay<B, Arguments = (crtc::Handle, Mode, Vec<connector::Handle>), Error=<<D as Device>::Surface as Surface>::Error> + AsSessionObserver<S> + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     fn observer(&mut self) -> EglDeviceObserver<S> {

--- a/src/backend/drm/egl/session.rs
+++ b/src/backend/drm/egl/session.rs
@@ -3,7 +3,7 @@
 //! to an open [`Session`](::backend::session::Session).
 //!
 
-use drm::control::crtc;
+use drm::control::{crtc, connector, Mode};
 use std::os::unix::io::RawFd;
 
 use super::EglDevice;
@@ -22,7 +22,7 @@ impl<S, B, D> AsSessionObserver<EglDeviceObserver<S>> for EglDevice<B, D>
 where
     S: SessionObserver + 'static,
     B: Backend<Surface = <D as Device>::Surface> + 'static,
-    D: Device + NativeDisplay<B, Arguments = crtc::Handle> + AsSessionObserver<S> + 'static,
+    D: Device + NativeDisplay<B, Arguments = (crtc::Handle, Mode, Vec<connector::Handle>)> + AsSessionObserver<S> + 'static,
     <D as Device>::Surface: NativeSurface,
 {
     fn observer(&mut self) -> EglDeviceObserver<S> {

--- a/src/backend/drm/egl/surface.rs
+++ b/src/backend/drm/egl/surface.rs
@@ -53,15 +53,15 @@ where
         self.surface.set_connectors(connectors).map_err(Error::Underlying)
     }
 
-    fn current_mode(&self) -> Option<Mode> {
+    fn current_mode(&self) -> Mode {
         self.surface.current_mode()
     }
 
-    fn pending_mode(&self) -> Option<Mode> {
+    fn pending_mode(&self) -> Mode {
         self.surface.pending_mode()
     }
 
-    fn use_mode(&self, mode: Option<Mode>) -> Result<(), Self::Error> {
+    fn use_mode(&self, mode: Mode) -> Result<(), Self::Error> {
         self.surface.use_mode(mode).map_err(Error::Underlying)
     }
 }
@@ -100,7 +100,7 @@ where
     }
 
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
-        let (w, h) = self.pending_mode().map(|mode| mode.size()).unwrap_or((1, 1));
+        let (w, h) = self.pending_mode().size();
         (w as u32, h as u32)
     }
 

--- a/src/backend/drm/egl/surface.rs
+++ b/src/backend/drm/egl/surface.rs
@@ -22,7 +22,7 @@ where
 }
 
 impl<N> Surface for EglSurface<N>
-where 
+where
     N: native::NativeSurface + Surface,
 {
     type Connectors = <N as Surface>::Connectors;
@@ -99,7 +99,9 @@ where
                 Ok(x) => x,
                 Err(x) => x.into(),
             })
-        } else { Ok(()) }
+        } else {
+            Ok(())
+        }
     }
 
     fn get_proc_address(&self, symbol: &str) -> *const c_void {
@@ -116,7 +118,9 @@ where
     }
 
     unsafe fn make_current(&self) -> ::std::result::Result<(), SwapBuffersError> {
-        self.context.make_current_with_surface(&self.surface).map_err(Into::into)
+        self.context
+            .make_current_with_surface(&self.surface)
+            .map_err(Into::into)
     }
 
     fn get_pixel_format(&self) -> PixelFormat {

--- a/src/backend/drm/gbm/egl.rs
+++ b/src/backend/drm/gbm/egl.rs
@@ -7,11 +7,11 @@
 use crate::backend::drm::{Device, RawDevice, Surface};
 use crate::backend::egl::ffi;
 use crate::backend::egl::native::{Backend, NativeDisplay, NativeSurface};
-use crate::backend::egl::{Error as EglBackendError, EGLError, wrap_egl_call};
+use crate::backend::egl::{wrap_egl_call, EGLError, Error as EglBackendError};
 
 use super::{Error, GbmDevice, GbmSurface};
 
-use drm::control::{crtc, connector, Device as ControlDevice, Mode};
+use drm::control::{connector, crtc, Device as ControlDevice, Mode};
 use gbm::AsRaw;
 use std::marker::PhantomData;
 use std::ptr;
@@ -36,13 +36,19 @@ impl<D: RawDevice + 'static> Backend for Gbm<D> {
     {
         if has_dp_extension("EGL_KHR_platform_gbm") && ffi::egl::GetPlatformDisplay::is_loaded() {
             trace!(log, "EGL Display Initialization via EGL_KHR_platform_gbm");
-            wrap_egl_call(|| ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_GBM_KHR, display as *mut _, ptr::null()))
+            wrap_egl_call(|| {
+                ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_GBM_KHR, display as *mut _, ptr::null())
+            })
         } else if has_dp_extension("EGL_MESA_platform_gbm") && ffi::egl::GetPlatformDisplayEXT::is_loaded() {
             trace!(log, "EGL Display Initialization via EGL_MESA_platform_gbm");
-            wrap_egl_call(|| ffi::egl::GetPlatformDisplayEXT(ffi::egl::PLATFORM_GBM_MESA, display as *mut _, ptr::null()))
+            wrap_egl_call(|| {
+                ffi::egl::GetPlatformDisplayEXT(ffi::egl::PLATFORM_GBM_MESA, display as *mut _, ptr::null())
+            })
         } else if has_dp_extension("EGL_MESA_platform_gbm") && ffi::egl::GetPlatformDisplay::is_loaded() {
             trace!(log, "EGL Display Initialization via EGL_MESA_platform_gbm");
-            wrap_egl_call(|| ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_GBM_MESA, display as *mut _, ptr::null()))
+            wrap_egl_call(|| {
+                ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_GBM_MESA, display as *mut _, ptr::null())
+            })
         } else {
             trace!(log, "Default EGL Display Initialization via GetDisplay");
             wrap_egl_call(|| ffi::egl::GetDisplay(display as *mut _))

--- a/src/backend/drm/gbm/egl.rs
+++ b/src/backend/drm/gbm/egl.rs
@@ -7,8 +7,7 @@
 use crate::backend::drm::{Device, RawDevice, Surface};
 use crate::backend::egl::ffi;
 use crate::backend::egl::native::{Backend, NativeDisplay, NativeSurface};
-use crate::backend::egl::Error as EglError;
-use crate::backend::graphics::SwapBuffersError;
+use crate::backend::egl::{Error as EglBackendError, EGLError, wrap_egl_call};
 
 use super::{Error, GbmDevice, GbmSurface};
 
@@ -31,22 +30,22 @@ impl<D: RawDevice + 'static> Backend for Gbm<D> {
         display: ffi::NativeDisplayType,
         has_dp_extension: F,
         log: ::slog::Logger,
-    ) -> ffi::egl::types::EGLDisplay
+    ) -> Result<ffi::egl::types::EGLDisplay, EGLError>
     where
         F: Fn(&str) -> bool,
     {
         if has_dp_extension("EGL_KHR_platform_gbm") && ffi::egl::GetPlatformDisplay::is_loaded() {
             trace!(log, "EGL Display Initialization via EGL_KHR_platform_gbm");
-            ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_GBM_KHR, display as *mut _, ptr::null())
+            wrap_egl_call(|| ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_GBM_KHR, display as *mut _, ptr::null()))
         } else if has_dp_extension("EGL_MESA_platform_gbm") && ffi::egl::GetPlatformDisplayEXT::is_loaded() {
             trace!(log, "EGL Display Initialization via EGL_MESA_platform_gbm");
-            ffi::egl::GetPlatformDisplayEXT(ffi::egl::PLATFORM_GBM_MESA, display as *mut _, ptr::null())
+            wrap_egl_call(|| ffi::egl::GetPlatformDisplayEXT(ffi::egl::PLATFORM_GBM_MESA, display as *mut _, ptr::null()))
         } else if has_dp_extension("EGL_MESA_platform_gbm") && ffi::egl::GetPlatformDisplay::is_loaded() {
             trace!(log, "EGL Display Initialization via EGL_MESA_platform_gbm");
-            ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_GBM_MESA, display as *mut _, ptr::null())
+            wrap_egl_call(|| ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_GBM_MESA, display as *mut _, ptr::null()))
         } else {
             trace!(log, "Default EGL Display Initialization via GetDisplay");
-            ffi::egl::GetDisplay(display as *mut _)
+            wrap_egl_call(|| ffi::egl::GetDisplay(display as *mut _))
         }
     }
 }
@@ -59,7 +58,7 @@ unsafe impl<D: RawDevice + ControlDevice + 'static> NativeDisplay<Gbm<D>> for Gb
         true
     }
 
-    fn ptr(&self) -> Result<ffi::NativeDisplayType, EglError> {
+    fn ptr(&self) -> Result<ffi::NativeDisplayType, EglBackendError> {
         Ok(self.dev.borrow().as_raw() as *const _)
     }
 
@@ -69,6 +68,8 @@ unsafe impl<D: RawDevice + ControlDevice + 'static> NativeDisplay<Gbm<D>> for Gb
 }
 
 unsafe impl<D: RawDevice + 'static> NativeSurface for GbmSurface<D> {
+    type Error = Error<<<D as RawDevice>::Surface as Surface>::Error>;
+
     fn ptr(&self) -> ffi::NativeWindowType {
         self.0.surface.borrow().as_raw() as *const _
     }
@@ -77,25 +78,13 @@ unsafe impl<D: RawDevice + 'static> NativeSurface for GbmSurface<D> {
         self.needs_recreation()
     }
 
-    fn recreate(&self) -> bool {
-        if let Err(err) = GbmSurface::recreate(self) {
-            error!(self.0.logger, "Failure recreating internal resources: {}", err);
-            false
-        } else {
-            true
-        }
+    fn recreate(&self) -> Result<(), Self::Error> {
+        GbmSurface::recreate(self)
     }
 
-    fn swap_buffers(&self) -> ::std::result::Result<(), SwapBuffersError> {
+    fn swap_buffers(&self) -> Result<(), Self::Error> {
         // this is safe since `eglSwapBuffers` will have been called exactly once
         // if this is used by our egl module, which is why this trait is unsafe.
-        match unsafe { self.page_flip() } {
-            Ok(()) => Ok(()),
-            Err(Error::FrontBuffersExhausted) => Err(SwapBuffersError::AlreadySwapped),
-            Err(err) => {
-                warn!(self.0.logger, "Page flip failed: {}", err);
-                Err(SwapBuffersError::Unknown(0))
-            }
-        }
+        unsafe { self.page_flip() }
     }
 }

--- a/src/backend/drm/gbm/egl.rs
+++ b/src/backend/drm/gbm/egl.rs
@@ -12,7 +12,7 @@ use crate::backend::graphics::SwapBuffersError;
 
 use super::{Error, GbmDevice, GbmSurface};
 
-use drm::control::{crtc, Device as ControlDevice};
+use drm::control::{crtc, connector, Device as ControlDevice, Mode};
 use gbm::AsRaw;
 use std::marker::PhantomData;
 use std::ptr;
@@ -52,7 +52,7 @@ impl<D: RawDevice + 'static> Backend for Gbm<D> {
 }
 
 unsafe impl<D: RawDevice + ControlDevice + 'static> NativeDisplay<Gbm<D>> for GbmDevice<D> {
-    type Arguments = crtc::Handle;
+    type Arguments = (crtc::Handle, Mode, Vec<connector::Handle>);
     type Error = Error<<<D as Device>::Surface as Surface>::Error>;
 
     fn is_backend(&self) -> bool {
@@ -63,8 +63,8 @@ unsafe impl<D: RawDevice + ControlDevice + 'static> NativeDisplay<Gbm<D>> for Gb
         Ok(self.dev.borrow().as_raw() as *const _)
     }
 
-    fn create_surface(&mut self, crtc: crtc::Handle) -> Result<GbmSurface<D>, Self::Error> {
-        Device::create_surface(self, crtc)
+    fn create_surface(&mut self, args: Self::Arguments) -> Result<GbmSurface<D>, Self::Error> {
+        Device::create_surface(self, args.0, args.1, &args.2)
     }
 }
 

--- a/src/backend/drm/gbm/mod.rs
+++ b/src/backend/drm/gbm/mod.rs
@@ -265,10 +265,10 @@ where
             Error::FrontBuffersExhausted => SwapBuffersError::AlreadySwapped,
             Error::FramebufferCreationFailed(x)
                 if match x.get_ref() {
-                    &drm::SystemError::Unknown {
+                    drm::SystemError::Unknown {
                         errno: nix::errno::Errno::EBUSY,
                     } => true,
-                    &drm::SystemError::Unknown {
+                    drm::SystemError::Unknown {
                         errno: nix::errno::Errno::EINTR,
                     } => true,
                     _ => false,

--- a/src/backend/drm/gbm/mod.rs
+++ b/src/backend/drm/gbm/mod.rs
@@ -39,9 +39,18 @@ pub enum Error<U: std::error::Error + std::fmt::Debug + std::fmt::Display + 'sta
     /// Writing to GBM buffer failed
     #[error("Writing to GBM buffer failed")]
     BufferWriteFailed(#[source] io::Error),
+    /// Creation of drm framebuffer failed
+    #[error("Creation of drm framebuffer failed")]
+    FramebufferCreationFailed(#[source] failure::Compat<drm::SystemError>),
     /// Lock of GBM surface front buffer failed
     #[error("Lock of GBM surface font buffer failed")]
     FrontBufferLockFailed,
+    /// No additional buffers are available
+    #[error("No additional buffers are available. Did you swap twice?")]
+    FrontBuffersExhausted,
+    /// Internal state was modified
+    #[error("Internal state was modified. Did you change gbm userdata?")]
+    InvalidInternalState,
     /// The GBM device was destroyed
     #[error("The GBM device was destroyed")]
     DeviceDestroyed,

--- a/src/backend/drm/gbm/session.rs
+++ b/src/backend/drm/gbm/session.rs
@@ -29,8 +29,8 @@ pub struct GbmDeviceObserver<
 
 impl<
         O: SessionObserver + 'static,
-        S: CursorBackend<CursorFormat=dyn drm::buffer::Buffer> + RawSurface + 'static,
-        D: RawDevice<Surface=S> + drm::control::Device + AsSessionObserver<O> + 'static,
+        S: CursorBackend<CursorFormat = dyn drm::buffer::Buffer> + RawSurface + 'static,
+        D: RawDevice<Surface = S> + drm::control::Device + AsSessionObserver<O> + 'static,
     > AsSessionObserver<GbmDeviceObserver<O, D>> for GbmDevice<D>
 {
     fn observer(&mut self) -> GbmDeviceObserver<O, D> {
@@ -44,8 +44,8 @@ impl<
 
 impl<
         O: SessionObserver + 'static,
-        S: CursorBackend<CursorFormat=dyn drm::buffer::Buffer> + RawSurface + 'static,
-        D: RawDevice<Surface=S> + drm::control::Device + AsSessionObserver<O> + 'static,
+        S: CursorBackend<CursorFormat = dyn drm::buffer::Buffer> + RawSurface + 'static,
+        D: RawDevice<Surface = S> + drm::control::Device + AsSessionObserver<O> + 'static,
     > SessionObserver for GbmDeviceObserver<O, D>
 {
     fn pause(&mut self, devnum: Option<(u32, u32)>) {
@@ -81,9 +81,7 @@ impl<
 
                         let &(ref cursor, ref hotspot): &(BufferObject<()>, (u32, u32)) =
                             unsafe { &*backend.cursor.as_ptr() };
-                        if backend.crtc.set_cursor_representation(cursor, *hotspot)
-                            .is_err()
-                        {
+                        if backend.crtc.set_cursor_representation(cursor, *hotspot).is_err() {
                             if let Err(err) = backend.dev.borrow().set_cursor(*crtc, Some(cursor)) {
                                 error!(self.logger, "Failed to reset cursor. Error: {}", err);
                             }

--- a/src/backend/drm/gbm/surface.rs
+++ b/src/backend/drm/gbm/surface.rs
@@ -93,8 +93,6 @@ impl<D: RawDevice + 'static> GbmSurfaceInternal<D> {
     pub fn recreate(&self) -> Result<(), Error<<<D as Device>::Surface as Surface>::Error>> {
         let (w, h) = self
             .pending_mode()
-            .or_else(|| self.current_mode())
-            .ok_or(Error::NoModeSet)?
             .size();
 
         // Recreate the surface and the related resources to match the new
@@ -167,15 +165,15 @@ impl<D: RawDevice + 'static> Surface for GbmSurfaceInternal<D> {
         self.crtc.set_connectors(connectors).map_err(Error::Underlying)
     }
 
-    fn current_mode(&self) -> Option<Mode> {
+    fn current_mode(&self) -> Mode {
         self.crtc.current_mode()
     }
 
-    fn pending_mode(&self) -> Option<Mode> {
+    fn pending_mode(&self) -> Mode {
         self.crtc.pending_mode()
     }
 
-    fn use_mode(&self, mode: Option<Mode>) -> Result<(), Self::Error> {
+    fn use_mode(&self, mode: Mode) -> Result<(), Self::Error> {
         self.crtc.use_mode(mode).map_err(Error::Underlying)
     }
 }
@@ -325,15 +323,15 @@ impl<D: RawDevice + 'static> Surface for GbmSurface<D> {
         self.0.set_connectors(connectors)
     }
 
-    fn current_mode(&self) -> Option<Mode> {
+    fn current_mode(&self) -> Mode {
         self.0.current_mode()
     }
 
-    fn pending_mode(&self) -> Option<Mode> {
+    fn pending_mode(&self) -> Mode {
         self.0.pending_mode()
     }
 
-    fn use_mode(&self, mode: Option<Mode>) -> Result<(), Self::Error> {
+    fn use_mode(&self, mode: Mode) -> Result<(), Self::Error> {
         self.0.use_mode(mode)
     }
 }

--- a/src/backend/drm/gbm/surface.rs
+++ b/src/backend/drm/gbm/surface.rs
@@ -2,9 +2,9 @@ use super::super::{Device, RawDevice, RawSurface, Surface};
 use super::Error;
 
 use drm::control::{connector, crtc, framebuffer, Device as ControlDevice, Mode};
+use failure::ResultExt;
 use gbm::{self, BufferObject, BufferObjectFlags, Format as GbmFormat, SurfaceBufferHandle};
 use image::{ImageBuffer, Rgba};
-use failure::ResultExt;
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -89,9 +89,7 @@ impl<D: RawDevice + 'static> GbmSurfaceInternal<D> {
     }
 
     pub fn recreate(&self) -> Result<(), Error<<<D as Device>::Surface as Surface>::Error>> {
-        let (w, h) = self
-            .pending_mode()
-            .size();
+        let (w, h) = self.pending_mode().size();
 
         // Recreate the surface and the related resources to match the new
         // resolution.

--- a/src/backend/drm/legacy/mod.rs
+++ b/src/backend/drm/legacy/mod.rs
@@ -76,9 +76,6 @@ impl<A: AsRawFd + 'static> Drop for Dev<A> {
                     error!(self.logger, "Failed to reset crtc ({:?}). Error: {}", handle, err);
                 }
             }
-            // turn it off, so that remaining surfaces (if any) will not change
-            // the state on drop
-            self.active.store(false, Ordering::SeqCst);
         }
         if self.privileged {
             if let Err(err) = self.release_master_lock() {

--- a/src/backend/drm/legacy/mod.rs
+++ b/src/backend/drm/legacy/mod.rs
@@ -76,6 +76,9 @@ impl<A: AsRawFd + 'static> Drop for Dev<A> {
                     error!(self.logger, "Failed to reset crtc ({:?}). Error: {}", handle, err);
                 }
             }
+            // turn it off, so that remaining surfaces (if any) will not change
+            // the state on drop
+            self.active.store(false, Ordering::SeqCst);
         }
         if self.privileged {
             if let Err(err) = self.release_master_lock() {

--- a/src/backend/drm/legacy/session.rs
+++ b/src/backend/drm/legacy/session.rs
@@ -8,13 +8,14 @@ use drm::Device as BasicDevice;
 use nix::libc::dev_t;
 use nix::sys::stat;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use failure::ResultExt;
 
-use super::{Dev, LegacyDrmDevice, LegacyDrmSurfaceInternal};
+use super::{Dev, LegacyDrmDevice, LegacyDrmSurfaceInternal, Error, DevPath};
 use crate::backend::session::{AsSessionObserver, SessionObserver};
 
 /// [`SessionObserver`](SessionObserver)
@@ -91,5 +92,77 @@ impl<A: AsRawFd + 'static> SessionObserver for LegacyDrmDeviceObserver<A> {
                 }
             }
         }
+        // okay, the previous session/whatever might left the drm devices in any state...
+        // lets fix that
+        if let Err(err) = self.reset_state() {
+            warn!(self.logger, "Unable to reset state after tty switch: {}", err);
+            // TODO call drm-handler::error
+        }
     }
 }
+
+impl<A: AsRawFd + 'static> LegacyDrmDeviceObserver<A> {
+    fn reset_state(&mut self) -> Result<(), Error> {
+        // lets enumerate it the current state
+        if let Some(dev) = self.dev.upgrade() {
+            let res_handles = ControlDevice::resource_handles(&*dev)
+                .compat()
+                .map_err(|source| Error::Access {
+                    errmsg: "Error loading drm resources",
+                    dev: dev.dev_path(),
+                    source,
+                })?;
+            
+            let mut used_connectors = HashSet::new();
+            if let Some(backends) = self.backends.upgrade() {
+                for surface in backends.borrow().values().filter_map(Weak::upgrade) {
+                    let mut current = surface.state.write().unwrap();
+                    let pending = surface.pending.read().unwrap();
+                    
+                    // store (soon to be) used connectors
+                    used_connectors.extend(pending.connectors.clone());
+                    
+                    // set current connectors
+                    current.connectors.clear();
+                    for conn in res_handles.connectors() {
+                        let conn_info = dev.get_connector(*conn).compat().map_err(|source| Error::Access {
+                            errmsg: "Could not load connector info",
+                            dev: dev.dev_path(),
+                            source,
+                        })?;
+                        if let Some(enc) = conn_info.current_encoder() {
+                            let enc_info = dev.get_encoder(enc).compat().map_err(|source| Error::Access {
+                                errmsg: "Could not load encoder info",
+                                dev: dev.dev_path(),
+                                source,
+                            })?;
+                            if enc_info.crtc().map(|crtc| crtc == surface.crtc).unwrap_or(false) {
+                                current.connectors.insert(*conn);
+                            }
+                        }
+                    }
+
+                    // set current mode
+                    let crtc_info = dev.get_crtc(surface.crtc).compat().map_err(|source| Error::Access {
+                        errmsg: "Could not load crtc info",
+                        dev: dev.dev_path(),
+                        source,
+                    })?;
+
+                    // If we have no current mode, we create a fake one, which will not match (and thus gets overriden on the commit below).
+                    // A better fix would probably be making mode an `Option`, but that would mean
+                    // we need to be sure, we require a mode to always be set without relying on the compiler.
+                    // So we cheat, because it works and is easier to handle later.
+                    current.mode = crtc_info.mode().unwrap_or_else(|| unsafe { std::mem::zeroed() });
+                }
+            }
+
+            // Disable unused connectors
+            let all_set = res_handles.connectors().iter().copied().collect::<HashSet<_>>();
+            let unused = used_connectors.difference(&all_set);
+            dev.set_connector_state(unused.copied(), false)?;
+        }
+        
+        Ok(())
+    }
+} 

--- a/src/backend/drm/legacy/surface.rs
+++ b/src/backend/drm/legacy/surface.rs
@@ -358,7 +358,7 @@ impl<A: AsRawFd + 'static> LegacyDrmSurfaceInternal<A> {
         };
         let pending = State {
             mode,
-            connectors: connectors.into_iter().copied().collect(),
+            connectors: connectors.iter().copied().collect(),
         };
 
         let surface = LegacyDrmSurfaceInternal {
@@ -437,9 +437,10 @@ impl<A: AsRawFd + 'static> Drop for LegacyDrmSurfaceInternal<A> {
         let _ = self.set_cursor(self.crtc, Option::<&DumbBuffer>::None);
         // disable connectors again
         let current = self.state.read().unwrap();
-        if let Ok(_) = self
+        if self
             .dev
             .set_connector_state(current.connectors.iter().copied(), false)
+            .is_ok()
         {
             // null commit
             let _ = self.set_crtc(self.crtc, None, (0, 0), &[], None);

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -51,8 +51,6 @@ use calloop::mio::Interest;
 use calloop::InsertError;
 use calloop::{LoopHandle, Source};
 
-use super::graphics::SwapBuffersError;
-
 #[cfg(feature = "backend_drm_atomic")]
 pub mod atomic;
 #[cfg(feature = "backend_drm")]
@@ -233,7 +231,7 @@ pub trait RawSurface: Surface + ControlDevice + BasicDevice {
     /// This operation is not blocking and will produce a `vblank` event once swapping is done.
     /// Make sure to [set a `DeviceHandler`](Device::set_handler) and
     /// [register the belonging `Device`](device_bind) before to receive the event in time.
-    fn page_flip(&self, framebuffer: framebuffer::Handle) -> Result<(), SwapBuffersError>;
+    fn page_flip(&self, framebuffer: framebuffer::Handle) -> Result<(), <Self as Surface>::Error>;
 }
 
 /// Trait representing open devices that *may* return a `Path`

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -169,6 +169,11 @@ pub trait Surface {
     /// Tries to add a new [`connector`](drm::control::connector)
     /// to be used after the next commit.
     ///
+    /// **Warning**: You need to make sure, that the connector is not used with another surface
+    /// or was properly removed via `remove_connector` + `commit` before adding it to another surface.
+    /// Behavior if failing to do so is undefined, but might result in rendering errors or the connector
+    /// getting removed from the other surface without updating it's internal state.
+    ///
     /// Fails if the `connector` is not compatible with the underlying [`crtc`](drm::control::crtc)
     /// (e.g. no suitable [`encoder`](drm::control::encoder) may be found)
     /// or is not compatible with the currently pending

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -108,7 +108,7 @@ pub trait Device: AsRawFd + DevPath {
         &mut self,
         crtc: crtc::Handle,
         mode: Mode,
-        connectors: &[connector::Handle]
+        connectors: &[connector::Handle],
     ) -> Result<Self::Surface, <Self::Surface as Surface>::Error>;
 
     /// Processes any open events of the underlying file descriptor.

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -1,10 +1,10 @@
 //! EGL context related structs
 
-use super::{ffi, Error};
+use super::{ffi, Error, MakeCurrentError, wrap_egl_call};
 use crate::backend::egl::display::{EGLDisplay, EGLDisplayHandle};
 use crate::backend::egl::native::NativeSurface;
 use crate::backend::egl::{native, EGLSurface};
-use crate::backend::graphics::{PixelFormat, SwapBuffersError};
+use crate::backend::graphics::PixelFormat;
 use std::os::raw::c_int;
 use std::ptr;
 use std::sync::Arc;
@@ -93,21 +93,14 @@ impl EGLContext {
 
         trace!(log, "Creating EGL context...");
         // TODO: Support shared contexts
-        let context = unsafe {
+        let context = wrap_egl_call(|| unsafe {
             ffi::egl::CreateContext(
                 **display.display,
                 config_id,
                 ptr::null(),
                 context_attributes.as_ptr(),
             )
-        };
-
-        if context.is_null() {
-            match unsafe { ffi::egl::GetError() } as u32 {
-                ffi::egl::BAD_ATTRIBUTE => return Err(Error::CreationFailed),
-                err_no => return Err(Error::Unknown(err_no)),
-            }
-        }
+        }).map_err(Error::CreationFailed)?;
 
         info!(log, "EGL context created");
 
@@ -129,22 +122,13 @@ impl EGLContext {
     pub unsafe fn make_current_with_surface<N>(
         &self,
         surface: &EGLSurface<N>,
-    ) -> ::std::result::Result<(), SwapBuffersError>
+    ) -> Result<(), MakeCurrentError>
     where
         N: NativeSurface,
     {
         let surface_ptr = surface.surface.get();
 
-        let ret = ffi::egl::MakeCurrent(**self.display, surface_ptr, surface_ptr, self.context);
-
-        if ret == 0 {
-            match ffi::egl::GetError() as u32 {
-                ffi::egl::CONTEXT_LOST => Err(SwapBuffersError::ContextLost),
-                err => panic!("eglMakeCurrent failed (eglGetError returned 0x{:x})", err),
-            }
-        } else {
-            Ok(())
-        }
+        wrap_egl_call(|| ffi::egl::MakeCurrent(**self.display, surface_ptr, surface_ptr, self.context)).map(|_| ()).map_err(Into::into)
     }
 
     /// Makes the OpenGL context the current context in the current thread with no surface bound.
@@ -152,18 +136,9 @@ impl EGLContext {
     /// # Safety
     ///
     /// This function is marked unsafe, because the context cannot be made current
-    /// on multiple threads.
-    pub unsafe fn make_current(&self) -> ::std::result::Result<(), SwapBuffersError> {
-        let ret = ffi::egl::MakeCurrent(**self.display, ptr::null(), ptr::null(), self.context);
-
-        if ret == 0 {
-            match ffi::egl::GetError() as u32 {
-                ffi::egl::CONTEXT_LOST => Err(SwapBuffersError::ContextLost),
-                err => panic!("eglMakeCurrent failed (eglGetError returned 0x{:x})", err),
-            }
-        } else {
-            Ok(())
-        }
+    /// on multiple threads without being unbound again (see `unbind`)
+    pub unsafe fn make_current(&self) -> Result<(), MakeCurrentError> {
+        wrap_egl_call(|| ffi::egl::MakeCurrent(**self.display, ffi::egl::NO_SURFACE, ffi::egl::NO_SURFACE, self.context)).map(|_| ()).map_err(Into::into)
     }
 
     /// Returns true if the OpenGL context is the current one in the thread.
@@ -180,16 +155,24 @@ impl EGLContext {
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.pixel_format
     }
+    
+    /// Unbinds this context from the current thread, if set.
+    ///
+    /// This does nothing if this context is not the current context
+    pub fn unbind(&self) -> Result<(), MakeCurrentError> {
+        if self.is_current() {
+            wrap_egl_call(|| unsafe { ffi::egl::MakeCurrent(**self.display, ffi::egl::NO_SURFACE, ffi::egl::NO_SURFACE, ffi::egl::NO_CONTEXT)})?;
+        }
+        Ok(())
+    }
 }
 
 impl Drop for EGLContext {
     fn drop(&mut self) {
         unsafe {
             // We need to ensure the context is unbound, otherwise it egl stalls the destroy call
-            if ffi::egl::GetCurrentContext() == self.context as *const _ {
-                ffi::egl::MakeCurrent(ptr::null(), ptr::null(), ptr::null(), ptr::null());
-            }
-
+            // ignore failures at this point
+            let _ = self.unbind();
             ffi::egl::DestroyContext(**self.display, self.context);
         }
     }
@@ -270,7 +253,7 @@ impl Default for PixelFormatRequirements {
 
 impl PixelFormatRequirements {
     /// Append the  requirements to the given attribute list
-    pub fn create_attributes(&self, out: &mut Vec<c_int>, logger: &slog::Logger) -> Result<(), Error> {
+    pub fn create_attributes(&self, out: &mut Vec<c_int>, logger: &slog::Logger) -> Result<(), ()> {
         if let Some(hardware_accelerated) = self.hardware_accelerated {
             out.push(ffi::egl::CONFIG_CAVEAT as c_int);
             out.push(if hardware_accelerated {
@@ -328,7 +311,7 @@ impl PixelFormatRequirements {
 
         if self.stereoscopy {
             error!(logger, "Stereoscopy is currently unsupported (sorry!)");
-            return Err(Error::NoAvailablePixelFormat);
+            return Err(()); 
         }
 
         Ok(())

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "use_system_lib")]
 use crate::backend::egl::EGLGraphicsBackend;
 use crate::backend::egl::{
-    ffi, get_proc_address, native, BufferAccessError, EGLContext, EGLImages, EGLSurface, Error, Format,
+    ffi, get_proc_address, native, BufferAccessError, SurfaceCreationError, EGLContext, EGLImages, EGLSurface, Error, Format, EGLError, wrap_egl_call,
 };
 use std::sync::Arc;
 
@@ -44,6 +44,7 @@ impl Deref for EGLDisplayHandle {
 impl Drop for EGLDisplayHandle {
     fn drop(&mut self) {
         unsafe {
+            // ignore errors on drop
             ffi::egl::Terminate(self.handle);
         }
     }
@@ -93,7 +94,7 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
 
         // the first step is to query the list of extensions without any display, if supported
         let dp_extensions = unsafe {
-            let p = ffi::egl::QueryString(ffi::egl::NO_DISPLAY, ffi::egl::EXTENSIONS as i32);
+            let p = wrap_egl_call(|| ffi::egl::QueryString(ffi::egl::NO_DISPLAY, ffi::egl::EXTENSIONS as i32)).map_err(Error::InitFailed)?;
 
             // this possibility is available only with EGL 1.5 or EGL_EXT_platform_base, otherwise
             // `eglQueryString` returns an error
@@ -105,23 +106,16 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
                 list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>()
             }
         };
-
         debug!(log, "EGL No-Display Extensions: {:?}", dp_extensions);
 
-        let display =
-            unsafe { B::get_display(ptr, |e: &str| dp_extensions.iter().any(|s| s == e), log.clone()) };
-        if display == ffi::egl::NO_DISPLAY {
-            error!(log, "EGL Display is not valid");
-            return Err(Error::DisplayNotSupported);
-        }
+        let display = unsafe { B::get_display(ptr, |e: &str| dp_extensions.iter().any(|s| s == e), log.clone()).map_err(Error::DisplayNotSupported)? };
 
         let egl_version = {
             let mut major: MaybeUninit<ffi::egl::types::EGLint> = MaybeUninit::uninit();
             let mut minor: MaybeUninit<ffi::egl::types::EGLint> = MaybeUninit::uninit();
 
-            if unsafe { ffi::egl::Initialize(display, major.as_mut_ptr(), minor.as_mut_ptr()) } == 0 {
-                return Err(Error::InitFailed);
-            }
+            wrap_egl_call(|| unsafe { ffi::egl::Initialize(display, major.as_mut_ptr(), minor.as_mut_ptr()) }).map_err(Error::InitFailed)?;
+            
             let major = unsafe { major.assume_init() };
             let minor = unsafe { minor.assume_init() };
 
@@ -134,19 +128,18 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
         // the list of extensions supported by the client once initialized is different from the
         // list of extensions obtained earlier
         let extensions = if egl_version >= (1, 2) {
-            let p = unsafe { CStr::from_ptr(ffi::egl::QueryString(display, ffi::egl::EXTENSIONS as i32)) };
+            let p = unsafe { CStr::from_ptr(wrap_egl_call(|| ffi::egl::QueryString(display, ffi::egl::EXTENSIONS as i32)).map_err(Error::InitFailed)?) };
             let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| String::new());
             list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>()
         } else {
             vec![]
         };
-
         info!(log, "EGL Extensions: {:?}", extensions);
 
-        if egl_version >= (1, 2) && unsafe { ffi::egl::BindAPI(ffi::egl::OPENGL_ES_API) } == 0 {
-            error!(log, "OpenGLES not supported by the underlying EGL implementation");
-            return Err(Error::OpenGlesNotSupported);
+        if egl_version >= (1, 2) {
+            return Err(Error::OpenGlesNotSupported(None));
         }
+        wrap_egl_call(|| unsafe { ffi::egl::BindAPI(ffi::egl::OPENGL_ES_API) }).map_err(|source| Error::OpenGlesNotSupported(Some(source)))?;
 
         Ok(EGLDisplay {
             native: RefCell::new(native),
@@ -219,15 +212,15 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
                 }
             };
 
-            reqs.create_attributes(&mut out, &self.logger)?;
+            reqs.create_attributes(&mut out, &self.logger).map_err(|()| Error::NoAvailablePixelFormat)?;
 
             out.push(ffi::egl::NONE as c_int);
             out
         };
 
         // calling `eglChooseConfig`
-        let mut num_configs = unsafe { std::mem::zeroed() };
-        if unsafe {
+        let mut num_configs = 0;
+        wrap_egl_call(|| unsafe {
             ffi::egl::ChooseConfig(
                 **self.display,
                 descriptor.as_ptr(),
@@ -235,18 +228,13 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
                 0,
                 &mut num_configs,
             )
-        } == 0
-        {
-            return Err(Error::ConfigFailed);
-        }
-
+        }).map_err(Error::ConfigFailed)?;
         if num_configs == 0 {
             return Err(Error::NoAvailablePixelFormat);
         }
 
-        let mut config_ids = Vec::with_capacity(num_configs as usize);
-        config_ids.resize_with(num_configs as usize, || unsafe { std::mem::zeroed() });
-        if unsafe {
+        let mut config_ids: Vec<ffi::egl::types::EGLConfig> = Vec::with_capacity(num_configs as usize);
+        wrap_egl_call(|| unsafe {
             ffi::egl::ChooseConfig(
                 **self.display,
                 descriptor.as_ptr(),
@@ -254,44 +242,43 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
                 num_configs,
                 &mut num_configs,
             )
-        } == 0
-        {
-            return Err(Error::ConfigFailed);
-        }
+        }).map_err(Error::ConfigFailed)?;
+        unsafe { config_ids.set_len(num_configs as usize); }
 
         // TODO: Deeper swap intervals might have some uses
         let desired_swap_interval = if attributes.vsync { 1 } else { 0 };
 
         let config_ids = config_ids
             .into_iter()
-            .filter(|&config| unsafe {
+            .map(|config| unsafe {
                 let mut min_swap_interval = 0;
-                ffi::egl::GetConfigAttrib(
+                wrap_egl_call(|| ffi::egl::GetConfigAttrib(
                     **self.display,
                     config,
                     ffi::egl::MIN_SWAP_INTERVAL as ffi::egl::types::EGLint,
                     &mut min_swap_interval,
-                );
+                ))?;
 
                 if desired_swap_interval < min_swap_interval {
-                    return false;
+                    return Ok(None);
                 }
 
                 let mut max_swap_interval = 0;
-                ffi::egl::GetConfigAttrib(
+                wrap_egl_call(|| ffi::egl::GetConfigAttrib(
                     **self.display,
                     config,
                     ffi::egl::MAX_SWAP_INTERVAL as ffi::egl::types::EGLint,
                     &mut max_swap_interval,
-                );
+                ))?;
 
                 if desired_swap_interval > max_swap_interval {
-                    return false;
+                    return Ok(None);
                 }
 
-                true
+                Ok(Some(config))
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<Option<ffi::egl::types::EGLConfig>>, EGLError>>().map_err(Error::ConfigFailed)?
+            .into_iter().flat_map(|x| x).collect::<Vec<_>>();
 
         if config_ids.is_empty() {
             return Err(Error::NoAvailablePixelFormat);
@@ -304,15 +291,12 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
         macro_rules! attrib {
             ($display:expr, $config:expr, $attr:expr) => {{
                 let mut value = MaybeUninit::uninit();
-                let res = ffi::egl::GetConfigAttrib(
+                wrap_egl_call(|| ffi::egl::GetConfigAttrib(
                     **$display,
                     $config,
                     $attr as ffi::egl::types::EGLint,
                     value.as_mut_ptr(),
-                );
-                if res == 0 {
-                    return Err(Error::ConfigFailed);
-                }
+                )).map_err(Error::ConfigFailed)?;
                 value.assume_init()
             }};
         };
@@ -357,12 +341,9 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
         double_buffer: Option<bool>,
         config: ffi::egl::types::EGLConfig,
         args: N::Arguments,
-    ) -> Result<EGLSurface<B::Surface>, Error> {
+    ) -> Result<EGLSurface<B::Surface>, SurfaceCreationError<N::Error>> {
         trace!(self.logger, "Creating EGL window surface.");
-        let surface = self.native.borrow_mut().create_surface(args).map_err(|e| {
-            error!(self.logger, "EGL surface creation failed: {}", e);
-            Error::SurfaceCreationFailed
-        })?;
+        let surface = self.native.borrow_mut().create_surface(args).map_err(SurfaceCreationError::NativeSurfaceCreationFailed)?;
 
         EGLSurface::new(
             self.display.clone(),
@@ -375,7 +356,7 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
         .map(|x| {
             debug!(self.logger, "EGL surface successfully created");
             x
-        })
+        }).map_err(SurfaceCreationError::EGLSurfaceCreationFailed)
     }
 
     /// Returns the runtime egl version of this display
@@ -426,10 +407,7 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLGraphicsBackend for EGL
         if !self.extensions.iter().any(|s| s == "EGL_WL_bind_wayland_display") {
             return Err(Error::EglExtensionNotSupported(&["EGL_WL_bind_wayland_display"]));
         }
-        let res = unsafe { ffi::egl::BindWaylandDisplayWL(**self.display, display.c_ptr() as *mut _) };
-        if res == 0 {
-            return Err(Error::OtherEGLDisplayAlreadyBound);
-        }
+        wrap_egl_call(|| unsafe { ffi::egl::BindWaylandDisplayWL(**self.display, display.c_ptr() as *mut _) }).map_err(Error::OtherEGLDisplayAlreadyBound)?;
         Ok(EGLBufferReader::new(self.display.clone(), display.c_ptr()))
     }
 }
@@ -469,16 +447,15 @@ impl EGLBufferReader {
         buffer: WlBuffer,
     ) -> ::std::result::Result<EGLImages, BufferAccessError> {
         let mut format: i32 = 0;
-        if unsafe {
+        wrap_egl_call(|| unsafe {
             ffi::egl::QueryWaylandBufferWL(
                 **self.display,
                 buffer.as_ref().c_ptr() as _,
                 ffi::egl::EGL_TEXTURE_FORMAT,
                 &mut format,
-            ) == 0
-        } {
-            return Err(BufferAccessError::NotManaged(buffer));
-        }
+            )
+        }).map_err(|source| BufferAccessError::NotManaged(buffer.clone(), source))?;
+        
         let format = match format {
             x if x == ffi::egl::TEXTURE_RGB as i32 => Format::RGB,
             x if x == ffi::egl::TEXTURE_RGBA as i32 => Format::RGBA,
@@ -490,40 +467,34 @@ impl EGLBufferReader {
         };
 
         let mut width: i32 = 0;
-        if unsafe {
+        wrap_egl_call(|| unsafe {
             ffi::egl::QueryWaylandBufferWL(
                 **self.display,
                 buffer.as_ref().c_ptr() as _,
                 ffi::egl::WIDTH as i32,
                 &mut width,
-            ) == 0
-        } {
-            return Err(BufferAccessError::NotManaged(buffer));
-        }
+            )
+        }).map_err(|source| BufferAccessError::NotManaged(buffer.clone(), source))?;
 
         let mut height: i32 = 0;
-        if unsafe {
+        wrap_egl_call(|| unsafe {
             ffi::egl::QueryWaylandBufferWL(
                 **self.display,
                 buffer.as_ref().c_ptr() as _,
                 ffi::egl::HEIGHT as i32,
                 &mut height,
-            ) == 0
-        } {
-            return Err(BufferAccessError::NotManaged(buffer));
-        }
+            )
+        }).map_err(|source| BufferAccessError::NotManaged(buffer.clone(), source))?;
 
         let mut inverted: i32 = 0;
-        if unsafe {
+        wrap_egl_call(|| unsafe {
             ffi::egl::QueryWaylandBufferWL(
                 **self.display,
                 buffer.as_ref().c_ptr() as _,
                 ffi::egl::WAYLAND_Y_INVERTED_WL,
                 &mut inverted,
-            ) != 0
-        } {
-            inverted = 1;
-        }
+            )
+        }).map_err(|source| BufferAccessError::NotManaged(buffer.clone(), source))?;
 
         let mut images = Vec::with_capacity(format.num_planes());
         for i in 0..format.num_planes() {
@@ -533,7 +504,7 @@ impl EGLBufferReader {
             out.push(ffi::egl::NONE as i32);
 
             images.push({
-                let image = unsafe {
+                let image = wrap_egl_call(|| unsafe {
                     ffi::egl::CreateImageKHR(
                         **self.display,
                         ffi::egl::NO_CONTEXT,
@@ -541,12 +512,8 @@ impl EGLBufferReader {
                         buffer.as_ref().c_ptr() as *mut _,
                         out.as_ptr(),
                     )
-                };
-                if image == ffi::egl::NO_IMAGE_KHR {
-                    return Err(BufferAccessError::EGLImageCreationFailed);
-                } else {
-                    image
-                }
+                }).map_err(BufferAccessError::EGLImageCreationFailed)?;
+                image
             });
         }
 
@@ -601,6 +568,7 @@ impl Drop for EGLBufferReader {
     fn drop(&mut self) {
         if !self.wayland.is_null() {
             unsafe {
+                // ignore errors on drop
                 ffi::egl::UnbindWaylandDisplayWL(**self.display, self.wayland as _);
             }
         }

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -304,7 +304,7 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
             .collect::<Result<Vec<Option<ffi::egl::types::EGLConfig>>, EGLError>>()
             .map_err(Error::ConfigFailed)?
             .into_iter()
-            .flat_map(|x| x)
+            .flatten()
             .collect::<Vec<_>>();
 
         if config_ids.is_empty() {
@@ -546,7 +546,7 @@ impl EGLBufferReader {
             out.push(ffi::egl::NONE as i32);
 
             images.push({
-                let image = wrap_egl_call(|| unsafe {
+                wrap_egl_call(|| unsafe {
                     ffi::egl::CreateImageKHR(
                         **self.display,
                         ffi::egl::NO_CONTEXT,
@@ -555,8 +555,7 @@ impl EGLBufferReader {
                         out.as_ptr(),
                     )
                 })
-                .map_err(BufferAccessError::EGLImageCreationFailed)?;
-                image
+                .map_err(BufferAccessError::EGLImageCreationFailed)?
             });
         }
 

--- a/src/backend/egl/error.rs
+++ b/src/backend/egl/error.rs
@@ -1,3 +1,5 @@
+use super::ffi;
+
 #[derive(thiserror::Error, Debug)]
 /// EGL errors
 pub enum Error {
@@ -5,8 +7,8 @@ pub enum Error {
     #[error("The requested OpenGL version {0:?} is not supported")]
     OpenGlVersionNotSupported((u8, u8)),
     /// The EGL implementation does not support creating OpenGL ES contexts
-    #[error("The EGL implementation does not support creating OpenGL ES contexts")]
-    OpenGlesNotSupported,
+    #[error("The EGL implementation does not support creating OpenGL ES contexts. Err: {0:?}")]
+    OpenGlesNotSupported(#[source] Option<EGLError>),
     /// No available pixel format matched the criteria
     #[error("No available pixel format matched the criteria")]
     NoAvailablePixelFormat,
@@ -14,26 +16,23 @@ pub enum Error {
     #[error("The expected backend '{0:?}' does not match the runtime")]
     NonMatchingBackend(&'static str),
     /// Unable to obtain a valid EGL Display
-    #[error("Unable to obtain a valid EGL Display")]
-    DisplayNotSupported,
+    #[error("Unable to obtain a valid EGL Display. Err: {0:}")]
+    DisplayNotSupported(#[source] EGLError),
     /// `eglInitialize` returned an error
-    #[error("Failed to initialize EGL")]
-    InitFailed,
+    #[error("Failed to initialize EGL. Err: {0:}")]
+    InitFailed(#[source] EGLError),
     /// Failed to configure the EGL context
     #[error("Failed to configure the EGL context")]
-    ConfigFailed,
+    ConfigFailed(#[source] EGLError),
     /// Context creation failed as one or more requirements could not be met. Try removing some gl attributes or pixel format requirements
-    #[error("Context creation failed as one or more requirements could not be met. Try removing some gl attributes or pixel format requirements")]
-    CreationFailed,
-    /// `eglCreateWindowSurface` failed
-    #[error("`eglCreateWindowSurface` failed")]
-    SurfaceCreationFailed,
+    #[error("Context creation failed as one or more requirements could not be met. Try removing some gl attributes or pixel format requirements. Err: {0:}")]
+    CreationFailed(#[source] EGLError),
     /// The required EGL extension is not supported by the underlying EGL implementation
     #[error("None of the following EGL extensions is supported by the underlying EGL implementation, at least one is required: {0:?}")]
     EglExtensionNotSupported(&'static [&'static str]),
     /// Only one EGLDisplay may be bound to a given `WlDisplay` at any time
     #[error("Only one EGLDisplay may be bound to a given `WlDisplay` at any time")]
-    OtherEGLDisplayAlreadyBound,
+    OtherEGLDisplayAlreadyBound(#[source] EGLError),
     /// No EGLDisplay is currently bound to this `WlDisplay`
     #[error("No EGLDisplay is currently bound to this `WlDisplay`")]
     NoEGLDisplayBound,
@@ -43,7 +42,89 @@ pub enum Error {
     /// Failed to create `EGLImages` from the buffer
     #[error("Failed to create `EGLImages` from the buffer")]
     EGLImageCreationFailed,
-    /// The reason of failure could not be determined
-    #[error("Unknown error: {0}")]
+}
+
+/// Raw EGL error
+#[derive(thiserror::Error, Debug)]
+pub enum EGLError {
+    /// EGL is not initialized, or could not be initialized, for the specified EGL display connection.
+    #[error("EGL is not initialized, or could not be initialized, for the specified EGL display connection.")]
+    NotInitialized,
+    /// EGL cannot access a requested resource (for example a context is bound in another thread).
+    #[error("EGL cannot access a requested resource (for example a context is bound in another thread).")]
+    BadAccess,
+    /// EGL failed to allocate resources for the requested operation.
+    #[error("EGL failed to allocate resources for the requested operation.")]
+    BadAlloc,
+    /// An unrecognized attribute or attribute value was passed in the attribute list.
+    #[error("An unrecognized attribute or attribute value was passed in the attribute list.")]
+    BadAttribute,
+    /// An EGLContext argument does not name a valid EGL rendering context.
+    #[error("An EGLContext argument does not name a valid EGL rendering context.")]
+    BadContext,
+    /// An EGLConfig argument does not name a valid EGL frame buffer configuration.
+    #[error("An EGLConfig argument does not name a valid EGL frame buffer configuration.")]
+    BadConfig,
+    /// The current surface of the calling thread is a window, pixel buffer or pixmap that is no longer valid.
+    #[error("The current surface of the calling thread is a window, pixel buffer or pixmap that is no longer valid.")]
+    BadCurrentSurface,
+    /// An EGLDisplay argument does not name a valid EGL display connection.
+    #[error("An EGLDisplay argument does not name a valid EGL display connection.")]
+    BadDisplay,
+    /// An EGLSurface argument does not name a valid surface (window, pixel buffer or pixmap) configured for GL rendering.
+    #[error("An EGLSurface argument does not name a valid surface (window, pixel buffer or pixmap) configured for GL rendering.")]
+    BadSurface,
+    /// Arguments are inconsistent (for example, a valid context requires buffers not supplied by a valid surface).
+    #[error("Arguments are inconsistent (for example, a valid context requires buffers not supplied by a valid surface).")]
+    BadMatch,
+    /// One or more argument values are invalid.
+    #[error("One or more argument values are invalid.")]
+    BadParameter,
+    /// A NativePixmapType argument does not refer to a valid native pixmap.
+    #[error("A NativePixmapType argument does not refer to a valid native pixmap.")]
+    BadNativePixmap,
+    /// A NativeWindowType argument does not refer to a valid native window.
+    #[error("A NativeWindowType argument does not refer to a valid native window.")]
+    BadNativeWindow,
+    /// A power management event has occurred. The application must destroy all contexts and reinitialise OpenGL ES state and objects to continue rendering.
+    #[error("A power management event has occurred. The application must destroy all contexts and reinitialise OpenGL ES state and objects to continue rendering.")]
+    ContextLost,
+    /// An unknown error
+    #[error("An unknown error ({0:x})")]    
     Unknown(u32),
+}
+
+impl From<u32> for EGLError {
+    fn from(value: u32) -> Self {
+        match value {
+            ffi::egl::NOT_INITIALIZED => EGLError::NotInitialized,
+            ffi::egl::BAD_ACCESS => EGLError::BadAccess,
+            ffi::egl::BAD_ALLOC => EGLError::BadAlloc,
+            ffi::egl::BAD_ATTRIBUTE => EGLError::BadAttribute,
+            ffi::egl::BAD_CONTEXT => EGLError::BadContext,
+            ffi::egl::BAD_CURRENT_SURFACE => EGLError::BadCurrentSurface,
+            ffi::egl::BAD_DISPLAY => EGLError::BadDisplay,
+            ffi::egl::BAD_SURFACE => EGLError::BadSurface,
+            ffi::egl::BAD_MATCH => EGLError::BadMatch,
+            ffi::egl::BAD_PARAMETER => EGLError::BadParameter,
+            ffi::egl::BAD_NATIVE_PIXMAP => EGLError::BadNativePixmap,
+            ffi::egl::BAD_NATIVE_WINDOW => EGLError::BadNativeWindow,
+            ffi::egl::CONTEXT_LOST => EGLError::ContextLost,
+            x => EGLError::Unknown(x),
+        }
+    }
+}
+
+impl EGLError {
+    fn from_last_call() -> Result<(), EGLError> {
+        match unsafe { ffi::egl::GetError() as u32 } {
+            ffi::egl::SUCCESS => Ok(()),
+            x => Err(EGLError::from(x)),
+        }
+    }
+}
+
+pub(crate) fn wrap_egl_call<R, F: FnOnce() -> R>(call: F) -> Result<R, EGLError> {
+    let res = call();
+    EGLError::from_last_call().map(|()| res)
 }

--- a/src/backend/egl/error.rs
+++ b/src/backend/egl/error.rs
@@ -48,7 +48,9 @@ pub enum Error {
 #[derive(thiserror::Error, Debug)]
 pub enum EGLError {
     /// EGL is not initialized, or could not be initialized, for the specified EGL display connection.
-    #[error("EGL is not initialized, or could not be initialized, for the specified EGL display connection.")]
+    #[error(
+        "EGL is not initialized, or could not be initialized, for the specified EGL display connection."
+    )]
     NotInitialized,
     /// EGL cannot access a requested resource (for example a context is bound in another thread).
     #[error("EGL cannot access a requested resource (for example a context is bound in another thread).")]
@@ -90,7 +92,7 @@ pub enum EGLError {
     #[error("A power management event has occurred. The application must destroy all contexts and reinitialise OpenGL ES state and objects to continue rendering.")]
     ContextLost,
     /// An unknown error
-    #[error("An unknown error ({0:x})")]    
+    #[error("An unknown error ({0:x})")]
     Unknown(u32),
 }
 

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -19,7 +19,7 @@
 //! of an EGL-based [`WlBuffer`](wayland_server::protocol::wl_buffer::WlBuffer) for rendering.
 
 #[cfg(feature = "renderer_gl")]
-use crate::backend::graphics::gl::{ffi as gl_ffi, GLGraphicsBackend};
+use crate::backend::graphics::{SwapBuffersError as GraphicsSwapBuffersError, gl::{ffi as gl_ffi, GLGraphicsBackend}};
 use nix::libc::c_uint;
 use std::fmt;
 #[cfg(feature = "wayland_frontend")]
@@ -28,7 +28,7 @@ use wayland_server::{protocol::wl_buffer::WlBuffer, Display};
 pub mod context;
 pub use self::context::EGLContext;
 mod error;
-pub use self::error::Error;
+pub use self::error::*;
 
 use nix::libc::c_void;
 
@@ -84,11 +84,11 @@ pub enum BufferAccessError {
     #[error("The corresponding context was lost")]
     ContextLost,
     /// This buffer is not managed by the EGL buffer
-    #[error("This buffer is not managed by EGL")]
-    NotManaged(WlBuffer),
+    #[error("This buffer is not managed by EGL. Err: {1:}")]
+    NotManaged(WlBuffer, #[source] EGLError),
     /// Failed to create `EGLImages` from the buffer
-    #[error("Failed to create EGLImages from the buffer")]
-    EGLImageCreationFailed,
+    #[error("Failed to create EGLImages from the buffer. Err: {0:}")]
+    EGLImageCreationFailed(#[source] EGLError),
     /// The required EGL extension is not supported by the underlying EGL implementation
     #[error("{0}")]
     EglExtensionNotSupported(#[from] EglExtensionNotSupportedError),
@@ -99,11 +99,83 @@ impl fmt::Debug for BufferAccessError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         match *self {
             BufferAccessError::ContextLost => write!(formatter, "BufferAccessError::ContextLost"),
-            BufferAccessError::NotManaged(_) => write!(formatter, "BufferAccessError::NotManaged"),
-            BufferAccessError::EGLImageCreationFailed => {
+            BufferAccessError::NotManaged(_, _) => write!(formatter, "BufferAccessError::NotManaged"),
+            BufferAccessError::EGLImageCreationFailed(_) => {
                 write!(formatter, "BufferAccessError::EGLImageCreationFailed")
             }
             BufferAccessError::EglExtensionNotSupported(ref err) => write!(formatter, "{:?}", err),
+        }
+    }
+}
+
+/// Error that can occur when creating a surface.
+#[derive(Debug, thiserror::Error)]
+pub enum SurfaceCreationError<E: std::error::Error + 'static> {
+    /// Native Surface creation failed
+    #[error("Surface creation failed. Err: {0:}")]
+    NativeSurfaceCreationFailed(#[source] E),
+    /// EGL surface creation failed
+    #[error("EGL surface creation failed. Err: {0:}")]
+    EGLSurfaceCreationFailed(#[source] EGLError)
+}
+
+/// Error that can happen when swapping buffers.
+#[derive(Debug, thiserror::Error)]
+pub enum SwapBuffersError<E: std::error::Error + 'static> {
+    /// Error of the underlying native surface
+    #[error("Underlying error: {0:?}")]
+    Underlying(#[source] E),
+    /// EGL error during `eglSwapBuffers`
+    #[error("{0:}")]
+    EGLSwapBuffers(#[source] EGLError),
+    /// EGL error during `eglCreateWindowSurface`
+    #[error("{0:}")]
+    EGLCreateWindowSurface(#[source] EGLError),
+}
+
+impl<E: std::error::Error> std::convert::TryFrom<SwapBuffersError<E>> for GraphicsSwapBuffersError {
+    type Error=E;
+    fn try_from(value: SwapBuffersError<E>) -> Result<Self, Self::Error> {
+        match value {
+            // bad surface is answered with a surface recreation in `swap_buffers`
+            x @ SwapBuffersError::EGLSwapBuffers(EGLError::BadSurface) => Ok(GraphicsSwapBuffersError::TemporaryFailure(Box::new(x))),
+            // the rest is either never happening or are unrecoverable
+            x @ SwapBuffersError::EGLSwapBuffers(_) => Ok(GraphicsSwapBuffersError::ContextLost(Box::new(x))),
+            x @ SwapBuffersError::EGLCreateWindowSurface(_) => Ok(GraphicsSwapBuffersError::ContextLost(Box::new(x))),
+            SwapBuffersError::Underlying(e) => Err(e),
+        }
+    }
+}
+
+/// Error that can happen when making a context (and surface) current on the active thread.
+#[derive(thiserror::Error, Debug)]
+#[error("`eglMakeCurrent` failed: {0}")]
+pub struct MakeCurrentError(#[from] EGLError);
+
+impl From<MakeCurrentError> for GraphicsSwapBuffersError {
+    fn from(err: MakeCurrentError) -> GraphicsSwapBuffersError {
+        match err {
+            /*
+            From khronos docs:
+                If draw or read are not compatible with context, then an EGL_BAD_MATCH error is generated.
+                If context is current to some other thread, or if either draw or read are bound to contexts in another thread, an EGL_BAD_ACCESS error is generated.
+                If binding context would exceed the number of current contexts of that client API type supported by the implementation, an EGL_BAD_ACCESS error is generated.
+                If either draw or read are pbuffers created with eglCreatePbufferFromClientBuffer, and the underlying bound client API buffers are in use by the client API that created them, an EGL_BAD_ACCESS error is generated.
+
+            Except for the first case all of these recoverable. This conversation is mostly used in winit & EglSurface, where compatible context and surfaces are build.
+            */
+            x @ MakeCurrentError(EGLError::BadAccess) => GraphicsSwapBuffersError::TemporaryFailure(Box::new(x)),
+            // BadSurface would result in a recreation in `eglSwapBuffers` -> recoverable
+            x @ MakeCurrentError(EGLError::BadSurface) => GraphicsSwapBuffersError::TemporaryFailure(Box::new(x)),
+            /*
+            From khronos docs:
+                If the previous context of the calling thread has unflushed commands, and the previous surface is no longer valid, an EGL_BAD_CURRENT_SURFACE error is generated.
+            
+            This does not consern this or future `makeCurrent`-calls.
+            */
+            x @ MakeCurrentError(EGLError::BadCurrentSurface) => GraphicsSwapBuffersError::TemporaryFailure(Box::new(x)),
+            // the rest is either never happening or are unrecoverable
+            x => GraphicsSwapBuffersError::ContextLost(Box::new(x)),
         }
     }
 }
@@ -249,6 +321,7 @@ impl EGLImages {
 impl Drop for EGLImages {
     fn drop(&mut self) {
         for image in self.images.drain(..) {
+            // ignore result on drop
             unsafe {
                 ffi::egl::DestroyImageKHR(**self.display, image);
             }

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -1,6 +1,6 @@
 //! Type safe native types for safe context/surface creation
 
-use super::{ffi, Error, EGLError, wrap_egl_call};
+use super::{ffi, wrap_egl_call, EGLError, Error};
 
 #[cfg(feature = "backend_winit")]
 use std::ptr;
@@ -47,11 +47,19 @@ impl Backend for Wayland {
     {
         if has_dp_extension("EGL_KHR_platform_wayland") && ffi::egl::GetPlatformDisplay::is_loaded() {
             trace!(log, "EGL Display Initialization via EGL_KHR_platform_wayland");
-            wrap_egl_call(|| ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_WAYLAND_KHR, display as *mut _, ptr::null()))
+            wrap_egl_call(|| {
+                ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_WAYLAND_KHR, display as *mut _, ptr::null())
+            })
         } else if has_dp_extension("EGL_EXT_platform_wayland") && ffi::egl::GetPlatformDisplayEXT::is_loaded()
         {
             trace!(log, "EGL Display Initialization via EGL_EXT_platform_wayland");
-            wrap_egl_call(|| ffi::egl::GetPlatformDisplayEXT(ffi::egl::PLATFORM_WAYLAND_EXT, display as *mut _, ptr::null()))
+            wrap_egl_call(|| {
+                ffi::egl::GetPlatformDisplayEXT(
+                    ffi::egl::PLATFORM_WAYLAND_EXT,
+                    display as *mut _,
+                    ptr::null(),
+                )
+            })
         } else {
             trace!(log, "Default EGL Display Initialization via GetDisplay");
             wrap_egl_call(|| ffi::egl::GetDisplay(display as *mut _))
@@ -79,10 +87,14 @@ impl Backend for X11 {
     {
         if has_dp_extension("EGL_KHR_platform_x11") && ffi::egl::GetPlatformDisplay::is_loaded() {
             trace!(log, "EGL Display Initialization via EGL_KHR_platform_x11");
-            wrap_egl_call(|| ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_X11_KHR, display as *mut _, ptr::null()))
+            wrap_egl_call(|| {
+                ffi::egl::GetPlatformDisplay(ffi::egl::PLATFORM_X11_KHR, display as *mut _, ptr::null())
+            })
         } else if has_dp_extension("EGL_EXT_platform_x11") && ffi::egl::GetPlatformDisplayEXT::is_loaded() {
             trace!(log, "EGL Display Initialization via EGL_EXT_platform_x11");
-            wrap_egl_call(|| ffi::egl::GetPlatformDisplayEXT(ffi::egl::PLATFORM_X11_EXT, display as *mut _, ptr::null()))
+            wrap_egl_call(|| {
+                ffi::egl::GetPlatformDisplayEXT(ffi::egl::PLATFORM_X11_EXT, display as *mut _, ptr::null())
+            })
         } else {
             trace!(log, "Default EGL Display Initialization via GetDisplay");
             wrap_egl_call(|| ffi::egl::GetDisplay(display as *mut _))
@@ -203,7 +215,9 @@ pub unsafe trait NativeSurface {
 #[derive(Debug)]
 pub enum Never {}
 impl std::fmt::Display for Never {
-    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { unreachable!() }
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unreachable!()
+    }
 }
 impl std::error::Error for Never {}
 
@@ -222,7 +236,7 @@ unsafe impl NativeSurface for XlibWindow {
 unsafe impl NativeSurface for wegl::WlEglSurface {
     // type Error = !;
     type Error = Never;
-    
+
     fn ptr(&self) -> ffi::NativeWindowType {
         self.ptr() as *const _
     }

--- a/src/backend/graphics/glium.rs
+++ b/src/backend/graphics/glium.rs
@@ -4,35 +4,30 @@ use crate::backend::graphics::{gl::GLGraphicsBackend, SwapBuffersError};
 use glium::{
     backend::{Backend, Context, Facade},
     debug::DebugCallbackBehavior,
-    Frame, SwapBuffersError as GliumSwapBuffersError,
+    SwapBuffersError as GliumSwapBuffersError,
 };
 use std::{
-    cell::{Ref, RefCell, RefMut},
+    cell::{Cell, Ref, RefCell, RefMut},
     os::raw::c_void,
     rc::Rc,
 };
-
-impl From<SwapBuffersError> for GliumSwapBuffersError {
-    fn from(error: SwapBuffersError) -> Self {
-        match error {
-            SwapBuffersError::ContextLost => GliumSwapBuffersError::ContextLost,
-            SwapBuffersError::AlreadySwapped => GliumSwapBuffersError::AlreadySwapped,
-            SwapBuffersError::Unknown(_) => GliumSwapBuffersError::ContextLost, // TODO
-        }
-    }
-}
 
 /// Wrapper to expose `Glium` compatibility
 pub struct GliumGraphicsBackend<T: GLGraphicsBackend> {
     context: Rc<Context>,
     backend: Rc<InternalBackend<T>>,
+    // at least this type is not `Send` or even `Sync`.
+    // while there can be multiple Frames, they cannot in parallel call `set_finish`.
+    // so a buffer of the last error is sufficient, if always cleared...
+    error_channel: Rc<Cell<Option<Box<dyn std::error::Error>>>>,
 }
 
-struct InternalBackend<T: GLGraphicsBackend>(RefCell<T>);
+struct InternalBackend<T: GLGraphicsBackend>(RefCell<T>, Rc<Cell<Option<Box<dyn std::error::Error>>>>);
 
 impl<T: GLGraphicsBackend + 'static> GliumGraphicsBackend<T> {
     fn new(backend: T) -> GliumGraphicsBackend<T> {
-        let internal = Rc::new(InternalBackend(RefCell::new(backend)));
+        let error_channel = Rc::new(Cell::new(None));
+        let internal = Rc::new(InternalBackend(RefCell::new(backend), error_channel.clone()));
 
         GliumGraphicsBackend {
             // cannot fail
@@ -40,6 +35,7 @@ impl<T: GLGraphicsBackend + 'static> GliumGraphicsBackend<T> {
                 Context::new(internal.clone(), true, DebugCallbackBehavior::default()).unwrap()
             },
             backend: internal,
+            error_channel,
         }
     }
 
@@ -51,7 +47,7 @@ impl<T: GLGraphicsBackend + 'static> GliumGraphicsBackend<T> {
     /// Note that destroying a [`Frame`] is immediate, even if vsync is enabled.
     #[inline]
     pub fn draw(&self) -> Frame {
-        Frame::new(self.context.clone(), self.backend.get_framebuffer_dimensions())
+        Frame(glium::Frame::new(self.context.clone(), self.backend.get_framebuffer_dimensions()), self.error_channel.clone())
     }
 
     /// Borrow the underlying backend.
@@ -88,7 +84,20 @@ impl<T: GLGraphicsBackend + 'static> From<T> for GliumGraphicsBackend<T> {
 
 unsafe impl<T: GLGraphicsBackend> Backend for InternalBackend<T> {
     fn swap_buffers(&self) -> Result<(), GliumSwapBuffersError> {
-        self.0.borrow().swap_buffers().map_err(Into::into)
+        if let Err(err) = self.0.borrow().swap_buffers() {
+            Err(match err {
+                SwapBuffersError::ContextLost(err) => {
+                    self.1.set(Some(err));
+                    GliumSwapBuffersError::ContextLost
+                },
+                SwapBuffersError::TemporaryFailure(err) => {
+                    self.1.set(Some(err));
+                    GliumSwapBuffersError::AlreadySwapped
+                }
+                // I do not think, this may happen, but why not
+                SwapBuffersError::AlreadySwapped => GliumSwapBuffersError::AlreadySwapped,
+            })
+        } else { Ok(()) }
     }
 
     unsafe fn get_proc_address(&self, symbol: &str) -> *const c_void {
@@ -104,6 +113,94 @@ unsafe impl<T: GLGraphicsBackend> Backend for InternalBackend<T> {
     }
 
     unsafe fn make_current(&self) {
+        // TODO, if this ever blows up anvil, we should probably silently ignore this.
+        // But I have no idea, if that may happen or what glium does, if the context is not current...
+        // So lets leave this in to do some real world testing
         self.0.borrow().make_current().expect("Context was lost")
+    }
+}
+
+/// Omplementation of `glium::Surface`, targeting the default framebuffer.
+/// 
+/// The back- and front-buffers are swapped when you call `finish`.
+/// 
+/// You **must** call either `finish` or `set_finish` or else the destructor will panic.
+pub struct Frame(glium::Frame, Rc<Cell<Option<Box<dyn std::error::Error>>>>);
+
+impl Frame {
+    /// Stop drawing, swap the buffers, and consume the Frame.
+    /// 
+    /// See the documentation of [`SwapBuffersError`] about what is being returned.
+    pub fn finish(mut self) -> Result<(), SwapBuffersError> {
+        self.set_finish()
+    }
+
+    /// Stop drawing, swap the buffers.
+    ///
+    /// The Frame can now be dropped regularly. Calling `finish()` or `set_finish()` again will cause `Err(SwapBuffersError::AlreadySwapped)` to be returned.
+    pub fn set_finish(&mut self) -> Result<(), SwapBuffersError> {
+        let res = self.0.set_finish();
+        let err = self.1.take();
+        match (res, err) {
+            (Ok(()), _) => Ok(()),
+            (Err(GliumSwapBuffersError::AlreadySwapped), Some(err)) => Err(SwapBuffersError::TemporaryFailure(err)),
+            (Err(GliumSwapBuffersError::AlreadySwapped), None) => Err(SwapBuffersError::AlreadySwapped),
+            (Err(GliumSwapBuffersError::ContextLost), Some(err)) => Err(SwapBuffersError::ContextLost(err)), 
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl glium::Surface for Frame {
+    fn clear(&mut self, rect: Option<&glium::Rect>, color: Option<(f32, f32, f32, f32)>, color_srgb: bool,
+             depth: Option<f32>, stencil: Option<i32>)
+    {
+        self.0.clear(rect, color, color_srgb, depth, stencil)
+    }
+    
+    fn get_dimensions(&self) -> (u32, u32) {
+        self.0.get_dimensions()
+    }
+
+    fn get_depth_buffer_bits(&self) -> Option<u16> {
+        self.0.get_depth_buffer_bits()
+    }
+
+    fn get_stencil_buffer_bits(&self) -> Option<u16> {
+        self.0.get_stencil_buffer_bits()
+    }
+
+    fn draw<'a, 'b, V, I, U>(&mut self, v: V, i: I, program: &glium::Program, uniforms: &U,
+        draw_parameters: &glium::draw_parameters::DrawParameters<'_>) -> Result<(), glium::DrawError> where
+        V: glium::vertex::MultiVerticesSource<'b>, I: Into<glium::index::IndicesSource<'a>>,
+        U: glium::uniforms::Uniforms
+    {
+        self.0.draw(v, i, program, uniforms, draw_parameters)
+    }
+
+    fn blit_from_frame(&self, source_rect: &glium::Rect, target_rect: &glium::BlitTarget,
+                       filter: glium::uniforms::MagnifySamplerFilter)
+    {
+        self.0.blit_from_frame(source_rect, target_rect, filter);
+    }
+
+    fn blit_from_simple_framebuffer(&self, source: &glium::framebuffer::SimpleFrameBuffer<'_>,
+                                    source_rect: &glium::Rect, target_rect: &glium::BlitTarget,
+                                    filter: glium::uniforms::MagnifySamplerFilter)
+    {
+        self.0.blit_from_simple_framebuffer(source, source_rect, target_rect, filter)
+    }
+
+    fn blit_from_multioutput_framebuffer(&self, source: &glium::framebuffer::MultiOutputFrameBuffer<'_>,
+                                         source_rect: &glium::Rect, target_rect: &glium::BlitTarget,
+                                         filter: glium::uniforms::MagnifySamplerFilter)
+    {
+        self.0.blit_from_multioutput_framebuffer(source, source_rect, target_rect, filter)
+    }
+
+    fn blit_color<S>(&self, source_rect: &glium::Rect, target: &S, target_rect: &glium::BlitTarget,
+                     filter: glium::uniforms::MagnifySamplerFilter) where S: glium::Surface
+    {
+        self.0.blit_color(source_rect, target, target_rect, filter)
     }
 }

--- a/src/backend/graphics/mod.rs
+++ b/src/backend/graphics/mod.rs
@@ -16,24 +16,33 @@ pub mod glium;
 pub mod software;
 
 /// Error that can happen when swapping buffers.
-#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum SwapBuffersError {
-    /// The corresponding context has been lost and needs to be recreated.
-    ///
-    /// All the objects associated to it (textures, buffers, programs, etc.)
-    /// need to be recreated from scratch.
-    ///
-    /// Operations will have no effect. Functions that read textures, buffers, etc.
-    /// will return uninitialized data instead.
-    #[error("The context has been lost, it needs to be recreated")]
-    ContextLost,
     /// The buffers have already been swapped.
     ///
     /// This error can be returned when `swap_buffers` has been called multiple times
     /// without any modification in between.
     #[error("Buffers are already swapped, swap_buffers was called too many times")]
     AlreadySwapped,
-    /// Unknown error
-    #[error("Unknown error: {0:x}")]
-    Unknown(u32),
+    /// The corresponding context has been lost and needs to be recreated.
+    ///
+    /// All the objects associated to it (textures, buffers, programs, etc.)
+    /// need to be recreated from scratch. Underlying resources like native surfaces
+    /// might also need to be recreated.
+    ///
+    /// Operations will have no effect. Functions that read textures, buffers, etc.
+    /// will return uninitialized data instead.
+    #[error("The context has been lost, it needs to be recreated")]
+    ContextLost(Box<dyn std::error::Error>),
+    /// A temporary condition caused to rendering to fail.
+    ///
+    /// Depending on the underlying error this *might* require fixing internal state of the rendering backend,
+    /// but failures mapped to `TemporaryFailure` are always recoverable without re-creating the entire stack,
+    /// as is represented by `ContextLost`.
+    ///
+    /// Proceed after investigating the source to reschedule another full rendering step or just this page_flip at a later time.
+    /// If the root cause cannot be discovered and subsequent renderings also fail, it is advised to fallback to
+    /// recreation.
+    #[error("A temporary condition caused the page flip to fail.")]
+    TemporaryFailure(Box<dyn std::error::Error>),
 }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -50,7 +50,7 @@ pub enum Error {
     EGL(#[from] EGLError),
     /// Surface Creation failed
     #[error("Surface creation failed: {0}")]
-    SurfaceCreationError(#[from] SurfaceCreationError<EGLError>)
+    SurfaceCreationError(#[from] SurfaceCreationError<EGLError>),
 }
 
 enum Window {
@@ -281,7 +281,9 @@ impl GLGraphicsBackend for WinitGraphicsBackend {
     fn swap_buffers(&self) -> ::std::result::Result<(), SwapBuffersError> {
         trace!(self.logger, "Swapping buffers");
         match *self.window {
-            Window::Wayland { ref surface, .. } => surface.swap_buffers().map_err(|err| err.try_into().unwrap()),
+            Window::Wayland { ref surface, .. } => {
+                surface.swap_buffers().map_err(|err| err.try_into().unwrap())
+            }
             Window::X11 { ref surface, .. } => surface.swap_buffers().map_err(|err| err.try_into().unwrap()),
         }
     }


### PR DESCRIPTION
This is a first of a set of PRs addressing #205 .

This consists out of a number of small commits each doing some refactoring on the drm code (mostly legacy/atomic).

The changes are addressing:
- [x] (Optionally) initialize all connectors to a known state on device creation (disabled)
- [x] Allow forcing the old `LegacyDrmDevice` for testing
- [x] Require all `Surface`s to always have a proper `Mode` set (after the first commit)
- [x] Properly enable/disable connectors when attached/detached to a `Surface`
- [x] Do not try any ioctl's on inactive `Device`s
- [x] Do not allow `Surface`s without a connector (just drop it instead)
- [ ] Some refinements on session-handling (not completely done, tty-switching is still broken, will be fixed when we can handle failed page_flips)
- Some cleanups