### PR TITLE
Move `EGLBufferReader` management into `ImportEgl`

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use slog::Logger;
 use smithay::{
     backend::{
-        renderer::{BufferType, Frame, ImportAll, Renderer, Texture, Transform},
+        renderer::{buffer_type, BufferType, Frame, ImportAll, Renderer, Texture, Transform},
         SwapBuffersError,
     },
     reexports::wayland_server::protocol::{wl_buffer, wl_surface},
@@ -96,7 +96,7 @@ where
 
                         match renderer.import_buffer(&buffer, Some(&attributes), &damage) {
                             Some(Ok(m)) => {
-                                if let Some(BufferType::Shm) = renderer.buffer_type(&buffer) {
+                                if let Some(BufferType::Shm) = buffer_type(&buffer) {
                                     buffer.release();
                                 }
                                 data.texture = Some(Box::new(BufferTextures {

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -3,11 +3,9 @@
 use std::cell::RefCell;
 
 use slog::Logger;
-#[cfg(feature = "egl")]
-use smithay::backend::{egl::display::EGLBufferReader, renderer::ImportEgl};
 use smithay::{
     backend::{
-        renderer::{buffer_type, BufferType, Frame, ImportDma, ImportShm, Renderer, Texture, Transform},
+        renderer::{BufferType, Frame, ImportAll, Renderer, Texture, Transform},
         SwapBuffersError,
     },
     reexports::wayland_server::protocol::{wl_buffer, wl_surface},
@@ -18,11 +16,6 @@ use smithay::{
         seat::CursorImageRole,
     },
 };
-// hacky...
-#[cfg(not(feature = "egl"))]
-pub trait ImportEgl {}
-#[cfg(not(feature = "egl"))]
-impl<T> ImportEgl for T {}
 
 use crate::shell::{MyCompositorToken, MyWindowMap, SurfaceData};
 
@@ -43,13 +36,12 @@ pub fn draw_cursor<R, E, F, T>(
     renderer: &mut R,
     frame: &mut F,
     surface: &wl_surface::WlSurface,
-    #[cfg(feature = "egl")] egl_buffer_reader: Option<&EGLBufferReader>,
     (x, y): (i32, i32),
     token: MyCompositorToken,
     log: &Logger,
 ) -> Result<(), SwapBuffersError>
 where
-    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl + ImportDma,
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
     F: Frame<Error = E, TextureId = T>,
     E: std::error::Error + Into<SwapBuffersError>,
     T: Texture + 'static,
@@ -64,29 +56,19 @@ where
             (0, 0)
         }
     };
-    draw_surface_tree(
-        renderer,
-        frame,
-        surface,
-        #[cfg(feature = "egl")]
-        egl_buffer_reader,
-        (x - dx, y - dy),
-        token,
-        log,
-    )
+    draw_surface_tree(renderer, frame, surface, (x - dx, y - dy), token, log)
 }
 
 fn draw_surface_tree<R, E, F, T>(
     renderer: &mut R,
     frame: &mut F,
     root: &wl_surface::WlSurface,
-    #[cfg(feature = "egl")] egl_buffer_reader: Option<&EGLBufferReader>,
     location: (i32, i32),
     compositor_token: MyCompositorToken,
     log: &Logger,
 ) -> Result<(), SwapBuffersError>
 where
-    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl + ImportDma,
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
     F: Frame<Error = E, TextureId = T>,
     E: std::error::Error + Into<SwapBuffersError>,
     T: Texture + 'static,
@@ -102,54 +84,36 @@ where
                 let mut data = data.borrow_mut();
                 if data.texture.is_none() {
                     if let Some(buffer) = data.current_state.buffer.take() {
-                        let texture = match buffer_type(
-                            &buffer,
-                            #[cfg(feature = "egl")]
-                            egl_buffer_reader,
-                        ) {
-                            Some(BufferType::Shm) => {
-                                let damage = attributes
-                                    .damage
-                                    .iter()
-                                    .map(|dmg| match dmg {
-                                        Damage::Buffer(rect) => *rect,
-                                        // TODO also apply transformations
-                                        Damage::Surface(rect) => rect.scale(attributes.buffer_scale),
-                                    })
-                                    .collect::<Vec<_>>();
-                                let result = renderer.import_shm_buffer(&buffer, Some(&attributes), &damage);
-                                buffer.release();
-                                // don't return the buffer as it is already released
-                                Some((result, None))
-                            }
-                            #[cfg(feature = "egl")]
-                            Some(BufferType::Egl) => Some((
-                                renderer.import_egl_buffer(&buffer, egl_buffer_reader.unwrap()),
-                                Some(buffer),
-                            )),
-                            Some(BufferType::Dma) => {
-                                Some((renderer.import_dma_buffer(&buffer), Some(buffer)))
-                            }
-                            _ => {
-                                error!(log, "Unknown buffer format for: {:?}", buffer);
-                                buffer.release();
-                                None
-                            }
-                        };
-                        match texture {
-                            Some((Ok(m), buffer)) => {
-                                data.texture = Some(Box::new(BufferTextures { buffer, texture: m })
-                                    as Box<dyn std::any::Any + 'static>)
-                            }
-                            // there was an error reading the buffer, release it.
-                            Some((Err(err), buffer)) => {
-                                warn!(log, "Error loading buffer: {:?}", err);
-                                if let Some(buffer) = buffer {
+                        let damage = attributes
+                            .damage
+                            .iter()
+                            .map(|dmg| match dmg {
+                                Damage::Buffer(rect) => *rect,
+                                // TODO also apply transformations
+                                Damage::Surface(rect) => rect.scale(attributes.buffer_scale),
+                            })
+                            .collect::<Vec<_>>();
+
+                        match renderer.import_buffer(&buffer, Some(&attributes), &damage) {
+                            Some(Ok(m)) => {
+                                if let Some(BufferType::Shm) = renderer.buffer_type(&buffer) {
                                     buffer.release();
                                 }
+                                data.texture = Some(Box::new(BufferTextures {
+                                    buffer: Some(buffer),
+                                    texture: m,
+                                })
+                                    as Box<dyn std::any::Any + 'static>)
                             }
-                            None => {}
-                        };
+                            Some(Err(err)) => {
+                                warn!(log, "Error loading buffer: {:?}", err);
+                                buffer.release();
+                            }
+                            None => {
+                                error!(log, "Unknown buffer format for: {:?}", buffer);
+                                buffer.release();
+                            }
+                        }
                     }
                 }
                 // Now, should we be drawn ?
@@ -204,14 +168,13 @@ where
 pub fn draw_windows<R, E, F, T>(
     renderer: &mut R,
     frame: &mut F,
-    #[cfg(feature = "egl")] egl_buffer_reader: Option<&EGLBufferReader>,
     window_map: &MyWindowMap,
     output_rect: Option<Rectangle>,
     compositor_token: MyCompositorToken,
     log: &::slog::Logger,
 ) -> Result<(), SwapBuffersError>
 where
-    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl + ImportDma,
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
     F: Frame<Error = E, TextureId = T>,
     E: std::error::Error + Into<SwapBuffersError>,
     T: Texture + 'static,
@@ -229,16 +192,9 @@ where
         }
         if let Some(wl_surface) = toplevel_surface.get_surface() {
             // this surface is a root of a subsurface tree that needs to be drawn
-            if let Err(err) = draw_surface_tree(
-                renderer,
-                frame,
-                &wl_surface,
-                #[cfg(feature = "egl")]
-                egl_buffer_reader,
-                initial_place,
-                compositor_token,
-                log,
-            ) {
+            if let Err(err) =
+                draw_surface_tree(renderer, frame, &wl_surface, initial_place, compositor_token, log)
+            {
                 result = Err(err);
             }
         }
@@ -251,13 +207,12 @@ pub fn draw_dnd_icon<R, E, F, T>(
     renderer: &mut R,
     frame: &mut F,
     surface: &wl_surface::WlSurface,
-    #[cfg(feature = "egl")] egl_buffer_reader: Option<&EGLBufferReader>,
     (x, y): (i32, i32),
     token: MyCompositorToken,
     log: &::slog::Logger,
 ) -> Result<(), SwapBuffersError>
 where
-    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportShm + ImportEgl + ImportDma,
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
     F: Frame<Error = E, TextureId = T>,
     E: std::error::Error + Into<SwapBuffersError>,
     T: Texture + 'static,
@@ -268,14 +223,5 @@ where
             "Trying to display as a dnd icon a surface that does not have the DndIcon role."
         );
     }
-    draw_surface_tree(
-        renderer,
-        frame,
-        surface,
-        #[cfg(feature = "egl")]
-        egl_buffer_reader,
-        (x, y),
-        token,
-        log,
-    )
+    draw_surface_tree(renderer, frame, surface, (x, y), token, log)
 }

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -20,8 +20,6 @@ use smithay::{
     },
 };
 
-#[cfg(feature = "egl")]
-use smithay::backend::egl::display::EGLBufferReader;
 #[cfg(feature = "xwayland")]
 use smithay::xwayland::{XWayland, XWaylandEvent};
 
@@ -177,6 +175,4 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
 
 pub trait Backend {
     fn seat_name(&self) -> String;
-    #[cfg(feature = "egl")]
-    fn egl_reader(&self) -> Option<EGLBufferReader>;
 }

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -45,8 +45,7 @@ pub struct AnvilState<BackendData> {
     pub cursor_status: Arc<Mutex<CursorImageStatus>>,
     pub seat_name: String,
     pub start_time: std::time::Instant,
-    #[cfg(feature = "egl")]
-    pub egl_reader: Option<EGLBufferReader>,
+    // things we must keep alive
     #[cfg(feature = "xwayland")]
     pub xwayland: XWayland<AnvilState<BackendData>>,
 }
@@ -56,7 +55,6 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
         display: Rc<RefCell<Display>>,
         handle: LoopHandle<'static, AnvilState<BackendData>>,
         backend_data: BackendData,
-        #[cfg(feature = "egl")] egl_reader: Option<EGLBufferReader>,
         log: slog::Logger,
     ) -> AnvilState<BackendData> {
         // init the wayland connection
@@ -170,8 +168,6 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
             cursor_status,
             pointer_location: (0.0, 0.0),
             seat_name,
-            #[cfg(feature = "egl")]
-            egl_reader,
             start_time: std::time::Instant::now(),
             #[cfg(feature = "xwayland")]
             xwayland,
@@ -181,4 +177,6 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
 
 pub trait Backend {
     fn seat_name(&self) -> String;
+    #[cfg(feature = "egl")]
+    fn egl_reader(&self) -> Option<EGLBufferReader>;
 }

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -60,7 +60,6 @@ use smithay::{
 use smithay::{
     backend::{
         drm::DevPath,
-        egl::display::EGLBufferReader,
         renderer::{ImportDma, ImportEgl},
         udev::primary_gpu,
     },
@@ -91,12 +90,6 @@ pub struct UdevData {
 }
 
 impl Backend for UdevData {
-    #[cfg(feature = "egl")]
-    fn egl_reader(&self) -> Option<EGLBufferReader> {
-        self.backends
-            .values()
-            .find_map(|backend| backend.renderer.borrow().egl_reader().cloned())
-    }
     fn seat_name(&self) -> String {
         self.session.seat()
     }

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -1,13 +1,7 @@
 use std::{cell::RefCell, rc::Rc, sync::atomic::Ordering, time::Duration};
 
 #[cfg(feature = "egl")]
-use smithay::{
-    backend::{
-        egl::display::EGLBufferReader,
-        renderer::{ImportDma, ImportEgl},
-    },
-    wayland::dmabuf::init_dmabuf_global,
-};
+use smithay::{backend::renderer::ImportDma, wayland::dmabuf::init_dmabuf_global};
 use smithay::{
     backend::{input::InputBackend, renderer::Frame, winit, SwapBuffersError},
     reexports::{
@@ -25,14 +19,9 @@ use slog::Logger;
 use crate::drawing::*;
 use crate::state::{AnvilState, Backend};
 
-pub struct WinitData(Rc<RefCell<winit::WinitGraphicsBackend>>);
+pub struct WinitData;
 
 impl Backend for WinitData {
-    #[cfg(feature = "egl")]
-    fn egl_reader(&self) -> Option<EGLBufferReader> {
-        self.0.borrow_mut().renderer().egl_reader().cloned()
-    }
-
     fn seat_name(&self) -> String {
         String::from("winit")
     }
@@ -75,7 +64,7 @@ pub fn run_winit(
     let mut state = AnvilState::init(
         display.clone(),
         event_loop.handle(),
-        WinitData(renderer.clone()),
+        WinitData,
         log.clone(),
     );
 

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -25,7 +25,7 @@ use crate::backend::allocator::{dmabuf::Dmabuf, Format};
     feature = "backend_egl",
     feature = "use_system_lib"
 ))]
-use crate::backend::egl::display::EGLBufferReader;
+use crate::backend::egl::{display::EGLBufferReader, Error as EglError};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 /// Possible transformations to two-dimensional planes
@@ -281,6 +281,34 @@ pub trait ImportShm: Renderer {
 ))]
 /// Trait for Renderers supporting importing wl_drm-based buffers.
 pub trait ImportEgl: Renderer {
+    /// Binds the underlying EGL display to the given Wayland display.
+    ///
+    /// This will allow clients to utilize EGL to create hardware-accelerated
+    /// surfaces. This renderer will thus be able to handle wl_drm-based buffers.
+    ///
+    /// ## Errors
+    ///
+    /// This might return [`EglExtensionNotSupported`](Error::EglExtensionNotSupported)
+    /// if binding is not supported by the EGL implementation.
+    ///
+    /// This might return [`OtherEGLDisplayAlreadyBound`](Error::OtherEGLDisplayAlreadyBound)
+    /// if called for the same [`Display`] multiple times, as only one egl display may be bound at any given time.
+    fn bind_wl_display(&mut self, display: &wayland_server::Display) -> Result<(), EglError>;
+
+    /// Unbinds a previously bound egl display, if existing.
+    ///
+    /// *Note*: As a result any previously created egl-based WlBuffers will not be readable anymore.
+    /// Your compositor will have to deal with existing buffers of *unknown* type.
+    fn unbind_wl_display(&mut self);
+
+    /// Returns the underlying [`EGLBufferReader`].
+    ///
+    /// The primary use for this is calling [`buffer_dimensions`] or [`buffer_type`].
+    ///
+    /// Returns `None` if no [`Display`] was previously bound to the underlying [`EGLDisplay`]
+    /// (see [`ImportEgl::bind_wl_display`]).
+    fn egl_reader(&self) -> Option<&EGLBufferReader>;
+
     /// Import a given wl_drm-based buffer into the renderer (see [`buffer_type`]).
     ///
     /// Returns a texture_id, which can be used with [`Frame::render_texture`] (or [`Frame::render_texture_at`])
@@ -295,7 +323,6 @@ pub trait ImportEgl: Renderer {
     fn import_egl_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
-        egl: &EGLBufferReader,
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>;
 }
 
@@ -351,12 +378,8 @@ pub trait ImportDma: Renderer {
 // pub type ImportAll = Renderer + ImportShm + ImportEgl;
 
 /// Common trait for renderers of any wayland buffer type
-#[cfg(all(
-    feature = "wayland_frontend",
-    feature = "backend_egl",
-    feature = "use_system_lib"
-))]
-pub trait ImportAll: Renderer + ImportShm + ImportEgl {
+#[cfg(feature = "wayland_frontend")]
+pub trait ImportAll: Renderer {
     /// Import a given buffer into the renderer.
     ///
     /// Returns a texture_id, which can be used with [`Frame::render_texture`] (or [`Frame::render_texture_at`])
@@ -380,21 +403,86 @@ pub trait ImportAll: Renderer + ImportShm + ImportEgl {
         buffer: &wl_buffer::WlBuffer,
         surface: Option<&SurfaceAttributes>,
         damage: &[Rectangle],
-        egl: Option<&EGLBufferReader>,
-    ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>> {
-        match buffer_type(buffer, egl) {
-            Some(BufferType::Shm) => Some(self.import_shm_buffer(buffer, surface, damage)),
-            Some(BufferType::Egl) => Some(self.import_egl_buffer(buffer, egl.unwrap())),
-            _ => None,
-        }
-    }
+    ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>>;
+
+    /// Returns the *type* of a wl_buffer
+    ///
+    /// *Note*: Different to [`buffer_type`] this variant uses its internal `EGLBufferReader`, if
+    /// - the underlying Renderer supports `ImportEgl`,
+    /// - smithay was compiled with the `backend_egl` and `use_system_lib`,
+    /// - and the underlying Renderer bound via [`ImportEgl::bind_wl_display`] successfully.
+    ///
+    /// Returns `None` if the type is not known to smithay
+    /// or otherwise not supported (e.g. not initialized using one of smithays [`crate::wayland`]-handlers).
+    fn buffer_type(&self, buffer: &wl_buffer::WlBuffer) -> Option<BufferType>;
+
+    /// Returns the dimensions of a wl_buffer
+    ///
+    /// *Note*: This will only return dimensions for buffer types known to smithay (see [`buffer_type`]).
+    ///
+    /// *Note*: Different to [`buffer_type`] this variant uses its internal `EGLBufferReader`, if
+    /// - the underlying Renderer supports `ImportEgl`,
+    /// - smithay was compiled with the `backend_egl` and `use_system_lib`,
+    /// - and the underlying Renderer bound via [`ImportEgl::bind_wl_display`] successfully.
+    fn buffer_dimensions(&self, buffer: &wl_buffer::WlBuffer) -> Option<(i32, i32)>;
 }
+
+// TODO: Do this with specialization, when possible and do default implementations
 #[cfg(all(
     feature = "wayland_frontend",
     feature = "backend_egl",
     feature = "use_system_lib"
 ))]
-impl<R: Renderer + ImportShm + ImportEgl> ImportAll for R {}
+impl<R: Renderer + ImportShm + ImportEgl + ImportDma> ImportAll for R {
+    fn import_buffer(
+        &mut self,
+        buffer: &wl_buffer::WlBuffer,
+        surface: Option<&SurfaceAttributes>,
+        damage: &[Rectangle],
+    ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>> {
+        match buffer_type(buffer, self.egl_reader()) {
+            Some(BufferType::Shm) => Some(self.import_shm_buffer(buffer, surface, damage)),
+            Some(BufferType::Egl) => Some(self.import_egl_buffer(buffer)),
+            Some(BufferType::Dma) => Some(self.import_dma_buffer(buffer)),
+            _ => None,
+        }
+    }
+
+    fn buffer_type(&self, buffer: &wl_buffer::WlBuffer) -> Option<BufferType> {
+        buffer_type(buffer, self.egl_reader())
+    }
+
+    fn buffer_dimensions(&self, buffer: &wl_buffer::WlBuffer) -> Option<(i32, i32)> {
+        buffer_dimensions(buffer, self.egl_reader())
+    }
+}
+
+#[cfg(all(
+    feature = "wayland_frontend",
+    not(all(feature = "backend_egl", feature = "use_system_lib"))
+))]
+impl<R: Renderer + ImportShm + ImportDma> ImportAll for R {
+    fn import_buffer(
+        &mut self,
+        buffer: &wl_buffer::WlBuffer,
+        surface: Option<&SurfaceAttributes>,
+        damage: &[Rectangle],
+    ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>> {
+        match buffer_type(buffer) {
+            Some(BufferType::Shm) => Some(self.import_shm_buffer(buffer, surface, damage)),
+            Some(BufferType::Dma) => Some(self.import_dma_buffer(buffer)),
+            _ => None,
+        }
+    }
+
+    fn buffer_type(&self, buffer: &wl_buffer::WlBuffer) -> Option<BufferType> {
+        buffer_type(buffer)
+    }
+
+    fn buffer_dimensions(&self, buffer: &wl_buffer::WlBuffer) -> Option<(i32, i32)> {
+        buffer_dimensions(buffer)
+    }
+}
 
 #[cfg(feature = "wayland_frontend")]
 #[non_exhaustive]


### PR DESCRIPTION
This moves the responsibility of managing an `EGLBufferReader` into types implementing `ImportEgl` (right now only our `Gles2Renderer`) to get rid of most of the `feature = egl` cfg-options in anvil.

Especially `anvil/src/drawing.rs` is now a lot cleaner, ~~but since the buffer reader (or the renderer) is required to read out the buffer dimensions, egl still bleeds into `anvil/src/shell.rs`~~ - worked around by using a global inside smithay.