### PR TITLE
Fix writing /tmp/.X{}.lock

### DIFF
--- a/src/xwayland/x11_sockets.rs
+++ b/src/xwayland/x11_sockets.rs
@@ -38,7 +38,7 @@ impl X11Lock {
         match lockfile {
             Ok(mut file) => {
                 // we got it, write our PID in it and we're good
-                let ret = file.write_fmt(format_args!("{:>10}", ::nix::unistd::Pid::this()));
+                let ret = file.write_fmt(format_args!("{:>10}\n", ::nix::unistd::Pid::this()));
                 if ret.is_err() {
                     // write to the file failed ? we abandon
                     ::std::mem::drop(file);


### PR DESCRIPTION
Here is a lock file not created by smithay:
```
$ xxd /tmp/.X0-lock
00000000: 2020 2020 2020 2035 3537 0a                     557.
```
And this is a lock file created by smithay:
```
$ xxd /tmp/.X23-lock
00000000: 2020 2020 3130 3733 3332                     107332
```
As you see, the difference is a trailing newline (0x0a).

Lock files 1 to 22 where also created by smithay, because I started it a
couple of times. Reading these lock files fails, since the code expects
a file with at least 11 bytes of content: It uses read_exact() with a
buffer of length 11 in the Err()-branch of the match that this commit
modifies.

Signed-off-by: Uli Schlachter <psychon@znc.in>