### PR TITLE
Various smaller fixes/additions to our egl stack

### DIFF
--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -14,12 +14,14 @@ rand = "0.7"
 slog = { version = "2.1.1" }
 slog-term = "2.8"
 slog-async = "2.2"
+slog-stdlog = "4.1.0"
+slog-scope = "4.4.0"
 xkbcommon = "0.4.0"
 
 [dependencies.smithay]
 path = ".."
 default-features = false
-features = [ "renderer_gl", "backend_egl", "wayland_frontend" ]
+features = [ "renderer_gl", "backend_egl", "wayland_frontend", "slog-stdlog" ]
 
 [dependencies.x11rb]
 optional = true

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -44,6 +44,8 @@ fn main() {
         //std::sync::Mutex::new(slog_term::term_full().fuse()).fuse(),
         o!(),
     );
+    let _guard = slog_scope::set_global_logger(log.clone());
+    slog_stdlog::init().expect("Could not setup log backend");
 
     let arg = ::std::env::args().nth(1);
     match arg.as_ref().map(|s| &s[..]) {

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -441,10 +441,13 @@ impl AnvilState<UdevData> {
             #[cfg(feature = "egl")]
             if path.canonicalize().ok() == self.backend_data.primary_gpu {
                 info!(self.log, "Initializing EGL Hardware Acceleration via {:?}", path);
-                renderer
+                if renderer
                     .borrow_mut()
                     .bind_wl_display(&*self.display.borrow())
-                    .expect("Unable to bind Wl Display?");
+                    .is_ok()
+                {
+                    info!(self.log, "EGL hardware-acceleration enabled");
+                }
             }
 
             let backends = Rc::new(RefCell::new(scan_connectors(

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -300,9 +300,6 @@ pub struct PixelFormatRequirements {
     pub depth_bits: Option<u8>,
     /// Minimum number of bits for the depth buffer. `None` means "don't care". The default value is `None`.
     pub stencil_bits: Option<u8>,
-    /// If `true`, only double-buffered formats will be considered. If `false`, only single-buffer formats.
-    /// `None` means "don't care". The default is `None`.
-    pub double_buffer: Option<bool>,
     /// Contains the minimum number of samples per pixel in the color, depth and stencil buffers.
     /// `None` means "don't care". Default is `None`. A value of `Some(0)` indicates that multisampling must not be enabled.
     pub multisampling: Option<u16>,
@@ -317,7 +314,6 @@ impl Default for PixelFormatRequirements {
             alpha_bits: Some(8),
             depth_bits: Some(24),
             stencil_bits: Some(8),
-            double_buffer: Some(true),
             multisampling: None,
         }
     }

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -403,6 +403,11 @@ impl EGLDisplay {
         Ok((desc, config_id))
     }
 
+    /// Get a handle to the underlying native EGLDisplay
+    pub fn get_display_handle(&self) -> Arc<EGLDisplayHandle> {
+        self.display.clone()
+    }
+
     /// Returns the runtime egl version of this display
     pub fn get_egl_version(&self) -> (i32, i32) {
         self.egl_version

--- a/src/backend/egl/error.rs
+++ b/src/backend/egl/error.rs
@@ -127,7 +127,7 @@ impl From<u32> for EGLError {
 }
 
 impl EGLError {
-    fn from_last_call() -> Result<(), EGLError> {
+    pub(super) fn from_last_call() -> Result<(), EGLError> {
         match unsafe { ffi::egl::GetError() as u32 } {
             ffi::egl::SUCCESS => Ok(()),
             x => Err(EGLError::from(x)),

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -182,7 +182,6 @@ pub unsafe trait EGLNativeSurface: Send + Sync {
         &self,
         display: &Arc<EGLDisplayHandle>,
         config_id: ffi::egl::types::EGLConfig,
-        surface_attributes: &[c_int],
     ) -> Result<*const c_void, super::EGLError>;
 
     /// Will be called to check if any internal resources will need
@@ -225,6 +224,13 @@ pub unsafe trait EGLNativeSurface: Send + Sync {
 }
 
 #[cfg(feature = "backend_winit")]
+static WINIT_SURFACE_ATTRIBUTES: [c_int; 3] = [
+    ffi::egl::RENDER_BUFFER as c_int,
+    ffi::egl::BACK_BUFFER as c_int,
+    ffi::egl::NONE as c_int,
+];
+
+#[cfg(feature = "backend_winit")]
 /// Typed Xlib window for the `X11` backend
 #[derive(Debug)]
 pub struct XlibWindow(pub std::os::raw::c_ulong);
@@ -235,7 +241,6 @@ unsafe impl EGLNativeSurface for XlibWindow {
         &self,
         display: &Arc<EGLDisplayHandle>,
         config_id: ffi::egl::types::EGLConfig,
-        surface_attributes: &[c_int],
     ) -> Result<*const c_void, super::EGLError> {
         wrap_egl_call(|| unsafe {
             let mut id = self.0;
@@ -243,7 +248,7 @@ unsafe impl EGLNativeSurface for XlibWindow {
                 display.handle,
                 config_id,
                 (&mut id) as *mut std::os::raw::c_ulong as *mut _,
-                surface_attributes.as_ptr(),
+                WINIT_SURFACE_ATTRIBUTES.as_ptr(),
             )
         })
     }
@@ -255,14 +260,13 @@ unsafe impl EGLNativeSurface for wegl::WlEglSurface {
         &self,
         display: &Arc<EGLDisplayHandle>,
         config_id: ffi::egl::types::EGLConfig,
-        surface_attributes: &[c_int],
     ) -> Result<*const c_void, super::EGLError> {
         wrap_egl_call(|| unsafe {
             ffi::egl::CreatePlatformWindowSurfaceEXT(
                 display.handle,
                 config_id,
                 self.ptr() as *mut _,
-                surface_attributes.as_ptr(),
+                WINIT_SURFACE_ATTRIBUTES.as_ptr(),
             )
         })
     }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -172,7 +172,6 @@ where
             EGLSurface::new(
                 &display,
                 context.pixel_format().unwrap(),
-                reqs.double_buffer,
                 context.config_id(),
                 surface,
                 log.clone(),
@@ -183,7 +182,6 @@ where
             EGLSurface::new(
                 &display,
                 context.pixel_format().unwrap(),
-                reqs.double_buffer,
                 context.config_id(),
                 xlib_window,
                 log.clone(),


### PR DESCRIPTION
Every commit stands for themselves, I have taken care to properly explain every commit in its message..
This is best reviewed one at a time.

I can easily drop any commit from this PR, if any turns out to be controversial, they do not depend on each other.

1. Makes the egl-display handle public, which it should have been in the first place.
2. Moves responsibility from the common egl-surface code into the native surface glue-code.
3. Adds debug logging to libEGL.
4. Fixes a recent regression @PolyMeilex pointed out on matrix.