### PR TITLE
backend: Support buffer age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Remove `InputBackend::dispatch_new_events`, turning `InputBackend` into a definition of backend event types. Future input backends should be a `calloop::EventSource`.
 - Remove `InputBackend::EventError` associated type as it is unneeded since `dispatch_new_events` was removed.
 - `Swapchain` does not have a generic Userdata-parameter anymore, but utilizes `UserDataMap` instead
+- `GbmBufferedSurface::next_buffer` now additionally returns the age of the buffer
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `render_texture` was removed from `Frame`, use `render_texture_at` or `render_texture_from_to` instead or use `Gles2Renderer::render_texture` as a direct replacement.
 - Remove `InputBackend::dispatch_new_events`, turning `InputBackend` into a definition of backend event types. Future input backends should be a `calloop::EventSource`.
 - Remove `InputBackend::EventError` associated type as it is unneeded since `dispatch_new_events` was removed.
+- `Swapchain` does not have a generic Userdata-parameter anymore, but utilizes `UserDataMap` instead
 
 ### Additions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ libc = "0.2.103"
 libseat= { version = "0.1.1", optional = true }
 libloading = { version="0.7.0", optional = true } 
 nix = "0.22"
+once_cell = "1.8.0"
 rand = "0.8.4"
 slog = "2"
 slog-stdlog = { version = "4", optional = true }

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -738,7 +738,7 @@ fn render_surface(
         return Ok(());
     };
 
-    let dmabuf = surface.surface.next_buffer()?;
+    let (dmabuf, _age) = surface.surface.next_buffer()?;
     renderer.bind(dmabuf)?;
 
     // and draw to our buffer
@@ -867,7 +867,7 @@ fn schedule_initial_render<Data: 'static>(
 }
 
 fn initial_render(surface: &mut RenderSurface, renderer: &mut Gles2Renderer) -> Result<(), SwapBuffersError> {
-    let dmabuf = surface.next_buffer()?;
+    let (dmabuf, _age) = surface.next_buffer()?;
     renderer.bind(dmabuf)?;
     // Does not matter if we render an empty frame
     renderer

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -17,20 +17,14 @@ use crate::backend::SwapBuffersError;
 use slog::{debug, error, o, trace, warn};
 
 /// Simplified abstraction of a swapchain for gbm-buffers displayed on a [`DrmSurface`].
+#[derive(Debug)]
 pub struct GbmBufferedSurface<D: AsRawFd + 'static> {
-    buffers: Buffers<D>,
+    current_fb: Slot<BufferObject<()>>,
+    pending_fb: Option<Slot<BufferObject<()>>>,
+    queued_fb: Option<Slot<BufferObject<()>>>,
+    next_fb: Option<Slot<BufferObject<()>>>,
     swapchain: Swapchain<GbmDevice<D>, BufferObject<()>>,
     drm: Arc<DrmSurface<D>>,
-}
-
-// TODO: Replace with #[derive(Debug)] once gbm::BufferObject implements debug
-impl<D: std::fmt::Debug + AsRawFd + 'static> std::fmt::Debug for GbmBufferedSurface<D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GbmBufferedSurface")
-            .field("buffers", &self.buffers)
-            .field("drm", &self.drm)
-            .finish_non_exhaustive()
-    }
 }
 
 impl<D> GbmBufferedSurface<D>
@@ -154,9 +148,11 @@ where
         match drm.test_buffer(handle, &mode, true) {
             Ok(_) => {
                 debug!(logger, "Choosen format: {:?}", format);
-                let buffers = Buffers::new(drm.clone(), buffer);
                 Ok(GbmBufferedSurface {
-                    buffers,
+                    current_fb: buffer,
+                    pending_fb: None,
+                    queued_fb: None,
+                    next_fb: None,
                     swapchain,
                     drm,
                 })
@@ -176,7 +172,24 @@ where
     /// *Note*: This function can be called multiple times and
     /// will return the same buffer until it is queued (see [`GbmBufferedSurface::queue_buffer`]).
     pub fn next_buffer(&mut self) -> Result<Dmabuf, Error> {
-        self.buffers.next(&mut self.swapchain)
+        if self.next_fb.is_none() {
+            let slot = self.swapchain.acquire()?.ok_or(Error::NoFreeSlotsError)?;
+
+            let maybe_buffer = slot.userdata().get::<Dmabuf>().cloned();
+            if maybe_buffer.is_none() {
+                let dmabuf = slot.export().map_err(Error::AsDmabufError)?;
+                let fb_handle = attach_framebuffer(&self.drm, &*slot)?;
+
+                let userdata = slot.userdata();
+                userdata.insert_if_missing(|| dmabuf);
+                userdata.insert_if_missing(|| fb_handle);
+            }
+
+            self.next_fb = Some(slot);
+        }
+
+        let slot = self.next_fb.as_ref().unwrap();
+        Ok(slot.userdata().get::<Dmabuf>().unwrap().clone())
     }
 
     /// Queues the current buffer for rendering.
@@ -185,7 +198,11 @@ where
     /// when a vblank event is received, that denotes successful scanout of the buffer.
     /// Otherwise the underlying swapchain will eventually run out of buffers.
     pub fn queue_buffer(&mut self) -> Result<(), Error> {
-        self.buffers.queue()
+        self.queued_fb = self.next_fb.take();
+        if self.pending_fb.is_none() && self.queued_fb.is_some() {
+            self.submit()?;
+        }
+        Ok(())
     }
 
     /// Marks the current frame as submitted.
@@ -194,7 +211,30 @@ where
     /// was received after calling [`GbmBufferedSurface::queue_buffer`] on this surface.
     /// Otherwise the underlying swapchain will run out of buffers eventually.
     pub fn frame_submitted(&mut self) -> Result<(), Error> {
-        self.buffers.submitted()
+        if let Some(mut pending) = self.pending_fb.take() {
+            std::mem::swap(&mut pending, &mut self.current_fb);
+            if self.queued_fb.is_some() {
+                self.submit()?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn submit(&mut self) -> Result<(), Error> {
+        // yes it does not look like it, but both of these lines should be safe in all cases.
+        let slot = self.queued_fb.take().unwrap();
+        let fb = slot.userdata().get::<FbHandle<D>>().unwrap().fb;
+
+        let flip = if self.drm.commit_pending() {
+            self.drm.commit([(fb, self.drm.plane())].iter(), true)
+        } else {
+            self.drm.page_flip([(fb, self.drm.plane())].iter(), true)
+        };
+        if flip.is_ok() {
+            self.pending_fb = Some(slot);
+        }
+        flip.map_err(Error::DrmError)
     }
 
     /// Returns the underlying [`crtc`](drm::control::crtc) of this surface
@@ -282,99 +322,6 @@ struct FbHandle<D: AsRawFd + 'static> {
 impl<A: AsRawFd + 'static> Drop for FbHandle<A> {
     fn drop(&mut self) {
         let _ = self.drm.destroy_framebuffer(self.fb);
-    }
-}
-
-struct Buffers<D: AsRawFd + 'static> {
-    drm: Arc<DrmSurface<D>>,
-    _current_fb: Slot<BufferObject<()>>,
-    pending_fb: Option<Slot<BufferObject<()>>>,
-    queued_fb: Option<Slot<BufferObject<()>>>,
-    next_fb: Option<Slot<BufferObject<()>>>,
-}
-
-// TODO: Replace with #[derive(Debug)] once gbm::BufferObject implements debug
-impl<D: std::fmt::Debug + AsRawFd + 'static> std::fmt::Debug for Buffers<D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Buffers")
-            .field("drm", &self.drm)
-            .finish_non_exhaustive()
-    }
-}
-
-impl<D> Buffers<D>
-where
-    D: AsRawFd + 'static,
-{
-    pub fn new(drm: Arc<DrmSurface<D>>, slot: Slot<BufferObject<()>>) -> Buffers<D> {
-        Buffers {
-            drm,
-            _current_fb: slot,
-            pending_fb: None,
-            queued_fb: None,
-            next_fb: None,
-        }
-    }
-
-    pub fn next(
-        &mut self,
-        swapchain: &mut Swapchain<GbmDevice<D>, BufferObject<()>>,
-    ) -> Result<Dmabuf, Error> {
-        if self.next_fb.is_none() {
-            let slot = swapchain.acquire()?.ok_or(Error::NoFreeSlotsError)?;
-
-            let maybe_buffer = slot.userdata().get::<Dmabuf>().clone();
-            if maybe_buffer.is_none() {
-                let dmabuf = slot.export().map_err(Error::AsDmabufError)?;
-                let fb_handle = attach_framebuffer(&self.drm, &*slot)?;
-
-                let userdata = slot.userdata();
-                userdata.insert_if_missing(|| dmabuf);
-                userdata.insert_if_missing(|| fb_handle);
-            }
-
-            self.next_fb = Some(slot);
-        }
-
-        let slot = self.next_fb.as_ref().unwrap();
-        Ok(slot.userdata().get::<Dmabuf>().unwrap().clone())
-    }
-
-    pub fn queue(&mut self) -> Result<(), Error> {
-        self.queued_fb = self.next_fb.take();
-        if self.pending_fb.is_none() && self.queued_fb.is_some() {
-            self.submit()
-        } else {
-            Ok(())
-        }
-    }
-
-    pub fn submitted(&mut self) -> Result<(), Error> {
-        if self.pending_fb.is_none() {
-            return Ok(());
-        }
-        self._current_fb = self.pending_fb.take().unwrap();
-        if self.queued_fb.is_some() {
-            self.submit()
-        } else {
-            Ok(())
-        }
-    }
-
-    fn submit(&mut self) -> Result<(), Error> {
-        // yes it does not look like it, but both of these lines should be safe in all cases.
-        let slot = self.queued_fb.take().unwrap();
-        let fb = slot.userdata().get::<FbHandle<D>>().unwrap().fb;
-
-        let flip = if self.drm.commit_pending() {
-            self.drm.commit([(fb, self.drm.plane())].iter(), true)
-        } else {
-            self.drm.page_flip([(fb, self.drm.plane())].iter(), true)
-        };
-        if flip.is_ok() {
-            self.pending_fb = Some(slot);
-        }
-        flip.map_err(Error::DrmError)
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,8 @@ pub mod signaling;
 #[cfg(feature = "x11rb_event_source")]
 pub mod x11rb;
 
+pub mod user_data;
+
 pub use self::geometry::{Buffer, Logical, Physical, Point, Raw, Rectangle, Size};
 
 /// This resource is not managed by Smithay

--- a/src/utils/user_data.rs
+++ b/src/utils/user_data.rs
@@ -1,0 +1,324 @@
+//! Various utilities used for user data implementations
+
+use once_cell::sync::OnceCell;
+
+use std::any::Any;
+use std::mem::ManuallyDrop;
+use std::thread::{self, ThreadId};
+
+use self::list::AppendList;
+
+/// A wrapper for user data, able to store any type, and correctly
+/// handling access from a wrong thread
+#[derive(Debug)]
+pub struct UserData {
+    inner: OnceCell<UserDataInner>,
+}
+
+#[derive(Debug)]
+enum UserDataInner {
+    ThreadSafe(Box<dyn Any + Send + Sync + 'static>),
+    NonThreadSafe(Box<ManuallyDrop<dyn Any + 'static>>, ThreadId),
+}
+
+// UserData itself is always threadsafe, as it only gives access to its
+// content if it is send+sync or we are on the right thread
+unsafe impl Send for UserData {}
+unsafe impl Sync for UserData {}
+
+impl UserData {
+    /// Create a new UserData instance
+    pub const fn new() -> UserData {
+        UserData {
+            inner: OnceCell::new(),
+        }
+    }
+
+    /// Sets the UserData to a given value
+    ///
+    /// The provided closure is called to init the UserData,
+    /// does nothing is the UserData had already been set.
+    pub fn set<T: Any + 'static, F: FnOnce() -> T>(&self, f: F) {
+        self.inner.get_or_init(|| {
+            UserDataInner::NonThreadSafe(Box::new(ManuallyDrop::new(f())), thread::current().id())
+        });
+    }
+
+    /// Sets the UserData to a given threadsafe value
+    ///
+    /// The provided closure is called to init the UserData,
+    /// does nothing is the UserData had already been set.
+    pub fn set_threadsafe<T: Any + Send + Sync + 'static, F: FnOnce() -> T>(&self, f: F) {
+        self.inner
+            .get_or_init(|| UserDataInner::ThreadSafe(Box::new(f())));
+    }
+
+    /// Attempt to access the wrapped user data
+    ///
+    /// Will return `None` if either:
+    ///
+    /// - The requested type `T` does not match the type used for construction
+    /// - This `UserData` has been created using the non-threadsafe variant and access
+    ///   is attempted from an other thread than the one it was created on
+    pub fn get<T: 'static>(&self) -> Option<&T> {
+        match self.inner.get() {
+            Some(&UserDataInner::ThreadSafe(ref val)) => <dyn Any>::downcast_ref::<T>(&**val),
+            Some(&UserDataInner::NonThreadSafe(ref val, threadid)) => {
+                // only give access if we are on the right thread
+                if threadid == thread::current().id() {
+                    <dyn Any>::downcast_ref::<T>(&***val)
+                } else {
+                    None
+                }
+            }
+            None => None,
+        }
+    }
+}
+
+impl Drop for UserData {
+    fn drop(&mut self) {
+        // only drop non-Send user data if we are on the right thread, leak it otherwise
+        if let Some(&mut UserDataInner::NonThreadSafe(ref mut val, threadid)) = self.inner.get_mut() {
+            if threadid == thread::current().id() {
+                unsafe {
+                    ManuallyDrop::drop(&mut **val);
+                }
+            }
+        }
+    }
+}
+
+/// A storage able to store several values of `UserData`
+/// of different types. It behaves similarly to a `TypeMap`.
+#[derive(Debug)]
+pub struct UserDataMap {
+    list: AppendList<UserData>,
+}
+
+impl UserDataMap {
+    /// Create a new map
+    pub fn new() -> UserDataMap {
+        UserDataMap {
+            list: AppendList::new(),
+        }
+    }
+
+    /// Attempt to access the wrapped user data of a given type
+    ///
+    /// Will return `None` if no value of type `T` is stored in this `UserDataMap`
+    /// and accessible from this thread
+    pub fn get<T: 'static>(&self) -> Option<&T> {
+        for user_data in &self.list {
+            if let Some(val) = user_data.get::<T>() {
+                return Some(val);
+            }
+        }
+        None
+    }
+
+    /// Insert a value in the map if it is not already there
+    ///
+    /// This is the non-threadsafe variant, the type you insert don't have to be
+    /// threadsafe, but they will not be visible from other threads (even if they are
+    /// actually threadsafe).
+    ///
+    /// If the value does not already exists, the closure is called to create it and
+    /// this function returns `true`. If the value already exists, the closure is not
+    /// called, and this function returns `false`.
+    pub fn insert_if_missing<T: 'static, F: FnOnce() -> T>(&self, init: F) -> bool {
+        if self.get::<T>().is_some() {
+            return false;
+        }
+        let data = UserData::new();
+        data.set(init);
+        self.list.append(data);
+        true
+    }
+
+    /// Insert a value in the map if it is not already there
+    ///
+    /// This is the threadsafe variant, the type you insert must be threadsafe and will
+    /// be visible from all threads.
+    ///
+    /// If the value does not already exists, the closure is called to create it and
+    /// this function returns `true`. If the value already exists, the closure is not
+    /// called, and this function returns `false`.
+    pub fn insert_if_missing_threadsafe<T: Send + Sync + 'static, F: FnOnce() -> T>(&self, init: F) -> bool {
+        if self.get::<T>().is_some() {
+            return false;
+        }
+        let data = UserData::new();
+        data.set_threadsafe(init);
+        self.list.append(data);
+        true
+    }
+}
+
+impl Default for UserDataMap {
+    fn default() -> UserDataMap {
+        UserDataMap::new()
+    }
+}
+
+mod list {
+    /*
+     * This is a lock-free append-only list, it is used as an implementation
+     * detail of the UserDataMap.
+     *
+     * It was extracted from https://github.com/Diggsey/lockless under MIT license
+     * Copyright © Diggory Blake <diggsey@googlemail.com>
+     */
+
+    use std::sync::atomic::{AtomicPtr, Ordering};
+    use std::{mem, ptr};
+
+    type NodePtr<T> = Option<Box<Node<T>>>;
+
+    #[derive(Debug)]
+    struct Node<T> {
+        value: T,
+        next: AppendList<T>,
+    }
+
+    #[derive(Debug)]
+    pub struct AppendList<T>(AtomicPtr<Node<T>>);
+
+    impl<T> AppendList<T> {
+        fn node_into_raw(ptr: NodePtr<T>) -> *mut Node<T> {
+            match ptr {
+                Some(b) => Box::into_raw(b),
+                None => ptr::null_mut(),
+            }
+        }
+        unsafe fn node_from_raw(ptr: *mut Node<T>) -> NodePtr<T> {
+            if ptr.is_null() {
+                None
+            } else {
+                Some(Box::from_raw(ptr))
+            }
+        }
+
+        fn new_internal(ptr: NodePtr<T>) -> Self {
+            AppendList(AtomicPtr::new(Self::node_into_raw(ptr)))
+        }
+
+        pub fn new() -> Self {
+            Self::new_internal(None)
+        }
+
+        pub fn append(&self, value: T) {
+            self.append_list(AppendList::new_internal(Some(Box::new(Node {
+                value,
+                next: AppendList::new(),
+            }))));
+        }
+
+        unsafe fn append_ptr(&self, p: *mut Node<T>) {
+            loop {
+                match self
+                    .0
+                    .compare_exchange_weak(ptr::null_mut(), p, Ordering::AcqRel, Ordering::Acquire)
+                {
+                    Ok(_) => return,
+                    Err(head) => {
+                        if !head.is_null() {
+                            return (*head).next.append_ptr(p);
+                        }
+                    }
+                }
+            }
+        }
+
+        pub fn append_list(&self, other: AppendList<T>) {
+            let p = other.0.load(Ordering::Acquire);
+            mem::forget(other);
+            unsafe { self.append_ptr(p) };
+        }
+
+        pub fn iter(&self) -> AppendListIterator<'_, T> {
+            AppendListIterator(&self.0)
+        }
+
+        pub fn iter_mut(&mut self) -> AppendListMutIterator<'_, T> {
+            AppendListMutIterator(&mut self.0)
+        }
+    }
+
+    impl<'a, T> IntoIterator for &'a AppendList<T> {
+        type Item = &'a T;
+        type IntoIter = AppendListIterator<'a, T>;
+
+        fn into_iter(self) -> AppendListIterator<'a, T> {
+            self.iter()
+        }
+    }
+
+    impl<'a, T> IntoIterator for &'a mut AppendList<T> {
+        type Item = &'a mut T;
+        type IntoIter = AppendListMutIterator<'a, T>;
+
+        fn into_iter(self) -> AppendListMutIterator<'a, T> {
+            self.iter_mut()
+        }
+    }
+
+    impl<T> Drop for AppendList<T> {
+        fn drop(&mut self) {
+            unsafe { Self::node_from_raw(mem::replace(self.0.get_mut(), ptr::null_mut())) };
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct AppendListIterator<'a, T>(&'a AtomicPtr<Node<T>>);
+
+    impl<'a, T: 'a> Iterator for AppendListIterator<'a, T> {
+        type Item = &'a T;
+
+        fn next(&mut self) -> Option<&'a T> {
+            let p = self.0.load(Ordering::Acquire);
+            if p.is_null() {
+                None
+            } else {
+                unsafe {
+                    self.0 = &(*p).next.0;
+                    Some(&(*p).value)
+                }
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct AppendListMutIterator<'a, T>(&'a mut AtomicPtr<Node<T>>);
+
+    impl<'a, T: 'a> Iterator for AppendListMutIterator<'a, T> {
+        type Item = &'a mut T;
+
+        fn next(&mut self) -> Option<&'a mut T> {
+            let p = self.0.load(Ordering::Acquire);
+            if p.is_null() {
+                None
+            } else {
+                unsafe {
+                    self.0 = &mut (*p).next.0;
+                    Some(&mut (*p).value)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UserDataMap;
+
+    #[test]
+    fn insert_twice() {
+        let map = UserDataMap::new();
+
+        assert_eq!(map.get::<usize>(), None);
+        assert!(map.insert_if_missing(|| 42usize));
+        assert!(!map.insert_if_missing(|| 43usize));
+        assert_eq!(map.get::<usize>(), Some(&42));
+    }
+}


### PR DESCRIPTION
Necessary changes (and some clean up) to support buffer age in the backend.
This is necessary to properly implement damage tracking.

Best reviewed on a commit-by-commit basis.

Explanation taken from [EGL_EXT_buffer_age](https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_buffer_age.txt).
>     Buffers' ages are initialized to 0 at buffer creation time.
>     When a frame boundary is reached, the following occurs before
>     any exchanging or copying of color buffers:
>
>          * The current back buffer's age is set to 1.
>          * Any other color buffers' ages are incremented by 1 if
>            their age was previously greater than 0.
>
>      For the purposes of buffer age tracking, a buffer's content
>      is considered defined when its age is a value greater than 0.
>
>      For example, with a double buffered surface and an
>      implementation that swaps via buffer exchanges, the age would
>      usually be 2. With a triple buffered surface the age would
>      usually be 3. An age of 1 means the previous swap was
>      implemented as a copy. An age of 0 means the buffer has only
>      just been initialized and the contents are undefined. Single
>      buffered surfaces have no frame boundaries and therefore
>      always have an age of 0.