### PR TITLE
Dmabuf support

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use slog::Logger;
 use smithay::{
     backend::{
-        renderer::{Frame, Renderer, Texture, Transform, ImportShm, BufferType, buffer_type},
+        renderer::{Frame, Renderer, Texture, Transform, ImportShm, ImportDma, BufferType, buffer_type},
         SwapBuffersError,
     },
     reexports::wayland_server::protocol::{wl_buffer, wl_surface},
@@ -19,7 +19,7 @@ use smithay::{
 #[cfg(feature = "egl")]
 use smithay::backend::{
     egl::display::EGLBufferReader,
-    renderer::ImportEgl
+    renderer::ImportEgl,
 };
 // hacky...
 #[cfg(not(feature = "egl"))]
@@ -53,7 +53,7 @@ pub fn draw_cursor<R, E, F, T>(
     log: &Logger,
 ) -> Result<(), SwapBuffersError>
 where
-    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl,
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl + ImportDma,
     F: Frame<Error = E, TextureId = T>,
     E: std::error::Error + Into<SwapBuffersError>,
     T: Texture + 'static,
@@ -91,7 +91,7 @@ fn draw_surface_tree<R, E, F, T>(
     log: &Logger,
 ) -> Result<(), SwapBuffersError>
 where
-    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl,
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl + ImportDma,
     F: Frame<Error = E, TextureId = T>,
     E: std::error::Error + Into<SwapBuffersError>,
     T: Texture + 'static,
@@ -130,6 +130,7 @@ where
                             },
                             #[cfg(feature = "egl")]
                             Some(BufferType::Egl) => Some(renderer.import_egl_buffer(&buffer, egl_buffer_reader.unwrap())),
+                            Some(BufferType::Dma) => Some(renderer.import_dma_buffer(&buffer)),
                             _ => {
                                 error!(log, "Unknown buffer format for: {:?}", buffer);
                                 None
@@ -209,7 +210,7 @@ pub fn draw_windows<R, E, F, T>(
     log: &::slog::Logger,
 ) -> Result<(), SwapBuffersError>
 where
-    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl,
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl + ImportDma,
     F: Frame<Error = E, TextureId = T>,
     E: std::error::Error + Into<SwapBuffersError>,
     T: Texture + 'static,
@@ -256,7 +257,7 @@ pub fn draw_dnd_icon<R, E, F, T>(
     log: &::slog::Logger,
 ) -> Result<(), SwapBuffersError>
 where
-    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl,
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl + ImportDma,
     F: Frame<Error = E, TextureId = T>,
     E: std::error::Error + Into<SwapBuffersError>,
     T: Texture + 'static,

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -11,6 +11,11 @@ use smithay::{
         seat::CursorImageStatus,
     },
 };
+#[cfg(feature = "egl")]
+use smithay::{
+    backend::renderer::ImportDma,
+    wayland::dmabuf::init_dmabuf_global,
+};
 
 use slog::Logger;
 
@@ -40,6 +45,11 @@ pub fn run_winit(
     #[cfg(feature = "egl")]
     if reader.is_some() {
         info!(log, "EGL hardware-acceleration enabled");
+        let dmabuf_formats = renderer.borrow_mut().renderer().dmabuf_formats().cloned().collect::<Vec<_>>();
+        let renderer = renderer.clone();
+        init_dmabuf_global(&mut *display.borrow_mut(), dmabuf_formats, move |buffer, _| {
+            renderer.borrow_mut().renderer().import_dmabuf(buffer).is_ok()
+        }, log.clone());
     };
 
     let (w, h): (u32, u32) = renderer.borrow().window_size().physical_size.into();

--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -10,21 +10,67 @@
 //! This can be especially useful in resources where other parts of the stack should decide upon
 //! the lifetime of the buffer. E.g. when you are only caching associated resources for a dmabuf.
 
-use super::{Buffer, Format, Modifier};
-use std::os::unix::io::RawFd;
+use super::{Buffer, Format, Fourcc, Modifier};
+use std::os::unix::io::{IntoRawFd, RawFd};
 use std::sync::{Arc, Weak};
+use std::hash::{Hash, Hasher};
 
-const MAX_PLANES: usize = 4;
+/// Maximum amount of planes this implementation supports
+pub const MAX_PLANES: usize = 4;
 
 #[derive(Debug)]
 pub(crate) struct DmabufInternal {
-    pub num_planes: usize,
-    pub offsets: [u32; MAX_PLANES],
-    pub strides: [u32; MAX_PLANES],
-    pub fds: [RawFd; MAX_PLANES],
-    pub width: u32,
-    pub height: u32,
-    pub format: Format,
+    /// The submitted planes
+    pub planes: Vec<Plane>,
+    /// The width of this buffer
+    pub width: i32,
+    /// The height of this buffer
+    pub height: i32,
+    /// The format in use
+    pub format: Fourcc,
+    /// The flags applied to it
+    ///
+    /// This is a bitflag, to be compared with the `Flags` enum re-exported by this module.
+    pub flags: DmabufFlags,
+}
+
+#[derive(Debug)]
+pub(crate) struct Plane {
+    pub fd: Option<RawFd>,
+    /// The plane index
+    pub plane_idx: u32,
+    /// Offset from the start of the Fd
+    pub offset: u32,
+    /// Stride for this plane
+    pub stride: u32,
+    /// Modifier for this plane
+    pub modifier: Modifier,
+}
+
+impl IntoRawFd for Plane {
+    fn into_raw_fd(mut self) -> RawFd {
+        self.fd.take().unwrap()
+    }
+}
+
+impl Drop for Plane {
+    fn drop(&mut self) {
+        if let Some(fd) = self.fd.take() {
+            let _ = nix::unistd::close(fd);
+        }
+    }
+}
+
+bitflags! {
+    /// Possible flags for a DMA buffer
+    pub struct DmabufFlags: u32 {
+        /// The buffer content is Y-inverted
+        const Y_INVERT = 1;
+        /// The buffer content is interlaced
+        const INTERLACED = 2;
+        /// The buffer content if interlaced is bottom-field first
+        const BOTTOM_FIRST = 4;
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -42,109 +88,138 @@ impl PartialEq for Dmabuf {
 }
 impl Eq for Dmabuf {}
 
-impl PartialEq<WeakDmabuf> for Dmabuf {
-    fn eq(&self, other: &WeakDmabuf) -> bool {
-        if let Some(dmabuf) = other.upgrade() {
-            return Arc::ptr_eq(&self.0, &dmabuf.0);
-        }
-        false
-    }
-}
-
 impl PartialEq for WeakDmabuf {
     fn eq(&self, other: &Self) -> bool {
-        if let Some(dmabuf) = self.upgrade() {
-            return &dmabuf == other;
-        }
-        false
+        Weak::ptr_eq(&self.0, &other.0)
+    }
+}
+impl Eq for WeakDmabuf {}
+
+impl Hash for Dmabuf {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.0).hash(state)
+    }
+}
+impl Hash for WeakDmabuf {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_ptr().hash(state)
     }
 }
 
 impl Buffer for Dmabuf {
     fn width(&self) -> u32 {
-        self.0.width
+        self.0.width as u32
     }
 
     fn height(&self) -> u32 {
-        self.0.height
+        self.0.height as u32
     }
 
     fn format(&self) -> Format {
-        self.0.format
+        Format {
+            code: self.0.format,
+            modifier: self.0.planes[0].modifier,
+        }
+    }
+}
+
+/// Builder for Dmabufs
+pub struct DmabufBuilder {
+    internal: DmabufInternal,
+}
+
+impl DmabufBuilder {
+    /// Add a plane to the construted Dmabuf
+    ///
+    /// *Note*: Each Dmabuf needs atleast one plane.
+    /// MAX_PLANES notes the maximum amount of planes any format may use with this implementation.
+    pub fn add_plane(&mut self, fd: RawFd, idx: u32, offset: u32, stride: u32, modifier: Modifier) -> bool {
+        if self.internal.planes.len() == MAX_PLANES {
+            return false;
+        }
+        self.internal.planes.push(Plane {
+            fd: Some(fd),
+            plane_idx: idx,
+            offset,
+            stride,
+            modifier,
+        });
+
+        true
+    }
+
+    /// Build a `Dmabuf` out of the provided parameters and planes
+    ///
+    /// Returns `None` if the builder has no planes attached.
+    pub fn build(mut self) -> Option<Dmabuf> {
+        if self.internal.planes.len() == 0 {
+            return None;
+        }
+
+        self.internal.planes.sort_by_key(|plane| plane.plane_idx);
+        Some(Dmabuf(Arc::new(self.internal)))
     }
 }
 
 impl Dmabuf {
+    /// Create a new Dmabuf by intializing with values from an existing buffer
+    ///
     // Note: the `src` Buffer is only used a reference for size and format.
     // The contents are determined by the provided file descriptors, which
     // do not need to refer to the same buffer `src` does.
-    pub(crate) fn new(
-        src: &impl Buffer,
-        planes: usize,
-        offsets: &[u32],
-        strides: &[u32],
-        fds: &[RawFd],
-    ) -> Option<Dmabuf> {
-        if offsets.len() < planes
-            || strides.len() < planes
-            || fds.len() < planes
-            || planes == 0
-            || planes > MAX_PLANES
-        {
-            return None;
+    pub fn new_from_buffer(src: &impl Buffer, flags: DmabufFlags) -> DmabufBuilder {
+        DmabufBuilder {
+            internal: DmabufInternal {
+                planes: Vec::with_capacity(MAX_PLANES),
+                width: src.width() as i32,
+                height: src.height() as i32,
+                format: src.format().code,
+                flags,
+            },
         }
-
-        let end = [0u32, 0, 0];
-        let end_fds = [0i32, 0, 0];
-        let mut offsets = offsets.iter().take(planes).chain(end.iter());
-        let mut strides = strides.iter().take(planes).chain(end.iter());
-        let mut fds = fds.iter().take(planes).chain(end_fds.iter());
-
-        Some(Dmabuf(Arc::new(DmabufInternal {
-            num_planes: planes,
-            offsets: [
-                *offsets.next().unwrap(),
-                *offsets.next().unwrap(),
-                *offsets.next().unwrap(),
-                *offsets.next().unwrap(),
-            ],
-            strides: [
-                *strides.next().unwrap(),
-                *strides.next().unwrap(),
-                *strides.next().unwrap(),
-                *strides.next().unwrap(),
-            ],
-            fds: [
-                *fds.next().unwrap(),
-                *fds.next().unwrap(),
-                *fds.next().unwrap(),
-                *fds.next().unwrap(),
-            ],
-
-            width: src.width(),
-            height: src.height(),
-            format: src.format(),
-        })))
     }
 
-    /// Return raw handles of the planes of this buffer
-    pub fn handles(&self) -> &[RawFd] {
-        self.0.fds.split_at(self.0.num_planes).0
+    /// Create a new Dmabuf
+    pub fn new(width: u32, height: u32, format: Fourcc, flags: DmabufFlags) -> DmabufBuilder {
+        DmabufBuilder {
+            internal: DmabufInternal {
+                planes: Vec::with_capacity(MAX_PLANES),
+                width: width as i32,
+                height: height as i32,
+                format,
+                flags,
+            },
+        }
     }
 
-    /// Return offsets for the planes of this buffer
-    pub fn offsets(&self) -> &[u32] {
-        self.0.offsets.split_at(self.0.num_planes).0
+    /// The amount of planes this Dmabuf has
+    pub fn num_planes(&self) -> usize {
+        self.0.planes.len()
     }
 
-    /// Return strides for the planes of this buffer
-    pub fn strides(&self) -> &[u32] {
-        self.0.strides.split_at(self.0.num_planes).0
+    /// Returns raw handles of the planes of this buffer
+    pub fn handles<'a>(&'a self) -> impl Iterator<Item = RawFd> + 'a {
+        self.0.planes.iter().map(|p| *p.fd.as_ref().unwrap())
     }
 
-    /// Check if this buffer format has any vendor-specific modifiers set or is implicit/linear
+    /// Returns offsets for the planes of this buffer
+    pub fn offsets<'a>(&'a self) -> impl Iterator<Item = u32> + 'a {
+        self.0.planes.iter().map(|p| p.offset)
+    }
+
+    /// Returns strides for the planes of this buffer
+    pub fn strides<'a>(&'a self) -> impl Iterator<Item = u32> + 'a {
+        self.0.planes.iter().map(|p| p.stride)
+    }
+
+    /// Returns if this buffer format has any vendor-specific modifiers set or is implicit/linear
     pub fn has_modifier(&self) -> bool {
-        self.0.format.modifier != Modifier::Invalid && self.0.format.modifier != Modifier::Linear
+        self.0.planes[0].modifier != Modifier::Invalid && self.0.planes[0].modifier != Modifier::Linear
+    }
+
+    /// Returns if the buffer is stored inverted on the y-axis
+    pub fn y_inverted(&self) -> bool {
+        self.0.flags.contains(DmabufFlags::Y_INVERT)
     }
 
     /// Create a weak reference to this dmabuf
@@ -159,16 +234,6 @@ impl WeakDmabuf {
     /// Fails if no strong references exist anymore and the handle was already closed.
     pub fn upgrade(&self) -> Option<Dmabuf> {
         self.0.upgrade().map(Dmabuf)
-    }
-}
-
-impl Drop for DmabufInternal {
-    fn drop(&mut self) {
-        for fd in self.fds.iter() {
-            if *fd != 0 {
-                let _ = nix::unistd::close(*fd);
-            }
-        }
     }
 }
 

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -1,8 +1,10 @@
 //! EGL context related structs
+use std::collections::HashSet;
 use std::os::raw::c_int;
 use std::sync::atomic::Ordering;
 
 use super::{ffi, wrap_egl_call, Error, MakeCurrentError};
+use crate::backend::allocator::Format as DrmFormat;
 use crate::backend::egl::display::{EGLDisplay, PixelFormat};
 use crate::backend::egl::EGLSurface;
 
@@ -226,6 +228,16 @@ impl EGLContext {
             })?;
         }
         Ok(())
+    }
+
+    /// Returns a list of formats for dmabufs that can be rendered to
+    pub fn dmabuf_render_formats(&self) -> &HashSet<DrmFormat> {
+        &self.display.dmabuf_render_formats
+    }
+
+    /// Returns a list of formats for dmabufs that can be used as textures
+    pub fn dmabuf_texture_formats(&self) -> &HashSet<DrmFormat> {
+        &self.display.dmabuf_import_formats
     }
 }
 

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -19,10 +19,10 @@ use crate::backend::egl::{
     ffi,
     ffi::egl::types::EGLImage,
     native::EGLNativeDisplay,
-    wrap_egl_call, EGLError, Error, Format,
+    wrap_egl_call, EGLError, Error,
 };
-#[cfg(feature = "wayland_frontend")]
-use crate::backend::egl::{BufferAccessError, EGLBuffer};
+#[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
+use crate::backend::egl::{BufferAccessError, EGLBuffer, Format};
 
 /// Wrapper around [`ffi::EGLDisplay`](ffi::egl::types::EGLDisplay) to ensure display is only destroyed
 /// once all resources bound to it have been dropped.
@@ -473,18 +473,17 @@ impl EGLDisplay {
 
         for (i, ((fd, offset), stride)) in dmabuf
             .handles()
-            .iter()
             .zip(dmabuf.offsets())
             .zip(dmabuf.strides())
             .enumerate()
         {
             out.extend(&[
                 names[i][0] as i32,
-                *fd,
+                fd,
                 names[i][1] as i32,
-                *offset as i32,
+                offset as i32,
                 names[i][2] as i32,
-                *stride as i32,
+                stride as i32,
             ]);
             if dmabuf.has_modifier() {
                 out.extend(&[
@@ -510,7 +509,6 @@ impl EGLDisplay {
             if image == ffi::egl::NO_IMAGE_KHR {
                 Err(Error::EGLImageCreationFailed)
             } else {
-                // TODO check for external
                 Ok(image)
             }
         }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -16,7 +16,6 @@ use crate::backend::{
 };
 use std::{cell::RefCell, rc::Rc, time::Instant};
 use wayland_egl as wegl;
-use wayland_server::Display;
 use winit::{
     dpi::{LogicalPosition, LogicalSize, PhysicalSize},
     event::{
@@ -29,6 +28,8 @@ use winit::{
     window::{Window as WinitWindow, WindowBuilder},
 };
 
+#[cfg(feature = "use_system_lib")]
+use wayland_server::Display;
 #[cfg(feature = "use_system_lib")]
 use crate::backend::egl::display::EGLBufferReader;
 

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -32,9 +32,8 @@
 //! let dmabuf_global = init_dmabuf_global(
 //!     &mut display,
 //!     formats,
-//!     |buffer, _| {
+//!     |buffer, dispatch_data| {
 //!         /* validate the dmabuf and import it into your renderer state */
-//!         let dmabuf = buffer.as_ref().user_data().get::<Dmabuf>().expect("dmabuf global sets this for us");
 //!         true
 //!     },
 //!     None // we don't provide a logger in this example

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -16,7 +16,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub mod compositor;
 pub mod data_device;
-#[cfg(feature = "backend_drm")]
 pub mod dmabuf;
 pub mod explicit_synchronization;
 pub mod output;


### PR DESCRIPTION
Based on #261.
Finally fixes #96.

Provides support for client buffers submitted through the `linux-dmabuf` protocol extensions. Takes the (in my opinion) cleaner code of the `BufferInfo` struct in the existing protocol implementation and unifies that with the `backend::allocator::dmabuf` module to provide a common dmabuf type across smithay.

Currently just as limited as our wl_drm/egl-buffer implementation. We can only display buffers on the primary gpu on multi-gpu setups.

Tested using `weston-simple-dmabuf-egl` and `XWayland`.