### PR TITLE
check for gl version in gles renderer...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ wayland-server = { version = "0.28.3", optional = true }
 wayland-sys = { version = "0.28", optional = true }
 winit = { version = "0.24.0", optional = true }
 xkbcommon = "0.4.0"
-scan_fmt = "0.2"
+scan_fmt = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 slog-term = "2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ wayland-server = { version = "0.28.3", optional = true }
 wayland-sys = { version = "0.28", optional = true }
 winit = { version = "0.24.0", optional = true }
 xkbcommon = "0.4.0"
+scan_fmt = "0.2"
 
 [dev-dependencies]
 slog-term = "2.3"

--- a/src/backend/renderer/gles2/version.rs
+++ b/src/backend/renderer/gles2/version.rs
@@ -1,0 +1,94 @@
+use std::{convert::TryFrom, ffi::CStr, os::raw::c_char};
+
+use scan_fmt::scan_fmt;
+
+use super::ffi::{self, Gles2};
+
+pub const GLES_3_0: GlVersion = GlVersion::new(3, 0);
+pub const GLES_2_0: GlVersion = GlVersion::new(2, 0);
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct GlVersion {
+    pub major: i32,
+    pub minor: i32,
+}
+
+impl GlVersion {
+    pub const fn new(major: i32, minor: i32) -> Self {
+        GlVersion { major, minor }
+    }
+}
+
+impl Eq for GlVersion {}
+
+impl Ord for GlVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.major.cmp(&other.major) {
+            std::cmp::Ordering::Equal => self.minor.cmp(&other.minor),
+            ord => ord,
+        }
+    }
+}
+
+impl PartialOrd for GlVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl TryFrom<&CStr> for GlVersion {
+    type Error = scan_fmt::parse::ScanError;
+
+    fn try_from(value: &CStr) -> Result<Self, Self::Error> {
+        scan_fmt!(&value.to_string_lossy(), "{d}.{d}", i32, i32)
+            .or_else(|_| scan_fmt!(&value.to_string_lossy(), "OpenGL ES {d}.{d}", i32, i32))
+            .map(|(major, minor)| GlVersion::new(major, minor))
+    }
+}
+
+impl TryFrom<&Gles2> for GlVersion {
+    type Error = scan_fmt::parse::ScanError;
+
+    fn try_from(value: &Gles2) -> Result<Self, Self::Error> {
+        let version = unsafe { CStr::from_ptr(value.GetString(ffi::VERSION) as *const c_char) };
+        GlVersion::try_from(version)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GlVersion;
+    use std::{convert::TryFrom, ffi::CStr, os::raw::c_char};
+
+    #[test]
+    fn test_parse_mesa_3_2() {
+        let gl_version = "OpenGL ES 3.2 Mesa 20.3.5";
+        let gl_version_str = unsafe { CStr::from_ptr(gl_version.as_ptr() as *const c_char) };
+        assert_eq!(GlVersion::try_from(gl_version_str), Ok(GlVersion::new(3, 2)))
+    }
+
+    #[test]
+    fn test_3_2_greater_3_0() {
+        assert!(GlVersion::new(3,2) > GlVersion::new(3,0))
+    }
+
+    #[test]
+    fn test_3_0_greater_or_equal_3_0() {
+        assert!(GlVersion::new(3,0) >= GlVersion::new(3,0))
+    }
+
+    #[test]
+    fn test_3_0_less_or_equal_3_0() {
+        assert!(GlVersion::new(3,0) <= GlVersion::new(3,0))
+    }
+
+    #[test]
+    fn test_3_0_eq_3_0() {
+        assert!(GlVersion::new(3,0) == GlVersion::new(3,0))
+    }
+
+    #[test]
+    fn test_2_0_less_3_0() {
+        assert!(GlVersion::new(2,0) < GlVersion::new(3,0))
+    }
+}

--- a/src/backend/renderer/gles2/version.rs
+++ b/src/backend/renderer/gles2/version.rs
@@ -69,26 +69,26 @@ mod tests {
 
     #[test]
     fn test_3_2_greater_3_0() {
-        assert!(GlVersion::new(3,2) > GlVersion::new(3,0))
+        assert!(GlVersion::new(3, 2) > GlVersion::new(3, 0))
     }
 
     #[test]
     fn test_3_0_greater_or_equal_3_0() {
-        assert!(GlVersion::new(3,0) >= GlVersion::new(3,0))
+        assert!(GlVersion::new(3, 0) >= GlVersion::new(3, 0))
     }
 
     #[test]
     fn test_3_0_less_or_equal_3_0() {
-        assert!(GlVersion::new(3,0) <= GlVersion::new(3,0))
+        assert!(GlVersion::new(3, 0) <= GlVersion::new(3, 0))
     }
 
     #[test]
     fn test_3_0_eq_3_0() {
-        assert!(GlVersion::new(3,0) == GlVersion::new(3,0))
+        assert!(GlVersion::new(3, 0) == GlVersion::new(3, 0))
     }
 
     #[test]
     fn test_2_0_less_3_0() {
-        assert!(GlVersion::new(2,0) < GlVersion::new(3,0))
+        assert!(GlVersion::new(2, 0) < GlVersion::new(3, 0))
     }
 }


### PR DESCRIPTION
Fixes #269 

Starting with Version 3.0 `UNPACK_ROW_LENGTH` is included in GLES and there is no need to check for
the `GL_EXT_unpack_subimage` extension. 
This allows to run anvil on platforms that do not explicit announce the `GL_EXT_unpack_subimage` extension like
the i.MX8M Processor.


## Proposed Changes

  - Check for gl version in gles renderer and only test for `GL_EXT_unpack_subimage` if the version is less than 3.0