### PR TITLE
Add missing check for dead surfaces

### DIFF
--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -96,6 +96,9 @@ impl PointerInternal {
         F: FnMut(&WlPointer, &WlSurface),
     {
         if let Some((ref focus, _)) = self.focus {
+            if !focus.as_ref().is_alive() {
+                return;
+            }
             for ptr in &self.known_pointers {
                 if ptr.as_ref().same_client_as(focus.as_ref()) {
                     f(ptr, focus)


### PR DESCRIPTION
Previously a pointer.leave event would be sent with a NULL target,
causing the client to disconnect.