### PR TITLE
Fix clippy warnings

### DIFF
--- a/anvil/src/glium_drawer.rs
+++ b/anvil/src/glium_drawer.rs
@@ -88,7 +88,7 @@ impl<T: Into<GliumGraphicsBackend<T>> + GLGraphicsBackend + 'static> GliumDrawer
 
         // building the index buffer
         let index_buffer =
-            glium::IndexBuffer::new(&display, PrimitiveType::TriangleStrip, &[1 as u16, 2, 0, 3]).unwrap();
+            glium::IndexBuffer::new(&display, PrimitiveType::TriangleStrip, &[1, 2, 0, 3]).unwrap();
 
         let programs = opengl_programs!(&display);
 

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -283,6 +283,7 @@ enum KeyAction {
     None,
 }
 
+#[allow(clippy::manual_range_contains)]
 fn process_keyboard_shortcut(modifiers: ModifiersState, keysym: Keysym) -> KeyAction {
     if modifiers.ctrl && modifiers.alt && keysym == xkb::KEY_BackSpace
         || modifiers.logo && keysym == xkb::KEY_q

--- a/src/backend/drm/atomic/mod.rs
+++ b/src/backend/drm/atomic/mod.rs
@@ -132,7 +132,7 @@ impl<A: AsRawFd + 'static> Drop for Dev<A> {
                         req.add_raw_property((*handle).into(), prop_handle, val);
                     }
                 }
-            };
+            }
 
             add_multiple_props(&mut req, &self.old_state.0);
             add_multiple_props(&mut req, &self.old_state.1);

--- a/src/backend/drm/common/fallback.rs
+++ b/src/backend/drm/common/fallback.rs
@@ -36,7 +36,6 @@ use drm::{
 use nix::libc::c_void;
 use nix::libc::dev_t;
 use std::env;
-use std::fmt;
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(feature = "use_system_lib")]
 use wayland_server::Display;
@@ -150,13 +149,13 @@ pub enum EitherError<E1: std::error::Error + 'static, E2: std::error::Error + 's
     Or(#[source] E2),
 }
 
-impl<E1, E2> Into<SwapBuffersError> for EitherError<E1, E2>
+impl<E1, E2> From<EitherError<E1, E2>> for SwapBuffersError
 where
     E1: std::error::Error + Into<SwapBuffersError> + 'static,
     E2: std::error::Error + Into<SwapBuffersError> + 'static,
 {
-    fn into(self) -> SwapBuffersError {
-        match self {
+    fn from(err: EitherError<E1, E2>) -> Self {
+        match err {
             EitherError::Either(err) => err.into(),
             EitherError::Or(err) => err.into(),
         }

--- a/src/backend/drm/common/mod.rs
+++ b/src/backend/drm/common/mod.rs
@@ -72,9 +72,10 @@ pub enum Error {
     TestFailed(crtc::Handle),
 }
 
-impl Into<SwapBuffersError> for Error {
-    fn into(self) -> SwapBuffersError {
-        match self {
+impl From<Error> for SwapBuffersError {
+    #[allow(clippy::match_like_matches_macro)]
+    fn from(err: Error) -> Self {
+        match err {
             x @ Error::DeviceInactive => SwapBuffersError::TemporaryFailure(Box::new(x)),
             Error::Access {
                 errmsg, dev, source, ..

--- a/src/backend/drm/eglstream/egl.rs
+++ b/src/backend/drm/eglstream/egl.rs
@@ -124,13 +124,11 @@ unsafe impl<A: AsRawFd + 'static> NativeSurface for EglStreamSurface<AtomicDrmSu
         config_id: ffi::egl::types::EGLConfig,
         surface_attribs: &[c_int],
     ) -> Result<*const c_void, SurfaceCreationError<Self::Error>> {
-        let output_attributes = {
-            let mut out: Vec<isize> = Vec::with_capacity(3);
-            out.push(ffi::egl::DRM_PLANE_EXT as isize);
-            out.push(Into::<u32>::into(self.0.crtc.0.planes.primary) as isize);
-            out.push(ffi::egl::NONE as isize);
-            out
-        };
+        let output_attributes = vec![
+            ffi::egl::DRM_PLANE_EXT as isize,
+            Into::<u32>::into(self.0.crtc.0.planes.primary) as isize,
+            ffi::egl::NONE as isize,
+        ];
 
         self.create_surface(display, config_id, surface_attribs, &output_attributes)
             .map_err(SurfaceCreationError::NativeSurfaceCreationFailed)
@@ -159,13 +157,11 @@ unsafe impl<A: AsRawFd + 'static> NativeSurface for EglStreamSurface<LegacyDrmSu
         config_id: ffi::egl::types::EGLConfig,
         surface_attribs: &[c_int],
     ) -> Result<*const c_void, SurfaceCreationError<Self::Error>> {
-        let output_attributes = {
-            let mut out: Vec<isize> = Vec::with_capacity(3);
-            out.push(ffi::egl::DRM_CRTC_EXT as isize);
-            out.push(Into::<u32>::into(self.0.crtc.0.crtc) as isize);
-            out.push(ffi::egl::NONE as isize);
-            out
-        };
+        let output_attributes = vec![
+            ffi::egl::DRM_CRTC_EXT as isize,
+            Into::<u32>::into(self.0.crtc.0.crtc) as isize,
+            ffi::egl::NONE as isize,
+        ];
 
         self.create_surface(display, config_id, surface_attribs, &output_attributes)
             .map_err(SurfaceCreationError::NativeSurfaceCreationFailed)

--- a/src/backend/drm/eglstream/surface.rs
+++ b/src/backend/drm/eglstream/surface.rs
@@ -395,17 +395,15 @@ impl<S: RawSurface + 'static> EglStreamSurface<S> {
         // which is handled by STREAM_FIFO_LENGTH_KHR = 0.
         // We also want to "acquire" the frames manually. Like this we can request page-flip events
         // to drive our event loop. Otherwise we would have no way to know rendering is finished.
-        let stream_attributes = {
-            let mut out: Vec<c_int> = Vec::with_capacity(7);
-            out.push(ffi::egl::STREAM_FIFO_LENGTH_KHR as i32);
-            out.push(0);
-            out.push(ffi::egl::CONSUMER_AUTO_ACQUIRE_EXT as i32);
-            out.push(ffi::egl::FALSE as i32);
-            out.push(ffi::egl::CONSUMER_ACQUIRE_TIMEOUT_USEC_KHR as i32);
-            out.push(0);
-            out.push(ffi::egl::NONE as i32);
-            out
-        };
+        let stream_attributes = vec![
+            ffi::egl::STREAM_FIFO_LENGTH_KHR as i32,
+            0,
+            ffi::egl::CONSUMER_AUTO_ACQUIRE_EXT as i32,
+            ffi::egl::FALSE as i32,
+            ffi::egl::CONSUMER_ACQUIRE_TIMEOUT_USEC_KHR as i32,
+            0,
+            ffi::egl::NONE as i32,
+        ];
 
         // okay, we have a config, lets create the stream.
         let raw_stream = unsafe { ffi::egl::CreateStreamKHR(display.handle, stream_attributes.as_ptr()) };
@@ -437,15 +435,13 @@ impl<S: RawSurface + 'static> EglStreamSurface<S> {
 
         let (w, h) = self.current_mode().size();
         info!(self.0.logger, "Creating stream surface with size: ({}:{})", w, h);
-        let surface_attributes = {
-            let mut out: Vec<c_int> = Vec::with_capacity(5);
-            out.push(ffi::egl::WIDTH as i32);
-            out.push(w as i32);
-            out.push(ffi::egl::HEIGHT as i32);
-            out.push(h as i32);
-            out.push(ffi::egl::NONE as i32);
-            out
-        };
+        let surface_attributes = vec![
+            ffi::egl::WIDTH as i32,
+            w as i32,
+            ffi::egl::HEIGHT as i32,
+            h as i32,
+            ffi::egl::NONE as i32,
+        ];
 
         // the stream is already connected to the consumer (output layer) during creation.
         // we now connect the producer (out egl surface, that we render to).

--- a/src/backend/drm/gbm/mod.rs
+++ b/src/backend/drm/gbm/mod.rs
@@ -237,12 +237,13 @@ impl<D: RawDevice + ControlDevice + 'static> Drop for GbmDevice<D> {
     }
 }
 
-impl<E> Into<SwapBuffersError> for Error<E>
+impl<E> From<Error<E>> for SwapBuffersError
 where
     E: std::error::Error + Into<SwapBuffersError> + 'static,
 {
-    fn into(self) -> SwapBuffersError {
-        match self {
+    #[allow(clippy::match_like_matches_macro)]
+    fn from(err: Error<E>) -> Self {
+        match err {
             Error::FrontBuffersExhausted => SwapBuffersError::AlreadySwapped,
             Error::FramebufferCreationFailed(x)
                 if match x.get_ref() {

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -325,7 +325,7 @@ impl<B: native::Backend, N: native::NativeDisplay<B>> EGLDisplay<B, N> {
                 .map_err(Error::ConfigFailed)?;
                 value.assume_init()
             }};
-        };
+        }
 
         // return the format that was selected for our config
         let desc = unsafe {
@@ -550,10 +550,7 @@ impl EGLBufferReader {
 
         let mut images = Vec::with_capacity(format.num_planes());
         for i in 0..format.num_planes() {
-            let mut out = Vec::with_capacity(3);
-            out.push(ffi::egl::WAYLAND_PLANE_WL as i32);
-            out.push(i as i32);
-            out.push(ffi::egl::NONE as i32);
+            let out = vec![ffi::egl::WAYLAND_PLANE_WL as i32, i as i32, ffi::egl::NONE as i32];
 
             images.push({
                 wrap_egl_call(|| unsafe {

--- a/src/backend/egl/error.rs
+++ b/src/backend/egl/error.rs
@@ -1,7 +1,7 @@
 use super::ffi;
 
-#[derive(thiserror::Error, Debug)]
 /// EGL errors
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// The requested OpenGL version is not supported
     #[error("The requested OpenGL version {0:?} is not supported")]

--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -22,7 +22,7 @@ pub fn make_sure_egl_is_loaded() {
             F: for<'a> Fn(&'a str) -> *const ::std::os::raw::c_void,
         {
             f
-        };
+        }
 
         egl::load_with(|sym| {
             let name = CString::new(sym).unwrap();

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -16,7 +16,6 @@ use input::event;
 use std::path::Path;
 use std::{
     collections::hash_map::HashMap,
-    fmt,
     io::Error as IoError,
     os::unix::io::{AsRawFd, RawFd},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
 #![warn(missing_docs, rust_2018_idioms)]
+
+// Allow returning Result<(), ()>
+#![allow(clippy::result_unit_err)]
+// Allow acronyms like EGL
+#![allow(clippy::upper_case_acronyms)]
+
 //! **Smithay: the Wayland compositor smithy**
 //!
 //! Most entry points in the modules can take an optional [`slog::Logger`](::slog::Logger) as argument


### PR DESCRIPTION
I fixed some clippy warnings by
- globally allowing upper case acronyms. There are a lot of structs/enum variants like *EGL*, therefore I allowed it globally. Should this be handled manually everywhere? There were many cases.
- globally allowing returning `Resulty<(), ()>` where clippy would warn about empty error types.
- locally allowing `match` that clippy would deem suitable to use `matches!()` instead. However, the code would not be more readable in my opinion, so I allowed those locally.
- updating the usage of a deprecated std function (since Rust version 1.50) to stable (since Rust version 1.10)
- using `vec![]` instead of manually creating mutable `Vec<>`
- using `From<>` instead of `Into<>`

For me the question remains whether the global allowing of acronyms and empty results is okay. I am not sure about standard practice here as I am only using Rust since end of last year.