### PR TITLE
Make clippy happy

### DIFF
--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -186,7 +186,7 @@ where
     let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "dmabuf_handler"));
 
     let max_planes = formats.iter().map(|f| f.plane_count).max().unwrap_or(0);
-    let formats = Rc::new(formats);
+    let formats = Rc::<[Format]>::from(formats);
     let handler = Rc::new(RefCell::new(handler));
 
     trace!(
@@ -262,7 +262,7 @@ struct ParamsHandler<H: DmabufHandler> {
     pending_planes: Vec<Plane>,
     max_planes: u32,
     used: bool,
-    formats: Rc<Vec<Format>>,
+    formats: Rc<[Format]>,
     handler: Rc<RefCell<H>>,
     log: ::slog::Logger,
 }

--- a/src/wayland/shm/mod.rs
+++ b/src/wayland/shm/mod.rs
@@ -88,7 +88,7 @@ mod pool;
 /// This type is only visible as type parameter of
 /// the `Global` handle you are provided.
 pub struct ShmGlobalData {
-    formats: Rc<Vec<wl_shm::Format>>,
+    formats: Rc<[wl_shm::Format]>,
     log: ::slog::Logger,
 }
 
@@ -115,7 +115,7 @@ where
     formats.push(wl_shm::Format::Argb8888);
     formats.push(wl_shm::Format::Xrgb8888);
     let data = ShmGlobalData {
-        formats: Rc::new(formats),
+        formats: formats.into(),
         log: log.new(o!("smithay_module" => "shm_handler")),
     };
 


### PR DESCRIPTION
This fixes the following clippy warnings:
```
error: usage of `Rc<T>` when T is a buffer type
   --> src/wayland/dmabuf/mod.rs:265:14
    |
265 |     formats: Rc<Vec<Format>>,
    |              ^^^^^^^^^^^^^^^ help: try: `Rc<[Format]>`
    |
    = note: `-D clippy::rc-buffer` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#rc_buffer

error: usage of `Rc<T>` when T is a buffer type
  --> src/wayland/shm/mod.rs:91:14
   |
91 |     formats: Rc<Vec<wl_shm::Format>>,
   |              ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Rc<[wl_shm::Format]>`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#rc_buffer
```
Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

I took another look at this due to all the mails that GitHub sends me about failing CI. Fixing this was easier than expected. No idea why I gave up last time I tried to fix this.