### PR TITLE
Large cleanup of the codebase

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -9,7 +9,7 @@ use crate::AnvilState;
 use smithay::{
     backend::input::{
         self, Event, InputBackend, InputEvent, KeyState, KeyboardKeyEvent, PointerAxisEvent,
-        PointerButtonEvent, PointerMotionAbsoluteEvent, PointerMotionEvent,
+        PointerButtonEvent,
     },
     reexports::wayland_server::protocol::wl_pointer,
     wayland::{
@@ -18,8 +18,11 @@ use smithay::{
     },
 };
 
+#[cfg(feature = "winit")]
+use smithay::backend::input::PointerMotionAbsoluteEvent;
+
 #[cfg(feature = "udev")]
-use smithay::backend::session::Session;
+use smithay::backend::{input::PointerMotionEvent, session::Session};
 
 impl<Backend> AnvilState<Backend> {
     fn keyboard_key_to_action<B: InputBackend>(&mut self, evt: B::KeyboardKeyEvent) -> KeyAction {

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -1,4 +1,10 @@
 #![warn(rust_2018_idioms)]
+// If no backend is enabled, a large portion of the codebase is unused.
+// So silence this useless warning for the CI.
+#![cfg_attr(
+    not(any(feature = "winit", feature = "udev")),
+    allow(dead_code, unused_imports)
+)]
 
 #[macro_use]
 extern crate slog;
@@ -57,7 +63,10 @@ fn main() {
                 crit!(log, "Failed to initialize tty backend.");
             }
         }
-        _ => {
+        Some(other) => {
+            crit!(log, "Unknown backend: {}", other);
+        }
+        None => {
             println!("USAGE: anvil --backend");
             println!();
             println!("Possible backends are:");

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -56,21 +56,18 @@ impl Kind {
 
     /// Activate/Deactivate this window
     pub fn set_activated(&self, active: bool) {
-        match *self {
-            Kind::Xdg(ref t) => {
-                let changed = t.with_pending_state(|state| {
-                    if active {
-                        state.states.set(xdg_toplevel::State::Activated)
-                    } else {
-                        state.states.unset(xdg_toplevel::State::Activated)
-                    }
-                });
-                if let Ok(true) = changed {
-                    t.send_configure();
+        if let Kind::Xdg(ref t) = self {
+            let changed = t.with_pending_state(|state| {
+                if active {
+                    state.states.set(xdg_toplevel::State::Activated)
+                } else {
+                    state.states.unset(xdg_toplevel::State::Activated)
                 }
+            });
+            if let Ok(true) = changed {
+                t.send_configure();
             }
-            _ => {}
-        };
+        }
     }
 }
 

--- a/anvil/src/window_map.rs
+++ b/anvil/src/window_map.rs
@@ -33,6 +33,7 @@ impl Kind {
             Kind::X11(ref t) => t.alive(),
         }
     }
+
     pub fn get_surface(&self) -> Option<&wl_surface::WlSurface> {
         match *self {
             Kind::Xdg(ref t) => t.get_surface(),
@@ -84,6 +85,7 @@ impl PopupKind {
             PopupKind::Xdg(ref t) => t.alive(),
         }
     }
+
     pub fn get_surface(&self) -> Option<&wl_surface::WlSurface> {
         match *self {
             PopupKind::Xdg(ref t) => t.get_surface(),

--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -61,7 +61,7 @@ impl Drop for Plane {
     }
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// Possible flags for a DMA buffer
     pub struct DmabufFlags: u32 {
         /// The buffer content is Y-inverted

--- a/src/backend/drm/device/atomic.rs
+++ b/src/backend/drm/device/atomic.rs
@@ -14,6 +14,8 @@ use drm::control::{
 use super::{DevPath, FdWrapper};
 use crate::backend::drm::error::Error;
 
+use slog::{error, o, trace};
+
 type OldState = (
     Vec<(connector::Handle, PropertyValueSet)>,
     Vec<(crtc::Handle, PropertyValueSet)>,

--- a/src/backend/drm/device/legacy.rs
+++ b/src/backend/drm/device/legacy.rs
@@ -10,6 +10,8 @@ use drm::control::{connector, crtc, Device as ControlDevice};
 use super::{DevPath, FdWrapper};
 use crate::backend::drm::error::Error;
 
+use slog::{error, info, o};
+
 pub struct LegacyDrmDevice<A: AsRawFd + 'static> {
     pub(crate) fd: Arc<FdWrapper<A>>,
     pub(crate) active: Arc<AtomicBool>,

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "backend_session")]
 use std::cell::RefCell;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
@@ -15,6 +16,8 @@ use super::surface::{atomic::AtomicDrmSurface, legacy::LegacyDrmSurface, DrmSurf
 use super::{error::Error, planes, Planes};
 use atomic::AtomicDrmDevice;
 use legacy::LegacyDrmDevice;
+
+use slog::{error, info, o, trace, warn};
 
 /// An open drm device
 pub struct DrmDevice<A: AsRawFd + 'static> {

--- a/src/backend/drm/session.rs
+++ b/src/backend/drm/session.rs
@@ -18,6 +18,8 @@ use crate::{
     signaling::{Linkable, Signaler},
 };
 
+use slog::{crit, error, info, o, warn};
+
 struct DrmDeviceObserver<A: AsRawFd + 'static> {
     dev_id: dev_t,
     dev: Weak<DrmDeviceInternal<A>>,

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -752,6 +752,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
     }
 
     // If a mode is set a matching blob needs to be set (the inverse is not true)
+    #[allow(clippy::too_many_arguments)]
     pub fn build_request<'a>(
         &self,
         new_connectors: &mut dyn Iterator<Item = &connector::Handle>,

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -17,6 +17,8 @@ use crate::backend::drm::{
     error::Error,
 };
 
+use slog::{debug, info, o, trace, warn};
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct State {
     pub mode: Mode,

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -313,7 +313,7 @@ where
 
         let maybe_buffer = slot.userdata().as_ref().map(|(buf, _)| buf.clone());
         let dmabuf = match maybe_buffer {
-            Some(buf) => buf.clone(),
+            Some(buf) => buf,
             None => {
                 let dmabuf = slot.export()?;
                 let fb_handle = attach_framebuffer(&self.drm, &*slot)?;

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -14,6 +14,8 @@ use crate::backend::allocator::{
 use crate::backend::drm::{device::DevPath, surface::DrmSurfaceInternal, DrmError, DrmSurface};
 use crate::backend::SwapBuffersError;
 
+use slog::{debug, error, o, trace, warn};
+
 /// Simplified by limited abstraction to link single [`DrmSurface`]s to renderers.
 ///
 /// # Use-case

--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -13,6 +13,8 @@ use crate::backend::drm::{
     error::Error,
 };
 
+use slog::{debug, info, o, trace};
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct State {
     pub mode: Mode,

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "backend_session")]
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::convert::TryFrom;
@@ -18,8 +19,12 @@ use crate::backend::allocator::{Format, Fourcc, Modifier};
 use atomic::AtomicDrmSurface;
 use legacy::LegacyDrmSurface;
 
+use slog::trace;
+
 /// An open crtc + plane combination that can be used for scan-out
 pub struct DrmSurface<A: AsRawFd + 'static> {
+    // This field is only read when 'backend_session' is enabled
+    #[allow(dead_code)]
     pub(super) dev_id: dev_t,
     pub(super) crtc: crtc::Handle,
     pub(super) primary: plane::Handle,

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -8,6 +8,8 @@ use crate::backend::allocator::Format as DrmFormat;
 use crate::backend::egl::display::{EGLDisplay, PixelFormat};
 use crate::backend::egl::EGLSurface;
 
+use slog::{info, o, trace};
+
 /// EGL context for rendering
 #[derive(Debug)]
 pub struct EGLContext {

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -26,8 +26,10 @@ use crate::backend::egl::{
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
 use crate::backend::egl::{BufferAccessError, EGLBuffer, Format};
 
+use slog::{debug, error, info, o, trace, warn};
+
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
-lazy_static! {
+lazy_static::lazy_static! {
     pub(crate) static ref BUFFER_READER: Mutex<Option<WeakBufferReader>> = Mutex::new(None);
 }
 

--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -48,7 +48,7 @@ pub mod egl {
     use libloading::Library;
     use std::sync::Once;
 
-    lazy_static! {
+    lazy_static::lazy_static! {
         pub static ref LIB: Library = unsafe { Library::new("libEGL.so.1") }.expect("Failed to load LibEGL");
     }
 

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -37,7 +37,8 @@ use nix::libc::c_void;
 
 #[allow(non_camel_case_types, dead_code, unused_mut, non_upper_case_globals)]
 pub mod ffi;
-use self::ffi::egl::types::EGLImage;
+#[cfg(feature = "wayland_frontend")]
+use self::{display::EGLDisplayHandle, ffi::egl::types::EGLImage};
 
 pub mod display;
 pub mod native;
@@ -45,8 +46,8 @@ pub mod surface;
 pub use self::display::EGLDisplay;
 pub use self::surface::EGLSurface;
 
-use self::display::EGLDisplayHandle;
 use std::ffi::CString;
+#[cfg(feature = "wayland_frontend")]
 use std::sync::Arc;
 
 /// Error that can happen on optional EGL features

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -70,6 +70,10 @@ impl ::std::error::Error for EglExtensionNotSupportedError {}
 /// Returns the address of an OpenGL function.
 ///
 /// Result is independent of displays and does not guarantee an extension is actually supported at runtime.
+///
+/// # Safety
+///
+/// This function should only be invoked while an EGL context is active.
 pub unsafe fn get_proc_address(symbol: &str) -> *const c_void {
     let addr = CString::new(symbol.as_bytes()).unwrap();
     let addr = addr.as_ptr();

--- a/src/backend/egl/surface.rs
+++ b/src/backend/egl/surface.rs
@@ -15,6 +15,8 @@ use crate::backend::egl::{
     EGLError, SwapBuffersError,
 };
 
+use slog::{debug, o, trace};
+
 /// EGL surface of a given EGL context for rendering
 pub struct EGLSurface {
     pub(crate) display: Arc<EGLDisplayHandle>,

--- a/src/backend/input.rs
+++ b/src/backend/input.rs
@@ -1,6 +1,6 @@
 //! Common traits for input backends to receive input from.
 
-use std::{error::Error, string::ToString};
+use std::error::Error;
 
 /// A seat describes a group of input devices and at least one
 /// graphics device belonging together.
@@ -21,7 +21,8 @@ pub struct Seat {
 }
 
 impl Seat {
-    pub(crate) fn new<S: ToString>(id: u64, name: S, capabilities: SeatCapabilities) -> Seat {
+    #[cfg(any(feature = "backend_winit", feature = "backend_libinput"))]
+    pub(crate) fn new<S: std::string::ToString>(id: u64, name: S, capabilities: SeatCapabilities) -> Seat {
         Seat {
             id,
             name: name.to_string(),
@@ -29,6 +30,7 @@ impl Seat {
         }
     }
 
+    #[cfg(feature = "backend_libinput")]
     pub(crate) fn capabilities_mut(&mut self) -> &mut SeatCapabilities {
         &mut self.capabilities
     }
@@ -329,6 +331,7 @@ pub struct TouchSlot {
     id: u64,
 }
 
+#[cfg(any(feature = "backend_winit", feature = "backend_libinput"))]
 impl TouchSlot {
     pub(crate) fn new(id: u64) -> Self {
         TouchSlot { id }

--- a/src/backend/libinput/helpers.rs
+++ b/src/backend/libinput/helpers.rs
@@ -11,6 +11,8 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+use slog::{info, warn};
+
 #[inline(always)]
 pub fn on_device_event<F>(
     callback: &mut F,

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -22,6 +22,8 @@ use std::{
 
 use calloop::{EventSource, Interest, Mode, Poll, Readiness, Token};
 
+use slog::{info, o};
+
 // No idea if this is the same across unix platforms
 // Lets make this linux exclusive for now, once someone tries to build it for
 // any BSD-like system, they can verify if this is right and make a PR to change this.
@@ -76,7 +78,7 @@ impl Linkable<SessionSignal> for LibinputInputBackend {
             }
             SessionSignal::ActivateSession | SessionSignal::ActivateDevice { .. } => {
                 if input.resume().is_err() {
-                    error!(log, "Failed to resume libinput context");
+                    slog::error!(log, "Failed to resume libinput context");
                 }
             }
             _ => {}

--- a/src/backend/session/auto.rs
+++ b/src/backend/session/auto.rs
@@ -45,6 +45,8 @@ use std::{cell::RefCell, io, os::unix::io::RawFd, path::Path, rc::Rc};
 
 use calloop::{EventSource, Poll, Readiness, Token};
 
+use slog::{error, info, o, warn};
+
 /// [`Session`] using the best available interface
 #[derive(Debug, Clone)]
 pub enum AutoSession {

--- a/src/backend/session/dbus/logind.rs
+++ b/src/backend/session/dbus/logind.rs
@@ -59,6 +59,8 @@ use std::{
 
 use calloop::{EventSource, Poll, Readiness, Token};
 
+use slog::{debug, error, info, o, warn};
+
 use super::DBusConnection;
 
 struct LogindSessionImpl {

--- a/src/backend/session/direct.rs
+++ b/src/backend/session/direct.rs
@@ -70,6 +70,8 @@ use std::{
 #[cfg(feature = "backend_udev")]
 use udev::Device as UdevDevice;
 
+use slog::{debug, error, info, o, trace, warn};
+
 /// This environment variable can be used to specify a tty path
 /// that will be used in [DirectSession::new] in case no explicit
 /// tty path has been provided.
@@ -77,23 +79,23 @@ pub const SMITHAY_DIRECT_TTY_ENV: &str = "SMITHAY_DIRECT_TTY";
 
 #[allow(dead_code)]
 mod tty {
-    ioctl_read_bad!(kd_get_mode, 0x4B3B, i16);
-    ioctl_write_int_bad!(kd_set_mode, 0x4B3A);
+    nix::ioctl_read_bad!(kd_get_mode, 0x4B3B, i16);
+    nix::ioctl_write_int_bad!(kd_set_mode, 0x4B3A);
     pub const KD_TEXT: i16 = 0x00;
     pub const KD_GRAPHICS: i16 = 0x00;
 
-    ioctl_read_bad!(kd_get_kb_mode, 0x4B44, i32);
-    ioctl_write_int_bad!(kd_set_kb_mode, 0x4B45);
+    nix::ioctl_read_bad!(kd_get_kb_mode, 0x4B44, i32);
+    nix::ioctl_write_int_bad!(kd_set_kb_mode, 0x4B45);
     pub const K_RAW: i32 = 0x00;
     pub const K_XLATE: i32 = 0x01;
     pub const K_MEDIUMRAW: i32 = 0x02;
     pub const K_UNICODE: i32 = 0x03;
     pub const K_OFF: i32 = 0x04;
 
-    ioctl_write_int_bad!(vt_activate, 0x5606);
-    ioctl_write_int_bad!(vt_wait_active, 0x5607);
-    ioctl_write_ptr_bad!(vt_set_mode, 0x5602, VtMode);
-    ioctl_write_int_bad!(vt_rel_disp, 0x5605);
+    nix::ioctl_write_int_bad!(vt_activate, 0x5606);
+    nix::ioctl_write_int_bad!(vt_wait_active, 0x5607);
+    nix::ioctl_write_ptr_bad!(vt_set_mode, 0x5602, VtMode);
+    nix::ioctl_write_int_bad!(vt_rel_disp, 0x5605);
     #[repr(C)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     pub struct VtMode {

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -52,6 +52,8 @@ use udev::{Enumerator, EventType, MonitorBuilder, MonitorSocket};
 
 use calloop::{EventSource, Interest, Mode, Poll, Readiness, Token};
 
+use slog::{debug, info, o, warn};
+
 /// Backend to monitor available drm devices.
 ///
 /// Provides a way to automatically scan for available gpus and notifies the

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -28,6 +28,8 @@ use winit::{
     window::{Window as WinitWindow, WindowBuilder},
 };
 
+use slog::{debug, error, info, o, trace, warn};
+
 /// Errors thrown by the `winit` backends
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,15 +10,8 @@
 //! `log` crate. If not, the logs will discarded. This cargo feature is part of the default set of
 //! features of Smithay.
 
-#[cfg_attr(feature = "backend_session", macro_use)]
 #[doc(hidden)]
 pub extern crate nix;
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate bitflags;
 
 pub mod backend;
 pub mod utils;
@@ -33,6 +26,7 @@ pub mod xwayland;
 pub mod reexports;
 
 #[cfg(feature = "slog-stdlog")]
+#[allow(dead_code)]
 fn slog_or_fallback<L>(logger: L) -> ::slog::Logger
 where
     L: Into<Option<::slog::Logger>>,
@@ -40,15 +34,16 @@ where
     use slog::Drain;
     logger
         .into()
-        .unwrap_or_else(|| ::slog::Logger::root(::slog_stdlog::StdLog.fuse(), o!()))
+        .unwrap_or_else(|| ::slog::Logger::root(::slog_stdlog::StdLog.fuse(), slog::o!()))
 }
 
 #[cfg(not(feature = "slog-stdlog"))]
+#[allow(dead_code)]
 fn slog_or_fallback<L>(logger: L) -> ::slog::Logger
 where
     L: Into<Option<::slog::Logger>>,
 {
     logger
         .into()
-        .unwrap_or_else(|| ::slog::Logger::root(::slog::Discard, o!()))
+        .unwrap_or_else(|| ::slog::Logger::root(::slog::Discard, slog::o!()))
 }

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -19,6 +19,8 @@ use super::{
     AlreadyHasRole, BufferAssignment, Damage, Rectangle, RectangleKind, RegionAttributes, SurfaceAttributes,
 };
 
+use slog::trace;
+
 /*
  * wl_compositor
  */

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -449,7 +449,7 @@ where
     L: Into<Option<::slog::Logger>>,
     Impl: for<'a> FnMut(WlSurface, DispatchData<'a>) + 'static,
 {
-    let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "compositor_handler"));
+    let log = crate::slog_or_fallback(logger).new(slog::o!("smithay_module" => "compositor_handler"));
     let implem = Rc::new(RefCell::new(implem));
 
     let compositor = display.create_global(

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -56,6 +56,8 @@ use wayland_server::{
     Client, Display, Filter, Global, Main,
 };
 
+use slog::{debug, error, o};
+
 use crate::wayland::{
     compositor,
     seat::{GrabStartData, Seat},

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -56,6 +56,8 @@ use wayland_protocols::unstable::linux_dmabuf::v1::server::{
 };
 use wayland_server::{protocol::wl_buffer, DispatchData, Display, Filter, Global, Main};
 
+use slog::{o, trace};
+
 use crate::backend::allocator::{
     dmabuf::{Dmabuf, DmabufFlags, Plane},
     Format, Fourcc, Modifier,

--- a/src/wayland/explicit_synchronization/mod.rs
+++ b/src/wayland/explicit_synchronization/mod.rs
@@ -190,7 +190,7 @@ where
     L: Into<Option<::slog::Logger>>,
 {
     let _log =
-        crate::slog_or_fallback(logger).new(o!("smithay_module" => "wayland_explicit_synchronization"));
+        crate::slog_or_fallback(logger).new(slog::o!("smithay_module" => "wayland_explicit_synchronization"));
 
     display.create_global::<ZwpLinuxExplicitSynchronizationV1, _>(
         2,

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -59,6 +59,8 @@ use wayland_server::{
     Display, Filter, Global, Main,
 };
 
+use slog::{info, o, trace, warn};
+
 /// An output mode
 ///
 /// A possible combination of dimensions and refresh rate for an output.

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -1,5 +1,6 @@
 use crate::backend::input::KeyState;
 use crate::wayland::Serial;
+use slog::{debug, info, o, trace, warn};
 use std::{
     cell::RefCell,
     default::Default,

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -133,7 +133,7 @@ impl Seat {
                 keyboard: None,
                 known_seats: Vec::new(),
             }),
-            log: log.new(o!("smithay_module" => "seat_handler", "seat_name" => name.clone())),
+            log: log.new(slog::o!("smithay_module" => "seat_handler", "seat_name" => name.clone())),
             name,
             user_data: UserDataMap::new(),
         });

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -679,7 +679,7 @@ where
     }));
 
     let shell_data = ShellData {
-        log: log.new(o!("smithay_module" => "xdg_shell_handler")),
+        log: log.new(slog::o!("smithay_module" => "xdg_shell_handler")),
         user_impl: Rc::new(RefCell::new(implementation)),
         shell_state: shell_state.clone(),
     };

--- a/src/wayland/shm/mod.rs
+++ b/src/wayland/shm/mod.rs
@@ -116,7 +116,7 @@ where
     formats.push(wl_shm::Format::Xrgb8888);
     let data = ShmGlobalData {
         formats: formats.into(),
-        log: log.new(o!("smithay_module" => "shm_handler")),
+        log: log.new(slog::o!("smithay_module" => "shm_handler")),
     };
 
     display.create_global::<wl_shm::WlShm, _>(

--- a/src/wayland/shm/pool.rs
+++ b/src/wayland/shm/pool.rs
@@ -13,6 +13,8 @@ use std::{
     sync::{Once, RwLock},
 };
 
+use slog::{debug, trace};
+
 thread_local!(static SIGBUS_GUARD: Cell<(*const MemMap, bool)> = Cell::new((ptr::null_mut(), false)));
 
 static SIGBUS_INIT: Once = Once::new();

--- a/src/xwayland/x11_sockets.rs
+++ b/src/xwayland/x11_sockets.rs
@@ -3,6 +3,8 @@ use std::{
     os::unix::{io::FromRawFd, net::UnixStream},
 };
 
+use slog::{debug, info, warn};
+
 use nix::{errno::Errno, sys::socket, Error as NixError, Result as NixResult};
 
 /// Find a free X11 display slot and setup

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -59,6 +59,8 @@ use calloop::{
     Interest, LoopHandle, Mode, RegistrationToken,
 };
 
+use slog::{error, info, o};
+
 use nix::Error as NixError;
 
 use wayland_server::{Client, Display, Filter};


### PR DESCRIPTION
Based on top of #304

This PR does a general cleanup of the Smithay codebase, for stuff that clippy & rustfmt don't handle by themselves

- [x] Ensure that all combinations of cargo features compile without warning, to unclutter the CI output from all these annoying annotations
- [ ] ~~Reorganize the imports in each file to follow a coherence scheme, in the order : 1) imports from std, 2) imports from external crates, 3) `crate::` imports, 4) `super::` imports, 5) `self::` imports~~ There is actually a (currently unstable) rustfmt option that will handle it, so lets not do this by hand and suffer. Postponing that for later.
- [x] Fix the last remaining clippy lints