### PR TITLE
use the latest pending server state if available instead of the current state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 #### Clients & Protocols
 
 - `Multicache::has()` now correctly does what is expected of it
+- `xdg_shell` had an issue where it was possible that configured state gets overwritten before it was acked/committed.
 
 #### Backends
 

--- a/src/wayland/shell/mod.rs
+++ b/src/wayland/shell/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! Smithay currently provides two of them:
 //!
-//! - The [`xdg`](xdg/index.hmtl) module provides handlers for the `xdg_shell` protocol, which is
+//! - The [`xdg`](xdg/index.html) module provides handlers for the `xdg_shell` protocol, which is
 //!   the current standard for desktop apps
 //! - The [`legacy`](legacy/index.html) module provides handlers for the `wl_shell` protocol, which
 //!   is now deprecated. You only need it if you want to support apps predating `xdg_shell`.

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -130,7 +130,7 @@ const XDG_TOPLEVEL_STATE_TILED_SINCE: u32 = 2;
 
 macro_rules! xdg_role {
     ($state:ty,
-     $(#[$configure_meta:meta])* $configure_name:ident {$($(#[$configure_field_meta:meta])* $configure_field_vis:vis$configure_field_name:ident:$configure_field_type:ty),*},
+     $(#[$configure_meta:meta])* $configure_name:ident $({$($(#[$configure_field_meta:meta])* $configure_field_vis:vis$configure_field_name:ident:$configure_field_type:ty),*}),*,
      $(#[$attributes_meta:meta])* $attributes_name:ident {$($(#[$attributes_field_meta:meta])* $attributes_field_vis:vis$attributes_field_name:ident:$attributes_field_type:ty),*}) => {
 
         $(#[$configure_meta])*
@@ -144,10 +144,10 @@ macro_rules! xdg_role {
                 /// serials.
                 pub serial: Serial,
 
-                $(
+                $($(
                     $(#[$configure_field_meta])*
                     $configure_field_vis $configure_field_name: $configure_field_type,
-                )*
+                )*)*
         }
 
         $(#[$attributes_meta])*
@@ -274,8 +274,7 @@ xdg_role!(
     ToplevelState,
     /// A configure message for toplevel surfaces
     #[derive(Debug, Clone)]
-    ToplevelConfigure {
-    },
+    ToplevelConfigure,
     /// Role specific attributes for xdg_toplevel
     ///
     /// This interface defines an xdg_surface role which allows a surface to,

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -212,14 +212,17 @@ macro_rules! xdg_role {
             }
 
             /// Gets the latest state that has been configured
-            /// on the server. The state can include changes
-            /// that have been made on the server but not yet
-            /// acked or committed by the client. It does not
-            /// include the current pending state.
+            /// on the server and sent to the client.
+            ///
+            /// The state includes all changes that have been
+            /// made on the server, including all not yet
+            /// acked or committed changes, but excludes the
+            /// current [`server_pending`](#structfield.server_pending) state.
             ///
             /// This can be used for example to check if the
-            /// pending state is different from the last configured.
-            fn current_server_state(&self) -> &$state {
+            /// [`server_pending`](#structfield.server_pending) state
+            /// is different from the last configured.
+            pub fn current_server_state(&self) -> &$state {
                 // We check if there is already a non-acked pending
                 // configure and use its state or otherwise we could
                 // loose some state that was previously configured
@@ -240,12 +243,13 @@ macro_rules! xdg_role {
                     .unwrap_or(&self.current)
             }
 
-            /// Check if the state has pending changes.
+            /// Check if the state has pending changes that have
+            /// not been sent to the client.
             ///
-            /// This differs to just checking if the server pending
-            /// state is some in that it also check if a pending
-            /// state is different from the current server state.
-            fn has_pending_changes(&self) -> bool {
+            /// This differs from just checking if the [`server_pending`](#structfield.server_pending)
+            /// state is [`Some`] in that it also checks if a current pending
+            /// state is different from the [`current_server_state`](#method.current_server_state).
+            pub fn has_pending_changes(&self) -> bool {
                 self.server_pending.as_ref().map(|s| s != self.current_server_state()).unwrap_or(false)
             }
         }

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1391,7 +1391,7 @@ impl PopupSurface {
     /// Send a configure event, including the `repositioned` event to the client
     /// in response to a `reposition` request.
     ///
-    /// For further information see [`XdgPopup::send_configure`]
+    /// For further information see [`send_configure`](#method.send_configure)
     pub fn send_repositioned(&self, token: u32) {
         self.send_configure_internal(Some(token))
     }


### PR DESCRIPTION
This PR fixes an Issue where consecutively calling the following code
could loose some configured state if the state is not acked by the client
between the calls.

```
ToplevelSurface::with_pending_state(|state| {
                    ...
                });
ToplevelSurface::send_configure();
```

The fix uses the latest non acked configure when available to accumulate
the pending state changes.