### PR TITLE
Replace usage of slog_or_stdlog with slog_or_fallback

### DIFF
--- a/src/backend/session/auto.rs
+++ b/src/backend/session/auto.rs
@@ -103,7 +103,7 @@ impl AutoSession {
     where
         L: Into<Option<::slog::Logger>>,
     {
-        let logger = crate::slog_or_stdlog(logger)
+        let logger = crate::slog_or_fallback(logger)
             .new(o!("smithay_module" => "backend_session_auto", "session_type" => "auto"));
 
         info!(logger, "Trying to create tty session");


### PR DESCRIPTION
I think this was missed on a previous refactoring pass, and never got
tested?

Here's the error I got trying to run anvil:
```
   Compiling smithay v0.2.0 (/home/benjamin/projects/rust/smithay)
error[E0425]: cannot find function `slog_or_stdlog` in module `crate`
   --> src/backend/session/auto.rs:106:29
    |
106 |         let logger = crate::slog_or_stdlog(logger)
    |                             ^^^^^^^^^^^^^^ not found in `crate`
```

I also got a whole bunch of warnings, but I can fix those in a different PR.