### PR TITLE
fix clippy unknown lint

### DIFF
--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -305,7 +305,7 @@ where
         }
     }
 
-    #[allow(clippy::clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn create_immed<'a>(
         &mut self,
         params: &BufferParams,


### PR DESCRIPTION
This PR just removes a duplicated `clippy` annotation.