### PR TITLE
Potential fix for #359

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- `XdgPopupSurfaceRoleAttributes::positioner` changed its type to Arc<Mutex<PositionerState>>
+
 ### Additions
 
 #### Clients & Protocols
@@ -17,6 +21,7 @@
 ### Bugfixes
 
 - EGLBufferReader now checks if buffers are alive before using them.
+- `XdgPopupSurfaceRoleAttributes::positioner` now always contains up to date data
 
 ## version 0.3.0 (2021-07-25)
 

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -320,7 +320,7 @@ xdg_role!(
         ///
         /// For example the compositor should prevent that a popup
         /// is placed outside the visible rectangle of a output.
-        pub positioner: PositionerState,
+        pub positioner: Arc<Mutex<PositionerState>>,
         /// Holds the last server_pending state that has been acknowledged
         /// by the client. This state should be cloned to the current
         /// during a commit.

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -458,7 +458,7 @@ impl PositionerState {
     /// The `constraint_adjustment` will not be considered by this
     /// implementation and the position and size should be re-calculated
     /// in the compositor if the compositor implements `constraint_adjustment`
-    pub(crate) fn get_geometry(&self) -> Rectangle<i32, Logical> {
+    pub fn get_geometry(&self) -> Rectangle<i32, Logical> {
         // From the `xdg_shell` prococol specification:
         //
         // set_offset:


### PR DESCRIPTION
I wrapped the `PositionerState` in a `Arc<Mutex<<>>`, not sure if this is the best solution.

While at it, I also made `PositionerState::get_geometry` public, as it is used to get new geometry, when we want to update popup position.

fixes: #359