### PR TITLE
Changes to drag and drop protocol

### DIFF
--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -300,7 +300,11 @@ fn implement_dnd_data_offer(
                 preferred_action,
             } => {
                 let preferred_action = preferred_action;
-                if ![DndAction::Move, DndAction::Copy, DndAction::Ask].contains(&preferred_action) {
+
+                // preferred_action must only contain one bitflag at the same time
+                if ![DndAction::None, DndAction::Move, DndAction::Copy, DndAction::Ask]
+                    .contains(&preferred_action)
+                {
                     offer.as_ref().post_error(
                         wl_data_offer::Error::InvalidAction as u32,
                         "Invalid preferred action.".into(),
@@ -312,7 +316,8 @@ fn implement_dnd_data_offer(
                 data.chosen_action = (&mut *action_choice.borrow_mut())(possible_actions, preferred_action);
                 // check that the user provided callback respects that one precise action should be chosen
                 debug_assert!(
-                    [DndAction::Move, DndAction::Copy, DndAction::Ask].contains(&data.chosen_action)
+                    [DndAction::None, DndAction::Move, DndAction::Copy, DndAction::Ask]
+                        .contains(&data.chosen_action)
                 );
                 offer.action(data.chosen_action);
                 source.action(data.chosen_action);

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -273,24 +273,28 @@ fn implement_dnd_data_offer(
                         wl_data_offer::Error::InvalidFinish as u32,
                         "Cannot finish a data offer that is no longer active.".into(),
                     );
+                    return;
                 }
                 if !data.accepted {
                     offer.as_ref().post_error(
                         wl_data_offer::Error::InvalidFinish as u32,
                         "Cannot finish a data offer that has not been accepted.".into(),
                     );
+                    return;
                 }
                 if !data.dropped {
                     offer.as_ref().post_error(
                         wl_data_offer::Error::InvalidFinish as u32,
                         "Cannot finish a data offer that has not been dropped.".into(),
                     );
+                    return;
                 }
                 if data.chosen_action.is_empty() {
                     offer.as_ref().post_error(
                         wl_data_offer::Error::InvalidFinish as u32,
                         "Cannot finish a data offer with no valid action.".into(),
                     );
+                    return;
                 }
                 source.dnd_finished();
                 data.active = false;
@@ -309,6 +313,7 @@ fn implement_dnd_data_offer(
                         wl_data_offer::Error::InvalidAction as u32,
                         "Invalid preferred action.".into(),
                     );
+                    return;
                 }
                 let source_actions = with_source_metadata(&source, |meta| meta.dnd_action)
                     .unwrap_or_else(|_| DndAction::empty());

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -295,7 +295,11 @@ where
                 preferred_action,
             } => {
                 let preferred_action = preferred_action;
-                if ![DndAction::Move, DndAction::Copy, DndAction::Ask].contains(&preferred_action) {
+
+                // preferred_action must only contain one bitflag at the same time
+                if ![DndAction::None, DndAction::Move, DndAction::Copy, DndAction::Ask]
+                    .contains(&preferred_action)
+                {
                     offer.as_ref().post_error(
                         wl_data_offer::Error::InvalidAction as u32,
                         "Invalid preferred action.".into(),
@@ -305,7 +309,8 @@ where
                 data.chosen_action = (&mut *action_choice.borrow_mut())(possible_actions, preferred_action);
                 // check that the user provided callback respects that one precise action should be chosen
                 debug_assert!(
-                    [DndAction::Move, DndAction::Copy, DndAction::Ask].contains(&data.chosen_action)
+                    [DndAction::None, DndAction::Move, DndAction::Copy, DndAction::Ask]
+                        .contains(&data.chosen_action)
                 );
                 offer.action(data.chosen_action);
                 (&mut *callback.borrow_mut())(ServerDndEvent::Action(data.chosen_action));

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -268,24 +268,28 @@ where
                         wl_data_offer::Error::InvalidFinish as u32,
                         "Cannot finish a data offer that is no longer active.".into(),
                     );
+                    return;
                 }
                 if !data.accepted {
                     offer.as_ref().post_error(
                         wl_data_offer::Error::InvalidFinish as u32,
                         "Cannot finish a data offer that has not been accepted.".into(),
                     );
+                    return;
                 }
                 if !data.dropped {
                     offer.as_ref().post_error(
                         wl_data_offer::Error::InvalidFinish as u32,
                         "Cannot finish a data offer that has not been dropped.".into(),
                     );
+                    return;
                 }
                 if data.chosen_action.is_empty() {
                     offer.as_ref().post_error(
                         wl_data_offer::Error::InvalidFinish as u32,
                         "Cannot finish a data offer with no valid action.".into(),
                     );
+                    return;
                 }
                 (&mut *callback.borrow_mut())(ServerDndEvent::Finished);
                 data.active = false;
@@ -304,6 +308,7 @@ where
                         wl_data_offer::Error::InvalidAction as u32,
                         "Invalid preferred action.".into(),
                     );
+                    return;
                 }
                 let possible_actions = metadata.dnd_action & dnd_actions;
                 data.chosen_action = (&mut *action_choice.borrow_mut())(possible_actions, preferred_action);


### PR DESCRIPTION
Addresses problem outlined in #326

### First commit (https://github.com/Smithay/smithay/commit/1601878bf98c2bc758ef8c340c1b7eddf3a05fa4):
I have read thought Weston implementation and Smithay one side by side, and it seems that they mostly work the same way, the only deference I can spot are the checks in data offer SetAction handler:
https://github.com/Smithay/smithay/blob/6b2273235a88032063063ac23b2dedd9fad93fb9/src/wayland/data_device/dnd_grab.rs#L312
Adding `DndAction::None` to the list seems to fix the problem. (it looks like [weston](https://github.com/wayland-project/weston/blob/7a44ee7f37803b8b1c3829672d07c5328b878456/libweston/data-device.c#L189) and [wlroots](https://github.com/swaywm/wlroots/blob/a38baec1f89d423dea4be85a6233fed26d13732f/types/data_device/wlr_data_offer.c#L155) do the same)

After this commit, the compositor no longer crashes when running apps like nautilus or gedit.

### Second commit (https://github.com/Smithay/smithay/commit/7c174d43f4d1ed8953877688781560b361668d17)
I noticed that dnd handlers don't return when the protocol error is raised, is this intended behavior? I believe that we should early return as soon as we realize that event is not valid.


---
Not sure if #326 should be closed yet, I haven't wrapped my head around data device protocol yet, so the possibility that I still missed something is quite high