### PR TITLE
anvil: Passing `ANVIL_MUTEX_LOG` uses Mutex logging drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 - EGLBufferReader now checks if buffers are alive before using them.
 - LibSeat no longer panics on seat disable event.
 
+### Anvil
+
+- Passing `ANVIL_MUTEX_LOG` in environment variables now uses the slower `Mutex` logging drain.
+
 ## version 0.3.0 (2021-07-25)
 
 Large parts of Smithay were changed with numerous API changes. It is thus recommended to

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -9,11 +9,15 @@ static POSSIBLE_BACKENDS: &[&str] = &[
 
 fn main() {
     // A logger facility, here we use the terminal here
-    let log = slog::Logger::root(
-        slog_async::Async::default(slog_term::term_full().fuse()).fuse(),
-        //std::sync::Mutex::new(slog_term::term_full().fuse()).fuse(),
-        o!(),
-    );
+    let log = if std::env::var("ANVIL_MUTEX_LOG").is_ok() {
+        slog::Logger::root(std::sync::Mutex::new(slog_term::term_full().fuse()).fuse(), o!())
+    } else {
+        slog::Logger::root(
+            slog_async::Async::default(slog_term::term_full().fuse()).fuse(),
+            o!(),
+        )
+    };
+
     let _guard = slog_scope::set_global_logger(log.clone());
     slog_stdlog::init().expect("Could not setup log backend");
 


### PR DESCRIPTION
This is primarily useful for debugging anvil when it panics.

Environment variable was chosen because it aligns with the `WAYLAND_DEBUG` pattern.