### PR TITLE
Refactor Renderer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - All winit backend internal event types now use `WinitInput` as the backend type.
 - `WinitEventLoop::dispatch_new_events` is now used to receive some `WinitEvent`s.
 - Added `TabletToolType::Unknown` as an option for tablet events
+- `render_texture` was removed from `Frame`, use `render_texture_at` or `render_texture_from_to` instead or use `Gles2Renderer::render_texture` as a direct replacement.
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - `KeyState`, `MouseButton`, `ButtonState` and `Axis` in `backend::input` now derive `Hash`.
 - New `DrmNode` type in drm backend. This is primarily for use a backend which needs to run as client inside another session.
 - The button code for a `PointerButtonEvent` may now be obtained using `PointerButtonEvent::button_code`. 
+- `Renderer` now allows texture filtering methods to be set.
 
 ### Bugfixes
 

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -11,7 +11,7 @@ use std::sync::{
 };
 use std::{collections::HashSet, os::raw::c_char};
 
-use cgmath::{prelude::*, Matrix3, Vector2};
+use cgmath::{prelude::*, Matrix3, Vector2, Vector3};
 
 mod shaders;
 mod version;
@@ -26,7 +26,7 @@ use crate::backend::egl::{
     EGLContext, EGLSurface, MakeCurrentError,
 };
 use crate::backend::SwapBuffersError;
-use crate::utils::{Buffer, Physical, Size};
+use crate::utils::{Buffer, Physical, Rectangle, Size};
 
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
 use super::ImportEgl;
@@ -34,8 +34,6 @@ use super::ImportEgl;
 use super::{ImportDma, ImportShm};
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
 use crate::backend::egl::{display::EGLBufferReader, Format as EGLFormat};
-#[cfg(feature = "wayland_frontend")]
-use crate::utils::Rectangle;
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::protocol::{wl_buffer, wl_shm};
 
@@ -515,8 +513,8 @@ impl Gles2Renderer {
             logger: log,
             _not_send: std::ptr::null_mut(),
         };
-        renderer.downscale_filter(TextureFilter::Nearest);
-        renderer.upscale_filter(TextureFilter::Linear);
+        renderer.downscale_filter(TextureFilter::Nearest)?;
+        renderer.upscale_filter(TextureFilter::Linear)?;
         renderer.egl.unbind()?;
         Ok(renderer)
     }
@@ -1009,28 +1007,35 @@ impl Renderer for Gles2Renderer {
     type Error = Gles2Error;
     type TextureId = Gles2Texture;
     type Frame = Gles2Frame;
-    
+
     fn downscale_filter(&mut self, filter: TextureFilter) -> Result<(), Self::Error> {
         self.make_current()?;
         unsafe {
-            self.gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, match filter {
-                TextureFilter::Nearest => ffi::NEAREST as i32,
-                TextureFilter::Linear => ffi::LINEAR as i32,
-            });
+            self.gl.TexParameteri(
+                ffi::TEXTURE_2D,
+                ffi::TEXTURE_MIN_FILTER,
+                match filter {
+                    TextureFilter::Nearest => ffi::NEAREST as i32,
+                    TextureFilter::Linear => ffi::LINEAR as i32,
+                },
+            );
         }
         Ok(())
     }
     fn upscale_filter(&mut self, filter: TextureFilter) -> Result<(), Self::Error> {
         self.make_current()?;
         unsafe {
-            self.gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, match filter {
-                TextureFilter::Nearest => ffi::NEAREST as i32,
-                TextureFilter::Linear => ffi::LINEAR as i32,
-            });
+            self.gl.TexParameteri(
+                ffi::TEXTURE_2D,
+                ffi::TEXTURE_MAG_FILTER,
+                match filter {
+                    TextureFilter::Nearest => ffi::NEAREST as i32,
+                    TextureFilter::Linear => ffi::LINEAR as i32,
+                },
+            );
         }
         Ok(())
     }
-
 
     fn render<F, R>(
         &mut self,
@@ -1125,13 +1130,60 @@ impl Frame for Gles2Frame {
         Ok(())
     }
 
-    fn render_texture(
+    fn render_texture_from_to(
         &mut self,
-        tex: &Self::TextureId,
+        texture: &Self::TextureId,
+        src: Rectangle<i32, Buffer>,
+        dest: Rectangle<f64, Physical>,
+        transform: Transform,
+        alpha: f32,
+    ) -> Result<(), Self::Error> {
+        let mut mat = Matrix3::<f32>::identity();
+
+        // position and scale
+        mat = mat * Matrix3::from_translation(Vector2::new(dest.loc.x as f32, dest.loc.y as f32));
+        mat = mat * Matrix3::from_nonuniform_scale(dest.size.w as f32, dest.size.h as f32);
+
+        //apply surface transformation
+        mat = mat * Matrix3::from_translation(Vector2::new(0.5, 0.5));
+        if transform == Transform::Normal {
+            assert_eq!(mat, mat * transform.invert().matrix());
+            assert_eq!(transform.matrix(), Matrix3::<f32>::identity());
+        }
+        mat = mat * transform.invert().matrix();
+        mat = mat * Matrix3::from_translation(Vector2::new(-0.5, -0.5));
+
+        // this matrix should be regular, we can expect invert to succeed
+        let tex_size = texture.size();
+        let texture_mat = Matrix3::from_nonuniform_scale(tex_size.w as f32, tex_size.h as f32)
+            .invert()
+            .unwrap();
+        let verts = [
+            (texture_mat * Vector3::new((src.loc.x + src.size.w) as f32, src.loc.y as f32, 0.0)).truncate(), // top-right
+            (texture_mat * Vector3::new(src.loc.x as f32, src.loc.y as f32, 0.0)).truncate(), // top-left
+            (texture_mat
+                * Vector3::new(
+                    (src.loc.x + src.size.w) as f32,
+                    (src.loc.y + src.size.h) as f32,
+                    0.0,
+                ))
+            .truncate(), // bottom-right
+            (texture_mat * Vector3::new(src.loc.x as f32, (src.loc.y + src.size.h) as f32, 0.0)).truncate(), // bottom-left
+        ];
+        self.render_texture(texture, mat, verts, alpha)
+    }
+}
+
+impl Gles2Frame {
+    /// Render a texture to the current target using given projection matrix and alpha.
+    /// The given vertices are used to source the texture. This is mostly useful for cropping the texture.    
+    pub fn render_texture(
+        &mut self,
+        tex: &Gles2Texture,
         mut matrix: Matrix3<f32>,
         tex_coords: [Vector2<f32>; 4],
         alpha: f32,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Gles2Error> {
         //apply output transformation
         matrix = self.current_projection * matrix;
 

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -14,7 +14,7 @@ use crate::utils::{Buffer, Physical, Point, Rectangle, Size};
 
 #[cfg(feature = "wayland_frontend")]
 use crate::wayland::compositor::SurfaceData;
-use cgmath::{prelude::*, Matrix3, Vector2, Vector3};
+use cgmath::Matrix3;
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::protocol::{wl_buffer, wl_shm};
 
@@ -172,15 +172,6 @@ pub trait Frame {
     /// This operation is only valid in between a `begin` and `finish`-call.
     /// If called outside this operation may error-out, do nothing or modify future rendering results in any way.
     fn clear(&mut self, color: [f32; 4]) -> Result<(), Self::Error>;
-    /// Render a texture to the current target using given projection matrix and alpha.
-    /// The given vertices are used to source the texture. This is mostly useful for cropping the texture.
-    fn render_texture(
-        &mut self,
-        texture: &Self::TextureId,
-        matrix: Matrix3<f32>,
-        tex_coords: [Vector2<f32>; 4],
-        alpha: f32,
-    ) -> Result<(), Self::Error>;
 
     /// Render a texture to the current target as a flat 2d-plane at a given
     /// position and applying the given transformation with the given alpha value.
@@ -218,41 +209,7 @@ pub trait Frame {
         dest: Rectangle<f64, Physical>,
         transform: Transform,
         alpha: f32,
-    ) -> Result<(), Self::Error> {
-        let mut mat = Matrix3::<f32>::identity();
-
-        // position and scale
-        mat = mat * Matrix3::from_translation(Vector2::new(dest.loc.x as f32, dest.loc.y as f32));
-        mat = mat * Matrix3::from_nonuniform_scale(dest.size.w as f32, dest.size.h as f32);
-
-        //apply surface transformation
-        mat = mat * Matrix3::from_translation(Vector2::new(0.5, 0.5));
-        if transform == Transform::Normal {
-            assert_eq!(mat, mat * transform.invert().matrix());
-            assert_eq!(transform.matrix(), Matrix3::<f32>::identity());
-        }
-        mat = mat * transform.invert().matrix();
-        mat = mat * Matrix3::from_translation(Vector2::new(-0.5, -0.5));
-
-        // this matrix should be regular, we can expect invert to succeed
-        let tex_size = texture.size();
-        let texture_mat = Matrix3::from_nonuniform_scale(tex_size.w as f32, tex_size.h as f32)
-            .invert()
-            .unwrap();
-        let verts = [
-            (texture_mat * Vector3::new((src.loc.x + src.size.w) as f32, src.loc.y as f32, 0.0)).truncate(), // top-right
-            (texture_mat * Vector3::new(src.loc.x as f32, src.loc.y as f32, 0.0)).truncate(), // top-left
-            (texture_mat
-                * Vector3::new(
-                    (src.loc.x + src.size.w) as f32,
-                    (src.loc.y + src.size.h) as f32,
-                    0.0,
-                ))
-            .truncate(), // bottom-right
-            (texture_mat * Vector3::new(src.loc.x as f32, (src.loc.y + src.size.h) as f32, 0.0)).truncate(), // bottom-left
-        ];
-        self.render_texture(texture, mat, verts, alpha)
-    }
+    ) -> Result<(), Self::Error>;
 }
 
 /// Abstraction of commonly used rendering operations for compositors.

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -53,6 +53,15 @@ pub enum Transform {
     Flipped270,
 }
 
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+/// Texture filtering methods
+pub enum TextureFilter {
+    /// Returns the value of the texture element that is nearest (in Manhattan distance) to the center of the pixel being textured.
+    Linear,
+    /// Returns the weighted average of the four texture elements that are closest to the center of the pixel being textured.
+    Nearest,
+}
+
 impl Transform {
     /// A projection matrix to apply this transformation
     pub fn matrix(&self) -> Matrix3<f32> {
@@ -254,6 +263,11 @@ pub trait Renderer {
     type TextureId: Texture;
     /// Type representing a currently in-progress frame during the [`Renderer::render`]-call
     type Frame: Frame<Error = Self::Error, TextureId = Self::TextureId>;
+
+    /// Set the filter method to be used when rendering a texture into a smaller area than its size
+    fn downscale_filter(&mut self, filter: TextureFilter) -> Result<(), Self::Error>;
+    /// Set the filter method to be used when rendering a texture into a larger area than its size
+    fn upscale_filter(&mut self, filter: TextureFilter) -> Result<(), Self::Error>;
 
     /// Initialize a rendering context on the current rendering target with given dimensions and transformation.
     ///

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -175,13 +175,14 @@ pub trait Frame {
 
     /// Render a texture to the current target as a flat 2d-plane at a given
     /// position and applying the given transformation with the given alpha value.
+    /// (Meaning `src_transform` should match the orientation of surface being rendered).
     fn render_texture_at(
         &mut self,
         texture: &Self::TextureId,
         pos: Point<f64, Physical>,
         texture_scale: i32,
         output_scale: f64,
-        transform: Transform,
+        src_transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error> {
         self.render_texture_from_to(
@@ -195,19 +196,20 @@ pub trait Frame {
                     .to_f64()
                     .to_physical(output_scale),
             ),
-            transform,
+            src_transform,
             alpha,
         )
     }
 
-    /// Render part of a texture as given by src to the current target into the rectangle described by dest
-    /// as a flat 2d-plane after applying the given transformations.
+    /// Render part of a texture as given by src to the current target into the rectangle described by dst
+    /// as a flat 2d-plane after applying the inverse of the given transformation.
+    /// (Meaning `src_transform` should match the orientation of surface being rendered).
     fn render_texture_from_to(
         &mut self,
         texture: &Self::TextureId,
         src: Rectangle<i32, Buffer>,
-        dest: Rectangle<f64, Physical>,
-        transform: Transform,
+        dst: Rectangle<f64, Physical>,
+        src_transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error>;
 }
@@ -236,7 +238,7 @@ pub trait Renderer {
     fn render<F, R>(
         &mut self,
         size: Size<i32, Physical>,
-        transform: Transform,
+        dst_transform: Transform,
         rendering: F,
     ) -> Result<R, Self::Error>
     where

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -1,10 +1,9 @@
 use std::cell::Cell;
 
-use cgmath::Vector2;
 use smithay::{
     backend::{
         allocator::dmabuf::Dmabuf,
-        renderer::{Frame, ImportDma, ImportShm, Renderer, Texture, Transform},
+        renderer::{Frame, ImportDma, ImportShm, Renderer, Texture, TextureFilter, Transform},
         SwapBuffersError,
     },
     reexports::wayland_server::protocol::wl_buffer,
@@ -28,7 +27,7 @@ impl Renderer for DummyRenderer {
     fn render<F, R>(
         &mut self,
         _size: Size<i32, Physical>,
-        _transform: Transform,
+        _dst_transform: Transform,
         rendering: F,
     ) -> Result<R, Self::Error>
     where
@@ -36,6 +35,14 @@ impl Renderer for DummyRenderer {
     {
         let mut frame = DummyFrame {};
         Ok(rendering(self, &mut frame))
+    }
+
+    fn upscale_filter(&mut self, _filter: TextureFilter) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn downscale_filter(&mut self, _filter: TextureFilter) -> Result<(), Self::Error> {
+        Ok(())
     }
 }
 
@@ -94,11 +101,12 @@ impl Frame for DummyFrame {
         Ok(())
     }
 
-    fn render_texture(
+    fn render_texture_from_to(
         &mut self,
         _texture: &Self::TextureId,
-        _matrix: cgmath::Matrix3<f32>,
-        _tex_coords: [Vector2<f32>; 4],
+        _src: Rectangle<i32, Buffer>,
+        _dst: Rectangle<f64, Physical>,
+        _src_transform: Transform,
         _alpha: f32,
     ) -> Result<(), Self::Error> {
         Ok(())


### PR DESCRIPTION
First set of changes discussed on matrix.

For motivation see https://github.com/Smithay/smithay/discussions/363#discussioncomment-1505061 .
TL;DR: A software renderer (and potentially others) cannot support the matrix style `render_texture` api, so lets move that into the `Gles2Renderer`.

Feedback welcome.