### PR TITLE
[Anvil] Fix ScaleDown scaling up

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -197,7 +197,7 @@ impl<Backend> AnvilState<Backend> {
 
                     self.output_map
                         .borrow_mut()
-                        .update_scale_by_name(f32::max(1.0f32, current_scale + 0.25f32), output_name);
+                        .update_scale_by_name(f32::max(1.0f32, current_scale - 0.25f32), output_name);
                 }
 
                 action => match action {


### PR DESCRIPTION
ScaleDown was doing the same thing as ScaleUp (probably someone copypasted and forgot to change the sign).
Now it should properly decrease scale.