### PR TITLE
docs: Update calloop in CLI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --no-deps --features "test_all_features" -p smithay -p calloop:0.9.0 -p dbus -p drm -p gbm -p input -p nix:0.20.0 -p udev -p slog -p wayland-server -p wayland-commons:0.29.0 -p wayland-protocols:0.29.0 -p winit
+          args: --no-deps --features "test_all_features" -p smithay -p calloop:0.9.1 -p dbus -p drm -p gbm -p input -p nix:0.20.0 -p udev -p slog -p wayland-server -p wayland-commons:0.29.0 -p wayland-protocols:0.29.0 -p winit
 
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html


### PR DESCRIPTION
This should hopefully fix the failing docs build.