### PR TITLE
Lighten some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ dbus = { version = "0.8.3", optional = true }
 drm = { version = "^0.4.0", git = "https://github.com/drakulix/drm-rs", branch = "develop", optional = true }
 gbm = { version = "^0.6.0", git = "https://github.com/drakulix/gbm.rs", branch = "thread-safe", optional = true, default-features = false, features = ["drm-support"] }
 glium = { version = "0.27.0", optional = true, default-features = false }
-image = { version = "0.23.0", optional = true }
+image = { version = "0.23.0", optional = true, default-features = false }
 input = { version = "0.5", default-features = false, optional = true }
 lazy_static = "1"
 libc = "0.2.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ libc = "0.2.70"
 libloading = "0.6.0"
 nix = "0.17"
 slog = "2"
-slog-stdlog = "4"
+slog-stdlog = { version = "4", optional = true }
 tempfile = "3.0"
 thiserror = "1"
 udev = { version = "0.4", optional = true }
@@ -46,7 +46,7 @@ gl_generator = { version = "0.14", optional = true }
 pkg-config = { version = "0.3.17", optional = true }
 
 [features]
-default = ["backend_winit", "backend_drm_legacy", "backend_drm_atomic", "backend_drm_gbm", "backend_drm_eglstream", "backend_drm_egl", "backend_libinput", "backend_udev", "backend_session_logind", "renderer_glium", "xwayland", "wayland_frontend"]
+default = ["backend_winit", "backend_drm_legacy", "backend_drm_atomic", "backend_drm_gbm", "backend_drm_eglstream", "backend_drm_egl", "backend_libinput", "backend_udev", "backend_session_logind", "renderer_glium", "xwayland", "wayland_frontend", "slog-stdlog"]
 backend_winit = ["winit", "wayland-server/dlopen", "backend_egl", "wayland-egl", "renderer_gl", "use_system_lib"]
 backend_drm = ["drm", "failure"]
 backend_drm_atomic = ["backend_drm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ libloading = "0.6.0"
 nix = "0.17"
 slog = "2"
 slog-stdlog = { version = "4", optional = true }
-tempfile = "3.0"
+tempfile = { version = "3.0", optional = true }
 thiserror = "1"
 udev = { version = "0.4", optional = true }
 wayland-commons = { version = "0.26", optional = true }
@@ -63,7 +63,7 @@ backend_session_elogind = ["backend_session_logind"]
 renderer_gl = ["gl_generator"]
 renderer_glium = ["renderer_gl", "glium"]
 use_system_lib = ["wayland_frontend", "wayland-sys", "wayland-server/use_system_lib"]
-wayland_frontend = ["wayland-server", "wayland-commons", "wayland-protocols"]
+wayland_frontend = ["wayland-server", "wayland-commons", "wayland-protocols", "tempfile"]
 xwayland = ["wayland_frontend"]
 test_all_features = ["default"]
 

--- a/src/backend/drm/atomic/mod.rs
+++ b/src/backend/drm/atomic/mod.rs
@@ -220,7 +220,7 @@ impl<A: AsRawFd + 'static> AtomicDrmDevice<A> {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_drm"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_drm"));
         info!(log, "AtomicDrmDevice initializing");
 
         let dev_id = fstat(fd.as_raw_fd()).map_err(Error::UnableToGetDeviceId)?.st_rdev;

--- a/src/backend/drm/common/fallback.rs
+++ b/src/backend/drm/common/fallback.rs
@@ -181,7 +181,7 @@ impl<A: AsRawFd + Clone + 'static> FallbackDevice<AtomicDrmDevice<A>, LegacyDrmD
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_drm_fallback"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_drm_fallback"));
         info!(log, "Trying to initialize AtomicDrmDevice");
 
         let force_legacy = env::var("SMITHAY_USE_LEGACY")
@@ -246,7 +246,7 @@ where
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_drm_fallback"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_drm_fallback"));
 
         let driver = crate::backend::udev::driver(dev.device_id()).expect("Failed to query device");
         info!(log, "Drm device driver: {:?}", driver);
@@ -299,7 +299,7 @@ where
         D2: NativeDisplay<B2, Arguments = EglDeviceArguments>,
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_drm_fallback"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_drm_fallback"));
         match dev {
             FallbackDevice::Preference(gbm) => match EglDevice::new(gbm, log) {
                 Ok(dev) => Ok(FallbackDevice::Preference(dev)),
@@ -335,7 +335,7 @@ where
         D2: NativeDisplay<B2, Arguments = EglDeviceArguments>,
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_drm_fallback"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_drm_fallback"));
         match dev {
             FallbackDevice::Preference(gbm) => {
                 match EglDevice::new_with_defaults(gbm, default_attributes, default_requirements, log) {

--- a/src/backend/drm/egl/mod.rs
+++ b/src/backend/drm/egl/mod.rs
@@ -123,7 +123,7 @@ where
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_egl"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_egl"));
 
         dev.clear_handler();
 

--- a/src/backend/drm/eglstream/mod.rs
+++ b/src/backend/drm/eglstream/mod.rs
@@ -98,7 +98,7 @@ impl<D: RawDevice + ControlDevice + 'static> EglStreamDevice<D> {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_eglstream"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_eglstream"));
 
         raw.clear_handler();
 

--- a/src/backend/drm/gbm/mod.rs
+++ b/src/backend/drm/gbm/mod.rs
@@ -106,7 +106,7 @@ impl<D: RawDevice + ControlDevice + 'static> GbmDevice<D> {
             );
         });
 
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_gbm"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_gbm"));
 
         dev.clear_handler();
 

--- a/src/backend/drm/legacy/mod.rs
+++ b/src/backend/drm/legacy/mod.rs
@@ -119,7 +119,7 @@ impl<A: AsRawFd + 'static> LegacyDrmDevice<A> {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_drm"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_drm"));
         info!(log, "LegacyDrmDevice initializing");
 
         let dev_id = fstat(dev.as_raw_fd())

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -33,7 +33,7 @@ impl EGLContext {
         B: native::Backend,
         N: native::NativeDisplay<B>,
     {
-        let log = crate::slog_or_stdlog(log.into()).new(o!("smithay_module" => "renderer_egl"));
+        let log = crate::slog_or_fallback(log.into()).new(o!("smithay_module" => "renderer_egl"));
 
         // If no version is given, try OpenGLES 3.0, if available,
         // fallback to 2.0 otherwise

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -69,7 +69,7 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger.into()).new(o!("smithay_module" => "renderer_egl"));
+        let log = crate::slog_or_fallback(logger.into()).new(o!("smithay_module" => "renderer_egl"));
         let ptr = native.ptr()?;
         let egl_attribs = native.attributes();
 

--- a/src/backend/egl/surface.rs
+++ b/src/backend/egl/surface.rs
@@ -50,7 +50,7 @@ impl<N: native::NativeSurface> EGLSurface<N> {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(log.into()).new(o!("smithay_module" => "renderer_egl"));
+        let log = crate::slog_or_fallback(log.into()).new(o!("smithay_module" => "renderer_egl"));
 
         let surface_attributes = {
             let mut out: Vec<c_int> = Vec::with_capacity(3);

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -47,7 +47,7 @@ impl LibinputInputBackend {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_libinput"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_libinput"));
         info!(log, "Initializing a libinput backend");
         LibinputInputBackend {
             context,

--- a/src/backend/session/auto.rs
+++ b/src/backend/session/auto.rs
@@ -69,7 +69,7 @@ impl AutoSession {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let logger = crate::slog_or_stdlog(logger)
+        let logger = crate::slog_or_fallback(logger)
             .new(o!("smithay_module" => "backend_session_auto", "session_type" => "auto"));
 
         info!(logger, "Trying to create logind session");

--- a/src/backend/session/dbus/logind.rs
+++ b/src/backend/session/dbus/logind.rs
@@ -89,7 +89,7 @@ impl LogindSession {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let logger = crate::slog_or_stdlog(logger)
+        let logger = crate::slog_or_fallback(logger)
             .new(o!("smithay_module" => "backend_session", "session_type" => "logind"));
 
         // Acquire session_id, seat and vt (if any) via libsystemd

--- a/src/backend/session/direct.rs
+++ b/src/backend/session/direct.rs
@@ -168,7 +168,7 @@ impl DirectSession {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let logger = crate::slog_or_stdlog(logger)
+        let logger = crate::slog_or_fallback(logger)
             .new(o!("smithay_module" => "backend_session", "session_type" => "direct/vt"));
 
         let fd = tty

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -78,7 +78,7 @@ impl UdevBackend {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_udev"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_udev"));
 
         let devices = all_gpus(seat)?
             .into_iter()

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -152,7 +152,7 @@ pub fn init_from_builder_with_gl_attr<L>(
 where
     L: Into<Option<::slog::Logger>>,
 {
-    let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "backend_winit"));
+    let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "backend_winit"));
     info!(log, "Initializing a winit backend");
 
     let events_loop = EventLoop::new();

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -491,7 +491,7 @@ where
     R: Default + RoleType + Role<SubsurfaceRole> + Send + 'static,
     Impl: FnMut(SurfaceEvent, WlSurface, CompositorToken<R>) + 'static,
 {
-    let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "compositor_handler"));
+    let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "compositor_handler"));
     let implem = Rc::new(RefCell::new(implem));
 
     let compositor = display.create_global(

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -286,7 +286,7 @@ where
     R: Role<DnDIconRole> + 'static,
     L: Into<Option<::slog::Logger>>,
 {
-    let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "data_device_mgr"));
+    let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "data_device_mgr"));
     let action_choice = Rc::new(RefCell::new(action_choice));
     let callback = Rc::new(RefCell::new(callback));
     display.create_global(

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -183,7 +183,7 @@ where
     L: Into<Option<::slog::Logger>>,
     H: DmabufHandler + 'static,
 {
-    let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "dmabuf_handler"));
+    let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "dmabuf_handler"));
 
     let max_planes = formats.iter().map(|f| f.plane_count).max().unwrap_or(0);
     let formats = Rc::new(formats);

--- a/src/wayland/explicit_synchronization/mod.rs
+++ b/src/wayland/explicit_synchronization/mod.rs
@@ -206,7 +206,8 @@ where
     L: Into<Option<::slog::Logger>>,
     R: 'static,
 {
-    let _log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "wayland_explicit_synchronization"));
+    let _log =
+        crate::slog_or_fallback(logger).new(o!("smithay_module" => "wayland_explicit_synchronization"));
 
     display.create_global::<ZwpLinuxExplicitSynchronizationV1, _>(
         2,

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -174,7 +174,7 @@ impl Output {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger).new(o!("smithay_module" => "output_handler"));
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "output_handler"));
 
         info!(log, "Creating new wl_output"; "name" => &name);
 

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -127,7 +127,7 @@ impl Seat {
         R: Role<CursorImageRole> + 'static,
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger);
+        let log = crate::slog_or_fallback(logger);
         let arc = Rc::new(SeatRc {
             inner: RefCell::new(Inner {
                 pointer: None,

--- a/src/wayland/shell/legacy/mod.rs
+++ b/src/wayland/shell/legacy/mod.rs
@@ -305,7 +305,7 @@ where
     L: Into<Option<::slog::Logger>>,
     Impl: FnMut(ShellRequest<R>) + 'static,
 {
-    let _log = crate::slog_or_stdlog(logger);
+    let _log = crate::slog_or_fallback(logger);
 
     let implementation = Rc::new(RefCell::new(implementation));
 

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -289,7 +289,7 @@ where
     L: Into<Option<::slog::Logger>>,
     Impl: FnMut(XdgRequest<R>) + 'static,
 {
-    let log = crate::slog_or_stdlog(logger);
+    let log = crate::slog_or_fallback(logger);
     let shell_state = Arc::new(Mutex::new(ShellState {
         known_toplevels: Vec::new(),
         known_popups: Vec::new(),

--- a/src/wayland/shm/mod.rs
+++ b/src/wayland/shm/mod.rs
@@ -109,7 +109,7 @@ pub fn init_shm_global<L>(
 where
     L: Into<Option<::slog::Logger>>,
 {
-    let log = crate::slog_or_stdlog(logger);
+    let log = crate::slog_or_fallback(logger);
 
     // always add the mandatory formats
     formats.push(wl_shm::Format::Argb8888);

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -88,7 +88,7 @@ impl<WM: XWindowManager + 'static> XWayland<WM> {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let log = crate::slog_or_stdlog(logger);
+        let log = crate::slog_or_fallback(logger);
         let inner = Rc::new(RefCell::new(Inner {
             wm,
             kill_source: {


### PR DESCRIPTION
- make `slog-stdlog` optional, but activated by default. This dependency has a significant dependency tree, but is not used at all if the downstream crate uses slog as well, rather than `log`.
- disable the default features of `image`, which we don't use at all
- make `tempfile` an optional dependency, it is only required by the wayland frontend.