### PR TITLE
Use Default derive for ModifiersState and remove new()

### DIFF
--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -45,8 +45,8 @@ pub struct ModifiersState {
     pub num_lock: bool,
 }
 
-impl ModifiersState {
-    fn new() -> ModifiersState {
+impl Default for ModifiersState {
+    fn default() -> Self {
         ModifiersState {
             ctrl: false,
             alt: false,
@@ -56,7 +56,9 @@ impl ModifiersState {
             num_lock: false,
         }
     }
+}
 
+impl ModifiersState {
     fn update_with(&mut self, state: &xkb::State) {
         self.ctrl = state.mod_name_is_active(&xkb::MOD_NAME_CTRL, xkb::STATE_MODS_EFFECTIVE);
         self.alt = state.mod_name_is_active(&xkb::MOD_NAME_ALT, xkb::STATE_MODS_EFFECTIVE);
@@ -170,7 +172,7 @@ impl KbdInternal {
             known_kbds: Vec::new(),
             focus: None,
             pressed_keys: Vec::new(),
-            mods_state: ModifiersState::new(),
+            mods_state: ModifiersState::default(),
             keymap,
             state,
             repeat_rate,

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -27,7 +27,7 @@ pub use xkbcommon::xkb::{keysyms, Keysym};
 ///
 /// For some modifiers, this means that the key is currently pressed, others are toggled
 /// (like caps lock).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct ModifiersState {
     /// The "control" key
     pub ctrl: bool,
@@ -43,19 +43,6 @@ pub struct ModifiersState {
     pub logo: bool,
     /// The "Num lock" key
     pub num_lock: bool,
-}
-
-impl Default for ModifiersState {
-    fn default() -> Self {
-        ModifiersState {
-            ctrl: false,
-            alt: false,
-            shift: false,
-            caps_lock: false,
-            logo: false,
-            num_lock: false,
-        }
-    }
 }
 
 impl ModifiersState {


### PR DESCRIPTION
Offer public default constructor for ModifiersState. The Default derive is sufficient because all bools are initialized to false anyway. Removed new() and replaced occurrence with default().

Useful when using configuration files for KeyBindings. These can be parsed and then directly compared to keyboard events, that already provide ModifiersState.