### PR TITLE
Add version method to ToplevelSurface

### DIFF
--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -903,6 +903,11 @@ impl ToplevelSurface {
         self.shell_surface.as_ref().is_alive() && self.wl_surface.as_ref().is_alive()
     }
 
+    /// Supported XDG shell protocol version.
+    pub fn version(&self) -> u32 {
+        self.shell_surface.as_ref().version()
+    }
+
     /// Retrieve the shell client owning this toplevel surface
     ///
     /// Returns `None` if the surface does actually no longer exist.


### PR DESCRIPTION
Currently the `shell_surface` is not accessible to the outside, meaning
there is no way to query for the XDG shell protocol version supported by
the client.

Adding a `version` method fixes that problem, which allows compositors
to act differently based on the supported protocol version. As an
example this allows setting the state to `State::Maximized` if the
tiling states are not available.