### PR TITLE
wayland/seat: Add `KeysymHandle` to allow for keycode conversions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `XdgPositionerState` moved to `XdgPopupState` and added to `XdgRequest::NewPopup`
 - `PopupSurface::send_configure` now checks the protocol version and returns an `Result`
+- `KeyboardHandle::input` filter closure now receives a `KeysymHandle` instead of a `Keysym`.
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - `XdgPositionerState` moved to `XdgPopupState` and added to `XdgRequest::NewPopup`
 - `PopupSurface::send_configure` now checks the protocol version and returns an `Result`
-- `KeyboardHandle::input` filter closure now receives a `KeysymHandle` instead of a `Keysym`.
+- `KeyboardHandle::input` filter closure now receives a `KeysymHandle` instead of a `Keysym` and returns a `FilterResult`.
 
 ### Additions
 

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -45,7 +45,9 @@ impl<Backend> AnvilState<Backend> {
         let mut action = KeyAction::None;
         let suppressed_keys = &mut self.suppressed_keys;
         self.keyboard
-            .input(keycode, state, serial, time, |modifiers, keysym| {
+            .input(keycode, state, serial, time, |modifiers, handle| {
+                let keysym = handle.modified_sym();
+
                 debug!(log, "keysym";
                     "state" => format!("{:?}", state),
                     "mods" => format!("{:?}", modifiers),

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -13,7 +13,7 @@ use smithay::{
     },
     reexports::wayland_server::protocol::wl_pointer,
     wayland::{
-        seat::{keysyms as xkb, AxisFrame, Keysym, ModifiersState},
+        seat::{keysyms as xkb, AxisFrame, FilterResult, Keysym, ModifiersState},
         SERIAL_COUNTER as SCOUNTER,
     },
 };
@@ -42,7 +42,6 @@ impl<Backend> AnvilState<Backend> {
         let serial = SCOUNTER.next_serial();
         let log = &self.log;
         let time = Event::time(&evt);
-        let mut action = KeyAction::None;
         let suppressed_keys = &mut self.suppressed_keys;
         self.keyboard
             .input(keycode, state, serial, time, |modifiers, handle| {
@@ -60,27 +59,26 @@ impl<Backend> AnvilState<Backend> {
                 // so that we can decide on a release if the key
                 // should be forwarded to the client or not.
                 if let KeyState::Pressed = state {
-                    action = process_keyboard_shortcut(*modifiers, keysym);
+                    let action = process_keyboard_shortcut(*modifiers, keysym);
 
-                    // forward to client only if action == KeyAction::Forward
-                    let forward = matches!(action, KeyAction::Forward);
-
-                    if !forward {
+                    if action.is_some() {
                         suppressed_keys.push(keysym);
                     }
 
-                    forward
+                    action
+                        .map(FilterResult::Intercept)
+                        .unwrap_or(FilterResult::Forward)
                 } else {
                     let suppressed = suppressed_keys.contains(&keysym);
-
                     if suppressed {
                         suppressed_keys.retain(|k| *k != keysym);
+                        FilterResult::Intercept(KeyAction::None)
+                    } else {
+                        FilterResult::Forward
                     }
-
-                    !suppressed
                 }
-            });
-        action
+            })
+            .unwrap_or(KeyAction::None)
     }
 
     fn on_pointer_button<B: InputBackend>(&mut self, evt: B::PointerButtonEvent) {
@@ -157,7 +155,7 @@ impl AnvilState<WinitData> {
 
         match event {
             InputEvent::Keyboard { event, .. } => match self.keyboard_key_to_action::<B>(event) {
-                KeyAction::None | KeyAction::Forward => {}
+                KeyAction::None => {}
                 KeyAction::Quit => {
                     info!(self.log, "Quitting.");
                     self.running.store(false, Ordering::SeqCst);
@@ -245,7 +243,7 @@ impl AnvilState<UdevData> {
     pub fn process_input_event<B: InputBackend>(&mut self, event: InputEvent<B>) {
         match event {
             InputEvent::Keyboard { event, .. } => match self.keyboard_key_to_action::<B>(event) {
-                KeyAction::None | KeyAction::Forward => {}
+                KeyAction::None => {}
                 KeyAction::Quit => {
                     info!(self.log, "Quitting.");
                     self.running.store(false, Ordering::SeqCst);
@@ -522,32 +520,32 @@ enum KeyAction {
     Screen(usize),
     ScaleUp,
     ScaleDown,
-    /// Forward the key to the client
-    Forward,
     /// Do nothing more
     None,
 }
 
-fn process_keyboard_shortcut(modifiers: ModifiersState, keysym: Keysym) -> KeyAction {
+fn process_keyboard_shortcut(modifiers: ModifiersState, keysym: Keysym) -> Option<KeyAction> {
     if modifiers.ctrl && modifiers.alt && keysym == xkb::KEY_BackSpace
         || modifiers.logo && keysym == xkb::KEY_q
     {
         // ctrl+alt+backspace = quit
         // logo + q = quit
-        KeyAction::Quit
+        Some(KeyAction::Quit)
     } else if (xkb::KEY_XF86Switch_VT_1..=xkb::KEY_XF86Switch_VT_12).contains(&keysym) {
         // VTSwicth
-        KeyAction::VtSwitch((keysym - xkb::KEY_XF86Switch_VT_1 + 1) as i32)
+        Some(KeyAction::VtSwitch(
+            (keysym - xkb::KEY_XF86Switch_VT_1 + 1) as i32,
+        ))
     } else if modifiers.logo && keysym == xkb::KEY_Return {
         // run terminal
-        KeyAction::Run("weston-terminal".into())
+        Some(KeyAction::Run("weston-terminal".into()))
     } else if modifiers.logo && keysym >= xkb::KEY_1 && keysym <= xkb::KEY_9 {
-        KeyAction::Screen((keysym - xkb::KEY_1) as usize)
+        Some(KeyAction::Screen((keysym - xkb::KEY_1) as usize))
     } else if modifiers.logo && modifiers.shift && keysym == xkb::KEY_M {
-        KeyAction::ScaleDown
+        Some(KeyAction::ScaleDown)
     } else if modifiers.logo && modifiers.shift && keysym == xkb::KEY_P {
-        KeyAction::ScaleUp
+        Some(KeyAction::ScaleUp)
     } else {
-        KeyAction::Forward
+        None
     }
 }

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -40,7 +40,9 @@ mod keyboard;
 mod pointer;
 
 pub use self::{
-    keyboard::{keysyms, Error as KeyboardError, KeyboardHandle, Keysym, ModifiersState, XkbConfig},
+    keyboard::{
+        keysyms, Error as KeyboardError, FilterResult, KeyboardHandle, Keysym, ModifiersState, XkbConfig,
+    },
     pointer::{
         AxisFrame, CursorImageAttributes, CursorImageStatus, GrabStartData, PointerGrab, PointerHandle,
         PointerInnerHandle,


### PR DESCRIPTION
Currently keycodes are always converted using xkbcommons
`State::key_get_one_sym` function. This may be not what the compositor
wants, e.g. if it represents keybindings with explicit modifiers.
Applying Shift in this case changes the sym, making it necessary for
the compositor to *undo* this transformation, which is hard or even
impossible and very unnecessary, when we have all the necessary
information in smithay.

Therefor this commit replaces the `Keysym` argument of the filter
closure with a `KeysymHandle`, which allows for different variants of
keysyms to be received. Modified (as previously), unmodified or even
as a raw keycode.