### PR TITLE
Add KDE server-decoration support

### DIFF
--- a/src/wayland/shell/kde/decoration.rs
+++ b/src/wayland/shell/kde/decoration.rs
@@ -72,7 +72,7 @@ pub trait KdeDecorationHandler {
     }
 
     /// Handle decoration object removal for a surface.
-    fn release(&mut self, _surface: &WlSurface) {}
+    fn release(&mut self, _decoration: &OrgKdeKwinServerDecoration, _surface: &WlSurface) {}
 }
 
 /// KDE server decoration state.

--- a/src/wayland/shell/kde/decoration.rs
+++ b/src/wayland/shell/kde/decoration.rs
@@ -62,14 +62,17 @@ pub trait KdeDecorationHandler {
     /// decoration request.
     ///
     /// **It is up to the compositor to prevent feedback loops**, a client is free to ignore modes
-    /// suggested by [`OrgKdeKwinServerDecoration::mode`] and instead keep requesting their
-    /// preferred mode instead.
+    /// suggested by [`OrgKdeKwinServerDecoration::mode`] and instead request their preferred mode
+    /// instead.
     fn request_mode(
         &mut self,
         _surface: &WlSurface,
-        _decoration: &OrgKdeKwinServerDecoration,
-        _mode: WEnum<Mode>,
+        decoration: &OrgKdeKwinServerDecoration,
+        mode: WEnum<Mode>,
     ) {
+        if let WEnum::Value(mode) = mode {
+            decoration.mode(mode);
+        }
     }
 
     /// Handle decoration object removal for a surface.

--- a/src/wayland/shell/kde/decoration.rs
+++ b/src/wayland/shell/kde/decoration.rs
@@ -1,0 +1,129 @@
+//! KDE Window decoration manager
+//!
+//! This interface allows a compositor to announce support for KDE's legacy server-side decorations.
+//!
+//! A client can use this protocol to request being decorated by a supporting compositor.
+//!
+//! ```
+//! extern crate wayland_server;
+//! extern crate smithay;
+//!
+//! use smithay::delegate_kde_decoration;
+//! use smithay::wayland::shell::kde::decoration::{KdeDecorationHandler, KdeDecorationState};
+//!
+//! # struct State { kde_decoration_state: KdeDecorationState };
+//! # let mut display = wayland_server::Display::<State>::new().unwrap();
+//!
+//! // Create the new KdeDecorationState.
+//! let state = KdeDecorationState::new::<State, _>(&display.handle(), None);
+//!
+//! // Insert KdeDecorationState into your compositor state.
+//! // …
+//!
+//! // Implement KDE server decoration handlers.
+//! impl KdeDecorationHandler for State {
+//!     fn kde_decoration_state(&self) -> &KdeDecorationState {
+//!         &self.kde_decoration_state
+//!     }
+//! }
+//!
+//! delegate_kde_decoration!(State);
+//! ```
+
+use slog::Logger;
+use wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration::{
+    Mode, OrgKdeKwinServerDecoration,
+};
+use wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration_manager::OrgKdeKwinServerDecorationManager;
+use wayland_server::backend::GlobalId;
+use wayland_server::protocol::wl_surface::WlSurface;
+use wayland_server::{Dispatch, DisplayHandle, GlobalDispatch, WEnum};
+
+/// KDE server decoration handler.
+pub trait KdeDecorationHandler {
+    /// Return the KDE server decoration state.
+    fn kde_decoration_state(&self) -> &KdeDecorationState;
+
+    /// Handle decoration manager creation.
+    ///
+    /// Allows setting up the decoration manager, like setting the default decoration mode using
+    /// [`OrgKdeKwinServerDecorationManager::default_mode`].
+    fn setup(&mut self, _kde_decoration_manager: &OrgKdeKwinServerDecorationManager) {}
+
+    /// Handle new decoration object creation.
+    ///
+    /// Called whenever a new decoration object is created, usually this happens when a new window
+    /// is opened.
+    fn new_decoration(&mut self, _surface: &WlSurface, _decoration: &OrgKdeKwinServerDecoration) {}
+
+    /// Handle surface decoration mode requests.
+    ///
+    /// Called when a surface requests a specific decoration mode or acknowledged the compositor's
+    /// decoration request.
+    ///
+    /// **It is up to the compositor to prevent feedback loops**, a client is free to ignore modes
+    /// suggested by [`OrgKdeKwinServerDecoration::mode`] and instead keep requesting their
+    /// preferred mode instead.
+    fn request_mode(
+        &mut self,
+        _surface: &WlSurface,
+        _decoration: &OrgKdeKwinServerDecoration,
+        _mode: WEnum<Mode>,
+    ) {
+    }
+
+    /// Handle decoration object removal for a surface.
+    fn release(&mut self, _surface: &WlSurface) {}
+}
+
+/// KDE server decoration state.
+#[derive(Debug)]
+pub struct KdeDecorationState {
+    pub(crate) logger: Logger,
+    kde_decoration_manager: GlobalId,
+}
+
+impl KdeDecorationState {
+    /// Create a new KDE server decoration global.
+    pub fn new<D, L>(display: &DisplayHandle, logger: L) -> Self
+    where
+        D: GlobalDispatch<OrgKdeKwinServerDecorationManager, ()>
+            + Dispatch<OrgKdeKwinServerDecorationManager, ()>
+            + Dispatch<OrgKdeKwinServerDecoration, WlSurface>
+            + KdeDecorationHandler
+            + 'static,
+        L: Into<Option<Logger>>,
+    {
+        let kde_decoration_manager = display.create_global::<D, OrgKdeKwinServerDecorationManager, _>(1, ());
+        let logger =
+            crate::slog_or_fallback(logger).new(slog::o!("smithay_module" => "kde_decoration_handler"));
+
+        Self {
+            kde_decoration_manager,
+            logger,
+        }
+    }
+
+    /// Returns the id of the [`OrgKdeKwinServerDecorationManager`] global.
+    pub fn global(&self) -> GlobalId {
+        self.kde_decoration_manager.clone()
+    }
+}
+
+#[allow(missing_docs)] // TODO
+#[macro_export]
+macro_rules! delegate_kde_decoration {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration_manager::OrgKdeKwinServerDecorationManager: ()
+        ] => $crate::wayland::shell::kde::decoration::KdeDecorationState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration_manager::OrgKdeKwinServerDecorationManager: ()
+        ] => $crate::wayland::shell::kde::decoration::KdeDecorationState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration::OrgKdeKwinServerDecoration: $crate::reexports::wayland_server::protocol::wl_surface::WlSurface
+        ] => $crate::wayland::shell::kde::decoration::KdeDecorationState);
+    };
+}

--- a/src/wayland/shell/kde/decoration.rs
+++ b/src/wayland/shell/kde/decoration.rs
@@ -34,7 +34,9 @@ use slog::Logger;
 use wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration::{
     Mode, OrgKdeKwinServerDecoration,
 };
-use wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration_manager::OrgKdeKwinServerDecorationManager;
+use wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration_manager::{
+    Mode as DefaultMode, OrgKdeKwinServerDecorationManager,
+};
 use wayland_server::backend::GlobalId;
 use wayland_server::protocol::wl_surface::WlSurface;
 use wayland_server::{Dispatch, DisplayHandle, GlobalDispatch, WEnum};
@@ -43,12 +45,6 @@ use wayland_server::{Dispatch, DisplayHandle, GlobalDispatch, WEnum};
 pub trait KdeDecorationHandler {
     /// Return the KDE server decoration state.
     fn kde_decoration_state(&self) -> &KdeDecorationState;
-
-    /// Handle decoration manager creation.
-    ///
-    /// Allows setting up the decoration manager, like setting the default decoration mode using
-    /// [`OrgKdeKwinServerDecorationManager::default_mode`].
-    fn setup(&mut self, _kde_decoration_manager: &OrgKdeKwinServerDecorationManager) {}
 
     /// Handle new decoration object creation.
     ///
@@ -82,13 +78,15 @@ pub trait KdeDecorationHandler {
 /// KDE server decoration state.
 #[derive(Debug)]
 pub struct KdeDecorationState {
+    pub(crate) default_mode: DefaultMode,
     pub(crate) logger: Logger,
+
     kde_decoration_manager: GlobalId,
 }
 
 impl KdeDecorationState {
     /// Create a new KDE server decoration global.
-    pub fn new<D, L>(display: &DisplayHandle, logger: L) -> Self
+    pub fn new<D, L>(display: &DisplayHandle, default_mode: DefaultMode, logger: L) -> Self
     where
         D: GlobalDispatch<OrgKdeKwinServerDecorationManager, ()>
             + Dispatch<OrgKdeKwinServerDecorationManager, ()>
@@ -103,6 +101,7 @@ impl KdeDecorationState {
 
         Self {
             kde_decoration_manager,
+            default_mode,
             logger,
         }
     }

--- a/src/wayland/shell/kde/decoration.rs
+++ b/src/wayland/shell/kde/decoration.rs
@@ -10,12 +10,13 @@
 //!
 //! use smithay::delegate_kde_decoration;
 //! use smithay::wayland::shell::kde::decoration::{KdeDecorationHandler, KdeDecorationState};
+//! use wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration_manager::Mode;
 //!
 //! # struct State { kde_decoration_state: KdeDecorationState };
 //! # let mut display = wayland_server::Display::<State>::new().unwrap();
 //!
 //! // Create the new KdeDecorationState.
-//! let state = KdeDecorationState::new::<State, _>(&display.handle(), None);
+//! let state = KdeDecorationState::new::<State, _>(&display.handle(), Mode::Server, None);
 //!
 //! // Insert KdeDecorationState into your compositor state.
 //! // …

--- a/src/wayland/shell/kde/handlers.rs
+++ b/src/wayland/shell/kde/handlers.rs
@@ -1,0 +1,97 @@
+//! Handlers for KDE decoration events.
+
+use wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration::{
+    OrgKdeKwinServerDecoration, Request,
+};
+use wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration_manager::{
+    OrgKdeKwinServerDecorationManager, Request as ManagerRequest,
+};
+use wayland_server::protocol::wl_surface::WlSurface;
+use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource};
+
+use crate::wayland::shell::kde::decoration::{KdeDecorationHandler, KdeDecorationState};
+
+impl<D> GlobalDispatch<OrgKdeKwinServerDecorationManager, (), D> for KdeDecorationState
+where
+    D: GlobalDispatch<OrgKdeKwinServerDecorationManager, ()>
+        + Dispatch<OrgKdeKwinServerDecorationManager, ()>
+        + Dispatch<OrgKdeKwinServerDecoration, WlSurface>
+        + KdeDecorationHandler
+        + 'static,
+{
+    fn bind(
+        state: &mut D,
+        _dh: &DisplayHandle,
+        _client: &Client,
+        resource: New<OrgKdeKwinServerDecorationManager>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        let kde_decoration_manager = data_init.init(resource, ());
+        state.setup(&kde_decoration_manager);
+
+        let logger = &state.kde_decoration_state().logger;
+        slog::trace!(logger, "Bound decoration manager global");
+    }
+}
+
+impl<D> Dispatch<OrgKdeKwinServerDecorationManager, (), D> for KdeDecorationState
+where
+    D: Dispatch<OrgKdeKwinServerDecorationManager, ()>
+        + Dispatch<OrgKdeKwinServerDecorationManager, ()>
+        + Dispatch<OrgKdeKwinServerDecoration, WlSurface>
+        + KdeDecorationHandler
+        + 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        _kde_decoration_manager: &OrgKdeKwinServerDecorationManager,
+        request: ManagerRequest,
+        _data: &(),
+        _dh: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        let (id, surface) = match request {
+            ManagerRequest::Create { id, surface } => (id, surface),
+            _ => unreachable!(),
+        };
+
+        let kde_decoration = data_init.init(id, surface);
+
+        let surface = kde_decoration.data().unwrap();
+        state.new_decoration(surface, &kde_decoration);
+
+        let logger = &state.kde_decoration_state().logger;
+        slog::trace!(logger, "Created decoration object for surface {:?}", surface);
+    }
+}
+
+impl<D> Dispatch<OrgKdeKwinServerDecoration, WlSurface, D> for KdeDecorationState
+where
+    D: Dispatch<OrgKdeKwinServerDecoration, WlSurface> + KdeDecorationHandler + 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        kde_decoration: &OrgKdeKwinServerDecoration,
+        request: Request,
+        surface: &WlSurface,
+        _dh: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        let logger = &state.kde_decoration_state().logger;
+        slog::trace!(
+            logger,
+            "Decoration request for surface {:?}: {:?}",
+            surface,
+            request
+        );
+
+        match request {
+            Request::RequestMode { mode } => state.request_mode(surface, kde_decoration, mode),
+            Request::Release => state.release(surface),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/wayland/shell/kde/handlers.rs
+++ b/src/wayland/shell/kde/handlers.rs
@@ -93,7 +93,7 @@ where
 
         match request {
             Request::RequestMode { mode } => state.request_mode(surface, kde_decoration, mode),
-            Request::Release => state.release(surface),
+            Request::Release => state.release(kde_decoration, surface),
             _ => unreachable!(),
         }
     }

--- a/src/wayland/shell/kde/handlers.rs
+++ b/src/wayland/shell/kde/handlers.rs
@@ -28,7 +28,10 @@ where
         data_init: &mut DataInit<'_, D>,
     ) {
         let kde_decoration_manager = data_init.init(resource, ());
-        state.setup(&kde_decoration_manager);
+
+        // Set default decoration mode.
+        let default_mode = state.kde_decoration_state().default_mode;
+        kde_decoration_manager.default_mode(default_mode);
 
         let logger = &state.kde_decoration_state().logger;
         slog::trace!(logger, "Bound decoration manager global");

--- a/src/wayland/shell/kde/mod.rs
+++ b/src/wayland/shell/kde/mod.rs
@@ -1,0 +1,4 @@
+//! Handler utilities for KDE shell protocols.
+
+pub mod decoration;
+mod handlers;

--- a/src/wayland/shell/mod.rs
+++ b/src/wayland/shell/mod.rs
@@ -7,19 +7,22 @@
 //! The shell protocols thus define what kind of interactions a client can have with
 //! the compositor to properly display its contents on the screen.
 //!
-//! Smithay currently provides two of them:
+//! Smithay currently provides three of them:
 //!
 //! - The [`xdg`](xdg/index.html) module provides handlers for the `xdg_shell` protocol, which is
 //!   the current standard for desktop apps
+//! - The [`wlr_layer`](wlr_layer/index.html) module provides handlers for the `wlr_layer_shell`
+//!   protocol, which is for windows rendering above/below normal XDG windows
+//! - The [`kde`](kde/index.html) module provides handlers for KDE-specific protocols
 
 use super::Serial;
 use crate::wayland::compositor;
 use thiserror::Error;
 use wayland_server::protocol::wl_surface::WlSurface;
 
-pub mod xdg;
-
+pub mod kde;
 pub mod wlr_layer;
+pub mod xdg;
 
 /// Represents the possible errors returned from
 /// a surface ping


### PR DESCRIPTION
This should add a very rough implementation of the server decoration protocol. I've tested it and it seems to work as far as I can tell. My priority was mostly to implement this for myself to force server-side decorations for GTK, this PR is more of an accident.

It's probably somewhat rough around the edges, especially since I'm not particularly familiar with all the wrappers like `Global`/`Main`/`Resource` etc, so please let me know if you have any suggestions for improvements.