### PR TITLE
Rework DrmRenderSurface into GbmBufferedSurface

### DIFF
--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -62,8 +62,6 @@
 
 pub(crate) mod device;
 pub(self) mod error;
-#[cfg(feature = "backend_gbm")]
-mod render;
 #[cfg(feature = "backend_session")]
 pub(self) mod session;
 pub(self) mod surface;
@@ -71,7 +69,7 @@ pub(self) mod surface;
 pub use device::{DevPath, DrmDevice, DrmEvent};
 pub use error::Error as DrmError;
 #[cfg(feature = "backend_gbm")]
-pub use render::{DrmRenderSurface, Error as DrmRenderError};
+pub use surface::gbm::{Error as GbmBufferedSurfaceError, GbmBufferedSurface};
 pub use surface::DrmSurface;
 
 use drm::control::{crtc, plane, Device as ControlDevice, PlaneType};

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -10,6 +10,8 @@ use drm::{Device as BasicDevice, DriverCapability};
 use nix::libc::dev_t;
 
 pub(super) mod atomic;
+#[cfg(feature = "backend_gbm")]
+pub(super) mod gbm;
 pub(super) mod legacy;
 use super::{device::DevPath, error::Error, plane_type, planes, PlaneType, Planes};
 use crate::backend::allocator::{Format, Fourcc, Modifier};


### PR DESCRIPTION
Removes the renderer from the `DrmRenderSurface` allowing anvil to use just one renderer per backend.
Will allow the `ImportEGL`-trait to hold the `EGLBufferReader` (to be done in a future PR).

Since the old `DrmRenderSurface` was dependant on gbm anyway to import buffers, the new `GbmBufferedSurface` does now only supports gbm as an allocator.

Thus it was renamed. This gets rid of tons of generics, which were not very useful to begin with. There are no useful other allocators that can be imported into gbm (only DumbBuffers might work here, but this still can be implemented, just not with this surface). This also allows us to skip our weird gbm->dmabuf->gbm export-import cycle. The buffer is now only exported once. (cc @cmeissl, if I remember correctly, this helps your compositor.)

The only short-coming is, that this exposes the weirdness of the buffer-scanout coordinate system directly to the user, who has to set Transform::Flipped180 to get a correct image. There is nothing we can do about this to "fix" this on the drm side and I was not able to come up with a satisfying work-around that hides this detail.