### PR TITLE
Anvil HiDPI

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -217,7 +217,7 @@ impl AnvilState<WinitData> {
             .output_map
             .borrow()
             .find_by_name(crate::winit::OUTPUT_NAME)
-            .map(|o| (o.size().w as u32, o.size().h as u32).into())
+            .map(|o| o.size())
             .unwrap();
         let pos = evt.position_transformed(output_size);
         self.pointer_location = pos;
@@ -365,8 +365,7 @@ impl AnvilState<UdevData> {
         let output_geometry = output_map.with_primary().map(|o| o.geometry());
 
         if let Some(rect) = output_geometry {
-            let rect_size = (rect.size.w as u32, rect.size.h as u32).into();
-            *pointer_location = evt.position_transformed(rect_size) + rect.loc.to_f64();
+            *pointer_location = evt.position_transformed(rect.size) + rect.loc.to_f64();
 
             let under = window_map.get_surface_under(*pointer_location);
             let tablet = tablet_seat.get_tablet(&TabletDescriptor::from(&evt.device()));
@@ -415,8 +414,7 @@ impl AnvilState<UdevData> {
             let tool = evt.tool();
             tablet_seat.add_tool(&tool);
 
-            let rect_size = (rect.size.h as u32, rect.size.w as u32).into();
-            *pointer_location = evt.position_transformed(rect_size) + rect.loc.to_f64();
+            *pointer_location = evt.position_transformed(rect.size) + rect.loc.to_f64();
 
             let under = window_map.get_surface_under(*pointer_location);
             let tablet = tablet_seat.get_tablet(&TabletDescriptor::from(&evt.device()));

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -301,7 +301,7 @@ fn fullscreen_output_geometry(
     // First test if a specific output has been requested
     // if the requested output is not found ignore the request
     if let Some(wl_output) = wl_output {
-        return output_map.find(&wl_output, |_, geometry| geometry).ok();
+        return output_map.find_by_output(&wl_output).map(|o| o.geometry());
     }
 
     // There is no output preference, try to find the output
@@ -311,7 +311,7 @@ fn fullscreen_output_geometry(
         .and_then(|kind| window_map.location(&kind));
 
     if let Some(location) = window_location {
-        let window_output = output_map.find_by_position(location, |_, geometry| geometry).ok();
+        let window_output = output_map.find_by_position(location).map(|o| o.geometry());
 
         if let Some(result) = window_output {
             return Some(result);
@@ -319,7 +319,7 @@ fn fullscreen_output_geometry(
     }
 
     // Fallback to primary output
-    output_map.with_primary(|_, geometry| geometry).ok()
+    output_map.with_primary().map(|o| o.geometry())
 }
 
 pub fn init_shell<BackendData: 'static>(display: Rc<RefCell<Display>>, log: ::slog::Logger) -> ShellHandles {
@@ -355,8 +355,8 @@ pub fn init_shell<BackendData: 'static>(display: Rc<RefCell<Display>>, log: ::sl
 
                 let output_geometry = xdg_output_map
                     .borrow()
-                    .with_primary(|_, geometry| geometry)
-                    .ok()
+                    .with_primary()
+                    .map(|o| o.geometry())
                     .unwrap_or_else(|| Rectangle::from_loc_and_size((0, 0), (800, 800)));
                 let max_x = output_geometry.loc.x + (((output_geometry.size.w as f32) / 3.0) * 2.0) as i32;
                 let max_y = output_geometry.loc.y + (((output_geometry.size.h as f32) / 3.0) * 2.0) as i32;
@@ -593,8 +593,8 @@ pub fn init_shell<BackendData: 'static>(display: Rc<RefCell<Display>>, log: ::sl
                         .and_then(|position| {
                             xdg_output_map
                                 .borrow()
-                                .find_by_position(position, |_, geometry| geometry)
-                                .ok()
+                                .find_by_position(position)
+                                .map(|o| o.geometry())
                         })
                 };
 
@@ -645,8 +645,8 @@ pub fn init_shell<BackendData: 'static>(display: Rc<RefCell<Display>>, log: ::sl
 
                     let output_geometry = shell_output_map
                         .borrow()
-                        .with_primary(|_, geometry| geometry)
-                        .ok()
+                        .with_primary()
+                        .map(|o| o.geometry())
                         .unwrap_or_else(|| Rectangle::from_loc_and_size((0, 0), (800, 800)));
                     let max_x =
                         output_geometry.loc.x + (((output_geometry.size.w as f32) / 3.0) * 2.0) as i32;

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -110,11 +110,11 @@ pub fn run_winit(
         {
             let mut renderer = renderer.borrow_mut();
             // This is safe to do as with winit we are guaranteed to have exactly one output
-            let output_geometry = state
+            let (output_geometry, output_scale) = state
                 .output_map
                 .borrow()
-                .find_by_name(OUTPUT_NAME, |_, geometry| geometry)
-                .ok()
+                .find_by_name(OUTPUT_NAME)
+                .map(|output| (output.geometry(), output.scale()))
                 .unwrap();
 
             let result = renderer
@@ -127,6 +127,7 @@ pub fn run_winit(
                         frame,
                         &*state.window_map.borrow(),
                         output_geometry,
+                        output_scale,
                         &log,
                     )?;
 
@@ -136,7 +137,14 @@ pub fn run_winit(
                         let guard = state.dnd_icon.lock().unwrap();
                         if let Some(ref surface) = *guard {
                             if surface.as_ref().is_alive() {
-                                draw_dnd_icon(renderer, frame, surface, (x as i32, y as i32).into(), &log)?;
+                                draw_dnd_icon(
+                                    renderer,
+                                    frame,
+                                    surface,
+                                    (x as i32, y as i32).into(),
+                                    output_scale,
+                                    &log,
+                                )?;
                             }
                         }
                     }
@@ -155,7 +163,14 @@ pub fn run_winit(
                         // draw as relevant
                         if let CursorImageStatus::Image(ref surface) = *guard {
                             cursor_visible = false;
-                            draw_cursor(renderer, frame, surface, (x as i32, y as i32).into(), &log)?;
+                            draw_cursor(
+                                renderer,
+                                frame,
+                                surface,
+                                (x as i32, y as i32).into(),
+                                output_scale,
+                                &log,
+                            )?;
                         } else {
                             cursor_visible = true;
                         }

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -9,7 +9,7 @@ pub use tablet::{
     TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent, TabletToolTipState, TabletToolType,
 };
 
-use crate::utils::{Logical, Point, Raw};
+use crate::utils::{Logical, Point, Raw, Size};
 
 /// Trait for generic functions every input device does provide
 pub trait Device: PartialEq + Eq + std::hash::Hash {
@@ -265,21 +265,21 @@ pub trait PointerMotionAbsoluteEvent<B: InputBackend>: Event<B> {
 
     /// Device position converted to the targets coordinate space.
     /// E.g. the focused output's resolution.
-    fn position_transformed(&self, coordinate_space: Point<u32, Logical>) -> Point<f64, Logical> {
+    fn position_transformed(&self, coordinate_space: Size<i32, Logical>) -> Point<f64, Logical> {
         (
-            self.x_transformed(coordinate_space.x),
-            self.y_transformed(coordinate_space.y),
+            self.x_transformed(coordinate_space.w),
+            self.y_transformed(coordinate_space.h),
         )
             .into()
     }
 
     /// Device x position converted to the targets coordinate space's width.
     /// E.g. the focused output's width.
-    fn x_transformed(&self, width: u32) -> f64;
+    fn x_transformed(&self, width: i32) -> f64;
 
     /// Device y position converted to the targets coordinate space's height.
     /// E.g. the focused output's height.
-    fn y_transformed(&self, height: u32) -> f64;
+    fn y_transformed(&self, height: i32) -> f64;
 }
 
 impl<B: InputBackend> PointerMotionAbsoluteEvent<B> for UnusedEvent {
@@ -291,11 +291,11 @@ impl<B: InputBackend> PointerMotionAbsoluteEvent<B> for UnusedEvent {
         match *self {}
     }
 
-    fn x_transformed(&self, _width: u32) -> f64 {
+    fn x_transformed(&self, _width: i32) -> f64 {
         match *self {}
     }
 
-    fn y_transformed(&self, _height: u32) -> f64 {
+    fn y_transformed(&self, _height: i32) -> f64 {
         match *self {}
     }
 }
@@ -331,10 +331,10 @@ pub trait TouchDownEvent<B: InputBackend>: Event<B> {
 
     /// Touch position converted into the target coordinate space.
     /// E.g. the focused output's resolution.
-    fn position_transformed(&self, coordinate_space: Point<u32, Logical>) -> Point<f64, Logical> {
+    fn position_transformed(&self, coordinate_space: Size<i32, Logical>) -> Point<f64, Logical> {
         (
-            self.x_transformed(coordinate_space.x),
-            self.y_transformed(coordinate_space.y),
+            self.x_transformed(coordinate_space.w),
+            self.y_transformed(coordinate_space.h),
         )
             .into()
     }
@@ -351,11 +351,11 @@ pub trait TouchDownEvent<B: InputBackend>: Event<B> {
 
     /// Touch event's x position converted to the targets coordinate space's width.
     /// E.g. the focused output's width.
-    fn x_transformed(&self, width: u32) -> f64;
+    fn x_transformed(&self, width: i32) -> f64;
 
     /// Touch event's y position converted to the targets coordinate space's width.
     /// E.g. the focused output's width.
-    fn y_transformed(&self, height: u32) -> f64;
+    fn y_transformed(&self, height: i32) -> f64;
 }
 
 impl<B: InputBackend> TouchDownEvent<B> for UnusedEvent {
@@ -371,11 +371,11 @@ impl<B: InputBackend> TouchDownEvent<B> for UnusedEvent {
         match *self {}
     }
 
-    fn x_transformed(&self, _width: u32) -> f64 {
+    fn x_transformed(&self, _width: i32) -> f64 {
         match *self {}
     }
 
-    fn y_transformed(&self, _height: u32) -> f64 {
+    fn y_transformed(&self, _height: i32) -> f64 {
         match *self {}
     }
 }
@@ -394,10 +394,10 @@ pub trait TouchMotionEvent<B: InputBackend>: Event<B> {
 
     /// Touch position converted into the target coordinate space.
     /// E.g. the focused output's resolution.
-    fn position_transformed(&self, coordinate_space: Point<u32, Logical>) -> Point<f64, Logical> {
+    fn position_transformed(&self, coordinate_space: Size<i32, Logical>) -> Point<f64, Logical> {
         (
-            self.x_transformed(coordinate_space.x),
-            self.y_transformed(coordinate_space.y),
+            self.x_transformed(coordinate_space.w),
+            self.y_transformed(coordinate_space.h),
         )
             .into()
     }
@@ -414,11 +414,11 @@ pub trait TouchMotionEvent<B: InputBackend>: Event<B> {
 
     /// Touch event's x position converted to the targets coordinate space's width.
     /// E.g. the focused output's width.
-    fn x_transformed(&self, width: u32) -> f64;
+    fn x_transformed(&self, width: i32) -> f64;
 
     /// Touch event's y position converted to the targets coordinate space's width.
     /// E.g. the focused output's width.
-    fn y_transformed(&self, height: u32) -> f64;
+    fn y_transformed(&self, height: i32) -> f64;
 }
 
 impl<B: InputBackend> TouchMotionEvent<B> for UnusedEvent {
@@ -434,11 +434,11 @@ impl<B: InputBackend> TouchMotionEvent<B> for UnusedEvent {
         match *self {}
     }
 
-    fn x_transformed(&self, _width: u32) -> f64 {
+    fn x_transformed(&self, _width: i32) -> f64 {
         match *self {}
     }
 
-    fn y_transformed(&self, _height: u32) -> f64 {
+    fn y_transformed(&self, _height: i32) -> f64 {
         match *self {}
     }
 }

--- a/src/backend/input/tablet.rs
+++ b/src/backend/input/tablet.rs
@@ -1,5 +1,5 @@
 use super::{ButtonState, Event, InputBackend, UnusedEvent};
-use crate::utils::{Logical, Point, Raw};
+use crate::utils::{Logical, Point, Raw, Size};
 use bitflags::bitflags;
 
 /// Description of physical tablet tool
@@ -73,10 +73,10 @@ pub trait TabletToolEvent<B: InputBackend> {
     }
 
     /// Tool position converted into the target coordinate space.
-    fn position_transformed(&self, coordinate_space: Point<u32, Logical>) -> Point<f64, Logical> {
+    fn position_transformed(&self, coordinate_space: Size<i32, Logical>) -> Point<f64, Logical> {
         (
-            self.x_transformed(coordinate_space.x),
-            self.y_transformed(coordinate_space.y),
+            self.x_transformed(coordinate_space.w),
+            self.y_transformed(coordinate_space.h),
         )
             .into()
     }
@@ -110,9 +110,9 @@ pub trait TabletToolEvent<B: InputBackend> {
     fn y(&self) -> f64;
 
     /// Return the current absolute X coordinate of the tablet tool event, transformed to screen coordinates.
-    fn x_transformed(&self, width: u32) -> f64;
+    fn x_transformed(&self, width: i32) -> f64;
     /// Return the current absolute Y coordinate of the tablet tool event, transformed to screen coordinates.
-    fn y_transformed(&self, height: u32) -> f64;
+    fn y_transformed(&self, height: i32) -> f64;
 
     /// Returns the current distance from the tablet's sensor, normalized to the range [0, 1]
     ///
@@ -205,10 +205,10 @@ impl<B: InputBackend> TabletToolEvent<B> for UnusedEvent {
     fn y(&self) -> f64 {
         match *self {}
     }
-    fn x_transformed(&self, _width: u32) -> f64 {
+    fn x_transformed(&self, _width: i32) -> f64 {
         match *self {}
     }
-    fn y_transformed(&self, _height: u32) -> f64 {
+    fn y_transformed(&self, _height: i32) -> f64 {
         match *self {}
     }
     fn distance(&self) -> f64 {

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -242,12 +242,12 @@ impl backend::PointerMotionAbsoluteEvent<LibinputInputBackend>
         self.absolute_y()
     }
 
-    fn x_transformed(&self, width: u32) -> f64 {
-        self.absolute_x_transformed(width)
+    fn x_transformed(&self, width: i32) -> f64 {
+        self.absolute_x_transformed(width as u32)
     }
 
-    fn y_transformed(&self, height: u32) -> f64 {
-        self.absolute_y_transformed(height)
+    fn y_transformed(&self, height: i32) -> f64 {
+        self.absolute_y_transformed(height as u32)
     }
 }
 
@@ -274,12 +274,12 @@ impl backend::TouchDownEvent<LibinputInputBackend> for event::touch::TouchDownEv
         event::touch::TouchEventPosition::y(self)
     }
 
-    fn x_transformed(&self, width: u32) -> f64 {
-        event::touch::TouchEventPosition::x_transformed(self, width)
+    fn x_transformed(&self, width: i32) -> f64 {
+        event::touch::TouchEventPosition::x_transformed(self, width as u32)
     }
 
-    fn y_transformed(&self, height: u32) -> f64 {
-        event::touch::TouchEventPosition::y_transformed(self, height)
+    fn y_transformed(&self, height: i32) -> f64 {
+        event::touch::TouchEventPosition::y_transformed(self, height as u32)
     }
 }
 
@@ -306,12 +306,12 @@ impl backend::TouchMotionEvent<LibinputInputBackend> for event::touch::TouchMoti
         event::touch::TouchEventPosition::y(self)
     }
 
-    fn x_transformed(&self, width: u32) -> f64 {
-        event::touch::TouchEventPosition::x_transformed(self, width)
+    fn x_transformed(&self, width: i32) -> f64 {
+        event::touch::TouchEventPosition::x_transformed(self, width as u32)
     }
 
-    fn y_transformed(&self, height: u32) -> f64 {
-        event::touch::TouchEventPosition::y_transformed(self, height)
+    fn y_transformed(&self, height: i32) -> f64 {
+        event::touch::TouchEventPosition::y_transformed(self, height as u32)
     }
 }
 

--- a/src/backend/libinput/tablet.rs
+++ b/src/backend/libinput/tablet.rs
@@ -103,12 +103,12 @@ where
         tablet_tool::TabletToolEventTrait::y(self)
     }
 
-    fn x_transformed(&self, width: u32) -> f64 {
-        tablet_tool::TabletToolEventTrait::x_transformed(self, width)
+    fn x_transformed(&self, width: i32) -> f64 {
+        tablet_tool::TabletToolEventTrait::x_transformed(self, width as u32)
     }
 
-    fn y_transformed(&self, height: u32) -> f64 {
-        tablet_tool::TabletToolEventTrait::y_transformed(self, height)
+    fn y_transformed(&self, height: i32) -> f64 {
+        tablet_tool::TabletToolEventTrait::y_transformed(self, height as u32)
     }
 
     fn distance(&self) -> f64 {

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -185,6 +185,7 @@ pub trait Frame {
         texture: &Self::TextureId,
         pos: Point<i32, Physical>,
         transform: Transform,
+        scale: f32,
         alpha: f32,
     ) -> Result<(), Self::Error> {
         let mut mat = Matrix3::<f32>::identity();
@@ -192,7 +193,7 @@ pub trait Frame {
         // position and scale
         let size = texture.size();
         mat = mat * Matrix3::from_translation(Vector2::new(pos.x as f32, pos.y as f32));
-        mat = mat * Matrix3::from_nonuniform_scale(size.0 as f32, size.1 as f32);
+        mat = mat * Matrix3::from_nonuniform_scale(size.0 as f32 * scale, size.1 as f32 * scale);
 
         //apply surface transformation
         mat = mat * Matrix3::from_translation(Vector2::new(0.5, 0.5));

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -397,13 +397,13 @@ impl PointerMotionAbsoluteEvent<WinitInputBackend> for WinitMouseMovedEvent {
         self.logical_position.y * wsize.scale_factor
     }
 
-    fn x_transformed(&self, width: u32) -> f64 {
+    fn x_transformed(&self, width: i32) -> f64 {
         let wsize = self.size.borrow();
         let w_width = wsize.logical_size().w;
         f64::max(self.logical_position.x * width as f64 / w_width, 0.0)
     }
 
-    fn y_transformed(&self, height: u32) -> f64 {
+    fn y_transformed(&self, height: i32) -> f64 {
         let wsize = self.size.borrow();
         let w_height = wsize.logical_size().h;
         f64::max(self.logical_position.y * height as f64 / w_height, 0.0)
@@ -514,13 +514,13 @@ impl TouchDownEvent<WinitInputBackend> for WinitTouchStartedEvent {
         self.location.y * wsize.scale_factor
     }
 
-    fn x_transformed(&self, width: u32) -> f64 {
+    fn x_transformed(&self, width: i32) -> f64 {
         let wsize = self.size.borrow();
         let w_width = wsize.logical_size().w;
         f64::max(self.location.x * width as f64 / w_width, 0.0)
     }
 
-    fn y_transformed(&self, height: u32) -> f64 {
+    fn y_transformed(&self, height: i32) -> f64 {
         let wsize = self.size.borrow();
         let w_height = wsize.logical_size().h;
         f64::max(self.location.y * height as f64 / w_height, 0.0)
@@ -561,13 +561,13 @@ impl TouchMotionEvent<WinitInputBackend> for WinitTouchMovedEvent {
         self.location.y * wsize.scale_factor
     }
 
-    fn x_transformed(&self, width: u32) -> f64 {
+    fn x_transformed(&self, width: i32) -> f64 {
         let wsize = self.size.borrow();
         let w_width = wsize.logical_size().w;
         f64::max(self.location.x * width as f64 / w_width, 0.0)
     }
 
-    fn y_transformed(&self, height: u32) -> f64 {
+    fn y_transformed(&self, height: i32) -> f64 {
         let wsize = self.size.borrow();
         let w_height = wsize.logical_size().h;
         f64::max(self.location.y * height as f64 / w_height, 0.0)


### PR DESCRIPTION
This PR adds support for HiDPI to anvil.

The scaling supports fractional scaling and will announce the rounded value to the wayland output.
The initial scale of an output can be set with the envorinment variable `ANVIL_SCALE_{short-name of output}`.
The scale can be changed with the keyboard shortcut `LOGO + SHIFT + P` to increase and  `LOGO + SHIFT + M` to decrease in 0.25f32 steps

Toplevels and the pointer (on udev) will be automatically moved after changing the scale so that they appear stable.

closes #104 