### PR TITLE
Automatically unmaximize toplevel when it is moved

### DIFF
--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -407,6 +407,20 @@ pub fn init_shell<BackendData: 'static>(display: Rc<RefCell<Display>>, log: ::sl
                     return;
                 }
 
+                // If surface is maximized then unmaximize it
+                if let Some(current_state) = surface.current_state() {
+                    if current_state.states.contains(xdg_toplevel::State::Maximized) {
+                        let fs_changed = surface.with_pending_state(|state| {
+                            state.states.unset(xdg_toplevel::State::Maximized);
+                            state.size = None;
+                        });
+
+                        if fs_changed.is_ok() {
+                            surface.send_configure();
+                        }
+                    }
+                }
+
                 let toplevel = SurfaceKind::Xdg(surface);
                 let initial_window_location = xdg_window_map.borrow().location(&toplevel).unwrap();
 


### PR DESCRIPTION
Currently, when you move a maximized toplevel in Anvil, it gets stuck in this confusing state where it thinks it is maximized (so for example we can't resize it), but in reality it no longer is maximized.

Possible solutions are:
- ignore move when toplevel is maximized (that's what Weston does)
- unmaximize it and start a MoveSurfaceGrab (that's what most compositors do)

This PR adds a second solution to anvil.
For Anvil's simplicity sake, it omits some positioning calculations, but I left a comment describing those in the code.