### PR TITLE
Rework rendering loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           override: true
       
       - name: System dependencies
-        run: sudo apt-get install libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libsystemd-dev libdbus-1-dev 
+        run: sudo apt-get update; sudo apt-get install libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libsystemd-dev libdbus-1-dev
 
       - name: Test features
         if: matrix.features != 'all'
@@ -100,7 +100,7 @@ jobs:
           override: true
 
       - name: System dependencies
-        run: sudo apt-get install libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libsystemd-dev libdbus-1-dev
+        run: sudo apt-get update; sudo apt-get install libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libsystemd-dev libdbus-1-dev
 
       - name: Test features
         if: matrix.features != 'all'
@@ -128,7 +128,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: System dependencies
-        run: sudo apt-get install libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libsystemd-dev libdbus-1-dev
+        run: sudo apt-get update; sudo apt-get install libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libsystemd-dev libdbus-1-dev
 
       - name: Cargo fmt
         run: cargo fmt --all -- --check

--- a/anvil/src/glium_drawer.rs
+++ b/anvil/src/glium_drawer.rs
@@ -16,7 +16,11 @@ use smithay::backend::egl::display::EGLBufferReader;
 use smithay::{
     backend::{
         egl::{BufferAccessError, EGLImages, Format},
-        graphics::{gl::GLGraphicsBackend, glium::{GliumGraphicsBackend, Frame}, SwapBuffersError},
+        graphics::{
+            gl::GLGraphicsBackend,
+            glium::{Frame, GliumGraphicsBackend},
+            SwapBuffersError,
+        },
     },
     reexports::{
         calloop::LoopHandle,
@@ -458,21 +462,21 @@ impl<F: GLGraphicsBackend + 'static> GliumDrawer<F> {
     }
 }
 
-pub fn schedule_initial_render<F: GLGraphicsBackend + 'static, Data: 'static>(renderer: Rc<GliumDrawer<F>>, evt_handle: &LoopHandle<Data>) {
+pub fn schedule_initial_render<F: GLGraphicsBackend + 'static, Data: 'static>(
+    renderer: Rc<GliumDrawer<F>>,
+    evt_handle: &LoopHandle<Data>,
+) {
     let mut frame = renderer.draw();
     frame.clear_color(0.8, 0.8, 0.9, 1.0);
     if let Err(err) = frame.set_finish() {
         match err {
-            SwapBuffersError::AlreadySwapped => {},
+            SwapBuffersError::AlreadySwapped => {}
             SwapBuffersError::TemporaryFailure(err) => {
                 // TODO dont reschedule after 3(?) retries
-                error!(
-                    renderer.log,
-                    "Failed to submit page_flip: {}", err
-                );
+                error!(renderer.log, "Failed to submit page_flip: {}", err);
                 let handle = evt_handle.clone();
                 evt_handle.insert_idle(move |_| schedule_initial_render(renderer, &handle));
-            },
+            }
             SwapBuffersError::ContextLost(err) => panic!("Rendering loop lost: {}", err),
         }
     }

--- a/anvil/src/glium_drawer.rs
+++ b/anvil/src/glium_drawer.rs
@@ -16,12 +16,12 @@ use smithay::backend::egl::display::EGLBufferReader;
 use smithay::{
     backend::{
         egl::{BufferAccessError, EGLImages, Format},
-        graphics::{
-            gl::GLGraphicsBackend,
-            glium::{Frame, GliumGraphicsBackend},
-        },
+        graphics::{gl::GLGraphicsBackend, glium::{GliumGraphicsBackend, Frame}, SwapBuffersError},
     },
-    reexports::wayland_server::protocol::{wl_buffer, wl_surface},
+    reexports::{
+        calloop::LoopHandle,
+        wayland_server::protocol::{wl_buffer, wl_surface},
+    },
     wayland::{
         compositor::{roles::Role, SubsurfaceRole, TraversalAction},
         data_device::DnDIconRole,
@@ -455,5 +455,25 @@ impl<F: GLGraphicsBackend + 'static> GliumDrawer<F> {
         }
         let screen_dimensions = self.borrow().get_framebuffer_dimensions();
         self.draw_surface_tree(frame, surface, (x, y), token, screen_dimensions);
+    }
+}
+
+pub fn schedule_initial_render<F: GLGraphicsBackend + 'static, Data: 'static>(renderer: Rc<GliumDrawer<F>>, evt_handle: &LoopHandle<Data>) {
+    let mut frame = renderer.draw();
+    frame.clear_color(0.8, 0.8, 0.9, 1.0);
+    if let Err(err) = frame.set_finish() {
+        match err {
+            SwapBuffersError::AlreadySwapped => {},
+            SwapBuffersError::TemporaryFailure(err) => {
+                // TODO dont reschedule after 3(?) retries
+                error!(
+                    renderer.log,
+                    "Failed to submit page_flip: {}", err
+                );
+                let handle = evt_handle.clone();
+                evt_handle.insert_idle(move |_| schedule_initial_render(renderer, &handle));
+            },
+            SwapBuffersError::ContextLost(err) => panic!("Rendering loop lost: {}", err),
+        }
     }
 }

--- a/anvil/src/glium_drawer.rs
+++ b/anvil/src/glium_drawer.rs
@@ -473,7 +473,7 @@ pub fn schedule_initial_render<F: GLGraphicsBackend + 'static, Data: 'static>(
             SwapBuffersError::AlreadySwapped => {}
             SwapBuffersError::TemporaryFailure(err) => {
                 // TODO dont reschedule after 3(?) retries
-                error!(renderer.log, "Failed to submit page_flip: {}", err);
+                warn!(renderer.log, "Failed to submit page_flip: {}", err);
                 let handle = evt_handle.clone();
                 evt_handle.insert_idle(move |_| schedule_initial_render(renderer, &handle));
             }

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -380,7 +380,7 @@ impl<S: SessionNotifier, Data: 'static> UdevHandlerImpl<S, Data> {
                 |fd| match FallbackDevice::new(SessionFd(fd), true, self.logger.clone()) {
                     Ok(drm) => Some(drm),
                     Err(err) => {
-                        error!(self.logger, "Skipping drm device, because of error: {}", err);
+                        warn!(self.logger, "Skipping drm device, because of error: {}", err);
                         None
                     }
                 },
@@ -388,14 +388,14 @@ impl<S: SessionNotifier, Data: 'static> UdevHandlerImpl<S, Data> {
             .and_then(|drm| match GbmDevice::new(drm, self.logger.clone()) {
                 Ok(gbm) => Some(gbm),
                 Err(err) => {
-                    error!(self.logger, "Skipping gbm device, because of error: {}", err);
+                    warn!(self.logger, "Skipping gbm device, because of error: {}", err);
                     None
                 }
             })
             .and_then(|gbm| match EglDevice::new(gbm, self.logger.clone()) {
                 Ok(egl) => Some(egl),
                 Err(err) => {
-                    error!(self.logger, "Skipping egl device, because of error: {}", err);
+                    warn!(self.logger, "Skipping egl device, because of error: {}", err);
                     None
                 }
             })
@@ -636,7 +636,7 @@ impl DrmRenderer {
             }
 
             if let Err(err) = result {
-                error!(self.logger, "Error during rendering: {:?}", err);
+                warn!(self.logger, "Error during rendering: {:?}", err);
                 let reschedule = match err {
                     SwapBuffersError::AlreadySwapped => false,
                     SwapBuffersError::TemporaryFailure(err) => {

--- a/src/backend/drm/atomic/mod.rs
+++ b/src/backend/drm/atomic/mod.rs
@@ -389,29 +389,21 @@ impl<A: AsRawFd + 'static> Device for AtomicDrmDevice<A> {
                 for event in events {
                     if let Event::PageFlip(event) = event {
                         trace!(self.logger, "Got a page-flip event for crtc ({:?})", event.crtc);
-                        if self.active.load(Ordering::SeqCst) {
-                            if self
-                                .backends
-                                .borrow()
-                                .get(&event.crtc)
-                                .iter()
-                                .flat_map(|x| x.upgrade())
-                                .next()
-                                .is_some()
-                            {
-                                trace!(self.logger, "Handling event for backend {:?}", event.crtc);
-                                if let Some(handler) = self.handler.as_ref() {
-                                    handler.borrow_mut().vblank(event.crtc);
-                                }
-                            } else {
-                                self.backends.borrow_mut().remove(&event.crtc);
+                        if self
+                            .backends
+                            .borrow()
+                            .get(&event.crtc)
+                            .iter()
+                            .flat_map(|x| x.upgrade())
+                            .next()
+                            .is_some()
+                        {
+                            trace!(self.logger, "Handling event for backend {:?}", event.crtc);
+                            if let Some(handler) = self.handler.as_ref() {
+                                handler.borrow_mut().vblank(event.crtc);
                             }
                         } else {
-                            debug!(
-                                self.logger,
-                                "Device ({:?}) not active. Ignoring PageFlip",
-                                self.dev_path()
-                            );
+                            self.backends.borrow_mut().remove(&event.crtc);
                         }
                     } else {
                         trace!(

--- a/src/backend/drm/atomic/session.rs
+++ b/src/backend/drm/atomic/session.rs
@@ -166,15 +166,15 @@ impl<A: AsRawFd + 'static> AtomicDrmDeviceObserver<A> {
                     current.mode = unsafe { std::mem::zeroed() };
 
                     // recreate property blob
-                    let mode = { 
+                    let mode = {
                         let pending = surface.pending.read().unwrap();
-                        pending.mode.clone()
+                        pending.mode
                     };
                     surface.use_mode(mode)?;
 
                     // drop cursor state
                     surface.cursor.position.set(None);
-                    surface.cursor.hotspot.set((0,0));
+                    surface.cursor.hotspot.set((0, 0));
                     surface.cursor.framebuffer.set(None);
                 }
             }

--- a/src/backend/drm/atomic/surface.rs
+++ b/src/backend/drm/atomic/surface.rs
@@ -535,20 +535,21 @@ impl<A: AsRawFd + 'static> RawSurface for AtomicDrmSurfaceInternal<A> {
         };
 
         debug!(self.logger, "Setting screen: {:?}", req);
-        let result = self.atomic_commit(
-            &[
-                AtomicCommitFlags::PageFlipEvent,
-                AtomicCommitFlags::AllowModeset,
-                AtomicCommitFlags::Nonblock,
-            ],
-            req,
-        )
-        .compat()
-        .map_err(|source| Error::Access {
-            errmsg: "Error setting crtc",
-            dev: self.dev_path(),
-            source,
-        });
+        let result = self
+            .atomic_commit(
+                &[
+                    AtomicCommitFlags::PageFlipEvent,
+                    AtomicCommitFlags::AllowModeset,
+                    AtomicCommitFlags::Nonblock,
+                ],
+                req,
+            )
+            .compat()
+            .map_err(|source| Error::Access {
+                errmsg: "Error setting crtc",
+                dev: self.dev_path(),
+                source,
+            });
 
         if result.is_ok() {
             *current = pending.clone();
@@ -617,13 +618,13 @@ impl<A: AsRawFd + 'static> CursorBackend for AtomicDrmSurfaceInternal<A> {
         }
 
         self.cursor.framebuffer.set(Some(
-            self.add_planar_framebuffer(buffer, &[0; 4], 0).compat().map_err(
-                |source| Error::Access {
+            self.add_planar_framebuffer(buffer, &[0; 4], 0)
+                .compat()
+                .map_err(|source| Error::Access {
                     errmsg: "Failed to import cursor",
                     dev: self.dev_path(),
                     source,
-                },
-            )?,
+                })?,
         ));
 
         self.cursor.hotspot.set(hotspot);
@@ -858,7 +859,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurfaceInternal<A> {
                         self.plane_prop_handle(planes.cursor, "FB_ID")?,
                         property::Value::Framebuffer(Some(fb)),
                     );
-                },
+                }
                 Err(err) => {
                     warn!(self.logger, "Cursor FB invalid: {}. Skipping.", err);
                     self.cursor.framebuffer.set(None);

--- a/src/backend/drm/atomic/surface.rs
+++ b/src/backend/drm/atomic/surface.rs
@@ -861,6 +861,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurfaceInternal<A> {
                 },
                 Err(err) => {
                     warn!(self.logger, "Cursor FB invalid: {}. Skipping.", err);
+                    self.cursor.framebuffer.set(None);
                 }
             }
         }

--- a/src/backend/drm/atomic/surface.rs
+++ b/src/backend/drm/atomic/surface.rs
@@ -20,9 +20,9 @@ use crate::backend::graphics::CursorBackend;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CursorState {
-    position: Cell<Option<(u32, u32)>>,
-    hotspot: Cell<(u32, u32)>,
-    framebuffer: Cell<Option<framebuffer::Handle>>,
+    pub position: Cell<Option<(u32, u32)>>,
+    pub hotspot: Cell<(u32, u32)>,
+    pub framebuffer: Cell<Option<framebuffer::Handle>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/backend/drm/atomic/surface.rs
+++ b/src/backend/drm/atomic/surface.rs
@@ -571,7 +571,7 @@ impl<A: AsRawFd + 'static> RawSurface for AtomicDrmSurfaceInternal<A> {
             None,
         )?;
 
-        trace!(self.logger, "Queueing page flip: {:#?}", req);
+        trace!(self.logger, "Queueing page flip: {:?}", req);
         self.atomic_commit(
             &[AtomicCommitFlags::PageFlipEvent, AtomicCommitFlags::Nonblock],
             req,

--- a/src/backend/drm/atomic/surface.rs
+++ b/src/backend/drm/atomic/surface.rs
@@ -454,7 +454,7 @@ impl<A: AsRawFd + 'static> RawSurface for AtomicDrmSurfaceInternal<A> {
         }
 
         let mut current = self.state.write().unwrap();
-        let mut pending = self.pending.write().unwrap();
+        let pending = self.pending.write().unwrap();
 
         debug!(
             self.logger,
@@ -510,18 +510,8 @@ impl<A: AsRawFd + 'static> RawSurface for AtomicDrmSurfaceInternal<A> {
                     self.logger,
                     "New screen configuration invalid!:\n\t{:#?}\n\t{}\n", req, err
                 );
-                info!(self.logger, "Reverting back to last know good state");
-
-                *pending = current.clone();
-
-                self.build_request(
-                    &mut [].iter(),
-                    &mut [].iter(),
-                    &self.planes,
-                    Some(framebuffer),
-                    Some(current.mode),
-                    Some(current.blob),
-                )?
+                
+                return Err(err);
             } else {
                 if current.mode != pending.mode {
                     if let Err(err) = self.dev.destroy_property_blob(current.blob.into()) {

--- a/src/backend/drm/atomic/surface.rs
+++ b/src/backend/drm/atomic/surface.rs
@@ -66,6 +66,11 @@ impl<A: AsRawFd + 'static> AtomicDrmSurfaceInternal<A> {
         connectors: &[connector::Handle],
         logger: ::slog::Logger,
     ) -> Result<Self, Error> {
+        info!(
+            logger,
+            "Initializing drm surface with mode {:?} and connectors {:?}", mode, connectors
+        );
+
         let crtc_info = dev.get_crtc(crtc).compat().map_err(|source| Error::Access {
             errmsg: "Error loading crtc info",
             dev: dev.dev_path(),
@@ -510,7 +515,7 @@ impl<A: AsRawFd + 'static> RawSurface for AtomicDrmSurfaceInternal<A> {
                     self.logger,
                     "New screen configuration invalid!:\n\t{:#?}\n\t{}\n", req, err
                 );
-                
+
                 return Err(err);
             } else {
                 if current.mode != pending.mode {

--- a/src/backend/drm/common/fallback.rs
+++ b/src/backend/drm/common/fallback.rs
@@ -191,7 +191,7 @@ impl<A: AsRawFd + Clone + 'static> FallbackDevice<AtomicDrmDevice<A>, LegacyDrmD
         match AtomicDrmDevice::new(fd.clone(), disable_connectors, log.clone()) {
             Ok(dev) => Ok(FallbackDevice::Preference(dev)),
             Err(err) => {
-                error!(log, "Failed to initialize preferred AtomicDrmDevice: {}", err);
+                warn!(log, "Failed to initialize preferred AtomicDrmDevice: {}", err);
                 info!(log, "Falling back to fallback LegacyDrmDevice");
                 Ok(FallbackDevice::Fallback(LegacyDrmDevice::new(
                     fd,

--- a/src/backend/drm/common/mod.rs
+++ b/src/backend/drm/common/mod.rs
@@ -78,6 +78,7 @@ impl Into<SwapBuffersError> for Error {
             x @ Error::DeviceInactive => SwapBuffersError::TemporaryFailure(Box::new(x)),
             Error::Access { errmsg, dev, source, .. }
                 if match source.get_ref() {
+                    drm::SystemError::PermissionDenied => true,
                     drm::SystemError::Unknown {
                         errno: nix::errno::Errno::EBUSY,
                     } => true,

--- a/src/backend/drm/common/mod.rs
+++ b/src/backend/drm/common/mod.rs
@@ -76,20 +76,21 @@ impl Into<SwapBuffersError> for Error {
     fn into(self) -> SwapBuffersError {
         match self {
             x @ Error::DeviceInactive => SwapBuffersError::TemporaryFailure(Box::new(x)),
-            Error::Access { errmsg, dev, source, .. }
-                if match source.get_ref() {
-                    drm::SystemError::PermissionDenied => true,
-                    drm::SystemError::Unknown {
-                        errno: nix::errno::Errno::EBUSY,
-                    } => true,
-                    drm::SystemError::Unknown {
-                        errno: nix::errno::Errno::EINTR,
-                    } => true,
-                    _ => false,
-                } =>
+            Error::Access {
+                errmsg, dev, source, ..
+            } if match source.get_ref() {
+                drm::SystemError::PermissionDenied => true,
+                drm::SystemError::Unknown {
+                    errno: nix::errno::Errno::EBUSY,
+                } => true,
+                drm::SystemError::Unknown {
+                    errno: nix::errno::Errno::EINTR,
+                } => true,
+                _ => false,
+            } =>
             {
                 SwapBuffersError::TemporaryFailure(Box::new(Error::Access { errmsg, dev, source }))
-            },
+            }
             x => SwapBuffersError::ContextLost(Box::new(x)),
         }
     }

--- a/src/backend/drm/common/mod.rs
+++ b/src/backend/drm/common/mod.rs
@@ -76,7 +76,7 @@ impl Into<SwapBuffersError> for Error {
     fn into(self) -> SwapBuffersError {
         match self {
             x @ Error::DeviceInactive => SwapBuffersError::TemporaryFailure(Box::new(x)),
-            Error::Access { source, .. }
+            Error::Access { errmsg, dev, source, .. }
                 if match source.get_ref() {
                     drm::SystemError::Unknown {
                         errno: nix::errno::Errno::EBUSY,
@@ -87,8 +87,8 @@ impl Into<SwapBuffersError> for Error {
                     _ => false,
                 } =>
             {
-                SwapBuffersError::TemporaryFailure(Box::new(source))
-            }
+                SwapBuffersError::TemporaryFailure(Box::new(Error::Access { errmsg, dev, source }))
+            },
             x => SwapBuffersError::ContextLost(Box::new(x)),
         }
     }

--- a/src/backend/drm/egl/mod.rs
+++ b/src/backend/drm/egl/mod.rs
@@ -11,7 +11,10 @@
 use drm::control::{connector, crtc, encoder, framebuffer, plane, Mode, ResourceHandles};
 use drm::SystemError as DrmError;
 use nix::libc::dev_t;
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::os::unix::io::{AsRawFd, RawFd};
+use std::rc::{Rc, Weak};
 #[cfg(feature = "use_system_lib")]
 use wayland_server::Display;
 
@@ -58,6 +61,7 @@ where
     logger: ::slog::Logger,
     default_attributes: GlAttributes,
     default_requirements: PixelFormatRequirements,
+    backends: Rc<RefCell<HashMap<crtc::Handle, Weak<EglSurfaceInternal<<D as Device>::Surface>>>>>,
 }
 
 impl<B, D> AsRawFd for EglDevice<B, D>
@@ -125,6 +129,7 @@ where
             dev: EGLDisplay::new(dev, log.clone()).map_err(Error::EGL)?,
             default_attributes,
             default_requirements,
+            backends: Rc::new(RefCell::new(HashMap::new())),
             logger: log,
         })
     }
@@ -208,7 +213,9 @@ where
                 SurfaceCreationError::NativeSurfaceCreationFailed(err) => Error::Underlying(err),
             })?;
 
-        Ok(EglSurface { context, surface })
+        let backend = Rc::new(EglSurfaceInternal { context, surface });
+        self.backends.borrow_mut().insert(crtc, Rc::downgrade(&backend));
+        Ok(EglSurface(backend))
     }
 
     fn process_events(&mut self) {

--- a/src/backend/drm/egl/mod.rs
+++ b/src/backend/drm/egl/mod.rs
@@ -47,6 +47,7 @@ pub enum Error<U: std::error::Error + std::fmt::Debug + std::fmt::Display + 'sta
 }
 
 type Arguments = (crtc::Handle, Mode, Vec<connector::Handle>);
+type BackendRef<D> = Weak<EglSurfaceInternal<<D as Device>::Surface>>;
 
 /// Representation of an egl device to create egl rendering surfaces
 pub struct EglDevice<B, D>
@@ -61,7 +62,7 @@ where
     logger: ::slog::Logger,
     default_attributes: GlAttributes,
     default_requirements: PixelFormatRequirements,
-    backends: Rc<RefCell<HashMap<crtc::Handle, Weak<EglSurfaceInternal<<D as Device>::Surface>>>>>,
+    backends: Rc<RefCell<HashMap<crtc::Handle, BackendRef<D>>>>,
 }
 
 impl<B, D> AsRawFd for EglDevice<B, D>

--- a/src/backend/drm/egl/session.rs
+++ b/src/backend/drm/egl/session.rs
@@ -11,7 +11,10 @@ use std::rc::{Rc, Weak};
 
 use super::{EglDevice, EglSurfaceInternal};
 use crate::backend::drm::{Device, Surface};
-use crate::backend::egl::{ffi, native::{Backend, NativeDisplay, NativeSurface}};
+use crate::backend::egl::{
+    ffi,
+    native::{Backend, NativeDisplay, NativeSurface},
+};
 use crate::backend::session::{AsSessionObserver, SessionObserver};
 
 /// [`SessionObserver`](SessionObserver)
@@ -55,7 +58,9 @@ impl<S: SessionObserver + 'static, N: NativeSurface + Surface> SessionObserver f
                 if let Some(backend) = backend.upgrade() {
                     let old_surface = backend.surface.surface.replace(std::ptr::null());
                     if !old_surface.is_null() {
-                        unsafe { ffi::egl::DestroySurface(**backend.surface.display, old_surface as *const _); }
+                        unsafe {
+                            ffi::egl::DestroySurface(**backend.surface.display, old_surface as *const _);
+                        }
                     }
                 }
             }

--- a/src/backend/drm/gbm/mod.rs
+++ b/src/backend/drm/gbm/mod.rs
@@ -274,7 +274,7 @@ where
                     _ => false,
                 } =>
             {
-                SwapBuffersError::TemporaryFailure(Box::new(x))
+                SwapBuffersError::TemporaryFailure(Box::new(Error::<E>::FramebufferCreationFailed(x)))
             }
             Error::Underlying(x) => x.into(),
             x => SwapBuffersError::ContextLost(Box::new(x)),

--- a/src/backend/drm/gbm/session.rs
+++ b/src/backend/drm/gbm/session.rs
@@ -58,22 +58,7 @@ impl<
         if let Some(backends) = self.backends.upgrade() {
             for (crtc, backend) in backends.borrow().iter() {
                 if let Some(backend) = backend.upgrade() {
-                    // restart rendering loop, if it was previously running
-                    if let Some(current_fb) = backend.current_frame_buffer.get() {
-                        let result = if backend.crtc.commit_pending() {
-                            backend.crtc.commit(current_fb)
-                        } else {
-                            RawSurface::page_flip(&backend.crtc, current_fb)
-                        };
-
-                        if let Err(err) = result {
-                            warn!(
-                                self.logger,
-                                "Failed to restart rendering loop. Re-creating resources. Error: {}", err
-                            );
-                            // TODO bubble up
-                        }
-                    }
+                    backend.clear_framebuffers();
 
                     // reset cursor
                     {

--- a/src/backend/drm/gbm/surface.rs
+++ b/src/backend/drm/gbm/surface.rs
@@ -93,7 +93,7 @@ impl<D: RawDevice + 'static> GbmSurfaceInternal<D> {
                 self.recreated.set(false);
                 self.current_frame_buffer.set(Some(fb));
                 Ok(())
-            },
+            }
             Err(err) => {
                 self.unlock_buffer();
                 Err(err)

--- a/src/backend/drm/legacy/mod.rs
+++ b/src/backend/drm/legacy/mod.rs
@@ -306,25 +306,21 @@ impl<A: AsRawFd + 'static> Device for LegacyDrmDevice<A> {
             Ok(events) => {
                 for event in events {
                     if let Event::PageFlip(event) = event {
-                        if self.active.load(Ordering::SeqCst) {
-                            if self
-                                .backends
-                                .borrow()
-                                .get(&event.crtc)
-                                .iter()
-                                .flat_map(|x| x.upgrade())
-                                .next()
-                                .is_some()
-                            {
-                                trace!(self.logger, "Handling event for backend {:?}", event.crtc);
-                                if let Some(handler) = self.handler.as_ref() {
-                                    handler.borrow_mut().vblank(event.crtc);
-                                }
-                            } else {
-                                self.backends.borrow_mut().remove(&event.crtc);
+                        if self
+                            .backends
+                            .borrow()
+                            .get(&event.crtc)
+                            .iter()
+                            .flat_map(|x| x.upgrade())
+                            .next()
+                            .is_some()
+                        {
+                            trace!(self.logger, "Handling event for backend {:?}", event.crtc);
+                            if let Some(handler) = self.handler.as_ref() {
+                                handler.borrow_mut().vblank(event.crtc);
                             }
                         } else {
-                            debug!(self.logger, "Device not active. Ignoring PageFlip");
+                            self.backends.borrow_mut().remove(&event.crtc);
                         }
                     } else {
                         trace!(self.logger, "Unrelated event");

--- a/src/backend/drm/legacy/surface.rs
+++ b/src/backend/drm/legacy/surface.rs
@@ -311,6 +311,11 @@ impl<A: AsRawFd + 'static> LegacyDrmSurfaceInternal<A> {
         connectors: &[connector::Handle],
         logger: ::slog::Logger,
     ) -> Result<LegacyDrmSurfaceInternal<A>, Error> {
+        info!(
+            logger,
+            "Initializing drm surface with mode {:?} and connectors {:?}", mode, connectors
+        );
+
         // Try to enumarate the current state to set the initial state variable correctly
         let crtc_info = dev.get_crtc(crtc).compat().map_err(|source| Error::Access {
             errmsg: "Error loading crtc info",

--- a/src/backend/egl/surface.rs
+++ b/src/backend/egl/surface.rs
@@ -90,7 +90,9 @@ impl<N: native::NativeSurface> EGLSurface<N> {
             wrap_egl_call(|| unsafe { ffi::egl::SwapBuffers(**self.display, surface as *const _) })
                 .map_err(SwapBuffersError::EGLSwapBuffers)
                 .and_then(|_| self.native.swap_buffers().map_err(SwapBuffersError::Underlying))
-        } else { Err(SwapBuffersError::EGLSwapBuffers(EGLError::BadSurface)) };
+        } else {
+            Err(SwapBuffersError::EGLSwapBuffers(EGLError::BadSurface))
+        };
 
         // workaround for missing `PartialEq` impl
         let is_bad_surface = if let Err(SwapBuffersError::EGLSwapBuffers(EGLError::BadSurface)) = result {

--- a/src/backend/egl/surface.rs
+++ b/src/backend/egl/surface.rs
@@ -72,6 +72,10 @@ impl<N: native::NativeSurface> EGLSurface<N> {
             ffi::egl::CreateWindowSurface(**display, config, native.ptr(), surface_attributes.as_ptr())
         })?;
 
+        if surface == ffi::egl::NO_SURFACE {
+            return Err(EGLError::BadSurface);
+        }
+
         Ok(EGLSurface {
             display,
             native,

--- a/src/backend/session/dbus/logind.rs
+++ b/src/backend/session/dbus/logind.rs
@@ -292,7 +292,7 @@ impl LogindSessionImpl {
                         self.logger,
                         "Request of type \"{}\" to close device ({},{})", pause_type, major, minor
                     );
-                    
+
                     // gone means the device was unplugged from the system and you will no longer get any
                     // notifications about it.
                     // This is handled via udev and is not part of our session api.


### PR DESCRIPTION
This PR ticks a lot of boxes in #205 (and likely fixes #208, #201, #168 along the way).

It is again best reviewed per commit.

- 75e7e47 fixes #208, which was broken by 31b6d844, which was not supposed to be merged in #206, but somehow landed on its branch. It was supposed to be part of this PR, so I cleaned and fixed it up here instead.
- retrying commits/page_flips needs some fixes to allow recovery:
   - b96c63a fixes gbm to unlock buffers again on a failed commit/page_flip
   - f30d9a1 makes sure resource cleanup on the last page_flip before pausing the device still happens
   - 5af599d in case a commit fails, the atomic backend needs to keep the correct state to construct working atomic requests.
   -  6550292 we sometimes get "permission denied", if we have not yet disabled the device, but are in progress of swapping the session. So we need to mark that as potentially temporary as well.
- a lot of stuff in resuming devices was broken:
   - 1cae4bb allows broken cursor framebuffers to be cleaned up (likely after resuming)
   - 428e2cb actually clears up cursor framebuffers on rendering
   - 65825d9 allows egl to cleanup resources on resume
   - d297ae9 forces the recreation of egl-surfaces after resume
   - b9d4e85 clears up cached resources on resume for the atomic code
   - 3228261 fixes invalid state after a failed commit in gbm
- since the rendering loop is now managed by the user/anvil we also do not want to implicitly resume it in smithay: aa65e3d
- 0a45cde is the single most important commit adding logic to anvil to retry failed rendering steps. It is rather quickly tagged onto the existing code and will get reworked, when I redesign the renderer (as planned in #205).
- d297ae9 fixes the issue discovered in #168 by ignoring "gone"-events. What seems like a hack, actually should be a correct fix. I have added documentation statements from logind to the corresponding lines to document the reasoning.
- and some additional cleanups:
  - 9f63364 logging
  - 9461ef0 and b01119d  for consistent errors in `SwapBuffersError`

With all those commits tty-switching and tty-startup works consistently on my machine for both the atomic and the legacy backend.

@kchibisov  @vberger @rvlander @PolyMeilex Some testing to confirm that this is indeed helping the various listed errors, would be very helpful. In case of any errors please save a debug log.

Note: anvil seems to crash sometimes on shutdown. I have no idea, which commits introduced that, but it is rather harmless and likely cause by a broken drop-order. I will investigate that issue, but I want to post-pone that until after the anvil-rendering refactor/rewrite.