### PR TITLE
allocator: Let the allocator select the best modifier out of a given set

### DIFF
--- a/src/backend/allocator/mod.rs
+++ b/src/backend/allocator/mod.rs
@@ -49,5 +49,11 @@ pub trait Allocator<B: Buffer> {
     type Error: std::error::Error;
 
     /// Try to create a buffer with the given dimensions and pixel format
-    fn create_buffer(&mut self, width: u32, height: u32, format: Format) -> Result<B, Self::Error>;
+    fn create_buffer(
+        &mut self,
+        width: u32,
+        height: u32,
+        fourcc: Fourcc,
+        modifiers: &[Modifier],
+    ) -> Result<B, Self::Error>;
 }

--- a/src/backend/allocator/swapchain.rs
+++ b/src/backend/allocator/swapchain.rs
@@ -4,7 +4,7 @@ use std::sync::{
     Arc, Mutex, MutexGuard,
 };
 
-use crate::backend::allocator::{Allocator, Buffer, Format};
+use crate::backend::allocator::{Allocator, Buffer, Fourcc, Modifier};
 
 pub const SLOT_CAP: usize = 4;
 
@@ -41,7 +41,8 @@ pub struct Swapchain<A: Allocator<B>, B: Buffer, U: 'static> {
 
     width: u32,
     height: u32,
-    format: Format,
+    fourcc: Fourcc,
+    modifiers: Vec<Modifier>,
 
     slots: [Arc<InternalSlot<B, U>>; SLOT_CAP],
 }
@@ -96,12 +97,19 @@ where
     U: 'static,
 {
     /// Create a new swapchain with the desired allocator and dimensions and pixel format for the created buffers.
-    pub fn new(allocator: A, width: u32, height: u32, format: Format) -> Swapchain<A, B, U> {
+    pub fn new(
+        allocator: A,
+        width: u32,
+        height: u32,
+        fourcc: Fourcc,
+        modifiers: Vec<Modifier>,
+    ) -> Swapchain<A, B, U> {
         Swapchain {
             allocator,
             width,
             height,
-            format,
+            fourcc,
+            modifiers,
             slots: Default::default(),
         }
     }
@@ -122,7 +130,8 @@ where
                 free_slot.buffer = Some(self.allocator.create_buffer(
                     self.width,
                     self.height,
-                    self.format,
+                    self.fourcc,
+                    &self.modifiers,
                 )?);
             }
             assert!(free_slot.buffer.is_some());


### PR DESCRIPTION
This change fixes modifier selection by delegating this to the allocators
and thus to libgbm, which can ask the driver for an appropriate modifier
for scanout, that results in the best possible performance.

We do not have this information, the order in which modifiers are returned
by EGL has no meaning and this is far better then testing modifiers
non-deterministically at random and choosing the first one, that does
not error out...