### PR TITLE
Fix wl_drm on winit backend

### DIFF
--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -1,7 +1,10 @@
 use std::{cell::RefCell, rc::Rc, sync::atomic::Ordering, time::Duration};
 
 #[cfg(feature = "egl")]
-use smithay::{backend::renderer::ImportDma, wayland::dmabuf::init_dmabuf_global};
+use smithay::{
+    backend::renderer::{ImportDma, ImportEgl},
+    wayland::dmabuf::init_dmabuf_global,
+};
 use smithay::{
     backend::{input::InputBackend, renderer::Frame, winit, SwapBuffersError},
     reexports::{
@@ -38,7 +41,12 @@ pub fn run_winit(
     let renderer = Rc::new(RefCell::new(renderer));
 
     #[cfg(feature = "egl")]
-    if renderer.borrow().bind_wl_display(&display.borrow()).is_ok() {
+    if renderer
+        .borrow_mut()
+        .renderer()
+        .bind_wl_display(&display.borrow())
+        .is_ok()
+    {
         info!(log, "EGL hardware-acceleration enabled");
         let dmabuf_formats = renderer
             .borrow_mut()

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -28,11 +28,6 @@ use winit::{
     window::{Window as WinitWindow, WindowBuilder},
 };
 
-#[cfg(feature = "use_system_lib")]
-use crate::backend::egl::display::EGLBufferReader;
-#[cfg(feature = "use_system_lib")]
-use wayland_server::Display;
-
 /// Errors thrown by the `winit` backends
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -235,16 +230,6 @@ pub enum WinitEvent {
 }
 
 impl WinitGraphicsBackend {
-    /// Bind a `wl_display` to allow hardware-accelerated clients using `wl_drm`.
-    ///
-    /// Returns an `EGLBufferReader` used to access the contents of these buffers.
-    ///
-    /// *Note*: Only on implementation of `wl_drm` can be bound by a single wayland display.
-    #[cfg(feature = "use_system_lib")]
-    pub fn bind_wl_display(&self, wl_display: &Display) -> Result<EGLBufferReader, EGLError> {
-        self.display.bind_wl_display(wl_display)
-    }
-
     /// Window size of the underlying window
     pub fn window_size(&self) -> WindowSize {
         self.size.borrow().clone()


### PR DESCRIPTION
A shortcut for `bind_wl_display` on the winit backend was left over from the egl-rework in #303.
Using that lead to dropping the `EGLBufferReader` after it was just created and also never assigning the reader to the `Gles2Renderer`. This is now fixed by removing the left over function and using the function of `ImportEgl` correctly in anvils winit-backend.