### PR TITLE
XWayland: Use a fork helper process to launch Xwayland

### DIFF
--- a/src/xwayland/launch_helper.rs
+++ b/src/xwayland/launch_helper.rs
@@ -5,9 +5,12 @@ use std::{
 
 use nix::{
     libc::exit,
-    unistd::{fork, ForkResult},
+    sys::signal,
+    unistd::{fork, ForkResult, Pid},
     Error as NixError, Result as NixResult
 };
+
+use super::xserver::exec_xwayland;
 
 /// A handle to a `fork()`'d child process that is used for starting XWayland
 pub struct LaunchHelper(UnixStream);
@@ -32,6 +35,68 @@ impl LaunchHelper {
                 }
             }
             ForkResult::Parent { child: _ } => Ok(Self(me))
+        }
+    }
+
+    /// Fork a child and call exec_xwayland() in it.
+    pub(crate) fn launch(
+        &self,
+        display: u32,
+        wayland_socket: UnixStream,
+        wm_socket: UnixStream,
+        listen_sockets: &[UnixStream],
+        log: &::slog::Logger,
+    ) -> Result<(Pid, UnixStream), ()> {
+        let (status_child, status_me) = UnixStream::pair().map_err(|_| ())?;
+        match unsafe { fork() } {
+            Ok(ForkResult::Parent { child }) => {
+                // we are the main smithay process
+                Ok((child, status_me))
+            }
+            Ok(ForkResult::Child) => {
+                // we are the first child
+                let mut set = signal::SigSet::empty();
+                set.add(signal::Signal::SIGUSR1);
+                set.add(signal::Signal::SIGCHLD);
+                // we can't handle errors here anyway
+                let _ = signal::sigprocmask(signal::SigmaskHow::SIG_BLOCK, Some(&set), None);
+                match unsafe { fork() } {
+                    Ok(ForkResult::Parent { child }) => {
+                        // When we exit(), we will close() this which wakes up the main process.
+                        let _status_child = status_child;
+                        // we are still the first child
+                        let sig = set.wait();
+                        // Parent will wait for us and know from out
+                        // exit status if XWayland launch was a success or not =)
+                        if let Ok(signal::Signal::SIGCHLD) = sig {
+                            // XWayland has exited before being ready
+                            let _ = ::nix::sys::wait::waitpid(child, None);
+                            unsafe { ::nix::libc::exit(1) };
+                        }
+                        unsafe { ::nix::libc::exit(0) };
+                    }
+                    Ok(ForkResult::Child) => {
+                        // we are the second child, we exec xwayland
+                        match exec_xwayland(display, wayland_socket, wm_socket, listen_sockets) {
+                            Ok(x) => match x {},
+                            Err(e) => {
+                                // well, what can we do ?
+                                error!(log, "exec XWayland failed"; "err" => format!("{:?}", e));
+                                unsafe { ::nix::libc::exit(1) };
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        // well, what can we do ?
+                        error!(log, "XWayland second fork failed"; "err" => format!("{:?}", e));
+                        unsafe { ::nix::libc::exit(1) };
+                    }
+                }
+            }
+            Err(e) => {
+                error!(log, "XWayland first fork failed"; "err" => format!("{:?}", e));
+                Err(())
+            }
         }
     }
 }

--- a/src/xwayland/launch_helper.rs
+++ b/src/xwayland/launch_helper.rs
@@ -1,0 +1,53 @@
+use std::{
+    io::{Result as IOResult, Error as IOError},
+    os::unix::net::UnixStream,
+};
+
+use nix::{
+    libc::exit,
+    unistd::{fork, ForkResult},
+    Error as NixError, Result as NixResult
+};
+
+/// A handle to a `fork()`'d child process that is used for starting XWayland
+pub struct LaunchHelper(UnixStream);
+
+impl LaunchHelper {
+    /// Start a new launch helper process.
+    ///
+    /// This function calls [`nix::unistd::fork`] to create a new process. This function is unsafe
+    /// because `fork` is unsafe. Most importantly: Calling `fork` in a multi-threaded process has
+    /// lots of limitations. Thus, you must call this function before any threads are created.
+    pub unsafe fn fork() -> IOResult<Self> {
+        let (child, me) = UnixStream::pair()?;
+        match fork().map_err(nix_error_to_io)? {
+            ForkResult::Child => {
+                drop(me);
+                match do_child(child) {
+                    Ok(()) => exit(0),
+                    Err(e) => {
+                        eprintln!("Error in smithay fork child: {:?}", e);
+                        exit(1);
+                    }
+                }
+            }
+            ForkResult::Parent { child: _ } => Ok(Self(me))
+        }
+    }
+}
+
+fn do_child(stream: UnixStream) -> NixResult<()> {
+    let _ = stream; // TODO
+    Ok(())
+}
+
+fn nix_error_to_io(err: NixError) -> IOError {
+    use std::io::ErrorKind;
+    match err {
+        NixError::Sys(errno) => errno.into(),
+        NixError::InvalidPath | NixError::InvalidUtf8 =>
+            IOError::new(ErrorKind::InvalidInput, err),
+        NixError::UnsupportedOperation =>
+            IOError::new(ErrorKind::Other, err),
+    }
+}

--- a/src/xwayland/mod.rs
+++ b/src/xwayland/mod.rs
@@ -15,5 +15,7 @@
 
 mod x11_sockets;
 mod xserver;
+mod launch_helper;
 
 pub use self::xserver::{XWayland, XWindowManager};
+pub use self::launch_helper::LaunchHelper;

--- a/src/xwayland/mod.rs
+++ b/src/xwayland/mod.rs
@@ -13,9 +13,9 @@
 //!
 //! Smithay does not provide any helper for doing that yet, but it is planned.
 
+mod launch_helper;
 mod x11_sockets;
 mod xserver;
-mod launch_helper;
 
-pub use self::xserver::{XWayland, XWindowManager};
 pub use self::launch_helper::LaunchHelper;
+pub use self::xserver::{XWayland, XWindowManager};

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -261,15 +261,15 @@ fn xwayland_ready<WM: XWindowManager>(inner: &Rc<RefCell<Inner<WM>>>) {
     };
 
     if success {
+        // setup the environemnt
+        ::std::env::set_var("DISPLAY", format!(":{}", instance.display_lock.display()));
+
         // signal the WM
         info!(inner.log, "XWayland is ready, signaling the WM.");
         wm.xwayland_ready(
             instance.wm_fd.take().unwrap(), // This is a bug if None
             instance.wayland_client.clone(),
         );
-
-        // setup the environemnt
-        ::std::env::set_var("DISPLAY", format!(":{}", instance.display_lock.display()));
     } else {
         error!(
             inner.log,

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -42,15 +42,18 @@ use std::{
     sync::Arc,
 };
 
-use calloop::{generic::{Fd, Generic}, Interest, LoopHandle, Mode, Source};
+use calloop::{
+    generic::{Fd, Generic},
+    Interest, LoopHandle, Mode, Source,
+};
 
 use nix::Result as NixResult;
 
 use wayland_server::{Client, Display, Filter};
 
 use super::{
-    LaunchHelper,
     x11_sockets::{prepare_x11_sockets, X11Lock},
+    LaunchHelper,
 };
 
 /// The XWayland handle
@@ -132,8 +135,7 @@ struct XWaylandInstance {
     started_at: ::std::time::Instant,
 }
 
-type SourceMaker<WM> =
-    dyn FnMut(Rc<RefCell<Inner<WM>>>, RawFd) -> Result<Source<Generic<Fd>>, ()>;
+type SourceMaker<WM> = dyn FnMut(Rc<RefCell<Inner<WM>>>, RawFd) -> Result<Source<Generic<Fd>>, ()>;
 
 // Inner implementation of the XWayland manager
 struct Inner<WM: XWindowManager> {
@@ -184,7 +186,7 @@ fn launch<WM: XWindowManager + 'static, T: Any>(
 
     // all is ready, we can do the fork dance
     match guard.helper.launch(lock.display(), wl_x11, x_wm_x11, &x_fds) {
-        Ok(()) => {},
+        Ok(()) => {}
         Err(e) => {
             error!(guard.log, "Could not initiate launch of Xwayland"; "err" => format!("{:?}", e));
             return Err(());

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -23,6 +23,11 @@
  *
  * cf https://github.com/swaywm/wlroots/blob/master/xwayland/xwayland.c
  *
+ * Since fork is not safe to call in a multi-threaded process, a process is
+ * forked of early (LaunchHelper). Via a shared FD, a command to actually launch
+ * Xwayland can be sent to that process. The process then does the fork and
+ * reports back when Xwayland successfully started (=SIGUSR1 was received) with
+ * another write on the pipe.
  */
 use std::{
     any::Any,


### PR DESCRIPTION
Calling `fork` in a multi-threaded program is dangerous. According to `man fork`, you are only allowed to call async-signal-safe functions afterwards. `exit` is not async-signal-safe. Hence in #244 I reported seeing crashes from some exit handlers when the forked child process tries to exit.

This PR adds a new `ForkHelper` to the public API. It can be created via `ForkHelper::fork()`, which is `unsafe`, because it calls `fork`. The `ForkHelper` can then later be used to actually launch XWayland.

(This PR also fixes the problem from #244 by simply not calling `exit`, because the fork helper process keeps running after starting `Xwayland`... However, I now get a double panic when closing the winit window because of a failed unwrap. At least no running processes seem to remain.)

This PR was tested via the following diff. The log following messages showed up, so apparently `Xwayland` managed to start:
```
Dec 29 13:50:14.960 INFO XWayland is ready, signaling the WM., smithay_module: XWayland
The XKEYBOARD keymap compiler (xkbcomp) reports:
> Warning:          Unsupported maximum keycode 569, clipping.
>                   X11 cannot support keycodes above 255.
Errors from xkbcomp are not fatal to the X server
```
```diff
diff --git a/anvil/Cargo.toml b/anvil/Cargo.toml
index 4dbfd7c1..9d56d058 100644
--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -19,7 +19,7 @@ xkbcommon = "0.4.0"
 [dependencies.smithay]
 path = ".."
 default-features = false
-features = [ "renderer_glium", "backend_egl", "wayland_frontend" ]
+features = [ "renderer_glium", "backend_egl", "wayland_frontend", "xwayland" ]
 
 [build-dependencies]
 gl_generator = "0.14"
diff --git a/anvil/src/main.rs b/anvil/src/main.rs
index f6d28ccd..6e97f8de 100644
--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -11,6 +11,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use slog::Drain;
 use smithay::reexports::{calloop::EventLoop, wayland_server::Display};
+use smithay::xwayland::LaunchHelper;
 
 #[macro_use]
 mod shaders;
@@ -36,6 +37,8 @@ static POSSIBLE_BACKENDS: &[&str] = &[
 ];
 
 fn main() {
+    let helper = unsafe { LaunchHelper::fork() }.unwrap();
+
     // A logger facility, here we use the terminal here
     let log = slog::Logger::root(
         slog_async::Async::default(slog_term::term_full().fuse()).fuse(),
@@ -50,7 +53,7 @@ fn main() {
         #[cfg(feature = "winit")]
         Some("--winit") => {
             info!(log, "Starting anvil with winit backend");
-            if let Err(()) = winit::run_winit(display, &mut event_loop, log.clone()) {
+            if let Err(()) = winit::run_winit(display, &mut event_loop, log.clone(), helper) {
                 crit!(log, "Failed to initialize winit backend.");
             }
         }
diff --git a/anvil/src/winit.rs b/anvil/src/winit.rs
index eafbfcf2..bed38c7c 100644
--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc, sync::atomic::Ordering, time::Duration};
+use std::{cell::RefCell, rc::Rc, sync::atomic::Ordering, time::Duration, os::unix::net::UnixStream};
 
 #[cfg(feature = "egl")]
 use smithay::backend::egl::EGLGraphicsBackend;
@@ -6,13 +6,14 @@ use smithay::{
     backend::{graphics::gl::GLGraphicsBackend, input::InputBackend, winit},
     reexports::{
         calloop::EventLoop,
-        wayland_server::{protocol::wl_output, Display},
+        wayland_server::{protocol::wl_output, Client, Display},
         winit::window::CursorIcon,
     },
     wayland::{
         output::{Mode, Output, PhysicalProperties},
         seat::CursorImageStatus,
     },
+    xwayland::{LaunchHelper, XWayland, XWindowManager}
 };
 
 use slog::Logger;
@@ -21,10 +22,24 @@ use crate::buffer_utils::BufferUtils;
 use crate::glium_drawer::GliumDrawer;
 use crate::state::AnvilState;
 
+#[derive(Default)]
+struct XWm;
+
+impl XWindowManager for XWm {
+    fn xwayland_ready(&mut self, _connection: UnixStream, _client: Client) {
+        println!("Hey Uli: XWayland is ready, DISPLAY={}", std::env::var("DISPLAY").unwrap_or("NONE".to_string()));
+    }
+
+    fn xwayland_exited(&mut self) {
+        println!("Hey Uli: XWayland exited");
+    }
+}
+
 pub fn run_winit(
     display: Rc<RefCell<Display>>,
     event_loop: &mut EventLoop<AnvilState>,
     log: Logger,
+    helper: LaunchHelper,
 ) -> Result<(), ()> {
     let (renderer, mut input) = winit::init(log.clone()).map_err(|err| {
         slog::crit!(log, "Failed to initialize Winit backend: {}", err);
@@ -89,6 +104,11 @@ pub fn run_winit(
         refresh: 60_000,
     });
 
+    info!(log, "Hey Uli: Starting XWayland");
+    let wm = XWm::default();
+    let mut data = ();
+    let _xwayland = XWayland::init(wm, event_loop.handle(), display.clone(), &mut data, log.clone(), helper);
+
     let start_time = std::time::Instant::now();
 
     info!(log, "Initialization completed, starting the main loop.");
diff --git a/src/backend/winit.rs b/src/backend/winit.rs
index 8bd2fce8..76f606d7 100644
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -252,6 +252,7 @@ impl CursorBackend for WinitGraphicsBackend {
     type Error = ();
 
     fn set_cursor_position(&self, x: u32, y: u32) -> ::std::result::Result<(), ()> {
+        return Ok(());
         debug!(self.logger, "Setting cursor position to {:?}", (x, y));
         self.window
             .window()
```