### PR TITLE
Fix XWayland panic on exit

### DIFF
--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -327,7 +327,11 @@ fn xwayland_ready<Data: 'static>(inner: &Rc<RefCell<Inner<Data>>>) {
         ::std::env::set_var("DISPLAY", format!(":{}", instance.display_lock.display()));
 
         // signal the WM
-        info!(guard.log, "XWayland is ready on DISPLAY \":{}\", signaling the WM.", instance.display_lock.display());
+        info!(
+            guard.log,
+            "XWayland is ready on DISPLAY \":{}\", signaling the WM.",
+            instance.display_lock.display()
+        );
         // send error occurs if the user dropped the channel... We cannot do much except ignore.
         let _ = guard.sender.send(XWaylandEvent::Ready {
             connection: instance.wm_fd.take().unwrap(), // This is a bug if None


### PR DESCRIPTION
This PR tries to fix the XWayland panic on exit.

The panic is caused by an already borrowed RefCell during XWayland shutdown.
When anvil is exiting the drop implemetation of the XWayland instance will borrow
the associated data and call shutdown.
During a shutdown the wayland client associated with XWayland will be killed explicit which
will invoke the registered destructor callback. The callback again borrows the data to call shutdown which
results in a panic.