### PR TITLE
drm: Make surfaces `Send`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bitflags = "1"
 calloop = "0.6.2"
 dbus = { version = "0.8", optional = true }
 drm = { version = "^0.4.0", git = "https://github.com/drakulix/drm-rs", branch = "develop", optional = true }
-gbm = { version = "^0.6.0", git = "https://github.com/drakulix/gbm.rs", branch = "develop", optional = true, default-features = false, features = ["drm-support"] }
+gbm = { version = "^0.6.0", git = "https://github.com/drakulix/gbm.rs", branch = "thread-safe", optional = true, default-features = false, features = ["drm-support"] }
 glium = { version = "0.27.0", optional = true, default-features = false }
 image = { version = "0.23.0", optional = true }
 input = { version = "0.5", default-features = false, optional = true }

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -17,13 +17,13 @@ use smithay::backend::egl::{display::EGLBufferReader, EGLGraphicsBackend};
 use smithay::{
     backend::{
         drm::{
-            atomic::AtomicDrmDevice,
+            atomic::{AtomicDrmDevice, AtomicDrmSurface},
             common::fallback::{FallbackDevice, FallbackSurface},
             device_bind,
             egl::{EglDevice, EglSurface},
             eglstream::{egl::EglStreamDeviceBackend, EglStreamDevice, EglStreamSurface},
             gbm::{egl::Gbm as EglGbmBackend, GbmDevice, GbmSurface},
-            legacy::LegacyDrmDevice,
+            legacy::{LegacyDrmDevice, LegacyDrmSurface},
             DevPath, Device, DeviceHandler, Surface,
         },
         graphics::{CursorBackend, SwapBuffersError},
@@ -86,8 +86,8 @@ type RenderDevice = FallbackDevice<
     >,
 >;
 type RenderSurface = FallbackSurface<
-    EglSurface<GbmSurface<FallbackDevice<AtomicDrmDevice<SessionFd>, LegacyDrmDevice<SessionFd>>>>,
-    EglSurface<EglStreamSurface<FallbackDevice<AtomicDrmDevice<SessionFd>, LegacyDrmDevice<SessionFd>>>>,
+    EglSurface<GbmSurface<FallbackSurface<AtomicDrmSurface<SessionFd>, LegacyDrmSurface<SessionFd>>>>,
+    EglSurface<EglStreamSurface<FallbackSurface<AtomicDrmSurface<SessionFd>, LegacyDrmSurface<SessionFd>>>>,
 >;
 
 pub fn run_udev(

--- a/examples/raw_nvidia.rs
+++ b/examples/raw_nvidia.rs
@@ -8,15 +8,15 @@ use slog::Drain;
 use smithay::{
     backend::{
         drm::{
-            atomic::AtomicDrmDevice,
-            common::fallback::{EitherError, FallbackDevice},
+            atomic::{AtomicDrmDevice, AtomicDrmSurface},
+            common::fallback::{EitherError, FallbackDevice, FallbackSurface},
             common::Error as DrmError,
             device_bind,
             egl::{EglDevice, EglSurface, Error as EglError},
             eglstream::{
                 egl::EglStreamDeviceBackend, EglStreamDevice, EglStreamSurface, Error as EglStreamError,
             },
-            legacy::LegacyDrmDevice,
+            legacy::{LegacyDrmDevice, LegacyDrmSurface},
             Device, DeviceHandler,
         },
         graphics::glium::GliumGraphicsBackend,
@@ -145,7 +145,7 @@ pub struct DrmHandlerImpl {
         GliumGraphicsBackend<
             EglSurface<
                 EglStreamSurface<
-                    FallbackDevice<AtomicDrmDevice<ClonableFile>, LegacyDrmDevice<ClonableFile>>,
+                    FallbackSurface<AtomicDrmSurface<ClonableFile>, LegacyDrmSurface<ClonableFile>>,
                 >,
             >,
         >,

--- a/src/backend/drm/egl/mod.rs
+++ b/src/backend/drm/egl/mod.rs
@@ -16,7 +16,8 @@ use nix::libc::dev_t;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
+use std::sync::{Arc, Weak as WeakArc};
 #[cfg(feature = "use_system_lib")]
 use wayland_server::Display;
 
@@ -49,7 +50,7 @@ pub enum Error<U: std::error::Error + std::fmt::Debug + std::fmt::Display + 'sta
 }
 
 pub(crate) type Arguments = (crtc::Handle, Mode, Vec<connector::Handle>);
-type BackendRef<D> = Weak<EglSurfaceInternal<<D as Device>::Surface>>;
+type BackendRef<D> = WeakArc<EglSurfaceInternal<<D as Device>::Surface>>;
 
 /// Representation of an egl device to create egl rendering surfaces
 pub struct EglDevice<B, D>
@@ -214,8 +215,8 @@ where
                 SurfaceCreationError::NativeSurfaceCreationFailed(err) => Error::Underlying(err),
             })?;
 
-        let backend = Rc::new(EglSurfaceInternal { context, surface });
-        self.backends.borrow_mut().insert(crtc, Rc::downgrade(&backend));
+        let backend = Arc::new(EglSurfaceInternal { context, surface });
+        self.backends.borrow_mut().insert(crtc, Arc::downgrade(&backend));
         Ok(EglSurface(backend))
     }
 

--- a/src/backend/drm/egl/surface.rs
+++ b/src/backend/drm/egl/surface.rs
@@ -1,6 +1,7 @@
 use drm::control::{connector, crtc, Mode};
 use nix::libc::c_void;
 use std::convert::TryInto;
+use std::sync::Arc;
 
 use super::Error;
 use crate::backend::drm::Surface;
@@ -12,10 +13,8 @@ use crate::backend::graphics::gl::GLGraphicsBackend;
 use crate::backend::graphics::PixelFormat;
 use crate::backend::graphics::{CursorBackend, SwapBuffersError};
 
-use std::rc::Rc;
-
 /// Egl surface for rendering
-pub struct EglSurface<N: native::NativeSurface + Surface>(pub(super) Rc<EglSurfaceInternal<N>>);
+pub struct EglSurface<N: native::NativeSurface + Surface>(pub(super) Arc<EglSurfaceInternal<N>>);
 
 pub(super) struct EglSurfaceInternal<N>
 where
@@ -134,5 +133,20 @@ where
 
     fn get_pixel_format(&self) -> PixelFormat {
         self.0.surface.get_pixel_format()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::EglSurface;
+    use crate::backend::drm::gbm::GbmSurface;
+    use crate::backend::drm::legacy::LegacyDrmSurface;
+    use std::fs::File;
+
+    fn is_send<S: Send>() {}
+
+    #[test]
+    fn surface_is_send() {
+        is_send::<EglSurface<GbmSurface<LegacyDrmSurface<File>>>>();
     }
 }

--- a/src/backend/drm/eglstream/session.rs
+++ b/src/backend/drm/eglstream/session.rs
@@ -4,7 +4,7 @@
 //!
 
 use super::{EglStreamDevice, EglStreamSurfaceInternal};
-use crate::backend::drm::{RawDevice, Surface};
+use crate::backend::drm::{Device, RawDevice, RawSurface};
 use crate::backend::egl::ffi;
 use crate::backend::session::Signal as SessionSignal;
 use crate::signaling::{Linkable, Signaler};
@@ -12,14 +12,15 @@ use crate::signaling::{Linkable, Signaler};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
+use std::sync::Weak as WeakArc;
 
 use drm::control::{crtc, Device as ControlDevice};
 
 /// [`SessionObserver`](SessionObserver)
 /// linked to the [`EglStreamDevice`](EglStreamDevice) it was
 /// created from.
-pub struct EglStreamDeviceObserver<D: RawDevice + 'static> {
-    backends: Weak<RefCell<HashMap<crtc::Handle, Weak<EglStreamSurfaceInternal<D>>>>>,
+pub struct EglStreamDeviceObserver<S: RawSurface + 'static> {
+    backends: Weak<RefCell<HashMap<crtc::Handle, WeakArc<EglStreamSurfaceInternal<S>>>>>,
     logger: ::slog::Logger,
 }
 
@@ -30,7 +31,7 @@ where
     fn link(&mut self, signaler: Signaler<SessionSignal>) {
         let lower_signal = Signaler::new();
         self.raw.link(lower_signal.clone());
-        let mut observer = EglStreamDeviceObserver {
+        let mut observer = EglStreamDeviceObserver::<<D as Device>::Surface> {
             backends: Rc::downgrade(&self.backends),
             logger: self.logger.clone(),
         };
@@ -52,19 +53,19 @@ where
     }
 }
 
-impl<D: RawDevice + 'static> EglStreamDeviceObserver<D> {
+impl<S: RawSurface + 'static> EglStreamDeviceObserver<S> {
     fn pause(&mut self) {
         if let Some(backends) = self.backends.upgrade() {
             for (_, backend) in backends.borrow().iter() {
                 if let Some(backend) = backend.upgrade() {
                     // destroy/disable the streams so it will not submit any pending frames
-                    if let Some((display, stream)) = backend.stream.replace(None) {
+                    if let Some((display, stream)) = backend.stream.lock().unwrap().take() {
                         unsafe {
-                            ffi::egl::DestroyStreamKHR(display.handle, stream);
+                            ffi::egl::DestroyStreamKHR(display.handle, stream.0);
                         }
                     }
                     // framebuffers will be likely not valid anymore, lets just recreate those after activation.
-                    if let Some((buffer, fb)) = backend.commit_buffer.take() {
+                    if let Some((buffer, fb)) = backend.commit_buffer.lock().unwrap().take() {
                         let _ = backend.crtc.destroy_framebuffer(fb);
                         let _ = backend.crtc.destroy_dumb_buffer(buffer);
                     }
@@ -77,17 +78,18 @@ impl<D: RawDevice + 'static> EglStreamDeviceObserver<D> {
         if let Some(backends) = self.backends.upgrade() {
             for (_, backend) in backends.borrow().iter() {
                 if let Some(backend) = backend.upgrade() {
-                    if let Some((cursor, hotspot)) = backend.cursor.get() {
+                    let cursor = backend.cursor.lock().unwrap();
+                    if let Some((ref cursor, ref hotspot)) = &*cursor {
                         if backend
                             .crtc
                             .set_cursor2(
                                 backend.crtc.crtc(),
-                                Some(&cursor),
+                                Some(cursor),
                                 (hotspot.0 as i32, hotspot.1 as i32),
                             )
                             .is_err()
                         {
-                            if let Err(err) = backend.crtc.set_cursor(backend.crtc.crtc(), Some(&cursor)) {
+                            if let Err(err) = backend.crtc.set_cursor(backend.crtc.crtc(), Some(cursor)) {
                                 warn!(self.logger, "Failed to reset cursor: {}", err)
                             }
                         }

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -32,6 +32,9 @@ pub struct EGLDisplayHandle {
     /// ffi EGLDisplay ptr
     pub handle: ffi::egl::types::EGLDisplay,
 }
+// EGLDisplay has an internal Mutex
+unsafe impl Send for EGLDisplayHandle {}
+unsafe impl Sync for EGLDisplayHandle {}
 
 impl Deref for EGLDisplayHandle {
     type Target = ffi::egl::types::EGLDisplay;


### PR DESCRIPTION
This PR tries to make the drm `Surface`-implementations all `Send` to allow the rendering to happen in another thread.

@csnewman I would especially like you to test this branch with your flutter compositor.
You should be able to remove your hacks and move the surfaces without any problems.
Please report all errors, crashes, deadlock you encounter.
This PR is work-in-progress, because I have not given this much testing.
But since it was already working for your use-case and is only safer now, I do not expect this to cause much fuzz.

That said, I do not think it is reasonable to assume, that I did not miss anything.
I actually expect this to contain some rare and hard to debug errors, but I have no idea, how we should verify this approach without testing it in the wild. The documentation of thread-safety of the mesa-libs is very sparse, especially for gbm (egl is way better).

Also note that this is a compromise between usability, maintainability and performance constraints.
Making the devices `Send` is technically an option, but the code is already complicated enough and I do not think you would gain much. They need to be connected to an event loop anyway and you can just create them on their target thread.
This also tries to minimize thread-synchronization like mutexes on frequent calls, like page_flips, but is very naively implemented for anything else. Even in page_flip there are potential performance improvements by using more atomic types instead of locks, but I would say we profile first, before any premature optimization takes place.