### PR TITLE
anvil: deduplicate some input handler logic

### DIFF
--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -132,16 +132,16 @@ pub fn run_winit(log: Logger) {
                             size,
                             refresh: 60_000,
                         },
-                        crate::winit::OUTPUT_NAME,
+                        OUTPUT_NAME,
                     );
 
                     let output_mut = state.output_map.borrow();
-                    let output = output_mut.find_by_name(crate::winit::OUTPUT_NAME).unwrap();
+                    let output = output_mut.find_by_name(OUTPUT_NAME).unwrap();
 
                     state.window_map.borrow_mut().layers.arange_layers(output);
                 }
 
-                WinitEvent::Input(event) => state.process_input_event(event),
+                WinitEvent::Input(event) => state.process_input_event_windowed(event, OUTPUT_NAME),
 
                 _ => (),
             })

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -164,7 +164,7 @@ pub fn run_x11(log: Logger) {
                 state.backend_data.render = true;
             }
 
-            X11Event::Input(event) => state.process_input_event(event),
+            X11Event::Input(event) => state.process_input_event_windowed(event, OUTPUT_NAME),
         })
         .expect("Failed to insert X11 Backend into event loop");
 


### PR DESCRIPTION
This PR exists to reduce the amount of duplicate code in anvil's input handling.

We merge the logic for winit and x11 backends through the `AnvilState::process_input_event_windowed`. The common key action logic is also taken into another function which winit, x11 and udev call for `None`, `Quit` and `Run`