### PR TITLE
feature/output-enter-leave

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -185,7 +185,7 @@ pub fn draw_windows<R, E, F, T>(
     renderer: &mut R,
     frame: &mut F,
     window_map: &WindowMap,
-    output_rect: Option<Rectangle>,
+    output_rect: Rectangle,
     log: &::slog::Logger,
 ) -> Result<(), SwapBuffersError>
 where
@@ -199,12 +199,10 @@ where
     // redraw the frame, in a simple but inneficient way
     window_map.with_windows_from_bottom_to_top(|toplevel_surface, mut initial_place, bounding_box| {
         // skip windows that do not overlap with a given output
-        if let Some(output) = output_rect {
-            if !output.overlaps(bounding_box) {
-                return;
-            }
-            initial_place.0 -= output.x;
+        if !output_rect.overlaps(bounding_box) {
+            return;
         }
+        initial_place.0 -= output_rect.x;
         if let Some(wl_surface) = toplevel_surface.get_surface() {
             // this surface is a root of a subsurface tree that needs to be drawn
             if let Err(err) = draw_surface_tree(renderer, frame, &wl_surface, initial_place, log) {

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -265,11 +265,18 @@ impl AnvilState<UdevData> {
         }
 
         let (pos_x, pos_y) = pos;
-        let (max_x, max_y) = self.output_map.borrow().size();
+        let output_map = self.output_map.borrow();
+        let max_x = output_map.width();
         let clamped_x = pos_x.max(0.0).min(max_x as f64);
-        let clamped_y = pos_y.max(0.0).min(max_y as f64);
+        let max_y = output_map.height(clamped_x as i32);
 
-        (clamped_x, clamped_y)
+        if let Some(max_y) = max_y {
+            let clamped_y = pos_y.max(0.0).min(max_y as f64);
+
+            (clamped_x, clamped_y)
+        } else {
+            (clamped_x, pos_y)
+        }
     }
 }
 

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -13,6 +13,7 @@ use smithay::{
     },
     reexports::wayland_server::protocol::wl_pointer,
     wayland::{
+        output::Mode,
         seat::{keysyms as xkb, AxisFrame, Keysym, ModifiersState},
         SERIAL_COUNTER as SCOUNTER,
     },
@@ -137,7 +138,12 @@ impl<Backend> AnvilState<Backend> {
 
 #[cfg(feature = "winit")]
 impl AnvilState<WinitData> {
-    pub fn process_input_event<B: InputBackend>(&mut self, event: InputEvent<B>) {
+    pub fn process_input_event<B>(&mut self, event: InputEvent<B>)
+    where
+        B: InputBackend<SpecialEvent = smithay::backend::winit::WinitEvent>,
+    {
+        use smithay::backend::winit::WinitEvent;
+
         match event {
             InputEvent::Keyboard { event, .. } => match self.keyboard_key_to_action::<B>(event) {
                 KeyAction::None | KeyAction::Forward => {}
@@ -162,6 +168,16 @@ impl AnvilState<WinitData> {
             InputEvent::PointerMotionAbsolute { event, .. } => self.on_pointer_move_absolute::<B>(event),
             InputEvent::PointerButton { event, .. } => self.on_pointer_button::<B>(event),
             InputEvent::PointerAxis { event, .. } => self.on_pointer_axis::<B>(event),
+            InputEvent::Special(WinitEvent::Resized { size, .. }) => {
+                self.output_map.borrow_mut().update_mode(
+                    crate::winit::OUTPUT_NAME,
+                    Mode {
+                        width: size.0 as i32,
+                        height: size.1 as i32,
+                        refresh: 60_000,
+                    },
+                );
+            }
             _ => {
                 // other events are not handled in anvil (yet)
             }
@@ -206,17 +222,16 @@ impl AnvilState<UdevData> {
                     }
                 }
                 KeyAction::Screen(num) => {
-                    if let Some(output) = self.backend_data.output_map.get(num) {
-                        let x = self
-                            .backend_data
-                            .output_map
-                            .iter()
-                            .take(num)
-                            .fold(0, |acc, output| acc + output.size.0)
-                            as f64
-                            + (output.size.0 as f64 / 2.0);
-                        let y = output.size.1 as f64 / 2.0;
-                        self.pointer_location = (x as f64, y as f64)
+                    let geometry = self
+                        .output_map
+                        .borrow()
+                        .find_by_index(num, |_, geometry| geometry)
+                        .ok();
+
+                    if let Some(geometry) = geometry {
+                        let x = geometry.x as f64 + geometry.width as f64 / 2.0;
+                        let y = geometry.height as f64 / 2.0;
+                        self.pointer_location = (x, y)
                     }
                 }
             },
@@ -245,47 +260,16 @@ impl AnvilState<UdevData> {
     }
 
     fn clamp_coords(&self, pos: (f64, f64)) -> (f64, f64) {
-        if self.backend_data.output_map.is_empty() {
+        if self.output_map.borrow().is_empty() {
             return pos;
         }
 
-        let (mut x, mut y) = pos;
-        // max_x is the sum of the width of all outputs
-        let max_x = self
-            .backend_data
-            .output_map
-            .iter()
-            .fold(0u32, |acc, output| acc + output.size.0);
-        x = x.max(0.0).min(max_x as f64);
+        let (pos_x, pos_y) = pos;
+        let (max_x, max_y) = self.output_map.borrow().size();
+        let clamped_x = pos_x.max(0.0).min(max_x as f64);
+        let clamped_y = pos_y.max(0.0).min(max_y as f64);
 
-        // max y depends on the current output
-        let max_y = self.current_output_size(x).1;
-        y = y.max(0.0).min(max_y as f64);
-
-        (x, y)
-    }
-
-    fn current_output_idx(&self, x: f64) -> usize {
-        self.backend_data
-            .output_map
-            .iter()
-            // map each output to their x position
-            .scan(0u32, |acc, output| {
-                let curr_x = *acc;
-                *acc += output.size.0;
-                Some(curr_x)
-            })
-            // get an index
-            .enumerate()
-            // find the first one with a greater x
-            .find(|(_idx, x_pos)| *x_pos as f64 > x)
-            // the previous output is the one we are on
-            .map(|(idx, _)| idx - 1)
-            .unwrap_or(self.backend_data.output_map.len() - 1)
-    }
-
-    fn current_output_size(&self, x: f64) -> (u32, u32) {
-        self.backend_data.output_map[self.current_output_idx(x)].size
+        (clamped_x, clamped_y)
     }
 }
 

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -26,6 +26,8 @@ mod winit;
 #[cfg(feature = "xwayland")]
 mod xwayland;
 
+mod output_map;
+
 use state::AnvilState;
 
 static POSSIBLE_BACKENDS: &[&str] = &[

--- a/anvil/src/output_map.rs
+++ b/anvil/src/output_map.rs
@@ -1,0 +1,403 @@
+use std::{cell::RefCell, rc::Rc};
+
+use smithay::{
+    reexports::{
+        wayland_protocols::xdg_shell::server::xdg_toplevel,
+        wayland_server::{
+            protocol::{wl_output, wl_surface::WlSurface},
+            Display, Global,
+        },
+    },
+    utils::Rectangle,
+    wayland::{
+        compositor::{with_surface_tree_downward, SubsurfaceCachedState, TraversalAction},
+        output::{self, Mode, PhysicalProperties},
+    },
+};
+
+use crate::shell::SurfaceData;
+
+struct Output {
+    name: String,
+    output: output::Output,
+    global: Option<Global<wl_output::WlOutput>>,
+    geometry: Rectangle,
+    surfaces: Vec<WlSurface>,
+    current_mode: Mode,
+}
+
+impl Output {
+    fn new<N>(
+        name: N,
+        location: (i32, i32),
+        display: &mut Display,
+        physical: PhysicalProperties,
+        mode: Mode,
+        logger: slog::Logger,
+    ) -> Self
+    where
+        N: AsRef<str>,
+    {
+        let (output, global) = output::Output::new(display, name.as_ref().into(), physical, logger);
+
+        output.change_current_state(Some(mode), None, None);
+        output.set_preferred(mode);
+
+        Self {
+            name: name.as_ref().to_owned(),
+            global: Some(global),
+            output,
+            geometry: Rectangle {
+                x: location.0,
+                y: location.1,
+                width: mode.width,
+                height: mode.height,
+            },
+            surfaces: Vec::new(),
+            current_mode: mode,
+        }
+    }
+}
+
+impl Drop for Output {
+    fn drop(&mut self) {
+        self.global.take().unwrap().destroy();
+    }
+}
+
+#[derive(Debug)]
+pub struct OutputNotFound;
+
+impl std::fmt::Display for OutputNotFound {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("The output could not be found")
+    }
+}
+
+impl std::error::Error for OutputNotFound {}
+
+pub struct OutputMap {
+    display: Rc<RefCell<Display>>,
+    outputs: Vec<Output>,
+    window_map: Rc<RefCell<crate::window_map::WindowMap>>,
+    logger: slog::Logger,
+}
+
+impl OutputMap {
+    pub fn new(
+        display: Rc<RefCell<Display>>,
+        window_map: Rc<RefCell<crate::window_map::WindowMap>>,
+        logger: ::slog::Logger,
+    ) -> Self {
+        Self {
+            display,
+            outputs: Vec::new(),
+            window_map,
+            logger,
+        }
+    }
+
+    pub fn arrange(&mut self) {
+        // First recalculate the outputs location
+        let mut output_x = 0;
+        for output in self.outputs.iter_mut() {
+            output.geometry.x = output_x;
+            output.geometry.y = 0;
+            output_x += output.geometry.width;
+        }
+
+        // Check if any windows are now out of outputs range
+        // and move them to the primary output
+        let primary_output_location = self
+            .with_primary(|_, geometry| geometry)
+            .ok()
+            .map(|o| (o.x, o.y))
+            .unwrap_or_default();
+        let mut window_map = self.window_map.borrow_mut();
+        // TODO: This is a bit unfortunate, we save the windows in a temp vector
+        // cause we can not call window_map.set_location within the closure.
+        let mut windows_to_move = Vec::new();
+        window_map.with_windows_from_bottom_to_top(|kind, _, bbox| {
+            let within_outputs = self.outputs.iter().any(|o| o.geometry.overlaps(bbox));
+
+            if !within_outputs {
+                windows_to_move.push((kind.to_owned(), primary_output_location));
+            }
+        });
+        for (window, location) in windows_to_move.drain(..) {
+            window_map.set_location(&window, location);
+        }
+
+        // Update the size and location for maximized and fullscreen windows
+        window_map.with_windows_from_bottom_to_top(|kind, location, _| {
+            if let crate::window_map::Kind::Xdg(xdg) = kind {
+                if let Some(state) = xdg.current_state() {
+                    if state.states.contains(xdg_toplevel::State::Maximized)
+                        || state.states.contains(xdg_toplevel::State::Fullscreen)
+                    {
+                        let output_geometry = if let Some(output) = state.fullscreen_output.as_ref() {
+                            self.find(output, |_, geometry| geometry).ok()
+                        } else {
+                            self.find_by_position(location, |_, geometry| geometry).ok()
+                        };
+
+                        if let Some(geometry) = output_geometry {
+                            if location != (geometry.x, geometry.y) {
+                                windows_to_move.push((kind.to_owned(), (geometry.x, geometry.y)));
+                            }
+
+                            let res = xdg.with_pending_state(|pending_state| {
+                                pending_state.size = Some((geometry.width, geometry.height));
+                            });
+
+                            if res.is_ok() {
+                                xdg.send_configure();
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        for (window, location) in windows_to_move.drain(..) {
+            window_map.set_location(&window, location);
+        }
+    }
+
+    pub fn add<N>(&mut self, name: N, physical: PhysicalProperties, mode: Mode)
+    where
+        N: AsRef<str>,
+    {
+        // Append the output to the end of the existing
+        // outputs by placing it after the current overall
+        // width
+        let location = (self.width() as i32, 0);
+
+        let output = Output::new(
+            name,
+            location,
+            &mut *self.display.borrow_mut(),
+            physical,
+            mode,
+            self.logger.clone(),
+        );
+
+        self.outputs.push(output);
+
+        // We call arrange here albeit the output is only appended and
+        // this would not affect windows, but arrange could re-organize
+        // outputs from a configuration.
+        self.arrange();
+    }
+
+    pub fn remove<N: AsRef<str>>(&mut self, name: N) {
+        let removed_outputs = self.outputs.iter_mut().filter(|o| o.name == name.as_ref());
+
+        for output in removed_outputs {
+            for surface in output.surfaces.drain(..) {
+                output.output.leave(&surface);
+            }
+        }
+        self.outputs.retain(|o| o.name != name.as_ref());
+
+        // Re-arrange outputs cause one or more outputs have
+        // been removed
+        self.arrange();
+    }
+
+    pub fn width(&self) -> u32 {
+        // This is a simplification, we only arrange the outputs on the y axis side-by-side
+        // so that the total width is simply the sum of all output widths.
+        self.outputs
+            .iter()
+            .fold(0u32, |acc, output| acc + output.geometry.width as u32)
+    }
+
+    pub fn height(&self) -> u32 {
+        // This is a simplification, we only arrange the outputs on the y axis side-by-side
+        // so that the max height is simply the max of all output heights.
+        self.outputs
+            .iter()
+            .map(|output| output.geometry.height as u32)
+            .max()
+            .unwrap_or_default()
+    }
+
+    pub fn size(&self) -> (u32, u32) {
+        (self.width(), self.height())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.outputs.is_empty()
+    }
+
+    pub fn with_primary<F, T>(&self, f: F) -> Result<T, OutputNotFound>
+    where
+        F: FnOnce(&output::Output, Rectangle) -> T,
+    {
+        let output = self.outputs.get(0).ok_or(OutputNotFound)?;
+
+        Ok(f(&output.output, output.geometry))
+    }
+
+    pub fn find<F, T>(&self, output: &wl_output::WlOutput, f: F) -> Result<T, OutputNotFound>
+    where
+        F: FnOnce(&output::Output, Rectangle) -> T,
+    {
+        let output = self
+            .outputs
+            .iter()
+            .find(|o| o.output.owns(output))
+            .ok_or(OutputNotFound)?;
+
+        Ok(f(&output.output, output.geometry))
+    }
+
+    pub fn find_by_name<N, F, T>(&self, name: N, f: F) -> Result<T, OutputNotFound>
+    where
+        N: AsRef<str>,
+        F: FnOnce(&output::Output, Rectangle) -> T,
+    {
+        let output = self
+            .outputs
+            .iter()
+            .find(|o| o.name == name.as_ref())
+            .ok_or(OutputNotFound)?;
+
+        Ok(f(&output.output, output.geometry))
+    }
+
+    pub fn find_by_position<F, T>(&self, position: (i32, i32), f: F) -> Result<T, OutputNotFound>
+    where
+        F: FnOnce(&output::Output, Rectangle) -> T,
+    {
+        let output = self
+            .outputs
+            .iter()
+            .find(|o| o.geometry.contains(position))
+            .ok_or(OutputNotFound)?;
+
+        Ok(f(&output.output, output.geometry))
+    }
+
+    pub fn find_by_index<F, T>(&self, index: usize, f: F) -> Result<T, OutputNotFound>
+    where
+        F: FnOnce(&output::Output, Rectangle) -> T,
+    {
+        let output = self.outputs.get(index).ok_or(OutputNotFound)?;
+
+        Ok(f(&output.output, output.geometry))
+    }
+
+    pub fn update_mode<N: AsRef<str>>(&mut self, name: N, mode: Mode) {
+        let output = self.outputs.iter_mut().find(|o| o.name == name.as_ref());
+
+        // NOTE: This will just simply shift all outputs after
+        // the output who's mode has changed left or right depending
+        // on if the mode width increased or decreased.
+        // We could also re-configure toplevels here.
+        // If a surface is now visible on an additional output because
+        // the output width decreased the refresh method will take
+        // care and will send enter for the output.
+        if let Some(output) = output {
+            output.geometry.width = mode.width;
+            output.geometry.height = mode.height;
+
+            output.output.delete_mode(output.current_mode);
+            output.output.change_current_state(Some(mode), None, None);
+            output.output.set_preferred(mode);
+            output.current_mode = mode;
+
+            // Re-arrange outputs cause the size of one output changed
+            self.arrange();
+        }
+    }
+
+    pub fn refresh(&mut self) {
+        // Clean-up dead surfaces
+        self.outputs
+            .iter_mut()
+            .for_each(|o| o.surfaces.retain(|s| s.as_ref().is_alive()));
+
+        let window_map = self.window_map.clone();
+
+        window_map
+            .borrow()
+            .with_windows_from_bottom_to_top(|kind, location, bbox| {
+                for output in self.outputs.iter_mut() {
+                    // Check if the bounding box of the toplevel intersects with
+                    // the output, if not no surface in the tree can intersect with
+                    // the output.
+                    if !output.geometry.overlaps(bbox) {
+                        if let Some(surface) = kind.get_surface() {
+                            with_surface_tree_downward(
+                                surface,
+                                (),
+                                |_, _, _| TraversalAction::DoChildren(()),
+                                |wl_surface, _, _| {
+                                    if output.surfaces.contains(wl_surface) {
+                                        output.output.leave(wl_surface);
+                                        output.surfaces.retain(|s| s != wl_surface);
+                                    }
+                                },
+                                |_, _, _| true,
+                            )
+                        }
+                        continue;
+                    }
+
+                    if let Some(surface) = kind.get_surface() {
+                        with_surface_tree_downward(
+                            surface,
+                            location,
+                            |_, states, &(mut x, mut y)| {
+                                let data = states.data_map.get::<RefCell<SurfaceData>>();
+
+                                if data.is_some() {
+                                    if states.role == Some("subsurface") {
+                                        let current = states.cached_state.current::<SubsurfaceCachedState>();
+                                        x += current.location.0;
+                                        y += current.location.1;
+                                    }
+
+                                    TraversalAction::DoChildren((x, y))
+                                } else {
+                                    // If the parent surface is unmapped, then the child surfaces are hidden as
+                                    // well, no need to consider them here.
+                                    TraversalAction::SkipChildren
+                                }
+                            },
+                            |wl_surface, states, &(x, y)| {
+                                let data = states.data_map.get::<RefCell<SurfaceData>>();
+
+                                if let Some((width, height)) = data.and_then(|d| d.borrow().size()) {
+                                    let surface_rectangle = Rectangle { x, y, width, height };
+
+                                    if output.geometry.overlaps(&surface_rectangle) {
+                                        // We found a matching output, check if we already sent enter
+                                        if !output.surfaces.contains(wl_surface) {
+                                            output.output.enter(wl_surface);
+                                            output.surfaces.push(wl_surface.clone());
+                                        }
+                                    } else {
+                                        // Surface does not match output, if we sent enter earlier
+                                        // we should now send leave
+                                        if output.surfaces.contains(wl_surface) {
+                                            output.output.leave(wl_surface);
+                                            output.surfaces.retain(|s| s != wl_surface);
+                                        }
+                                    }
+                                } else {
+                                    // Maybe the the surface got unmapped, send leave on output
+                                    if output.surfaces.contains(wl_surface) {
+                                        output.output.leave(wl_surface);
+                                        output.surfaces.retain(|s| s != wl_surface);
+                                    }
+                                }
+                            },
+                            |_, _, _| true,
+                        )
+                    }
+                }
+            });
+    }
+}

--- a/anvil/src/output_map.rs
+++ b/anvil/src/output_map.rs
@@ -212,18 +212,12 @@ impl OutputMap {
             .fold(0u32, |acc, output| acc + output.geometry.width as u32)
     }
 
-    pub fn height(&self) -> u32 {
+    pub fn height(&self, x: i32) -> Option<u32> {
         // This is a simplification, we only arrange the outputs on the y axis side-by-side
-        // so that the max height is simply the max of all output heights.
         self.outputs
             .iter()
+            .find(|output| x >= output.geometry.x && x < (output.geometry.x + output.geometry.width))
             .map(|output| output.geometry.height as u32)
-            .max()
-            .unwrap_or_default()
-    }
-
-    pub fn size(&self) -> (u32, u32) {
-        (self.width(), self.height())
     }
 
     pub fn is_empty(&self) -> bool {

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -31,6 +31,7 @@ pub struct AnvilState<BackendData> {
     pub display: Rc<RefCell<Display>>,
     pub handle: LoopHandle<'static, AnvilState<BackendData>>,
     pub window_map: Rc<RefCell<crate::window_map::WindowMap>>,
+    pub output_map: Rc<RefCell<crate::output_map::OutputMap>>,
     pub dnd_icon: Arc<Mutex<Option<WlSurface>>>,
     pub log: slog::Logger,
     // input-related fields
@@ -76,7 +77,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
 
         init_shm_global(&mut (*display).borrow_mut(), vec![], log.clone());
 
-        let shell_handles = init_shell::<BackendData>(&mut display.borrow_mut(), log.clone());
+        let shell_handles = init_shell::<BackendData>(display.clone(), log.clone());
 
         let socket_name = display
             .borrow_mut()
@@ -148,6 +149,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
             display,
             handle,
             window_map: shell_handles.window_map,
+            output_map: shell_handles.output_map,
             dnd_icon,
             log,
             socket_name,

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -613,7 +613,7 @@ impl AnvilState<UdevData> {
                 device_backend.dev_id,
                 crtc,
                 &mut *self.window_map.borrow_mut(),
-                &mut self.backend_data.output_map,
+                &self.backend_data.output_map,
                 &*self.output_map.borrow(),
                 &self.pointer_location,
                 &device_backend.pointer_image,

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -11,9 +11,8 @@ use smithay::{
         calloop::EventLoop,
         wayland_server::{protocol::wl_output, Display},
     },
-    utils::Rectangle,
     wayland::{
-        output::{Mode, Output, PhysicalProperties},
+        output::{Mode, PhysicalProperties},
         seat::CursorImageStatus,
     },
 };
@@ -22,6 +21,8 @@ use slog::Logger;
 
 use crate::drawing::*;
 use crate::state::{AnvilState, Backend};
+
+pub const OUTPUT_NAME: &'static str = "winit";
 
 pub struct WinitData;
 
@@ -72,9 +73,14 @@ pub fn run_winit(
 
     let mut state = AnvilState::init(display.clone(), event_loop.handle(), WinitData, log.clone());
 
-    let (output, _) = Output::new(
-        &mut display.borrow_mut(),
-        "Winit".into(),
+    let mode = Mode {
+        width: w as i32,
+        height: h as i32,
+        refresh: 60_000,
+    };
+
+    state.output_map.borrow_mut().add(
+        OUTPUT_NAME,
         PhysicalProperties {
             width: 0,
             height: 0,
@@ -82,23 +88,8 @@ pub fn run_winit(
             make: "Smithay".into(),
             model: "Winit".into(),
         },
-        log.clone(),
+        mode,
     );
-
-    output.change_current_state(
-        Some(Mode {
-            width: w as i32,
-            height: h as i32,
-            refresh: 60_000,
-        }),
-        None,
-        None,
-    );
-    output.set_preferred(Mode {
-        width: w as i32,
-        height: h as i32,
-        refresh: 60_000,
-    });
 
     let start_time = std::time::Instant::now();
     let mut cursor_visible = true;
@@ -120,16 +111,13 @@ pub fn run_winit(
         // drawing logic
         {
             let mut renderer = renderer.borrow_mut();
-
-            let output_rect = {
-                let (width, height) = renderer.window_size().physical_size.into();
-                Rectangle {
-                    x: 0,
-                    y: 0,
-                    width,
-                    height,
-                }
-            };
+            // This is safe to do as with winit we are guaranteed to have exactly one output
+            let output_geometry = state
+                .output_map
+                .borrow()
+                .find_by_name(OUTPUT_NAME, |_, geometry| geometry)
+                .ok()
+                .unwrap();
 
             let result = renderer
                 .render(|renderer, frame| {
@@ -140,7 +128,7 @@ pub fn run_winit(
                         renderer,
                         frame,
                         &*state.window_map.borrow(),
-                        Some(output_rect),
+                        output_geometry,
                         &log,
                     )?;
 
@@ -203,6 +191,7 @@ pub fn run_winit(
         } else {
             display.borrow_mut().flush_clients(&mut state);
             state.window_map.borrow_mut().refresh();
+            state.output_map.borrow_mut().refresh();
         }
     }
 

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -22,7 +22,7 @@ use slog::Logger;
 use crate::drawing::*;
 use crate::state::{AnvilState, Backend};
 
-pub const OUTPUT_NAME: &'static str = "winit";
+pub const OUTPUT_NAME: &str = "winit";
 
 pub struct WinitData;
 

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1113,6 +1113,30 @@ impl ToplevelSurface {
         })
         .unwrap())
     }
+
+    /// Gets a copy of the current state of this toplevel
+    ///
+    /// Returns `None` if the underlying surface has been
+    /// destroyed
+    pub fn current_state(&self) -> Option<ToplevelState> {
+        if !self.alive() {
+            return None;
+        }
+
+        Some(
+            compositor::with_states(&self.wl_surface, |states| {
+                let attributes = states
+                    .data_map
+                    .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+                    .unwrap()
+                    .lock()
+                    .unwrap();
+
+                attributes.current.clone()
+            })
+            .unwrap(),
+        )
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR adds an output map, similar to the window map, that keeps track of the known outputs and
their location.

The output map additionally keeps track of the surfaces shown on a specific output and sends `wl_surface.enter`
and `wl_surface.leave` accordingly. This is neseccary in prepartion for handling HiDPI as the client will
use this information for deciding which scale it should use. 

The shell implementation now uses the output geometry for initial window placement and
maximize/fullscreen handling.

The name of the output is expected to be unique and again this can be used for setting scale factors on specific
outputs.

The winit backend creates a virtual output that gets updated when the window is resized.

Additionally the output map will re-configure maximized/fullscreen windows when the mode changes.
When a output is removed the output map will try to move the now off-screen windows to a different
active output.