### PR TITLE
Winit: Share the resized size instead of using egl display field

### DIFF
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -74,8 +74,6 @@ pub struct WinitGraphicsBackend {
 /// periodically to receive any events.
 #[derive(Debug)]
 pub struct WinitInputBackend {
-    // TODO: Find out how to get rid of this egl surface so the input backend is renderer agnostic.
-    resize_notification: Rc<Cell<Option<(u32, u32)>>>,
     window: Rc<WinitWindow>,
     events_loop: EventLoop<()>,
     time: Instant,
@@ -83,6 +81,7 @@ pub struct WinitInputBackend {
     logger: ::slog::Logger,
     initialized: bool,
     size: Rc<RefCell<WindowSize>>,
+    resize_notification: Rc<Cell<Option<(u32, u32)>>>,
 }
 
 /// Create a new [`WinitGraphicsBackend`], which implements the [`Renderer`] trait and a corresponding [`WinitInputBackend`],

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -72,6 +72,7 @@ pub struct WinitGraphicsBackend {
 /// periodically to receive any events.
 #[derive(Debug)]
 pub struct WinitInputBackend {
+    // TODO: Find out how to get rid of this egl surface so the input backend is renderer agnostic.
     egl: Rc<EGLSurface>,
     window: Rc<WinitWindow>,
     events_loop: EventLoop<()>,

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -193,7 +193,7 @@ where
         WinitGraphicsBackend {
             window: window.clone(),
             display,
-            egl: egl.clone(),
+            egl,
             renderer,
             size: size.clone(),
             resize_notification: resize_notification.clone(),


### PR DESCRIPTION
The simple explanation for this pull request is the input handling for winit should be entirely graphics independent. Currently the input has to have an egl surface to resize. This simply adds a Cell<Option<(u32, u32)>> to tell the graphics backend when a resize occurs and resize before rendering. This shifts the responsibility of resizing the egl surface to the graphics backend.