### PR TITLE
wayland.compositor: fix leak of surface data

### DIFF
--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -112,7 +112,7 @@ impl PrivateSurfaceData {
                 .retain(|c| !c.as_ref().equals(surface.as_ref()));
         }
         // orphan all our children
-        for child in &my_data.children {
+        for child in my_data.children.drain(..) {
             let child_mutex = child
                 .as_ref()
                 .user_data()


### PR DESCRIPTION
The subsurface logic holds a self-reference to the WlSurface to
track stacking orders of the children relative to the parent. This
self-reference needs be dropped during cleanup to avoid reference
cycles.

This was not the case, and caused every surface user data to be
leaked as it kept a reference to itself (and all of its children).