### PR TITLE
wayland.seat: Send key event before modifier event

### DIFF
--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -335,10 +335,12 @@ impl KeyboardHandle {
             KeyState::Released => WlKeyState::Released,
         };
         guard.with_focused_kbds(|kbd, _| {
+            // key event must be sent before modifers event for libxkbcommon
+            // to process them correctly
+            kbd.key(serial, time, keycode, wl_state);
             if let Some((dep, la, lo, gr)) = modifiers {
                 kbd.modifiers(serial, dep, la, lo, gr);
             }
-            kbd.key(serial, time, keycode, wl_state);
         });
         if guard.focus.is_some() {
             trace!(self.arc.logger, "Input forwarded to client");


### PR DESCRIPTION
According to this: https://lists.x.org/archives/xorg-devel/2014-July/043110.html

> Sending modifiers before key is _seriously_ broken, and no-one should ever
do it. There are corner cases it completely and horrifically breaks.

So this PR fixes Smithay to not do that.

Thanks @kchibisov for finding this.