### PR TITLE
Desktop abstractions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
         - backend_session_logind
         - backend_session_libseat
         - backend_x11
+        - desktop
         - renderer_gl
         - wayland_frontend
         - xwayland

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Add support for the zxdg-foreign-v2 protocol.
 - Support for `xdg_wm_base` protocol version 3
 - Added the option to initialize the dmabuf global with a client filter
+- `wayland::output::Output` now has user data attached to it and more functions to query its properties
 
 #### Backends
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `X11Surface::buffer` now additionally returns the age of the buffer
 - `X11Surface` now has an explicit `submit` function
 - `X11Surface` is now multi-window capable.
+- `Renderer::clear` now expects a second argument to optionally only clear parts of the buffer/surface
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `X11Surface` is now multi-window capable.
 - `Renderer::clear` now expects a second argument to optionally only clear parts of the buffer/surface
 - `Transform::transform_size` now takes a `Size` instead of two `u32`
+- `Gles2Renderer` now automatically flips the `render` result to account for OpenGLs coordinate system
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `X11Surface` now has an explicit `submit` function
 - `X11Surface` is now multi-window capable.
 - `Renderer::clear` now expects a second argument to optionally only clear parts of the buffer/surface
+- `Transform::transform_size` now takes a `Size` instead of two `u32`
 
 ### Additions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ drm = { version = "0.5.0", optional = true }
 drm-ffi = { version = "0.2.0", optional = true }
 gbm = { version = "0.7.0", optional = true, default-features = false, features = ["drm-support"] }
 input = { version = "0.7", default-features = false, features=["libinput_1_14"], optional = true }
+indexmap = { version = "1.7", optional = true }
 lazy_static = "1"
 libc = "0.2.103"
 libseat= { version = "0.1.1", optional = true }
@@ -59,7 +60,7 @@ gl_generator = { version = "0.14", optional = true }
 pkg-config = { version = "0.3.17", optional = true }
 
 [features]
-default = ["backend_drm", "backend_gbm", "backend_libinput", "backend_udev", "backend_session_logind", "backend_winit", "renderer_gl", "xwayland", "wayland_frontend", "slog-stdlog", "backend_x11"]
+default = ["backend_drm", "backend_gbm", "backend_libinput", "backend_udev", "backend_session_logind", "backend_winit", "desktop", "renderer_gl", "xwayland", "wayland_frontend", "slog-stdlog", "backend_x11"]
 backend_winit = ["winit", "wayland-server/dlopen", "backend_egl", "wayland-egl", "renderer_gl"]
 backend_x11 = ["x11rb", "x11rb/dri3", "x11rb/xfixes", "x11rb/present", "x11rb_event_source", "backend_gbm", "backend_drm", "backend_egl"]
 backend_drm = ["drm", "drm-ffi"]
@@ -71,6 +72,7 @@ backend_udev = ["udev", "input/udev"]
 backend_session_logind = ["dbus", "backend_session", "pkg-config"]
 backend_session_elogind = ["backend_session_logind"]
 backend_session_libseat = ["backend_session", "libseat"]
+desktop = ["indexmap", "wayland_frontend"]
 renderer_gl = ["gl_generator", "backend_egl"]
 use_system_lib = ["wayland_frontend", "wayland-sys", "wayland-server/use_system_lib"]
 wayland_frontend = ["wayland-server", "wayland-commons", "wayland-protocols", "tempfile"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rand = "0.8.4"
 slog = "2"
 slog-stdlog = { version = "4", optional = true }
 tempfile = { version = "3.0", optional = true }
-thiserror = "1.0.7"
+thiserror = "1.0.25"
 udev = { version = "0.6", optional = true }
 wayland-commons = { version = "0.29.0", optional = true }
 wayland-egl = { version = "0.29.0", optional = true }

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -178,6 +178,7 @@ where
                         buffer_scale,
                         output_scale as f64,
                         Transform::Normal, /* TODO */
+                        &[Rectangle::from_loc_and_size((0, 0), (i32::MAX, i32::MAX))],
                         1.0,
                     ) {
                         result = Err(err.into());
@@ -355,6 +356,7 @@ where
                     _ => unreachable!(),
                 },
                 Rectangle::from_loc_and_size((offset_x, 0.0), (22.0 * output_scale, 35.0 * output_scale)),
+                &[Rectangle::from_loc_and_size((0, 0), (i32::MAX, i32::MAX))],
                 Transform::Normal,
                 1.0,
             )

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -24,7 +24,7 @@ pub fn render_layers_and_windows(
     output_scale: f32,
     logger: &Logger,
 ) -> Result<(), SwapBuffersError> {
-    frame.clear([0.8, 0.8, 0.9, 1.0])?;
+    frame.clear([0.8, 0.8, 0.9, 1.0], None)?;
 
     for layer in [Layer::Background, Layer::Bottom] {
         draw_layers(

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -24,7 +24,10 @@ pub fn render_layers_and_windows(
     output_scale: f32,
     logger: &Logger,
 ) -> Result<(), SwapBuffersError> {
-    frame.clear([0.8, 0.8, 0.9, 1.0], None)?;
+    frame.clear(
+        [0.8, 0.8, 0.9, 1.0],
+        &[Rectangle::from_loc_and_size((0, 0), (i32::MAX, i32::MAX))],
+    )?;
 
     for layer in [Layer::Background, Layer::Bottom] {
         draw_layers(

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -873,7 +873,7 @@ fn initial_render(surface: &mut RenderSurface, renderer: &mut Gles2Renderer) -> 
     renderer
         .render((1, 1).into(), Transform::Normal, |_, frame| {
             frame
-                .clear([0.8, 0.8, 0.9, 1.0])
+                .clear([0.8, 0.8, 0.9, 1.0], None)
                 .map_err(Into::<SwapBuffersError>::into)
         })
         .map_err(Into::<SwapBuffersError>::into)

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -50,7 +50,7 @@ use smithay::{
     },
     utils::{
         signaling::{Linkable, SignalToken, Signaler},
-        Logical, Point,
+        Logical, Point, Rectangle,
     },
     wayland::{
         output::{Mode, PhysicalProperties},
@@ -797,6 +797,7 @@ fn render_surface(
                             1,
                             output_scale as f64,
                             Transform::Normal,
+                            &[Rectangle::from_loc_and_size((0, 0), (i32::MAX, i32::MAX))],
                             1.0,
                         )?;
                     }
@@ -862,7 +863,10 @@ fn initial_render(surface: &mut RenderSurface, renderer: &mut Gles2Renderer) -> 
     renderer
         .render((1, 1).into(), Transform::Normal, |_, frame| {
             frame
-                .clear([0.8, 0.8, 0.9, 1.0], None)
+                .clear(
+                    [0.8, 0.8, 0.9, 1.0],
+                    &[Rectangle::from_loc_and_size((0, 0), (i32::MAX, i32::MAX))],
+                )
                 .map_err(Into::<SwapBuffersError>::into)
         })
         .map_err(Into::<SwapBuffersError>::into)

--- a/build.rs
+++ b/build.rs
@@ -35,6 +35,8 @@ fn gl_generate() {
                 "EGL_KHR_image_base",
                 "EGL_EXT_image_dma_buf_import",
                 "EGL_EXT_image_dma_buf_import_modifiers",
+                "EGL_EXT_buffer_age",
+                "EGL_EXT_swap_buffers_with_damage",
             ],
         )
         .write_bindings(gl_generator::GlobalGenerator, &mut file)

--- a/src/backend/allocator/swapchain.rs
+++ b/src/backend/allocator/swapchain.rs
@@ -196,6 +196,15 @@ where
 
     /// Remove all internally cached buffers to e.g. reset age values
     pub fn reset_buffers(&mut self) {
-        self.slots = Default::default();
+        for slot in &mut self.slots {
+            if let Some(internal_slot) = Arc::get_mut(slot) {
+                *internal_slot = InternalSlot {
+                    buffer: internal_slot.buffer.take(),
+                    ..Default::default()
+                };
+            } else {
+                *slot = Default::default();
+            }
+        }
     }
 }

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -238,6 +238,11 @@ where
         flip.map_err(Error::DrmError)
     }
 
+    /// Reset the underlying buffers
+    pub fn reset_buffers(&mut self) {
+        self.swapchain.reset_buffers()
+    }
+
     /// Returns the underlying [`crtc`](drm::control::crtc) of this surface
     pub fn crtc(&self) -> crtc::Handle {
         self.drm.crtc()

--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -40,7 +40,7 @@ extern "system" fn egl_debug_log(
             }
             egl::DEBUG_MSG_WARN_KHR => slog::warn!(logger, "[EGL] {}: {}", command_utf8, message_utf8),
             egl::DEBUG_MSG_INFO_KHR => slog::info!(logger, "[EGL] {}: {}", command_utf8, message_utf8),
-            _ => slog::debug!(logger, "[EGL] {}: {}", command_utf8, message_utf8),
+            _ => {}
         };
     });
 }

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1077,11 +1077,14 @@ impl Renderer for Gles2Renderer {
         renderer[2][0] = -(1.0f32.copysign(renderer[0][0] + renderer[1][0]));
         renderer[2][1] = -(1.0f32.copysign(renderer[0][1] + renderer[1][1]));
 
+        // We account for OpenGLs coordinate system here
+        let flip180 = Matrix3::new(1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0);
+
         let mut frame = Gles2Frame {
             gl: self.gl.clone(),
             programs: self.programs.clone(),
             // output transformation passed in by the user
-            current_projection: transform.matrix() * renderer,
+            current_projection: flip180 * transform.matrix() * renderer,
         };
 
         let result = rendering(self, &mut frame);

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1121,10 +1121,17 @@ impl Frame for Gles2Frame {
     type Error = Gles2Error;
     type TextureId = Gles2Texture;
 
-    fn clear(&mut self, color: [f32; 4]) -> Result<(), Self::Error> {
+    fn clear(&mut self, color: [f32; 4], at: Option<Rectangle<i32, Physical>>) -> Result<(), Self::Error> {
         unsafe {
+            if let Some(rect) = at {
+                self.gl.Enable(ffi::SCISSOR_TEST);
+                self.gl.Scissor(rect.loc.x, rect.loc.y, rect.size.w, rect.size.h);
+            }
             self.gl.ClearColor(color[0], color[1], color[2], color[3]);
             self.gl.Clear(ffi::COLOR_BUFFER_BIT);
+            if at.is_some() {
+                self.gl.Disable(ffi::SCISSOR_TEST);
+            }
         }
 
         Ok(())

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1286,11 +1286,18 @@ impl Frame for Gles2Frame {
         let damage = damage
             .iter()
             .map(|rect| {
+                let rect = rect.to_f64();
+
+                let rect_constrained_loc = rect
+                    .loc
+                    .constrain(Rectangle::from_extemities((0f64, 0f64), dest.size.to_point()));
+                let rect_clamped_size = rect.size.clamp((0f64, 0f64), dest.size);
+
                 [
-                    rect.loc.x as f32 / dest.size.w as f32,
-                    rect.loc.y as f32 / dest.size.h as f32,
-                    rect.size.w as f32 / dest.size.w as f32,
-                    rect.size.h as f32 / dest.size.h as f32,
+                    (rect_constrained_loc.x / dest.size.w) as f32,
+                    (rect_constrained_loc.y / dest.size.h) as f32,
+                    (rect_clamped_size.w / dest.size.w) as f32,
+                    (rect_clamped_size.h / dest.size.h) as f32,
                 ]
             })
             .flatten()

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -5,10 +5,7 @@ use std::ffi::CStr;
 use std::fmt;
 use std::ptr;
 use std::rc::Rc;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    mpsc::{channel, Receiver, Sender},
-};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::{collections::HashSet, os::raw::c_char};
 
 use cgmath::{prelude::*, Matrix3, Vector2, Vector3};

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -44,21 +44,25 @@ pub mod ffi {
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
 }
 
-// This static is used to assign every created Renderer a unique ID (until is overflows...).
-//
-// This id is used to differenciate between user_data of different renderers, because one
-// cannot assume, that resources between two renderers are (and even can be) shared.
-static RENDERER_COUNTER: AtomicUsize = AtomicUsize::new(0);
-
 #[derive(Debug, Clone)]
-struct Gles2Program {
+struct Gles2TexProgram {
     program: ffi::types::GLuint,
     uniform_tex: ffi::types::GLint,
     uniform_matrix: ffi::types::GLint,
     uniform_invert_y: ffi::types::GLint,
     uniform_alpha: ffi::types::GLint,
+    attrib_vert: ffi::types::GLint,
     attrib_position: ffi::types::GLint,
     attrib_tex_coords: ffi::types::GLint,
+}
+
+#[derive(Debug, Clone)]
+struct Gles2SolidProgram {
+    program: ffi::types::GLuint,
+    uniform_matrix: ffi::types::GLint,
+    uniform_color: ffi::types::GLint,
+    attrib_vert: ffi::types::GLint,
+    attrib_position: ffi::types::GLint,
 }
 
 /// A handle to a GLES2 texture
@@ -158,40 +162,20 @@ struct Gles2Buffer {
     _dmabuf: Dmabuf,
 }
 
-#[cfg(feature = "wayland_frontend")]
-struct BufferEntry {
-    id: u32,
-    buffer: wl_buffer::WlBuffer,
-}
-
-#[cfg(feature = "wayland_frontend")]
-impl std::hash::Hash for BufferEntry {
-    fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
-        self.id.hash(hasher);
-    }
-}
-#[cfg(feature = "wayland_frontend")]
-impl PartialEq for BufferEntry {
-    fn eq(&self, other: &Self) -> bool {
-        self.buffer == other.buffer
-    }
-}
-#[cfg(feature = "wayland_frontend")]
-impl Eq for BufferEntry {}
-
 /// A renderer utilizing OpenGL ES 2
 pub struct Gles2Renderer {
-    id: usize,
     buffers: Vec<WeakGles2Buffer>,
     target_buffer: Option<Gles2Buffer>,
     target_surface: Option<Rc<EGLSurface>>,
     extensions: Vec<String>,
-    programs: [Gles2Program; shaders::FRAGMENT_COUNT],
+    tex_programs: [Gles2TexProgram; shaders::FRAGMENT_COUNT],
+    solid_program: Gles2SolidProgram,
     #[cfg(feature = "wayland_frontend")]
     dmabuf_cache: std::collections::HashMap<WeakDmabuf, Gles2Texture>,
     egl: EGLContext,
     #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
     egl_reader: Option<EGLBufferReader>,
+    vbos: [ffi::types::GLuint; 2],
     gl: ffi::Gles2,
     destruction_callback: Receiver<CleanupResource>,
     // This field is only accessed if the image or wayland_frontend features are active
@@ -206,14 +190,19 @@ pub struct Gles2Renderer {
 pub struct Gles2Frame {
     current_projection: Matrix3<f32>,
     gl: ffi::Gles2,
-    programs: [Gles2Program; shaders::FRAGMENT_COUNT],
+    tex_programs: [Gles2TexProgram; shaders::FRAGMENT_COUNT],
+    solid_program: Gles2SolidProgram,
+    vbos: [ffi::types::GLuint; 2],
+    size: Size<i32, Physical>,
 }
 
 impl fmt::Debug for Gles2Frame {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Gles2Frame")
             .field("current_projection", &self.current_projection)
-            .field("programs", &self.programs)
+            .field("tex_programs", &self.tex_programs)
+            .field("solid_program", &self.solid_program)
+            .field("size", &self.size)
             .finish_non_exhaustive()
     }
 }
@@ -221,12 +210,12 @@ impl fmt::Debug for Gles2Frame {
 impl fmt::Debug for Gles2Renderer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Gles2Renderer")
-            .field("id", &self.id)
             .field("buffers", &self.buffers)
             .field("target_buffer", &self.target_buffer)
             .field("target_surface", &self.target_surface)
             .field("extensions", &self.extensions)
-            .field("programs", &self.programs)
+            .field("tex_programs", &self.tex_programs)
+            .field("solid_program", &self.solid_program)
             // ffi::Gles2 does not implement Debug
             .field("egl", &self.egl)
             .field("logger", &self.logger)
@@ -382,9 +371,10 @@ unsafe fn link_program(
     Ok(program)
 }
 
-unsafe fn texture_program(gl: &ffi::Gles2, frag: &'static str) -> Result<Gles2Program, Gles2Error> {
+unsafe fn texture_program(gl: &ffi::Gles2, frag: &'static str) -> Result<Gles2TexProgram, Gles2Error> {
     let program = link_program(gl, shaders::VERTEX_SHADER, frag)?;
 
+    let vert = CStr::from_bytes_with_nul(b"vert\0").expect("NULL terminated");
     let position = CStr::from_bytes_with_nul(b"position\0").expect("NULL terminated");
     let tex_coords = CStr::from_bytes_with_nul(b"tex_coords\0").expect("NULL terminated");
     let tex = CStr::from_bytes_with_nul(b"tex\0").expect("NULL terminated");
@@ -392,14 +382,32 @@ unsafe fn texture_program(gl: &ffi::Gles2, frag: &'static str) -> Result<Gles2Pr
     let invert_y = CStr::from_bytes_with_nul(b"invert_y\0").expect("NULL terminated");
     let alpha = CStr::from_bytes_with_nul(b"alpha\0").expect("NULL terminated");
 
-    Ok(Gles2Program {
+    Ok(Gles2TexProgram {
         program,
         uniform_tex: gl.GetUniformLocation(program, tex.as_ptr() as *const ffi::types::GLchar),
         uniform_matrix: gl.GetUniformLocation(program, matrix.as_ptr() as *const ffi::types::GLchar),
         uniform_invert_y: gl.GetUniformLocation(program, invert_y.as_ptr() as *const ffi::types::GLchar),
         uniform_alpha: gl.GetUniformLocation(program, alpha.as_ptr() as *const ffi::types::GLchar),
+        attrib_vert: gl.GetAttribLocation(program, vert.as_ptr() as *const ffi::types::GLchar),
         attrib_position: gl.GetAttribLocation(program, position.as_ptr() as *const ffi::types::GLchar),
         attrib_tex_coords: gl.GetAttribLocation(program, tex_coords.as_ptr() as *const ffi::types::GLchar),
+    })
+}
+
+unsafe fn solid_program(gl: &ffi::Gles2) -> Result<Gles2SolidProgram, Gles2Error> {
+    let program = link_program(gl, shaders::VERTEX_SHADER_SOLID, shaders::FRAGMENT_SHADER_SOLID)?;
+
+    let matrix = CStr::from_bytes_with_nul(b"matrix\0").expect("NULL terminated");
+    let color = CStr::from_bytes_with_nul(b"color\0").expect("NULL terminated");
+    let vert = CStr::from_bytes_with_nul(b"vert\0").expect("NULL terminated");
+    let position = CStr::from_bytes_with_nul(b"position\0").expect("NULL terminated");
+
+    Ok(Gles2SolidProgram {
+        program,
+        uniform_matrix: gl.GetUniformLocation(program, matrix.as_ptr() as *const ffi::types::GLchar),
+        uniform_color: gl.GetUniformLocation(program, color.as_ptr() as *const ffi::types::GLchar),
+        attrib_vert: gl.GetAttribLocation(program, vert.as_ptr() as *const ffi::types::GLchar),
+        attrib_position: gl.GetAttribLocation(program, position.as_ptr() as *const ffi::types::GLchar),
     })
 }
 
@@ -473,6 +481,16 @@ impl Gles2Renderer {
             if gl_version < version::GLES_3_0 && !exts.iter().any(|ext| ext == "GL_EXT_unpack_subimage") {
                 return Err(Gles2Error::GLExtensionNotSupported(&["GL_EXT_unpack_subimage"]));
             }
+            // required for instanced damage rendering
+            if gl_version < version::GLES_3_0
+                && !(exts.iter().any(|ext| ext == "GL_EXT_instanced_arrays")
+                    && exts.iter().any(|ext| ext == "GL_EXT_draw_instanced"))
+            {
+                return Err(Gles2Error::GLExtensionNotSupported(&[
+                    "GL_EXT_instanced_arrays",
+                    "GL_EXT_draw_instanced",
+                ]));
+            }
 
             let logger = if exts.iter().any(|ext| ext == "GL_KHR_debug") {
                 let logger = Box::into_raw(Box::new(log.clone()));
@@ -487,21 +505,33 @@ impl Gles2Renderer {
             (gl, exts, logger)
         };
 
-        let programs = [
+        let tex_programs = [
             texture_program(&gl, shaders::FRAGMENT_SHADER_ABGR)?,
             texture_program(&gl, shaders::FRAGMENT_SHADER_XBGR)?,
             texture_program(&gl, shaders::FRAGMENT_SHADER_EXTERNAL)?,
         ];
+        let solid_program = solid_program(&gl)?;
+
+        let mut vbos = [0; 2];
+        gl.GenBuffers(2, vbos.as_mut_ptr());
+        gl.BindBuffer(ffi::ARRAY_BUFFER, vbos[0]);
+        gl.BufferData(
+            ffi::ARRAY_BUFFER,
+            (std::mem::size_of::<ffi::types::GLfloat>() * VERTS.len()) as isize,
+            VERTS.as_ptr() as *const _,
+            ffi::STATIC_DRAW,
+        );
+        gl.BindBuffer(ffi::ARRAY_BUFFER, 0);
 
         let (tx, rx) = channel();
         let mut renderer = Gles2Renderer {
-            id: RENDERER_COUNTER.fetch_add(1, Ordering::SeqCst),
             gl,
             egl: context,
             #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
             egl_reader: None,
             extensions: exts,
-            programs,
+            tex_programs,
+            solid_program,
             target_buffer: None,
             target_surface: None,
             buffers: Vec::new(),
@@ -509,6 +539,7 @@ impl Gles2Renderer {
             dmabuf_cache: std::collections::HashMap::new(),
             destruction_callback: rx,
             destruction_callback_sender: tx,
+            vbos,
             logger_ptr,
             logger: log,
             _not_send: std::ptr::null_mut(),
@@ -966,9 +997,11 @@ impl Drop for Gles2Renderer {
         unsafe {
             if self.egl.make_current().is_ok() {
                 self.gl.BindFramebuffer(ffi::FRAMEBUFFER, 0);
-                for program in &self.programs {
+                for program in &self.tex_programs {
                     self.gl.DeleteProgram(program.program);
                 }
+                self.gl.DeleteProgram(self.solid_program.program);
+                self.gl.DeleteBuffers(2, self.vbos.as_ptr());
 
                 if self.extensions.iter().any(|ext| ext == "GL_KHR_debug") {
                     self.gl.Disable(ffi::DEBUG_OUTPUT);
@@ -1082,9 +1115,12 @@ impl Renderer for Gles2Renderer {
 
         let mut frame = Gles2Frame {
             gl: self.gl.clone(),
-            programs: self.programs.clone(),
+            tex_programs: self.tex_programs.clone(),
+            solid_program: self.solid_program.clone(),
             // output transformation passed in by the user
             current_projection: flip180 * transform.matrix() * renderer,
+            vbos: self.vbos,
+            size,
         };
 
         let result = rendering(self, &mut frame);
@@ -1124,17 +1160,85 @@ impl Frame for Gles2Frame {
     type Error = Gles2Error;
     type TextureId = Gles2Texture;
 
-    fn clear(&mut self, color: [f32; 4], at: Option<Rectangle<i32, Physical>>) -> Result<(), Self::Error> {
+    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+        if at.is_empty() {
+            return Ok(());
+        }
+
+        let mut mat = Matrix3::<f32>::identity();
+        mat = mat * Matrix3::from_translation(Vector2::new(0.0, 0.0));
+        mat = mat * Matrix3::from_nonuniform_scale(self.size.w as f32, self.size.h as f32);
+        mat = self.current_projection * mat;
+
+        let damage = at
+            .iter()
+            .map(|rect| {
+                [
+                    rect.loc.x as f32 / self.size.w as f32,
+                    rect.loc.y as f32 / self.size.h as f32,
+                    rect.size.w as f32 / self.size.w as f32,
+                    rect.size.h as f32 / self.size.h as f32,
+                ]
+            })
+            .flatten()
+            .collect::<Vec<ffi::types::GLfloat>>();
+
         unsafe {
-            if let Some(rect) = at {
-                self.gl.Enable(ffi::SCISSOR_TEST);
-                self.gl.Scissor(rect.loc.x, rect.loc.y, rect.size.w, rect.size.h);
-            }
-            self.gl.ClearColor(color[0], color[1], color[2], color[3]);
-            self.gl.Clear(ffi::COLOR_BUFFER_BIT);
-            if at.is_some() {
-                self.gl.Disable(ffi::SCISSOR_TEST);
-            }
+            self.gl.UseProgram(self.solid_program.program);
+            self.gl.Uniform4f(
+                self.solid_program.uniform_color,
+                color[0],
+                color[1],
+                color[2],
+                color[3],
+            );
+            self.gl
+                .UniformMatrix3fv(self.solid_program.uniform_matrix, 1, ffi::FALSE, mat.as_ptr());
+
+            self.gl
+                .EnableVertexAttribArray(self.solid_program.attrib_vert as u32);
+            self.gl.BindBuffer(ffi::ARRAY_BUFFER, self.vbos[0]);
+            self.gl.VertexAttribPointer(
+                self.solid_program.attrib_vert as u32,
+                2,
+                ffi::FLOAT,
+                ffi::FALSE,
+                0,
+                std::ptr::null(),
+            );
+
+            self.gl
+                .EnableVertexAttribArray(self.solid_program.attrib_position as u32);
+            self.gl.BindBuffer(ffi::ARRAY_BUFFER, self.vbos[1]);
+            self.gl.BufferData(
+                ffi::ARRAY_BUFFER,
+                (std::mem::size_of::<ffi::types::GLfloat>() * damage.len()) as isize,
+                damage.as_ptr() as *const _,
+                ffi::STREAM_DRAW,
+            );
+
+            self.gl.VertexAttribPointer(
+                self.solid_program.attrib_position as u32,
+                4,
+                ffi::FLOAT,
+                ffi::FALSE,
+                0,
+                std::ptr::null(),
+            );
+            self.gl
+                .VertexAttribDivisor(self.solid_program.attrib_vert as u32, 0);
+
+            self.gl
+                .VertexAttribDivisor(self.solid_program.attrib_position as u32, 1);
+
+            self.gl
+                .DrawArraysInstanced(ffi::TRIANGLE_STRIP, 0, 4, at.len() as i32);
+
+            self.gl.BindBuffer(ffi::ARRAY_BUFFER, 0);
+            self.gl
+                .DisableVertexAttribArray(self.solid_program.attrib_vert as u32);
+            self.gl
+                .DisableVertexAttribArray(self.solid_program.attrib_position as u32);
         }
 
         Ok(())
@@ -1145,6 +1249,7 @@ impl Frame for Gles2Frame {
         texture: &Self::TextureId,
         src: Rectangle<i32, Buffer>,
         dest: Rectangle<f64, Physical>,
+        damage: &[Rectangle<i32, Physical>],
         transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error> {
@@ -1168,7 +1273,7 @@ impl Frame for Gles2Frame {
         let texture_mat = Matrix3::from_nonuniform_scale(tex_size.w as f32, tex_size.h as f32)
             .invert()
             .unwrap();
-        let verts = [
+        let tex_verts = [
             (texture_mat * Vector3::new((src.loc.x + src.size.w) as f32, src.loc.y as f32, 0.0)).truncate(), // top-right
             (texture_mat * Vector3::new(src.loc.x as f32, src.loc.y as f32, 0.0)).truncate(), // top-left
             (texture_mat
@@ -1180,7 +1285,21 @@ impl Frame for Gles2Frame {
             .truncate(), // bottom-right
             (texture_mat * Vector3::new(src.loc.x as f32, (src.loc.y + src.size.h) as f32, 0.0)).truncate(), // bottom-left
         ];
-        self.render_texture(texture, mat, verts, alpha)
+
+        let damage = damage
+            .iter()
+            .map(|rect| {
+                [
+                    rect.loc.x as f32 / dest.size.w as f32,
+                    rect.loc.y as f32 / dest.size.h as f32,
+                    rect.size.w as f32 / dest.size.w as f32,
+                    rect.size.h as f32 / dest.size.h as f32,
+                ]
+            })
+            .flatten()
+            .collect::<Vec<_>>();
+
+        self.render_texture(texture, mat, Some(&damage), tex_verts, alpha)
     }
 }
 
@@ -1191,6 +1310,7 @@ impl Gles2Frame {
         &mut self,
         tex: &Gles2Texture,
         mut matrix: Matrix3<f32>,
+        instances: Option<&[ffi::types::GLfloat]>,
         tex_coords: [Vector2<f32>; 4],
         alpha: f32,
     ) -> Result<(), Gles2Error> {
@@ -1209,33 +1329,27 @@ impl Gles2Frame {
             self.gl.BindTexture(target, tex.0.texture);
             self.gl
                 .TexParameteri(target, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
-            self.gl.UseProgram(self.programs[tex.0.texture_kind].program);
+            self.gl.UseProgram(self.tex_programs[tex.0.texture_kind].program);
 
             self.gl
-                .Uniform1i(self.programs[tex.0.texture_kind].uniform_tex, 0);
+                .Uniform1i(self.tex_programs[tex.0.texture_kind].uniform_tex, 0);
             self.gl.UniformMatrix3fv(
-                self.programs[tex.0.texture_kind].uniform_matrix,
+                self.tex_programs[tex.0.texture_kind].uniform_matrix,
                 1,
                 ffi::FALSE,
                 matrix.as_ptr(),
             );
             self.gl.Uniform1i(
-                self.programs[tex.0.texture_kind].uniform_invert_y,
+                self.tex_programs[tex.0.texture_kind].uniform_invert_y,
                 if tex.0.y_inverted { 1 } else { 0 },
             );
             self.gl
-                .Uniform1f(self.programs[tex.0.texture_kind].uniform_alpha, alpha);
+                .Uniform1f(self.tex_programs[tex.0.texture_kind].uniform_alpha, alpha);
 
+            self.gl
+                .EnableVertexAttribArray(self.tex_programs[tex.0.texture_kind].attrib_tex_coords as u32);
             self.gl.VertexAttribPointer(
-                self.programs[tex.0.texture_kind].attrib_position as u32,
-                2,
-                ffi::FLOAT,
-                ffi::FALSE,
-                0,
-                VERTS.as_ptr() as *const _,
-            );
-            self.gl.VertexAttribPointer(
-                self.programs[tex.0.texture_kind].attrib_tex_coords as u32,
+                self.tex_programs[tex.0.texture_kind].attrib_tex_coords as u32,
                 2,
                 ffi::FLOAT,
                 ffi::FALSE,
@@ -1244,18 +1358,55 @@ impl Gles2Frame {
             );
 
             self.gl
-                .EnableVertexAttribArray(self.programs[tex.0.texture_kind].attrib_position as u32);
-            self.gl
-                .EnableVertexAttribArray(self.programs[tex.0.texture_kind].attrib_tex_coords as u32);
+                .EnableVertexAttribArray(self.tex_programs[tex.0.texture_kind].attrib_vert as u32);
+            self.gl.BindBuffer(ffi::ARRAY_BUFFER, self.vbos[0]);
+            self.gl.VertexAttribPointer(
+                self.solid_program.attrib_vert as u32,
+                2,
+                ffi::FLOAT,
+                ffi::FALSE,
+                0,
+                std::ptr::null(),
+            );
 
-            self.gl.DrawArrays(ffi::TRIANGLE_STRIP, 0, 4);
+            let damage = instances.unwrap_or(&[0.0, 0.0, 1.0, 1.0]);
+            self.gl
+                .EnableVertexAttribArray(self.tex_programs[tex.0.texture_kind].attrib_position as u32);
+            self.gl.BindBuffer(ffi::ARRAY_BUFFER, self.vbos[1]);
+            self.gl.BufferData(
+                ffi::ARRAY_BUFFER,
+                (std::mem::size_of::<ffi::types::GLfloat>() * damage.len()) as isize,
+                damage.as_ptr() as *const _,
+                ffi::STREAM_DRAW,
+            );
+
+            let count = (damage.len() / 4) as i32;
+            self.gl.VertexAttribPointer(
+                self.tex_programs[tex.0.texture_kind].attrib_position as u32,
+                4,
+                ffi::FLOAT,
+                ffi::FALSE,
+                0,
+                std::ptr::null(),
+            );
 
             self.gl
-                .DisableVertexAttribArray(self.programs[tex.0.texture_kind].attrib_position as u32);
+                .VertexAttribDivisor(self.tex_programs[tex.0.texture_kind].attrib_vert as u32, 0);
             self.gl
-                .DisableVertexAttribArray(self.programs[tex.0.texture_kind].attrib_tex_coords as u32);
+                .VertexAttribDivisor(self.tex_programs[tex.0.texture_kind].attrib_tex_coords as u32, 0);
+            self.gl
+                .VertexAttribDivisor(self.tex_programs[tex.0.texture_kind].attrib_position as u32, 1);
 
+            self.gl.DrawArraysInstanced(ffi::TRIANGLE_STRIP, 0, 4, count);
+
+            self.gl.BindBuffer(ffi::ARRAY_BUFFER, 0);
             self.gl.BindTexture(target, 0);
+            self.gl
+                .DisableVertexAttribArray(self.tex_programs[tex.0.texture_kind].attrib_tex_coords as u32);
+            self.gl
+                .DisableVertexAttribArray(self.tex_programs[tex.0.texture_kind].attrib_vert as u32);
+            self.gl
+                .DisableVertexAttribArray(self.tex_programs[tex.0.texture_kind].attrib_position as u32);
         }
 
         Ok(())

--- a/src/backend/renderer/gles2/shaders.rs
+++ b/src/backend/renderer/gles2/shaders.rs
@@ -2,29 +2,48 @@
  * OpenGL Shaders
  */
 pub const VERTEX_SHADER: &str = r#"
+
 #version 100
 uniform mat3 matrix;
 uniform bool invert_y;
-attribute vec2 position;
+
+attribute vec2 vert;
 attribute vec2 tex_coords;
+attribute vec4 position;
+
 varying vec2 v_tex_coords;
+
+mat2 scale(vec2 scale_vec){
+    return mat2(
+        scale_vec.x, 0.0,
+        0.0, scale_vec.y
+    );
+}
+
 void main() {
-    gl_Position = vec4(matrix * vec3(position, 1.0), 1.0);
     if (invert_y) {
         v_tex_coords = vec2(tex_coords.x, 1.0 - tex_coords.y);
     } else {
         v_tex_coords = tex_coords;
     }
-}"#;
+    
+    vec2 transform_translation = position.xy;
+    vec2 transform_scale = position.zw;
+    v_tex_coords = (vec3((tex_coords * scale(transform_scale)) + transform_translation, 1.0)).xy;
+    gl_Position = vec4(matrix * vec3((vert * scale(transform_scale)) + transform_translation, 1.0), 1.0);
+}
+"#;
 
 pub const FRAGMENT_COUNT: usize = 3;
 
 pub const FRAGMENT_SHADER_ABGR: &str = r#"
 #version 100
+
 precision mediump float;
 uniform sampler2D tex;
 uniform float alpha;
 varying vec2 v_tex_coords;
+
 void main() {
     gl_FragColor = texture2D(tex, v_tex_coords) * alpha;
 }
@@ -32,10 +51,12 @@ void main() {
 
 pub const FRAGMENT_SHADER_XBGR: &str = r#"
 #version 100
+
 precision mediump float;
 uniform sampler2D tex;
 uniform float alpha;
 varying vec2 v_tex_coords;
+
 void main() {
     gl_FragColor = vec4(texture2D(tex, v_tex_coords).rgb, 1.0) * alpha;
 }
@@ -44,11 +65,45 @@ void main() {
 pub const FRAGMENT_SHADER_EXTERNAL: &str = r#"
 #version 100
 #extension GL_OES_EGL_image_external : require
+
 precision mediump float;
 uniform samplerExternalOES tex;
 uniform float alpha;
 varying vec2 v_tex_coords;
+
 void main() {
     gl_FragColor = texture2D(tex, v_tex_coords) * alpha;
+}
+"#;
+
+pub const VERTEX_SHADER_SOLID: &str = r#"
+#version 100
+
+uniform mat3 matrix;
+attribute vec2 vert;
+attribute vec4 position;
+
+mat2 scale(vec2 scale_vec){
+    return mat2(
+        scale_vec.x, 0.0,
+        0.0, scale_vec.y
+    );
+}
+
+void main() {
+    vec2 transform_translation = position.xy;
+    vec2 transform_scale = position.zw;
+    gl_Position = vec4(matrix * vec3((vert * scale(transform_scale)) + transform_translation, 1.0), 1.0);
+}
+"#;
+
+pub const FRAGMENT_SHADER_SOLID: &str = r#"
+#version 100
+
+precision mediump float;
+uniform vec4 color;
+
+void main() {
+    gl_FragColor = color;
 }
 "#;

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -171,7 +171,7 @@ pub trait Frame {
     ///
     /// This operation is only valid in between a `begin` and `finish`-call.
     /// If called outside this operation may error-out, do nothing or modify future rendering results in any way.
-    fn clear(&mut self, color: [f32; 4]) -> Result<(), Self::Error>;
+    fn clear(&mut self, color: [f32; 4], at: Option<Rectangle<i32, Physical>>) -> Result<(), Self::Error>;
 
     /// Render a texture to the current target as a flat 2d-plane at a given
     /// position and applying the given transformation with the given alpha value.

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -10,7 +10,7 @@
 use std::collections::HashSet;
 use std::error::Error;
 
-use crate::utils::{Buffer, Physical, Point, Rectangle, Size};
+use crate::utils::{Buffer, Coordinate, Physical, Point, Rectangle, Size};
 
 #[cfg(feature = "wayland_frontend")]
 use crate::wayland::compositor::SurfaceData;
@@ -94,15 +94,15 @@ impl Transform {
     }
 
     /// Transformed size after applying this transformation.
-    pub fn transform_size(&self, width: u32, height: u32) -> (u32, u32) {
+    pub fn transform_size<N: Coordinate, Kind>(&self, size: Size<N, Kind>) -> Size<N, Kind> {
         if *self == Transform::_90
             || *self == Transform::_270
             || *self == Transform::Flipped90
             || *self == Transform::Flipped270
         {
-            (height, width)
+            (size.h, size.w).into()
         } else {
-            (width, height)
+            size
         }
     }
 }

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -173,7 +173,7 @@ pub trait Frame {
     ///
     /// This operation is only valid in between a `begin` and `finish`-call.
     /// If called outside this operation may error-out, do nothing or modify future rendering results in any way.
-    fn clear(&mut self, color: [f32; 4], at: Option<Rectangle<i32, Physical>>) -> Result<(), Self::Error>;
+    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error>;
 
     /// Render a texture to the current target as a flat 2d-plane at a given
     /// position and applying the given transformation with the given alpha value.
@@ -185,6 +185,7 @@ pub trait Frame {
         texture_scale: i32,
         output_scale: f64,
         src_transform: Transform,
+        damage: &[Rectangle<i32, Physical>],
         alpha: f32,
     ) -> Result<(), Self::Error> {
         self.render_texture_from_to(
@@ -198,6 +199,7 @@ pub trait Frame {
                     .to_f64()
                     .to_physical(output_scale),
             ),
+            damage,
             src_transform,
             alpha,
         )
@@ -211,6 +213,7 @@ pub trait Frame {
         texture: &Self::TextureId,
         src: Rectangle<i32, Buffer>,
         dst: Rectangle<f64, Physical>,
+        damage: &[Rectangle<i32, Physical>],
         src_transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error>;

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -32,6 +32,8 @@ use crate::backend::egl::{
     Error as EglError,
 };
 
+pub mod utils;
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 /// Possible transformations to two-dimensional planes
 pub enum Transform {

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -257,7 +257,7 @@ pub trait Renderer {
 pub trait ImportShm: Renderer {
     /// Import a given shm-based buffer into the renderer (see [`buffer_type`]).
     ///
-    /// Returns a texture_id, which can be used with [`Frame::render_texture`] (or [`Frame::render_texture_at`])
+    /// Returns a texture_id, which can be used with [`Frame::render_texture_from_to`] (or [`Frame::render_texture_at`])
     /// or implementation-specific functions.
     ///
     /// If not otherwise defined by the implementation, this texture id is only valid for the renderer, that created it.
@@ -324,7 +324,7 @@ pub trait ImportEgl: Renderer {
 
     /// Import a given wl_drm-based buffer into the renderer (see [`buffer_type`]).
     ///
-    /// Returns a texture_id, which can be used with [`Frame::render_texture`] (or [`Frame::render_texture_at`])
+    /// Returns a texture_id, which can be used with [`Frame::render_texture_from_to`] (or [`Frame::render_texture_at`])
     /// or implementation-specific functions.
     ///
     /// If not otherwise defined by the implementation, this texture id is only valid for the renderer, that created it.
@@ -372,7 +372,7 @@ pub trait ImportDma: Renderer {
 
     /// Import a given raw dmabuf into the renderer.
     ///
-    /// Returns a texture_id, which can be used with [`Frame::render_texture`] (or [`Frame::render_texture_at`])
+    /// Returns a texture_id, which can be used with [`Frame::render_texture_from_to`] (or [`Frame::render_texture_at`])
     /// or implementation-specific functions.
     ///
     /// If not otherwise defined by the implementation, this texture id is only valid for the renderer, that created it.
@@ -395,7 +395,7 @@ pub trait ImportDma: Renderer {
 pub trait ImportAll: Renderer {
     /// Import a given buffer into the renderer.
     ///
-    /// Returns a texture_id, which can be used with [`Frame::render_texture`] (or [`Frame::render_texture_at`])
+    /// Returns a texture_id, which can be used with [`Frame::render_texture_from_to`] (or [`Frame::render_texture_at`])
     /// or implementation-specific functions.
     ///
     /// If not otherwise defined by the implementation, this texture id is only valid for the renderer, that created it.

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -178,6 +178,7 @@ pub trait Frame {
     /// Render a texture to the current target as a flat 2d-plane at a given
     /// position and applying the given transformation with the given alpha value.
     /// (Meaning `src_transform` should match the orientation of surface being rendered).
+    #[allow(clippy::too_many_arguments)]
     fn render_texture_at(
         &mut self,
         texture: &Self::TextureId,

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -32,6 +32,7 @@ use crate::backend::egl::{
     Error as EglError,
 };
 
+#[cfg(feature = "wayland_frontend")]
 pub mod utils;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -15,7 +15,7 @@ pub(crate) struct SurfaceState {
     pub(crate) buffer_scale: i32,
     pub(crate) buffer: Option<WlBuffer>,
     pub(crate) texture: Option<Box<dyn std::any::Any + 'static>>,
-    pub(crate) damage_seen: HashSet<(usize, *const ())>,
+    pub(crate) damage_seen: HashSet<crate::desktop::space::SpaceOutputHash>,
 }
 
 impl SurfaceState {
@@ -69,7 +69,6 @@ pub fn on_commit_buffer_handler(surface: &WlSurface) {
     }
 }
 
-/// TODO
 pub fn draw_surface_tree<R, E, F, T>(
     renderer: &mut R,
     frame: &mut F,

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -8,7 +8,9 @@ use crate::{
         SurfaceAttributes, TraversalAction,
     },
 };
-use std::{cell::RefCell, collections::HashSet};
+use std::cell::RefCell;
+#[cfg(feature = "desktop")]
+use std::collections::HashSet;
 use wayland_server::protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface};
 
 #[derive(Default)]
@@ -17,6 +19,7 @@ pub(crate) struct SurfaceState {
     pub(crate) buffer_scale: i32,
     pub(crate) buffer: Option<WlBuffer>,
     pub(crate) texture: Option<Box<dyn std::any::Any + 'static>>,
+    #[cfg(feature = "desktop")]
     pub(crate) damage_seen: HashSet<crate::desktop::space::SpaceOutputHash>,
 }
 
@@ -33,6 +36,7 @@ impl SurfaceState {
                     }
                 }
                 self.texture = None;
+                #[cfg(feature = "desktop")]
                 self.damage_seen.clear();
             }
             Some(BufferAssignment::Removed) => {
@@ -42,6 +46,7 @@ impl SurfaceState {
                     buffer.release();
                 };
                 self.texture = None;
+                #[cfg(feature = "desktop")]
                 self.damage_seen.clear();
             }
             None => {}

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -1,3 +1,5 @@
+//! Utility module for helpers around drawing [`WlSurface`]s with [`Renderer`]s.
+
 use crate::{
     backend::renderer::{buffer_dimensions, Frame, ImportAll, Renderer, Texture},
     utils::{Logical, Physical, Point, Rectangle, Size},
@@ -47,6 +49,15 @@ impl SurfaceState {
     }
 }
 
+/// Handler to let smithay take over buffer management.
+///
+/// Needs to be called first on the commit-callback of
+/// [`crate::wayland::compositor::compositor_init`].
+///
+/// Consumes the buffer of [`SurfaceAttributes`], the buffer will
+/// not be accessible anymore, but [`draw_surface_tree`] and other
+/// `draw_*` helpers of the [desktop module](`crate::desktop`) will
+/// become usable for surfaces handled this way.
 pub fn on_commit_buffer_handler(surface: &WlSurface) {
     if !is_sync_subsurface(surface) {
         with_surface_tree_upward(
@@ -69,6 +80,15 @@ pub fn on_commit_buffer_handler(surface: &WlSurface) {
     }
 }
 
+/// Draws a surface and its subsurfaces using a given [`Renderer`] and [`Frame`].
+///
+/// - `scale` needs to be equivalent to the fractional scale the rendered result should have.
+/// - `location` is the position the surface should be drawn at.
+/// - `damage` is the set of regions of the surface that should be drawn.
+///
+/// Note: This element will render nothing, if you are not using
+/// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
+/// to let smithay handle buffer management.
 pub fn draw_surface_tree<R, E, F, T>(
     renderer: &mut R,
     frame: &mut F,

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -1,0 +1,167 @@
+use crate::{
+    backend::renderer::{buffer_dimensions, Frame, ImportAll, Renderer, Texture},
+    utils::{Logical, Physical, Point, Size},
+    wayland::compositor::{
+        is_sync_subsurface, with_surface_tree_upward, BufferAssignment, Damage, SubsurfaceCachedState,
+        SurfaceAttributes, TraversalAction,
+    },
+};
+use std::cell::RefCell;
+use wayland_server::protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface};
+
+#[derive(Default)]
+pub(crate) struct SurfaceState {
+    pub(crate) buffer_dimensions: Option<Size<i32, Physical>>,
+    pub(crate) buffer_scale: i32,
+    pub(crate) buffer: Option<WlBuffer>,
+    pub(crate) texture: Option<Box<dyn std::any::Any + 'static>>,
+}
+
+impl SurfaceState {
+    pub fn update_buffer(&mut self, attrs: &mut SurfaceAttributes) {
+        match attrs.buffer.take() {
+            Some(BufferAssignment::NewBuffer { buffer, .. }) => {
+                // new contents
+                self.buffer_dimensions = buffer_dimensions(&buffer);
+                self.buffer_scale = attrs.buffer_scale;
+                if let Some(old_buffer) = std::mem::replace(&mut self.buffer, Some(buffer)) {
+                    if &old_buffer != self.buffer.as_ref().unwrap() {
+                        old_buffer.release();
+                    }
+                }
+                self.texture = None;
+            }
+            Some(BufferAssignment::Removed) => {
+                // remove the contents
+                self.buffer_dimensions = None;
+                if let Some(buffer) = self.buffer.take() {
+                    buffer.release();
+                };
+                self.texture = None;
+            }
+            None => {}
+        }
+    }
+}
+
+pub fn on_commit_buffer_handler(surface: &WlSurface) {
+    if !is_sync_subsurface(surface) {
+        with_surface_tree_upward(
+            surface,
+            (),
+            |_, _, _| TraversalAction::DoChildren(()),
+            |_surf, states, _| {
+                states
+                    .data_map
+                    .insert_if_missing(|| RefCell::new(SurfaceState::default()));
+                let mut data = states
+                    .data_map
+                    .get::<RefCell<SurfaceState>>()
+                    .unwrap()
+                    .borrow_mut();
+                data.update_buffer(&mut *states.cached_state.current::<SurfaceAttributes>());
+            },
+            |_, _, _| true,
+        );
+    }
+}
+
+pub fn draw_surface_tree<R, E, F, T>(
+    renderer: &mut R,
+    frame: &mut F,
+    surface: &WlSurface,
+    scale: f64,
+    location: Point<i32, Logical>,
+    log: &slog::Logger,
+) -> Result<(), R::Error>
+where
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
+    F: Frame<Error = E, TextureId = T>,
+    E: std::error::Error,
+    T: Texture + 'static,
+{
+    let mut result = Ok(());
+    with_surface_tree_upward(
+        surface,
+        location,
+        |_surface, states, location| {
+            let mut location = *location;
+            if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
+                let mut data = data.borrow_mut();
+                let attributes = states.cached_state.current::<SurfaceAttributes>();
+                // Import a new buffer if necessary
+                if data.texture.is_none() {
+                    if let Some(buffer) = data.buffer.as_ref() {
+                        let damage = attributes
+                            .damage
+                            .iter()
+                            .map(|dmg| match dmg {
+                                Damage::Buffer(rect) => *rect,
+                                // TODO also apply transformations
+                                Damage::Surface(rect) => rect.to_buffer(attributes.buffer_scale),
+                            })
+                            .collect::<Vec<_>>();
+
+                        match renderer.import_buffer(buffer, Some(states), &damage) {
+                            Some(Ok(m)) => {
+                                data.texture = Some(Box::new(m));
+                            }
+                            Some(Err(err)) => {
+                                slog::warn!(log, "Error loading buffer: {}", err);
+                            }
+                            None => {
+                                slog::error!(log, "Unknown buffer format for: {:?}", buffer);
+                            }
+                        }
+                    }
+                }
+                // Now, should we be drawn ?
+                if data.texture.is_some() {
+                    // if yes, also process the children
+                    if states.role == Some("subsurface") {
+                        let current = states.cached_state.current::<SubsurfaceCachedState>();
+                        location += current.location;
+                    }
+                    TraversalAction::DoChildren(location)
+                } else {
+                    // we are not displayed, so our children are neither
+                    TraversalAction::SkipChildren
+                }
+            } else {
+                // we are not displayed, so our children are neither
+                TraversalAction::SkipChildren
+            }
+        },
+        |surface, states, location| {
+            let mut location = *location;
+            if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
+                let mut data = data.borrow_mut();
+                let buffer_scale = data.buffer_scale;
+                let attributes = states.cached_state.current::<SurfaceAttributes>();
+                if let Some(texture) = data.texture.as_mut().and_then(|x| x.downcast_mut::<T>()) {
+                    // we need to re-extract the subsurface offset, as the previous closure
+                    // only passes it to our children
+                    if states.role == Some("subsurface") {
+                        let current = states.cached_state.current::<SubsurfaceCachedState>();
+                        location += current.location;
+                    }
+
+                    // TODO: Take wp_viewporter into account
+                    if let Err(err) = frame.render_texture_at(
+                        texture,
+                        location.to_f64().to_physical(scale).to_i32_round(),
+                        buffer_scale,
+                        scale,
+                        attributes.buffer_transform.into(),
+                        1.0,
+                    ) {
+                        result = Err(err);
+                    }
+                }
+            }
+        },
+        |_, _, _| true,
+    );
+
+    result
+}

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     backend::renderer::{buffer_dimensions, Frame, ImportAll, Renderer, Texture},
-    utils::{Buffer, Logical, Physical, Point, Rectangle, Size},
+    utils::{Logical, Physical, Point, Rectangle, Size},
     wayland::compositor::{
         is_sync_subsurface, with_surface_tree_upward, BufferAssignment, Damage, SubsurfaceCachedState,
         SurfaceAttributes, TraversalAction,

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -165,8 +165,7 @@ where
                     let new_damage = damage
                         .iter()
                         .cloned()
-                        .filter(|geo| geo.overlaps(rect))
-                        .map(|geo| geo.intersection(rect))
+                        .flat_map(|geo| geo.intersection(rect))
                         .map(|mut geo| {
                             geo.loc -= rect.loc;
                             geo

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -6,7 +6,7 @@ use crate::{
         SurfaceAttributes, TraversalAction,
     },
 };
-use std::cell::RefCell;
+use std::{cell::RefCell, collections::HashSet};
 use wayland_server::protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface};
 
 #[derive(Default)]
@@ -15,6 +15,7 @@ pub(crate) struct SurfaceState {
     pub(crate) buffer_scale: i32,
     pub(crate) buffer: Option<WlBuffer>,
     pub(crate) texture: Option<Box<dyn std::any::Any + 'static>>,
+    pub(crate) damage_seen: HashSet<(usize, *const ())>,
 }
 
 impl SurfaceState {
@@ -30,6 +31,7 @@ impl SurfaceState {
                     }
                 }
                 self.texture = None;
+                self.damage_seen.clear();
             }
             Some(BufferAssignment::Removed) => {
                 // remove the contents
@@ -38,6 +40,7 @@ impl SurfaceState {
                     buffer.release();
                 };
                 self.texture = None;
+                self.damage_seen.clear();
             }
             None => {}
         }

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -88,7 +88,7 @@ where
     let mut result = Ok(());
     let damage = damage
         .iter()
-        .map(|geo| geo.to_f64().to_physical(scale).to_i32_round())
+        .map(|geo| geo.to_f64().to_physical(scale).to_i32_up())
         .collect::<Vec<_>>();
     with_surface_tree_upward(
         surface,
@@ -160,7 +160,12 @@ where
 
                     let rect = Rectangle::<i32, Physical>::from_loc_and_size(
                         surface_offset.to_f64().to_physical(scale).to_i32_round(),
-                        buffer_dimensions.unwrap(),
+                        buffer_dimensions
+                            .unwrap_or_default()
+                            .to_logical(buffer_scale)
+                            .to_f64()
+                            .to_physical(scale)
+                            .to_i32_round(),
                     );
                     let new_damage = damage
                         .iter()

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -141,7 +141,7 @@ where
                 TraversalAction::SkipChildren
             }
         },
-        |surface, states, location| {
+        |_surface, states, location| {
             let mut location = *location;
             if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
                 let mut data = data.borrow_mut();

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -298,7 +298,8 @@ impl WinitGraphicsBackend {
         };
 
         self.renderer.bind(self.egl.clone())?;
-        let result = self.renderer.render(size, Transform::Normal, rendering)?;
+        // Why is winit falling out of place with the coordinate system?
+        let result = self.renderer.render(size, Transform::Flipped180, rendering)?;
         self.egl.swap_buffers()?;
         self.renderer.unbind()?;
         Ok(result)

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -10,7 +10,8 @@
 //! you want on the initialization of the backend. These functions will provide you
 //! with two objects:
 //!
-//! - a [`WinitGraphicsBackend`], which can give you an implementation of a [`Renderer`]
+//! - a [`WinitGraphicsBackend`], which can give you an implementation of a
+//!   [`Renderer`](crate::backend::renderer::Renderer)
 //!   (or even [`Gles2Renderer`]) through its `renderer` method in addition to further
 //!   functionality to access and manage the created winit-window.
 //! - a [`WinitEventLoop`], which dispatches some [`WinitEvent`] from the host graphics server.
@@ -81,7 +82,7 @@ impl WindowSize {
     }
 }
 
-/// Window with an active EGL Context created by `winit`. Implements the [`Renderer`] trait
+/// Window with an active EGL Context created by `winit`.
 #[derive(Debug)]
 pub struct WinitGraphicsBackend {
     renderer: Gles2Renderer,
@@ -112,7 +113,8 @@ pub struct WinitEventLoop {
     is_x11: bool,
 }
 
-/// Create a new [`WinitGraphicsBackend`], which implements the [`Renderer`] trait and a corresponding
+/// Create a new [`WinitGraphicsBackend`], which implements the
+/// [`Renderer`](crate::backend::renderer::Renderer) trait and a corresponding
 /// [`WinitEventLoop`].
 pub fn init<L>(logger: L) -> Result<(WinitGraphicsBackend, WinitEventLoop), Error>
 where
@@ -127,7 +129,8 @@ where
     )
 }
 
-/// Create a new [`WinitGraphicsBackend`], which implements the [`Renderer`] trait, from a given [`WindowBuilder`]
+/// Create a new [`WinitGraphicsBackend`], which implements the
+/// [`Renderer`](crate::backend::renderer::Renderer) trait, from a given [`WindowBuilder`]
 /// struct and a corresponding [`WinitEventLoop`].
 pub fn init_from_builder<L>(
     builder: WindowBuilder,
@@ -148,7 +151,8 @@ where
     )
 }
 
-/// Create a new [`WinitGraphicsBackend`], which implements the [`Renderer`] trait, from a given [`WindowBuilder`]
+/// Create a new [`WinitGraphicsBackend`], which implements the
+/// [`Renderer`](crate::backend::renderer::Renderer) trait, from a given [`WindowBuilder`]
 /// struct, as well as given [`GlAttributes`] for further customization of the rendering pipeline and a
 /// corresponding [`WinitEventLoop`].
 pub fn init_from_builder_with_gl_attr<L>(

--- a/src/backend/x11/surface.rs
+++ b/src/backend/x11/surface.rs
@@ -72,7 +72,7 @@ impl X11Surface {
     ///
     /// You may bind this buffer to a renderer to render.
     /// This function will return the same buffer until [`submit`](Self::submit) is called
-    /// or [`reset_buffers`](Self::reset_buffer) is used to reset the buffers.
+    /// or [`reset_buffers`](Self::reset_buffers) is used to reset the buffers.
     pub fn buffer(&mut self) -> Result<(Dmabuf, u8), AllocateBuffersError> {
         if let Some(new_size) = self.resize.try_iter().last() {
             self.resize(new_size);

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -1,6 +1,6 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, Frame, ImportAll, Renderer, Texture},
-    desktop::{utils::*, PopupManager, Space},
+    desktop::{space::RenderElement, utils::*, PopupManager, Space},
     utils::{user_data::UserDataMap, Logical, Point, Rectangle},
     wayland::{
         compositor::with_states,
@@ -267,12 +267,12 @@ impl LayerMap {
 }
 
 #[derive(Debug, Default)]
-pub(super) struct LayerState {
-    location: Point<i32, Logical>,
+pub struct LayerState {
+    pub location: Point<i32, Logical>,
 }
 
 type LayerUserdata = RefCell<Option<LayerState>>;
-fn layer_state(layer: &LayerSurface) -> RefMut<'_, LayerState> {
+pub fn layer_state(layer: &LayerSurface) -> RefMut<'_, LayerState> {
     let userdata = layer.user_data();
     userdata.insert_if_missing(LayerUserdata::default);
     RefMut::map(userdata.get::<LayerUserdata>().unwrap().borrow_mut(), |opt| {

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -504,7 +504,7 @@ impl LayerSurface {
 /// Note: This function will render nothing, if you are not using
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
-pub fn draw_layer<R, E, F, T, P>(
+pub fn draw_layer_surface<R, E, F, T, P>(
     renderer: &mut R,
     frame: &mut F,
     layer: &LayerSurface,

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -438,15 +438,20 @@ impl LayerSurface {
     ) -> Vec<Rectangle<i32, Logical>> {
         let mut damage = Vec::new();
         if let Some(surface) = self.get_surface() {
-            damage.extend(damage_from_surface_tree(surface, (0, 0), for_values));
+            damage.extend(
+                damage_from_surface_tree(surface, (0, 0), for_values)
+                    .into_iter()
+                    .flat_map(|rect| rect.intersection(self.bbox())),
+            );
             for (popup, location) in PopupManager::popups_for_surface(surface)
                 .ok()
                 .into_iter()
                 .flatten()
             {
                 if let Some(surface) = popup.get_surface() {
+                    let bbox = bbox_from_surface_tree(surface, location);
                     let popup_damage = damage_from_surface_tree(surface, location, for_values);
-                    damage.extend(popup_damage);
+                    damage.extend(popup_damage.into_iter().flat_map(|rect| rect.intersection(bbox)));
                 }
             }
         }

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -307,7 +307,7 @@ impl Hash for LayerSurface {
 }
 
 #[derive(Debug)]
-pub struct LayerSurfaceInner {
+pub(crate) struct LayerSurfaceInner {
     pub(crate) id: usize,
     surface: WlrLayerSurface,
     namespace: String,

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -1,6 +1,6 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, Frame, ImportAll, Renderer, Texture},
-    desktop::{utils::*, PopupManager},
+    desktop::{utils::*, PopupManager, Space},
     utils::{user_data::UserDataMap, Logical, Point, Rectangle},
     wayland::{
         compositor::with_states,
@@ -423,17 +423,20 @@ impl LayerSurface {
     }
 
     /// Damage of all the surfaces of this layer
-    pub(super) fn accumulated_damage(&self) -> Vec<Rectangle<i32, Logical>> {
+    pub(super) fn accumulated_damage(
+        &self,
+        for_values: Option<(&Space, &Output)>,
+    ) -> Vec<Rectangle<i32, Logical>> {
         let mut damage = Vec::new();
         if let Some(surface) = self.get_surface() {
-            damage.extend(damage_from_surface_tree(surface, (0, 0)));
+            damage.extend(damage_from_surface_tree(surface, (0, 0), for_values));
             for (popup, location) in PopupManager::popups_for_surface(surface)
                 .ok()
                 .into_iter()
                 .flatten()
             {
                 if let Some(surface) = popup.get_surface() {
-                    let popup_damage = damage_from_surface_tree(surface, location);
+                    let popup_damage = damage_from_surface_tree(surface, location, for_values);
                     damage.extend(popup_damage);
                 }
             }

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -84,11 +84,14 @@ impl LayerMap {
         self.zone
     }
 
-    pub fn layer_geometry(&self, layer: &LayerSurface) -> Rectangle<i32, Logical> {
+    pub fn layer_geometry(&self, layer: &LayerSurface) -> Option<Rectangle<i32, Logical>> {
+        if !self.layers.contains(layer) {
+            return None;
+        }
         let mut bbox = layer.bbox_with_popups();
         let state = layer_state(layer);
         bbox.loc += state.location;
-        bbox
+        Some(bbox)
     }
 
     pub fn layer_under<P: Into<Point<f64, Logical>>>(
@@ -98,7 +101,7 @@ impl LayerMap {
     ) -> Option<&LayerSurface> {
         let point = point.into();
         self.layers_on(layer).rev().find(|l| {
-            let bbox = self.layer_geometry(l);
+            let bbox = self.layer_geometry(l).unwrap();
             bbox.to_f64().contains(point)
         })
     }

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -1,6 +1,6 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, Frame, ImportAll, Renderer, Texture},
-    desktop::{space::RenderElement, utils::*, PopupManager, Space},
+    desktop::{utils::*, PopupManager, Space},
     utils::{user_data::UserDataMap, Logical, Point, Rectangle},
     wayland::{
         compositor::with_states,

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -117,7 +117,12 @@ impl LayerMap {
         bbox
     }
 
-    pub fn layer_under(&self, layer: WlrLayer, point: Point<f64, Logical>) -> Option<&LayerSurface> {
+    pub fn layer_under<P: Into<Point<f64, Logical>>>(
+        &self,
+        layer: WlrLayer,
+        point: P,
+    ) -> Option<&LayerSurface> {
+        let point = point.into();
         self.layers_on(layer).rev().find(|l| {
             let bbox = self.layer_geometry(l);
             bbox.to_f64().contains(point)
@@ -401,7 +406,11 @@ impl LayerSurface {
 
     /// Finds the topmost surface under this point if any and returns it together with the location of this
     /// surface.
-    pub fn surface_under(&self, point: Point<f64, Logical>) -> Option<(WlSurface, Point<i32, Logical>)> {
+    pub fn surface_under<P: Into<Point<f64, Logical>>>(
+        &self,
+        point: P,
+    ) -> Option<(WlSurface, Point<i32, Logical>)> {
+        let point = point.into();
         if let Some(surface) = self.get_surface() {
             for (popup, location) in PopupManager::popups_for_surface(surface)
                 .ok()
@@ -457,12 +466,12 @@ impl LayerSurface {
     }
 }
 
-pub fn draw_layer<R, E, F, T>(
+pub fn draw_layer<R, E, F, T, P>(
     renderer: &mut R,
     frame: &mut F,
     layer: &LayerSurface,
     scale: f64,
-    location: Point<i32, Logical>,
+    location: P,
     damage: &[Rectangle<i32, Logical>],
     log: &slog::Logger,
 ) -> Result<(), R::Error>
@@ -471,7 +480,9 @@ where
     F: Frame<Error = E, TextureId = T>,
     E: std::error::Error,
     T: Texture + 'static,
+    P: Into<Point<i32, Logical>>,
 {
+    let location = location.into();
     if let Some(surface) = layer.get_surface() {
         draw_surface_tree(renderer, frame, surface, scale, location, damage, log)?;
         for (popup, p_location) in PopupManager::popups_for_surface(surface)

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -1,0 +1,501 @@
+use crate::{
+    backend::renderer::{utils::draw_surface_tree, Frame, ImportAll, Renderer, Texture},
+    desktop::{utils::*, PopupManager},
+    utils::{user_data::UserDataMap, Logical, Point, Rectangle},
+    wayland::{
+        compositor::with_states,
+        output::{Inner as OutputInner, Output},
+        shell::wlr_layer::{
+            Anchor, ExclusiveZone, KeyboardInteractivity, Layer as WlrLayer, LayerSurface as WlrLayerSurface,
+            LayerSurfaceCachedState,
+        },
+    },
+};
+use indexmap::IndexSet;
+use wayland_server::protocol::wl_surface::WlSurface;
+
+use std::{
+    cell::{RefCell, RefMut},
+    collections::HashSet,
+    hash::{Hash, Hasher},
+    rc::Rc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex, Weak,
+    },
+};
+
+// TODO: Should this be a macro?
+static LAYER_ID: AtomicUsize = AtomicUsize::new(0);
+lazy_static::lazy_static! {
+    static ref LAYER_IDS: Mutex<HashSet<usize>> = Mutex::new(HashSet::new());
+}
+
+fn next_layer_id() -> usize {
+    let mut ids = LAYER_IDS.lock().unwrap();
+    if ids.len() == usize::MAX {
+        // Theoretically the code below wraps around correctly,
+        // but that is hard to detect and might deadlock.
+        // Maybe make this a debug_assert instead?
+        panic!("Out of window ids");
+    }
+
+    let mut id = LAYER_ID.fetch_add(1, Ordering::SeqCst);
+    while ids.iter().any(|k| *k == id) {
+        id = LAYER_ID.fetch_add(1, Ordering::SeqCst);
+    }
+
+    ids.insert(id);
+    id
+}
+
+#[derive(Debug)]
+pub struct LayerMap {
+    layers: IndexSet<LayerSurface>,
+    output: Weak<(Mutex<OutputInner>, wayland_server::UserDataMap)>,
+    zone: Rectangle<i32, Logical>,
+}
+
+pub fn layer_map_for_output(o: &Output) -> RefMut<'_, LayerMap> {
+    let userdata = o.user_data();
+    let weak_output = Arc::downgrade(&o.inner);
+    userdata.insert_if_missing(|| {
+        RefCell::new(LayerMap {
+            layers: IndexSet::new(),
+            output: weak_output,
+            zone: Rectangle::from_loc_and_size(
+                (0, 0),
+                o.current_mode()
+                    .map(|mode| mode.size.to_logical(o.current_scale()))
+                    .unwrap_or((0, 0).into()),
+            ),
+        })
+    });
+    userdata.get::<RefCell<LayerMap>>().unwrap().borrow_mut()
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LayerError {
+    #[error("Layer is already mapped to a different map")]
+    AlreadyMapped,
+}
+
+impl LayerMap {
+    pub fn map_layer(&mut self, layer: &LayerSurface) -> Result<(), LayerError> {
+        if !self.layers.contains(layer) {
+            if layer
+                .0
+                .userdata
+                .get::<LayerUserdata>()
+                .map(|s| s.borrow().is_some())
+                .unwrap_or(false)
+            {
+                return Err(LayerError::AlreadyMapped);
+            }
+
+            self.layers.insert(layer.clone());
+            self.arrange();
+        }
+        Ok(())
+    }
+
+    pub fn unmap_layer(&mut self, layer: &LayerSurface) {
+        if self.layers.shift_remove(layer) {
+            let _ = layer.user_data().get::<LayerUserdata>().take();
+            self.arrange();
+        }
+    }
+
+    pub fn non_exclusive_zone(&self) -> Rectangle<i32, Logical> {
+        self.zone
+    }
+
+    pub fn layer_geometry(&self, layer: &LayerSurface) -> Rectangle<i32, Logical> {
+        let mut bbox = layer.bbox_with_popups();
+        let state = layer_state(layer);
+        bbox.loc += state.location;
+        bbox
+    }
+
+    pub fn layer_under(&self, layer: WlrLayer, point: Point<f64, Logical>) -> Option<&LayerSurface> {
+        self.layers_on(layer).rev().find(|l| {
+            let bbox = self.layer_geometry(l);
+            bbox.to_f64().contains(point)
+        })
+    }
+
+    pub fn layers(&self) -> impl DoubleEndedIterator<Item = &LayerSurface> {
+        self.layers.iter()
+    }
+
+    pub fn layers_on(&self, layer: WlrLayer) -> impl DoubleEndedIterator<Item = &LayerSurface> {
+        self.layers
+            .iter()
+            .filter(move |l| l.layer().map(|l| l == layer).unwrap_or(false))
+    }
+
+    pub fn layer_for_surface(&self, surface: &WlSurface) -> Option<&LayerSurface> {
+        if !surface.as_ref().is_alive() {
+            return None;
+        }
+
+        self.layers
+            .iter()
+            .find(|w| w.get_surface().map(|x| x == surface).unwrap_or(false))
+    }
+
+    pub fn arrange(&mut self) {
+        if let Some(output) = self.output() {
+            let output_rect = Rectangle::from_loc_and_size(
+                (0, 0),
+                output
+                    .current_mode()
+                    .map(|mode| mode.size.to_logical(output.current_scale()))
+                    .unwrap_or((0, 0).into()),
+            );
+            let mut zone = output_rect.clone();
+            slog::debug!(
+                crate::slog_or_fallback(None),
+                "Arranging layers into {:?}",
+                output_rect.size
+            );
+
+            for layer in self.layers.iter() {
+                let surface = if let Some(surface) = layer.get_surface() {
+                    surface
+                } else {
+                    continue;
+                };
+
+                let data = with_states(surface, |states| {
+                    *states.cached_state.current::<LayerSurfaceCachedState>()
+                })
+                .unwrap();
+
+                let source = match data.exclusive_zone {
+                    ExclusiveZone::Neutral | ExclusiveZone::Exclusive(_) => &zone,
+                    ExclusiveZone::DontCare => &output_rect,
+                };
+
+                let mut size = data.size;
+                if size.w == 0 {
+                    size.w = source.size.w / 2;
+                }
+                if size.h == 0 {
+                    size.h = source.size.h / 2;
+                }
+                if data.anchor.anchored_horizontally() {
+                    size.w = source.size.w;
+                }
+                if data.anchor.anchored_vertically() {
+                    size.h = source.size.h;
+                }
+
+                let x = if data.anchor.contains(Anchor::LEFT) {
+                    source.loc.x + data.margin.left
+                } else if data.anchor.contains(Anchor::RIGHT) {
+                    source.loc.x + (source.size.w - size.w) - data.margin.right
+                } else {
+                    source.loc.x + ((source.size.w / 2) - (size.w / 2))
+                };
+
+                let y = if data.anchor.contains(Anchor::TOP) {
+                    source.loc.y + data.margin.top
+                } else if data.anchor.contains(Anchor::BOTTOM) {
+                    source.loc.y + (source.size.h - size.h) - data.margin.bottom
+                } else {
+                    source.loc.y + ((source.size.h / 2) - (size.h / 2))
+                };
+
+                let location: Point<i32, Logical> = (x, y).into();
+
+                if let ExclusiveZone::Exclusive(amount) = data.exclusive_zone {
+                    match data.anchor {
+                        x if x.contains(Anchor::LEFT) && !x.contains(Anchor::RIGHT) => {
+                            zone.loc.x += amount as i32 + data.margin.left + data.margin.right
+                        }
+                        x if x.contains(Anchor::TOP) && !x.contains(Anchor::BOTTOM) => {
+                            zone.loc.y += amount as i32 + data.margin.top + data.margin.bottom
+                        }
+                        x if x.contains(Anchor::RIGHT) && !x.contains(Anchor::LEFT) => {
+                            zone.size.w -= amount as i32 + data.margin.left + data.margin.right
+                        }
+                        x if x.contains(Anchor::BOTTOM) && !x.contains(Anchor::TOP) => {
+                            zone.size.h -= amount as i32 + data.margin.top + data.margin.top
+                        }
+                        _ => {}
+                    }
+                }
+
+                slog::debug!(
+                    crate::slog_or_fallback(None),
+                    "Setting layer to pos {:?} and size {:?}",
+                    location,
+                    size
+                );
+                if layer
+                    .0
+                    .surface
+                    .with_pending_state(|state| {
+                        state.size.replace(size).map(|old| old != size).unwrap_or(true)
+                    })
+                    .unwrap()
+                {
+                    layer.0.surface.send_configure();
+                }
+
+                layer_state(&layer).location = location;
+            }
+
+            slog::debug!(crate::slog_or_fallback(None), "Remaining zone {:?}", zone);
+            self.zone = zone;
+        }
+    }
+
+    fn output(&self) -> Option<Output> {
+        self.output.upgrade().map(|inner| Output { inner })
+    }
+
+    pub fn cleanup(&mut self) {
+        self.layers.retain(|layer| layer.alive())
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct LayerState {
+    location: Point<i32, Logical>,
+}
+
+type LayerUserdata = RefCell<Option<LayerState>>;
+fn layer_state(layer: &LayerSurface) -> RefMut<'_, LayerState> {
+    let userdata = layer.user_data();
+    userdata.insert_if_missing(LayerUserdata::default);
+    RefMut::map(userdata.get::<LayerUserdata>().unwrap().borrow_mut(), |opt| {
+        if opt.is_none() {
+            *opt = Some(LayerState::default());
+        }
+        opt.as_mut().unwrap()
+    })
+}
+
+#[derive(Debug, Clone)]
+pub struct LayerSurface(pub(crate) Rc<LayerSurfaceInner>);
+
+impl PartialEq for LayerSurface {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.id == other.0.id
+    }
+}
+
+impl Eq for LayerSurface {}
+
+impl Hash for LayerSurface {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.id.hash(state);
+    }
+}
+
+#[derive(Debug)]
+pub struct LayerSurfaceInner {
+    pub(crate) id: usize,
+    surface: WlrLayerSurface,
+    namespace: String,
+    userdata: UserDataMap,
+}
+
+impl Drop for LayerSurfaceInner {
+    fn drop(&mut self) {
+        LAYER_IDS.lock().unwrap().remove(&self.id);
+    }
+}
+
+impl LayerSurface {
+    pub fn new(surface: WlrLayerSurface, namespace: String) -> LayerSurface {
+        LayerSurface(Rc::new(LayerSurfaceInner {
+            id: next_layer_id(),
+            surface,
+            namespace,
+            userdata: UserDataMap::new(),
+        }))
+    }
+
+    pub fn alive(&self) -> bool {
+        self.0.surface.alive()
+    }
+
+    pub fn layer_surface(&self) -> &WlrLayerSurface {
+        &self.0.surface
+    }
+
+    pub fn get_surface(&self) -> Option<&WlSurface> {
+        self.0.surface.get_surface()
+    }
+
+    pub fn cached_state(&self) -> Option<LayerSurfaceCachedState> {
+        self.0.surface.get_surface().map(|surface| {
+            with_states(surface, |states| {
+                *states.cached_state.current::<LayerSurfaceCachedState>()
+            })
+            .unwrap()
+        })
+    }
+
+    pub fn can_receive_keyboard_focus(&self) -> bool {
+        self.0
+            .surface
+            .get_surface()
+            .map(|surface| {
+                with_states(surface, |states| {
+                    match states
+                        .cached_state
+                        .current::<LayerSurfaceCachedState>()
+                        .keyboard_interactivity
+                    {
+                        KeyboardInteractivity::Exclusive | KeyboardInteractivity::OnDemand => true,
+                        KeyboardInteractivity::None => false,
+                    }
+                })
+                .unwrap()
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn layer(&self) -> Option<WlrLayer> {
+        self.0.surface.get_surface().map(|surface| {
+            with_states(surface, |states| {
+                states.cached_state.current::<LayerSurfaceCachedState>().layer
+            })
+            .unwrap()
+        })
+    }
+
+    pub fn namespace(&self) -> &str {
+        &self.0.namespace
+    }
+
+    /// A bounding box over this window and its children.
+    // TODO: Cache and document when to trigger updates. If possible let space do it
+    pub fn bbox(&self) -> Rectangle<i32, Logical> {
+        if let Some(surface) = self.0.surface.get_surface() {
+            bbox_from_surface_tree(surface, (0, 0))
+        } else {
+            Rectangle::from_loc_and_size((0, 0), (0, 0))
+        }
+    }
+
+    pub fn bbox_with_popups(&self) -> Rectangle<i32, Logical> {
+        let mut bounding_box = self.bbox();
+        if let Some(surface) = self.0.surface.get_surface() {
+            for (popup, location) in PopupManager::popups_for_surface(surface)
+                .ok()
+                .into_iter()
+                .flatten()
+            {
+                if let Some(surface) = popup.get_surface() {
+                    bounding_box = bounding_box.merge(bbox_from_surface_tree(surface, location));
+                }
+            }
+        }
+        bounding_box
+    }
+
+    /// Finds the topmost surface under this point if any and returns it together with the location of this
+    /// surface.
+    pub fn surface_under(&self, point: Point<f64, Logical>) -> Option<(WlSurface, Point<i32, Logical>)> {
+        if let Some(surface) = self.get_surface() {
+            for (popup, location) in PopupManager::popups_for_surface(surface)
+                .ok()
+                .into_iter()
+                .flatten()
+            {
+                if let Some(result) = popup
+                    .get_surface()
+                    .and_then(|surface| under_from_surface_tree(surface, point, location))
+                {
+                    return Some(result);
+                }
+            }
+
+            under_from_surface_tree(surface, point, (0, 0))
+        } else {
+            None
+        }
+    }
+
+    /// Damage of all the surfaces of this layer
+    pub(super) fn accumulated_damage(&self) -> Vec<Rectangle<i32, Logical>> {
+        let mut damage = Vec::new();
+        if let Some(surface) = self.get_surface() {
+            damage.extend(damage_from_surface_tree(surface, (0, 0)));
+            for (popup, location) in PopupManager::popups_for_surface(surface)
+                .ok()
+                .into_iter()
+                .flatten()
+            {
+                if let Some(surface) = popup.get_surface() {
+                    let popup_damage = damage_from_surface_tree(surface, location);
+                    damage.extend(popup_damage);
+                }
+            }
+        }
+        damage
+    }
+
+    /// Sends the frame callback to all the subsurfaces in this
+    /// window that requested it
+    pub fn send_frame(&self, time: u32) {
+        if let Some(wl_surface) = self.0.surface.get_surface() {
+            send_frames_surface_tree(wl_surface, time)
+        }
+    }
+
+    pub fn user_data(&self) -> &UserDataMap {
+        &self.0.userdata
+    }
+}
+
+pub fn draw_layer<R, E, F, T>(
+    renderer: &mut R,
+    frame: &mut F,
+    layer: &LayerSurface,
+    scale: f64,
+    location: Point<i32, Logical>,
+    damage: &[Rectangle<i32, Logical>],
+    log: &slog::Logger,
+) -> Result<(), R::Error>
+where
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
+    F: Frame<Error = E, TextureId = T>,
+    E: std::error::Error,
+    T: Texture + 'static,
+{
+    if let Some(surface) = layer.get_surface() {
+        draw_surface_tree(renderer, frame, surface, scale, location, damage, log)?;
+        for (popup, p_location) in PopupManager::popups_for_surface(surface)
+            .ok()
+            .into_iter()
+            .flatten()
+        {
+            if let Some(surface) = popup.get_surface() {
+                let damage = damage
+                    .iter()
+                    .cloned()
+                    .map(|mut geo| {
+                        geo.loc -= p_location;
+                        geo
+                    })
+                    .collect::<Vec<_>>();
+                draw_surface_tree(
+                    renderer,
+                    frame,
+                    surface,
+                    scale,
+                    location + p_location,
+                    &damage,
+                    log,
+                )?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -97,9 +97,9 @@ impl LayerMap {
         self.zone
     }
 
-    /// Returns the geometry of a given mapped layer.
+    /// Returns the geometry of a given mapped [`LayerSurface`].
     ///
-    /// If the layer was not previously mapped onto this layer map,
+    /// If the surface was not previously mapped onto this layer map,
     /// this function return `None`.
     pub fn layer_geometry(&self, layer: &LayerSurface) -> Option<Rectangle<i32, Logical>> {
         if !self.layers.contains(layer) {
@@ -111,7 +111,7 @@ impl LayerMap {
         Some(bbox)
     }
 
-    /// Returns a `LayerSurface` under a given point and on a given layer, if any.
+    /// Returns a [`LayerSurface`] under a given point and on a given layer, if any.
     pub fn layer_under<P: Into<Point<f64, Logical>>>(
         &self,
         layer: WlrLayer,
@@ -147,9 +147,9 @@ impl LayerMap {
             .find(|w| w.get_surface().map(|x| x == surface).unwrap_or(false))
     }
 
-    /// Force re-arranging the layers, e.g. when the output size changes.
+    /// Force re-arranging the layer surfaces, e.g. when the output size changes.
     ///
-    /// Note: Mapping or unmapping a layer will automatically cause a re-arrangement.
+    /// Note: Mapping or unmapping a layer surface will automatically cause a re-arrangement.
     pub fn arrange(&mut self) {
         if let Some(output) = self.output() {
             let output_rect = Rectangle::from_loc_and_size(
@@ -401,7 +401,7 @@ impl LayerSurface {
         }
     }
 
-    /// Returns the bounding box over this layer, it subsurfaces as well as any popups.
+    /// Returns the bounding box over this layer surface, it subsurfaces as well as any popups.
     ///
     /// Note: You need to use a [`PopupManager`] to track popups, otherwise the bounding box
     /// will not include the popups.
@@ -450,7 +450,7 @@ impl LayerSurface {
         }
     }
 
-    /// Returns the damage of all the surfaces of this layer.
+    /// Returns the damage of all the surfaces of this layer surface.
     ///
     /// If `for_values` is `Some(_)` it will only return the damage on the
     /// first call for a given [`Space`] and [`Output`], if the buffer hasn't changed.

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -41,7 +41,7 @@ pub fn layer_map_for_output(o: &Output) -> RefMut<'_, LayerMap> {
                 (0, 0),
                 o.current_mode()
                     .map(|mode| mode.size.to_logical(o.current_scale()))
-                    .unwrap_or((0, 0).into()),
+                    .unwrap_or_else(|| (0, 0).into()),
             ),
         })
     });
@@ -130,9 +130,9 @@ impl LayerMap {
                 output
                     .current_mode()
                     .map(|mode| mode.size.to_logical(output.current_scale()))
-                    .unwrap_or((0, 0).into()),
+                    .unwrap_or_else(|| (0, 0).into()),
             );
-            let mut zone = output_rect.clone();
+            let mut zone = output_rect;
             slog::debug!(
                 crate::slog_or_fallback(None),
                 "Arranging layers into {:?}",
@@ -212,18 +212,18 @@ impl LayerMap {
                     location,
                     size
                 );
-                if layer
+                let size_changed = layer
                     .0
                     .surface
                     .with_pending_state(|state| {
                         state.size.replace(size).map(|old| old != size).unwrap_or(true)
                     })
-                    .unwrap()
-                {
+                    .unwrap();
+                if size_changed {
                     layer.0.surface.send_configure();
                 }
 
-                layer_state(&layer).location = location;
+                layer_state(layer).location = location;
             }
 
             slog::debug!(crate::slog_or_fallback(None), "Remaining zone {:?}", zone);

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,0 +1,7 @@
+// TODO: Remove - but for now, this makes sure these files are not completely highlighted with warnings
+#![allow(missing_docs, clippy::all)]
+mod space;
+mod window;
+
+pub use self::space::*;
+pub use self::window::*;

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,7 +1,9 @@
 // TODO: Remove - but for now, this makes sure these files are not completely highlighted with warnings
 #![allow(missing_docs, clippy::all)]
+mod popup;
 mod space;
 mod window;
 
+pub use self::popup::*;
 pub use self::space::*;
 pub use self::window::*;

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,11 +1,13 @@
 // TODO: Remove - but for now, this makes sure these files are not completely highlighted with warnings
 #![allow(missing_docs, clippy::all)]
+mod layer;
 mod output;
 mod popup;
 mod space;
 pub mod utils;
 mod window;
 
+pub use self::layer::*;
 pub use self::popup::*;
 pub use self::space::*;
 pub use self::window::*;

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -35,13 +35,13 @@
 //!
 //! Each [`Output`](crate::wayland::output::Output) can be associated a [`LayerMap`] by calling [`layer_map_for_output`],
 //! which [`LayerSurface`]s can be mapped upon. Associated layer maps are automatically rendered by [`Space::render_output`],
-//! but a [draw function](`draw_layer`) is also provided for manual layer-surface management.
+//! but a [draw function](`draw_layer_surface`) is also provided for manual layer-surface management.
 //!
 //! ### Popups
 //!
 //! Provides a [`PopupManager`], which can be used to automatically keep track of popups and their
 //! relations to one-another. Popups are then automatically rendered with their matching toplevel surfaces,
-//! when either [`draw_window`], [`draw_layer`] or [`Space::render_output`] is called.
+//! when either [`draw_window`], [`draw_layer_surface`] or [`Space::render_output`] is called.
 //!
 //! ## Remarks
 //!
@@ -55,7 +55,7 @@ pub mod space;
 pub mod utils;
 mod window;
 
-pub use self::layer::{draw_layer, layer_map_for_output, LayerMap, LayerSurface};
+pub use self::layer::{draw_layer_surface, layer_map_for_output, LayerMap, LayerSurface};
 pub use self::popup::*;
 pub use self::space::Space;
 pub use self::window::*;

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -28,7 +28,7 @@
 //! Windows get a position and stacking order through mapping. Outputs become views of a part of the [`Space`]
 //! and can be rendered via [`Space::render_output`]. Rendering results of spaces are automatically damage-tracked.
 //!
-//! ### Layer
+//! ### Layer Shell
 //!
 //! A [`LayerSurface`] represents a surface as provided by e.g. the layer-shell protocol.
 //! It provides similar helper methods as a [`Window`] does to toplevel surfaces.

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,7 +1,9 @@
 // TODO: Remove - but for now, this makes sure these files are not completely highlighted with warnings
 #![allow(missing_docs, clippy::all)]
+mod output;
 mod popup;
 mod space;
+pub mod utils;
 mod window;
 
 pub use self::popup::*;

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains helpers to organize and interact with desktop-style shells.
 //!
-//! It is therefor a lot more opinionate then for example the [xdg-shell handler](crate::wayland::shell::xdg::xdg_shell_init)
+//! It is therefore a lot more opinionated than for example the [xdg-shell handler](crate::wayland::shell::xdg::xdg_shell_init)
 //! and tightly integrates with some protocols (e.g. xdg-shell).
 //!
 //! The usage of this module is therefor entirely optional and depending on your use-case you might also only want
@@ -12,7 +12,7 @@
 //!
 //! ### [`Window`]
 //!
-//! A window represents what is by the user typically understood as a single application window.
+//! A window represents what is typically understood by the end-user as a single application window.
 //!
 //! Currently it abstracts over xdg-shell toplevels and Xwayland surfaces (TODO).
 //! It provides a bunch of methods to calculate and retrieve its size, manage itself, attach additional user_data
@@ -45,9 +45,9 @@
 //!
 //! ## Remarks
 //!
-//! Note that the desktop abstractions are concerned with easing rendering different clients and therefor need to be able
+//! Note that the desktop abstractions are concerned with easing rendering different clients and therefore need to be able
 //! to manage client buffers to do so. If you plan to use the provided drawing functions, you need to use
-//! [`crate::backend::renderer::utils::on_commit_buffer_handler`].
+//! [`on_commit_buffer_handler`](crate::backend::renderer::utils::on_commit_buffer_handler).
 
 pub(crate) mod layer;
 mod popup;

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,13 +1,12 @@
 // TODO: Remove - but for now, this makes sure these files are not completely highlighted with warnings
 #![allow(missing_docs, clippy::all)]
-mod layer;
-mod output;
+pub(crate) mod layer;
 mod popup;
-mod space;
+pub mod space;
 pub mod utils;
 mod window;
 
-pub use self::layer::*;
+pub use self::layer::{draw_layer, layer_map_for_output, LayerMap, LayerSurface};
 pub use self::popup::*;
-pub use self::space::*;
+pub use self::space::Space;
 pub use self::window::*;

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,5 +1,54 @@
-// TODO: Remove - but for now, this makes sure these files are not completely highlighted with warnings
-#![allow(missing_docs)]
+//! Desktop management helpers
+//!
+//! This module contains helpers to organize and interact with desktop-style shells.
+//!
+//! It is therefor a lot more opinionate then for example the [xdg-shell handler](crate::wayland::shell::xdg::xdg_shell_init)
+//! and tightly integrates with some protocols (e.g. xdg-shell).
+//!
+//! The usage of this module is therefor entirely optional and depending on your use-case you might also only want
+//! to use a limited set of the helpers provided.
+//!
+//! ## Helpers
+//!
+//! ### [`Window`]
+//!
+//! A window represents what is by the user typically understood as a single application window.
+//!
+//! Currently it abstracts over xdg-shell toplevels and Xwayland surfaces (TODO).
+//! It provides a bunch of methods to calculate and retrieve its size, manage itself, attach additional user_data
+//! as well as a [drawing function](`draw_window`) to ease rendering it's related surfaces.
+//!
+//! Note that a [`Window`] on it's own has no position. For that it needs to be placed inside a [`Space`].
+//!
+//! ### [`Space`]
+//!
+//! A space represents a two-dimensional plane of undefined dimensions.
+//! [`Window`]s and [`Output`](crate::wayland::output::Output)s can be mapped onto it.
+//!
+//! Windows get a position and stacking order through mapping. Outputs become views of a part of the [`Space`]
+//! and can be rendered via [`Space::render_output`]. Rendering results of spaces are automatically damage-tracked.
+//!
+//! ### Layer
+//!
+//! A [`LayerSurface`] represents a surface as provided by e.g. the layer-shell protocol.
+//! It provides similar helper methods as a [`Window`] does to toplevel surfaces.
+//!
+//! Each [`Output`](crate::wayland::output::Output) can be associated a [`LayerMap`] by calling [`layer_map_for_output`],
+//! which [`LayerSurface`]s can be mapped upon. Associated layer maps are automatically rendered by [`Space::render_output`],
+//! but a [draw function](`draw_layer`) is also provided for manual layer-surface management.
+//!
+//! ### Popups
+//!
+//! Provides a [`PopupManager`], which can be used to automatically keep track of popups and their
+//! relations to one-another. Popups are then automatically rendered with their matching toplevel surfaces,
+//! when either [`draw_window`], [`draw_layer`] or [`Space::render_output`] is called.
+//!
+//! ## Remarks
+//!
+//! Note that the desktop abstractions are concerned with easing rendering different clients and therefor need to be able
+//! to manage client buffers to do so. If you plan to use the provided drawing functions, you need to use
+//! [`crate::backend::renderer::utils::on_commit_buffer_handler`].
+
 pub(crate) mod layer;
 mod popup;
 pub mod space;

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -1,5 +1,5 @@
 // TODO: Remove - but for now, this makes sure these files are not completely highlighted with warnings
-#![allow(missing_docs, clippy::all)]
+#![allow(missing_docs)]
 pub(crate) mod layer;
 mod popup;
 pub mod space;

--- a/src/desktop/output.rs
+++ b/src/desktop/output.rs
@@ -6,6 +6,7 @@ use indexmap::IndexMap;
 use wayland_server::protocol::wl_surface::WlSurface;
 
 use std::{
+    any::TypeId,
     cell::{RefCell, RefMut},
     collections::{HashMap, VecDeque},
 };
@@ -14,6 +15,7 @@ use std::{
 pub(super) enum ToplevelId {
     Xdg(usize),
     Layer(usize),
+    Custom(TypeId, usize),
 }
 
 impl ToplevelId {
@@ -27,6 +29,13 @@ impl ToplevelId {
     pub fn is_layer(&self) -> bool {
         match self {
             ToplevelId::Layer(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_custom(&self) -> bool {
+        match self {
+            ToplevelId::Custom(_, _) => true,
             _ => false,
         }
     }

--- a/src/desktop/output.rs
+++ b/src/desktop/output.rs
@@ -1,0 +1,47 @@
+use crate::{
+    utils::{Logical, Point, Rectangle},
+    wayland::output::Output,
+};
+use indexmap::IndexMap;
+use wayland_server::protocol::wl_surface::WlSurface;
+
+use std::{
+    cell::{RefCell, RefMut},
+    collections::{HashMap, VecDeque},
+};
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub(super) enum ToplevelId {
+    Xdg(usize),
+}
+
+impl ToplevelId {
+    pub fn is_xdg(&self) -> bool {
+        match self {
+            ToplevelId::Xdg(_) => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(super) struct OutputState {
+    pub location: Point<i32, Logical>,
+    pub render_scale: f64,
+
+    // damage and last_state are in space coordinate space
+    pub old_damage: VecDeque<Vec<Rectangle<i32, Logical>>>,
+    pub last_state: IndexMap<ToplevelId, Rectangle<i32, Logical>>,
+
+    // surfaces for tracking enter and leave events
+    pub surfaces: Vec<WlSurface>,
+}
+
+pub(super) type OutputUserdata = RefCell<HashMap<usize, OutputState>>;
+pub(super) fn output_state(space: usize, o: &Output) -> RefMut<'_, OutputState> {
+    let userdata = o.user_data();
+    userdata.insert_if_missing(OutputUserdata::default);
+    RefMut::map(userdata.get::<OutputUserdata>().unwrap().borrow_mut(), |m| {
+        m.entry(space).or_default()
+    })
+}

--- a/src/desktop/output.rs
+++ b/src/desktop/output.rs
@@ -13,12 +13,20 @@ use std::{
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub(super) enum ToplevelId {
     Xdg(usize),
+    Layer(usize),
 }
 
 impl ToplevelId {
     pub fn is_xdg(&self) -> bool {
         match self {
             ToplevelId::Xdg(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_layer(&self) -> bool {
+        match self {
+            ToplevelId::Layer(_) => true,
             _ => false,
         }
     }

--- a/src/desktop/popup.rs
+++ b/src/desktop/popup.rs
@@ -1,0 +1,262 @@
+use crate::{
+    utils::{DeadResource, Logical, Point},
+    wayland::{
+        compositor::{get_role, with_states},
+        shell::xdg::{PopupSurface, XdgPopupSurfaceRoleAttributes, XDG_POPUP_ROLE},
+    },
+};
+use std::sync::{Arc, Mutex};
+use wayland_server::protocol::wl_surface::WlSurface;
+
+#[derive(Debug)]
+pub struct PopupManager {
+    unmapped_popups: Vec<PopupKind>,
+    popup_trees: Vec<PopupTree>,
+    logger: ::slog::Logger,
+}
+
+impl PopupManager {
+    pub fn new<L: Into<Option<::slog::Logger>>>(logger: L) -> Self {
+        PopupManager {
+            unmapped_popups: Vec::new(),
+            popup_trees: Vec::new(),
+            logger: crate::slog_or_fallback(logger),
+        }
+    }
+
+    pub fn track_popup(&mut self, kind: PopupKind) -> Result<(), DeadResource> {
+        if kind.parent().is_some() {
+            self.add_popup(kind)
+        } else {
+            slog::trace!(self.logger, "Adding unmapped popups: {:?}", kind);
+            self.unmapped_popups.push(kind);
+            Ok(())
+        }
+    }
+
+    pub fn commit(&mut self, surface: &WlSurface) {
+        if get_role(surface) == Some(XDG_POPUP_ROLE) {
+            if let Some(i) = self
+                .unmapped_popups
+                .iter()
+                .enumerate()
+                .find(|(_, p)| p.get_surface() == Some(surface))
+                .map(|(i, _)| i)
+            {
+                slog::trace!(self.logger, "Popup got mapped");
+                let popup = self.unmapped_popups.swap_remove(i);
+                // at this point the popup must have a parent,
+                // or it would have raised a protocol error
+                let _ = self.add_popup(popup);
+            }
+        }
+    }
+
+    fn add_popup(&mut self, popup: PopupKind) -> Result<(), DeadResource> {
+        let mut parent = popup.parent().unwrap();
+        while get_role(&parent) == Some(XDG_POPUP_ROLE) {
+            parent = with_states(&parent, |states| {
+                states
+                    .data_map
+                    .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                    .unwrap()
+                    .lock()
+                    .unwrap()
+                    .parent
+                    .as_ref()
+                    .cloned()
+                    .unwrap()
+            })?;
+        }
+
+        with_states(&parent, |states| {
+            let tree = PopupTree::default();
+            if states.data_map.insert_if_missing(|| tree.clone()) {
+                self.popup_trees.push(tree);
+            };
+            let tree = states.data_map.get::<PopupTree>().unwrap();
+            if !tree.alive() {
+                // if it previously had no popups, we likely removed it from our list already
+                self.popup_trees.push(tree.clone());
+            }
+            slog::trace!(self.logger, "Adding popup {:?} to parent {:?}", popup, parent);
+            tree.insert(popup);
+        })
+    }
+
+    pub fn find_popup(&self, surface: &WlSurface) -> Option<PopupKind> {
+        self.unmapped_popups
+            .iter()
+            .find(|p| p.get_surface() == Some(surface))
+            .cloned()
+            .or_else(|| {
+                self.popup_trees
+                    .iter()
+                    .map(|tree| tree.iter_popups())
+                    .flatten()
+                    .find(|(p, _)| p.get_surface() == Some(surface))
+                    .map(|(p, _)| p)
+            })
+    }
+
+    pub fn popups_for_surface(
+        surface: &WlSurface,
+    ) -> Result<impl Iterator<Item = (PopupKind, Point<i32, Logical>)>, DeadResource> {
+        with_states(surface, |states| {
+            states
+                .data_map
+                .get::<PopupTree>()
+                .map(|x| x.iter_popups())
+                .into_iter()
+                .flatten()
+        })
+    }
+
+    pub fn cleanup(&mut self) {
+        // retain_mut is sadly still unstable
+        self.popup_trees.iter_mut().for_each(|tree| tree.cleanup());
+        self.popup_trees.retain(|tree| tree.alive());
+        self.unmapped_popups.retain(|surf| surf.alive());
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct PopupTree(Arc<Mutex<Vec<PopupNode>>>);
+
+#[derive(Debug, Clone)]
+struct PopupNode {
+    surface: PopupKind,
+    children: Vec<PopupNode>,
+}
+
+impl PopupTree {
+    fn iter_popups(&self) -> impl Iterator<Item = (PopupKind, Point<i32, Logical>)> {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|n| n.iter_popups_relative_to((0, 0)).map(|(p, l)| (p.clone(), l)))
+            .flatten()
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    fn insert(&self, popup: PopupKind) {
+        let children = &mut *self.0.lock().unwrap();
+        for child in children.iter_mut() {
+            if child.insert(popup.clone()) {
+                return;
+            }
+        }
+        children.push(PopupNode::new(popup));
+    }
+
+    fn cleanup(&mut self) {
+        let mut children = self.0.lock().unwrap();
+        for child in children.iter_mut() {
+            child.cleanup();
+        }
+        children.retain(|n| n.surface.alive());
+    }
+
+    fn alive(&self) -> bool {
+        !self.0.lock().unwrap().is_empty()
+    }
+}
+
+impl PopupNode {
+    fn new(surface: PopupKind) -> Self {
+        PopupNode {
+            surface,
+            children: Vec::new(),
+        }
+    }
+
+    fn iter_popups_relative_to<P: Into<Point<i32, Logical>>>(
+        &self,
+        loc: P,
+    ) -> impl Iterator<Item = (&PopupKind, Point<i32, Logical>)> {
+        let relative_to = loc.into() + self.surface.location();
+        std::iter::once((&self.surface, relative_to)).chain(
+            self.children
+                .iter()
+                .map(move |x| {
+                    Box::new(x.iter_popups_relative_to(relative_to))
+                        as Box<dyn Iterator<Item = (&PopupKind, Point<i32, Logical>)>>
+                })
+                .flatten(),
+        )
+    }
+
+    fn insert(&mut self, popup: PopupKind) -> bool {
+        let parent = popup.parent().unwrap();
+        if self.surface.get_surface() == Some(&parent) {
+            self.children.push(PopupNode::new(popup));
+            true
+        } else {
+            for child in &mut self.children {
+                if child.insert(popup.clone()) {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+
+    fn cleanup(&mut self) {
+        for child in &mut self.children {
+            child.cleanup();
+        }
+        self.children.retain(|n| n.surface.alive());
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum PopupKind {
+    Xdg(PopupSurface),
+}
+
+impl PopupKind {
+    fn alive(&self) -> bool {
+        match *self {
+            PopupKind::Xdg(ref t) => t.alive(),
+        }
+    }
+
+    pub fn get_surface(&self) -> Option<&WlSurface> {
+        match *self {
+            PopupKind::Xdg(ref t) => t.get_surface(),
+        }
+    }
+
+    fn parent(&self) -> Option<WlSurface> {
+        match *self {
+            PopupKind::Xdg(ref t) => t.get_parent_surface(),
+        }
+    }
+
+    fn location(&self) -> Point<i32, Logical> {
+        let wl_surface = match self.get_surface() {
+            Some(s) => s,
+            None => return (0, 0).into(),
+        };
+        with_states(wl_surface, |states| {
+            states
+                .data_map
+                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .current
+                .geometry
+        })
+        .unwrap_or_default()
+        .loc
+    }
+}
+
+impl From<PopupSurface> for PopupKind {
+    fn from(p: PopupSurface) -> PopupKind {
+        PopupKind::Xdg(p)
+    }
+}

--- a/src/desktop/popup.rs
+++ b/src/desktop/popup.rs
@@ -43,9 +43,7 @@ impl PopupManager {
             if let Some(i) = self
                 .unmapped_popups
                 .iter()
-                .enumerate()
-                .find(|(_, p)| p.get_surface() == Some(surface))
-                .map(|(i, _)| i)
+                .position(|p| p.get_surface() == Some(surface))
             {
                 slog::trace!(self.logger, "Popup got mapped");
                 let popup = self.unmapped_popups.swap_remove(i);

--- a/src/desktop/space.rs
+++ b/src/desktop/space.rs
@@ -287,14 +287,15 @@ impl Space {
             if old_geo.map(|old_geo| old_geo != geo).unwrap_or(false) {
                 // Add damage for the old position of the window
                 damage.push(old_geo.unwrap());
-            } /* else {
-                  // window stayed at its place
-                  // TODO: Only push surface damage
-                  //       But this would need to take subsurfaces into account and accumulate damage at least.
-                  //       Even better would be if damage would be ignored that is hidden by subsurfaces...
-              }*/
-            // Add damage for the new position (see TODO above for a better approach)
-            damage.push(geo);
+                damage.push(geo);
+            } else {
+                // window stayed at its place
+                let loc = window_loc(window, &self.id);
+                damage.extend(window.accumulated_damage().into_iter().map(|mut rect| {
+                    rect.loc += loc;
+                    rect
+                }));
+            }
         }
 
         // That is all completely new damage, which we need to store for subsequent renders

--- a/src/desktop/space.rs
+++ b/src/desktop/space.rs
@@ -401,7 +401,7 @@ impl Space {
 
     /// Automatically calls `Window::refresh` for the window that belongs to the given surface,
     /// if managed by this space.
-    pub fn commit(&mut self, surface: &WlSurface) {
+    pub fn commit(&self, surface: &WlSurface) {
         if is_sync_subsurface(surface) {
             return;
         }

--- a/src/desktop/space.rs
+++ b/src/desktop/space.rs
@@ -1,0 +1,419 @@
+use super::{draw_window, Window};
+use crate::{
+    backend::renderer::{Frame, ImportAll, Renderer, Transform},
+    utils::{Logical, Point, Rectangle},
+    wayland::output::Output,
+};
+use indexmap::{IndexMap, IndexSet};
+use std::{
+    cell::{RefCell, RefMut},
+    collections::{HashMap, HashSet, VecDeque},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    },
+};
+use wayland_server::protocol::wl_surface;
+
+static SPACE_ID: AtomicUsize = AtomicUsize::new(0);
+lazy_static::lazy_static! {
+    static ref SPACE_IDS: Mutex<HashSet<usize>> = Mutex::new(HashSet::new());
+}
+fn next_space_id() -> usize {
+    let mut ids = SPACE_IDS.lock().unwrap();
+    if ids.len() == usize::MAX {
+        // Theoretically the code below wraps around correctly,
+        // but that is hard to detect and might deadlock.
+        // Maybe make this a debug_assert instead?
+        panic!("Out of space ids");
+    }
+
+    let mut id = SPACE_ID.fetch_add(1, Ordering::SeqCst);
+    while ids.iter().any(|k| *k == id) {
+        id = SPACE_ID.fetch_add(1, Ordering::SeqCst);
+    }
+
+    ids.insert(id);
+    id
+}
+
+#[derive(Default)]
+struct WindowState {
+    location: Point<i32, Logical>,
+    drawn: bool,
+}
+
+type WindowUserdata = RefCell<HashMap<usize, WindowState>>;
+fn window_state(space: usize, w: &Window) -> RefMut<'_, WindowState> {
+    let userdata = w.user_data();
+    userdata.insert_if_missing(WindowUserdata::default);
+    RefMut::map(userdata.get::<WindowUserdata>().unwrap().borrow_mut(), |m| {
+        m.entry(space).or_default()
+    })
+}
+
+#[derive(Clone, Default)]
+struct OutputState {
+    location: Point<i32, Logical>,
+    render_scale: f64,
+    // damage and last_state in space coordinate space
+    old_damage: VecDeque<Vec<Rectangle<i32, Logical>>>,
+    last_state: IndexMap<usize, Rectangle<i32, Logical>>,
+}
+
+type OutputUserdata = RefCell<HashMap<usize, OutputState>>;
+fn output_state(space: usize, o: &Output) -> RefMut<'_, OutputState> {
+    let userdata = o.user_data();
+    userdata.insert_if_missing(OutputUserdata::default);
+    RefMut::map(userdata.get::<OutputUserdata>().unwrap().borrow_mut(), |m| {
+        m.entry(space).or_default()
+    })
+}
+
+// TODO: Maybe replace UnmanagedResource if nothing else comes up?
+#[derive(Debug, thiserror::Error)]
+pub enum SpaceError {
+    #[error("Window is not mapped to this space")]
+    UnknownWindow,
+}
+
+#[derive(Debug)]
+pub struct Space {
+    id: usize,
+    // in z-order, back to front
+    windows: IndexSet<Window>,
+    outputs: Vec<Output>,
+    // TODO:
+    //layers: Vec<Layer>,
+    logger: ::slog::Logger,
+}
+
+impl Drop for Space {
+    fn drop(&mut self) {
+        SPACE_IDS.lock().unwrap().remove(&self.id);
+    }
+}
+
+impl Space {
+    pub fn new<L>(log: L) -> Space
+    where
+        L: Into<slog::Logger>,
+    {
+        Space {
+            id: next_space_id(),
+            windows: IndexSet::new(),
+            outputs: Vec::new(),
+            logger: log.into(),
+        }
+    }
+
+    /// Map window and moves it to top of the stack
+    ///
+    /// This can safely be called on an already mapped window
+    pub fn map_window(&mut self, window: &Window, location: Point<i32, Logical>) -> Result<(), SpaceError> {
+        window_state(self.id, window).location = location;
+        self.windows.shift_remove(window);
+        self.windows.insert(window.clone());
+        Ok(())
+    }
+
+    pub fn raise_window(&mut self, window: &Window) {
+        let loc = window_state(self.id, window).location;
+        let _ = self.map_window(window, loc);
+
+        // TODO: should this be handled by us?
+        window.set_activated(true);
+        for w in self.windows.iter() {
+            if w != window {
+                w.set_activated(false);
+            }
+        }
+    }
+
+    /// Unmap a window from this space by its id
+    pub fn unmap_window(&mut self, window: &Window) {
+        if let Some(map) = window.user_data().get::<WindowUserdata>() {
+            map.borrow_mut().remove(&self.id);
+        }
+        self.windows.shift_remove(window);
+    }
+
+    /// Iterate window in z-order back to front
+    pub fn windows(&self) -> impl Iterator<Item = &Window> {
+        self.windows.iter()
+    }
+
+    /// Get a reference to the window under a given point, if any
+    pub fn window_under(&self, point: Point<f64, Logical>) -> Option<&Window> {
+        self.windows.iter().find(|w| {
+            let loc = window_state(self.id, w).location;
+            let mut bbox = w.bbox();
+            bbox.loc += loc;
+            bbox.to_f64().contains(point)
+        })
+    }
+
+    pub fn window_for_surface(&self, surface: &wl_surface::WlSurface) -> Option<&Window> {
+        if !surface.as_ref().is_alive() {
+            return None;
+        }
+
+        self.windows
+            .iter()
+            .find(|w| w.toplevel().get_surface().map(|x| x == surface).unwrap_or(false))
+    }
+
+    pub fn window_geometry(&self, w: &Window) -> Option<Rectangle<i32, Logical>> {
+        if !self.windows.contains(w) {
+            return None;
+        }
+
+        Some(window_rect(w, &self.id))
+    }
+
+    pub fn map_output(&mut self, output: &Output, scale: f64, location: Point<i32, Logical>) {
+        let mut state = output_state(self.id, output);
+        *state = OutputState {
+            location,
+            render_scale: scale,
+            ..Default::default()
+        };
+        if !self.outputs.contains(output) {
+            self.outputs.push(output.clone());
+        }
+    }
+
+    pub fn outputs(&self) -> impl Iterator<Item = &Output> {
+        self.outputs.iter()
+    }
+
+    pub fn unmap_output(&mut self, output: &Output) {
+        if let Some(map) = output.user_data().get::<OutputUserdata>() {
+            map.borrow_mut().remove(&self.id);
+        }
+        self.outputs.retain(|o| o != output);
+    }
+
+    pub fn output_geometry(&self, o: &Output) -> Option<Rectangle<i32, Logical>> {
+        if !self.outputs.contains(o) {
+            return None;
+        }
+
+        let state = output_state(self.id, o);
+        o.current_mode().map(|mode| {
+            Rectangle::from_loc_and_size(
+                state.location,
+                mode.size.to_f64().to_logical(state.render_scale).to_i32_round(),
+            )
+        })
+    }
+
+    pub fn output_scale(&self, o: &Output) -> Option<f64> {
+        if !self.outputs.contains(o) {
+            return None;
+        }
+
+        let state = output_state(self.id, o);
+        Some(state.render_scale)
+    }
+
+    pub fn output_for_window(&self, w: &Window) -> Option<Output> {
+        if !self.windows.contains(w) {
+            return None;
+        }
+
+        let w_geo = self.window_geometry(w).unwrap();
+        for o in &self.outputs {
+            let o_geo = self.output_geometry(o).unwrap();
+            if w_geo.overlaps(o_geo) {
+                return Some(o.clone());
+            }
+        }
+
+        // TODO primary output
+        self.outputs.get(0).cloned()
+    }
+
+    pub fn cleanup(&mut self) {
+        self.windows.retain(|w| w.toplevel().alive());
+    }
+
+    pub fn render_output<R>(
+        &mut self,
+        renderer: &mut R,
+        output: &Output,
+        age: usize,
+        clear_color: [f32; 4],
+    ) -> Result<bool, RenderError<R>>
+    where
+        R: Renderer + ImportAll,
+        R::TextureId: 'static,
+    {
+        let mut state = output_state(self.id, output);
+        let output_size = output
+            .current_mode()
+            .ok_or(RenderError::OutputNoMode)?
+            .size
+            .to_f64()
+            .to_logical(state.render_scale)
+            .to_i32_round();
+        let output_geo = Rectangle::from_loc_and_size(state.location, output_size);
+
+        // This will hold all the damage we need for this rendering step
+        let mut damage = Vec::<Rectangle<i32, Logical>>::new();
+        // First add damage for windows gone
+        for old_window in state
+            .last_state
+            .iter()
+            .filter_map(|(id, w)| {
+                if !self.windows.iter().any(|w| w.0.id == *id) {
+                    Some(*w)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<Rectangle<i32, Logical>>>()
+        {
+            slog::debug!(self.logger, "Removing window at: {:?}", old_window);
+            damage.push(old_window);
+        }
+
+        // lets iterate front to back and figure out, what new windows or unmoved windows we have
+        for window in self.windows.iter().rev() {
+            let geo = window_rect(window, &self.id);
+            let old_geo = state.last_state.get(&window.0.id).cloned();
+
+            // window was moved or resized
+            if old_geo.map(|old_geo| old_geo != geo).unwrap_or(false) {
+                // Add damage for the old position of the window
+                damage.push(old_geo.unwrap());
+            } /* else {
+                  // window stayed at its place
+                  // TODO: Only push surface damage
+                  //       But this would need to take subsurfaces into account and accumulate damage at least.
+                  //       Even better would be if damage would be ignored that is hidden by subsurfaces...
+              }*/
+            // Add damage for the new position (see TODO above for a better approach)
+            damage.push(geo);
+        }
+
+        // That is all completely new damage, which we need to store for subsequent renders
+        let new_damage = damage.clone();
+        // We now add old damage states, if we have an age value
+        if age > 0 && state.old_damage.len() >= age {
+            // We do not need older states anymore
+            state.old_damage.truncate(age);
+            damage.extend(state.old_damage.iter().flatten().copied());
+        } else {
+            // just damage everything, if we have no damage
+            damage = vec![output_geo];
+        }
+
+        // Optimize the damage for rendering
+        damage.retain(|rect| rect.overlaps(output_geo));
+        damage.retain(|rect| rect.size.h > 0 && rect.size.w > 0);
+        for rect in damage.clone().iter() {
+            // if this rect was already removed, because it was smaller as another one,
+            // there is no reason to evaluate this.
+            if damage.contains(rect) {
+                // remove every rectangle that is contained in this rectangle
+                damage.retain(|other| !rect.contains_rect(*other));
+            }
+        }
+
+        let output_transform: Transform = output.current_transform().into();
+        if let Err(err) = renderer.render(
+            output_transform
+                .transform_size(output_size)
+                .to_f64()
+                .to_physical(state.render_scale)
+                .to_i32_round(),
+            output_transform,
+            |renderer, frame| {
+                // First clear all damaged regions
+                for geo in &damage {
+                    slog::debug!(self.logger, "Clearing at {:?}", geo);
+                    frame.clear(
+                        clear_color,
+                        Some(geo.to_f64().to_physical(state.render_scale).to_i32_ceil()),
+                    )?;
+                }
+
+                // Then re-draw all window overlapping with a damage rect.
+                for window in self.windows.iter() {
+                    let wgeo = window_rect(window, &self.id);
+                    let mut loc = window_loc(window, &self.id);
+                    if damage.iter().any(|geo| wgeo.overlaps(*geo)) {
+                        loc -= output_geo.loc;
+                        slog::debug!(self.logger, "Rendering window at {:?}", wgeo);
+                        draw_window(renderer, frame, window, state.render_scale, loc, &self.logger)?;
+                        window_state(self.id, window).drawn = true;
+                    }
+                }
+
+                Result::<(), R::Error>::Ok(())
+            },
+        ) {
+            // if the rendering errors on us, we need to be prepared, that this whole buffer was partially updated and thus now unusable.
+            // thus clean our old states before returning
+            state.old_damage = VecDeque::new();
+            state.last_state = IndexMap::new();
+            return Err(RenderError::Rendering(err));
+        }
+
+        // If rendering was successful capture the state and add the damage
+        state.last_state = self
+            .windows
+            .iter()
+            .map(|window| {
+                let wgeo = window_rect(window, &self.id);
+                (window.0.id, wgeo)
+            })
+            .collect();
+        state.old_damage.push_front(new_damage);
+
+        // Return if we actually rendered something
+        Ok(!damage.is_empty())
+    }
+
+    pub fn send_frames(&self, all: bool, time: u32) {
+        for window in self.windows.iter().filter(|w| {
+            all || {
+                let mut state = window_state(self.id, w);
+                std::mem::replace(&mut state.drawn, false)
+            }
+        }) {
+            window.send_frame(time);
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError<R: Renderer> {
+    #[error(transparent)]
+    Rendering(R::Error),
+    #[error("Output has no active mode")]
+    OutputNoMode,
+}
+
+fn window_rect(window: &Window, space_id: &usize) -> Rectangle<i32, Logical> {
+    let loc = window_loc(window, space_id);
+    window_bbox_with_pos(window, loc)
+}
+
+fn window_loc(window: &Window, space_id: &usize) -> Point<i32, Logical> {
+    window
+        .user_data()
+        .get::<RefCell<HashMap<usize, WindowState>>>()
+        .unwrap()
+        .borrow()
+        .get(space_id)
+        .unwrap()
+        .location
+}
+
+fn window_bbox_with_pos(window: &Window, pos: Point<i32, Logical>) -> Rectangle<i32, Logical> {
+    let mut wgeo = window.bbox();
+    wgeo.loc += pos;
+    wgeo
+}

--- a/src/desktop/space.rs
+++ b/src/desktop/space.rs
@@ -118,7 +118,11 @@ impl Space {
     ///
     /// This can safely be called on an already mapped window
     pub fn map_window(&mut self, window: &Window, location: Point<i32, Logical>) {
-        window_state(self.id, window).location = location - window.geometry().loc;
+        self.raise_window(window);
+        window_state(self.id, window).location = location;
+    }
+
+    pub fn raise_window(&mut self, window: &Window) {
         self.windows.shift_remove(window);
         self.windows.insert(window.clone());
 
@@ -129,11 +133,6 @@ impl Space {
                 w.set_activated(false);
             }
         }
-    }
-
-    pub fn raise_window(&mut self, window: &Window) {
-        let loc = window_geo(window, &self.id).loc;
-        self.map_window(window, loc);
     }
 
     /// Unmap a window from this space by its id
@@ -540,7 +539,7 @@ pub enum RenderError<R: Renderer> {
 fn window_geo(window: &Window, space_id: &usize) -> Rectangle<i32, Logical> {
     let loc = window_loc(window, space_id);
     let mut wgeo = window.geometry();
-    wgeo.loc += loc;
+    wgeo.loc = loc;
     wgeo
 }
 

--- a/src/desktop/space.rs
+++ b/src/desktop/space.rs
@@ -80,7 +80,7 @@ pub enum SpaceError {
 
 #[derive(Debug)]
 pub struct Space {
-    id: usize,
+    pub(super) id: usize,
     // in z-order, back to front
     windows: IndexSet<Window>,
     outputs: Vec<Output>,
@@ -450,10 +450,15 @@ impl Space {
             } else {
                 // window stayed at its place
                 let loc = window_loc(window, &self.id);
-                damage.extend(window.accumulated_damage().into_iter().map(|mut rect| {
-                    rect.loc += loc;
-                    rect
-                }));
+                damage.extend(
+                    window
+                        .accumulated_damage(Some((self, output)))
+                        .into_iter()
+                        .map(|mut rect| {
+                            rect.loc += loc;
+                            rect
+                        }),
+                );
             }
         }
         for layer in layer_map.layers() {
@@ -467,10 +472,15 @@ impl Space {
                 damage.push(geo);
             } else {
                 let location = geo.loc;
-                damage.extend(layer.accumulated_damage().into_iter().map(|mut rect| {
-                    rect.loc += location;
-                    rect
-                }));
+                damage.extend(
+                    layer
+                        .accumulated_damage(Some((self, output)))
+                        .into_iter()
+                        .map(|mut rect| {
+                            rect.loc += location;
+                            rect
+                        }),
+                );
             }
         }
 

--- a/src/desktop/space.rs
+++ b/src/desktop/space.rs
@@ -570,8 +570,7 @@ impl Space {
                     if damage.iter().any(|geo| lgeo.overlaps(*geo)) {
                         let layer_damage = damage
                             .iter()
-                            .filter(|geo| geo.overlaps(lgeo))
-                            .map(|geo| geo.intersection(lgeo))
+                            .flat_map(|geo| geo.intersection(lgeo))
                             .map(|geo| Rectangle::from_loc_and_size(geo.loc - lgeo.loc, geo.size))
                             .collect::<Vec<_>>();
                         slog::trace!(
@@ -600,8 +599,7 @@ impl Space {
                         loc -= output_geo.loc;
                         let win_damage = damage
                             .iter()
-                            .filter(|geo| geo.overlaps(wgeo))
-                            .map(|geo| geo.intersection(wgeo))
+                            .flat_map(|geo| geo.intersection(wgeo))
                             .map(|geo| Rectangle::from_loc_and_size(geo.loc - loc, geo.size))
                             .collect::<Vec<_>>();
                         slog::trace!(
@@ -631,8 +629,7 @@ impl Space {
                     if damage.iter().any(|geo| lgeo.overlaps(*geo)) {
                         let layer_damage = damage
                             .iter()
-                            .filter(|geo| geo.overlaps(lgeo))
-                            .map(|geo| geo.intersection(lgeo))
+                            .flat_map(|geo| geo.intersection(lgeo))
                             .map(|geo| Rectangle::from_loc_and_size(geo.loc - lgeo.loc, geo.size))
                             .collect::<Vec<_>>();
                         slog::trace!(

--- a/src/desktop/space.rs
+++ b/src/desktop/space.rs
@@ -582,7 +582,7 @@ impl Space {
                             .iter()
                             .filter(|geo| geo.overlaps(wgeo))
                             .map(|geo| geo.intersection(wgeo))
-                            .map(|geo| Rectangle::from_loc_and_size(geo.loc - wgeo.loc, geo.size))
+                            .map(|geo| Rectangle::from_loc_and_size(geo.loc - loc, geo.size))
                             .collect::<Vec<_>>();
                         slog::trace!(
                             self.logger,

--- a/src/desktop/space.rs
+++ b/src/desktop/space.rs
@@ -1,11 +1,12 @@
 use super::{draw_window, Window};
 use crate::{
     backend::renderer::{utils::SurfaceState, Frame, ImportAll, Renderer, Transform},
-    desktop::output::*,
+    desktop::{layer::*, output::*},
     utils::{Logical, Point, Rectangle},
     wayland::{
         compositor::{with_surface_tree_downward, SubsurfaceCachedState, TraversalAction},
         output::Output,
+        shell::wlr_layer::Layer as WlrLayer,
     },
 };
 use indexmap::{IndexMap, IndexSet};
@@ -52,6 +53,20 @@ fn window_state(space: usize, w: &Window) -> RefMut<'_, WindowState> {
     let userdata = w.user_data();
     userdata.insert_if_missing(WindowUserdata::default);
     RefMut::map(userdata.get::<WindowUserdata>().unwrap().borrow_mut(), |m| {
+        m.entry(space).or_default()
+    })
+}
+
+#[derive(Default)]
+struct LayerState {
+    drawn: bool,
+}
+
+type LayerUserdata = RefCell<HashMap<usize, LayerState>>;
+fn layer_state(space: usize, l: &LayerSurface) -> RefMut<'_, LayerState> {
+    let userdata = l.user_data();
+    userdata.insert_if_missing(LayerUserdata::default);
+    RefMut::map(userdata.get::<LayerUserdata>().unwrap().borrow_mut(), |m| {
         m.entry(space).or_default()
     })
 }
@@ -156,6 +171,16 @@ impl Space {
         self.windows
             .iter()
             .find(|w| w.toplevel().get_surface().map(|x| x == surface).unwrap_or(false))
+    }
+
+    pub fn layer_for_surface(&self, surface: &WlSurface) -> Option<LayerSurface> {
+        if !surface.as_ref().is_alive() {
+            return None;
+        }
+        self.outputs.iter().find_map(|o| {
+            let map = layer_map_for_output(o);
+            map.layer_for_surface(surface).cloned()
+        })
     }
 
     pub fn window_geometry(&self, w: &Window) -> Option<Rectangle<i32, Logical>> {
@@ -389,6 +414,7 @@ impl Space {
             .to_logical(state.render_scale)
             .to_i32_round();
         let output_geo = Rectangle::from_loc_and_size(state.location, output_size);
+        let layer_map = layer_map_for_output(output);
 
         // This will hold all the damage we need for this rendering step
         let mut damage = Vec::<Rectangle<i32, Logical>>::new();
@@ -397,7 +423,9 @@ impl Space {
             .last_state
             .iter()
             .filter_map(|(id, w)| {
-                if !self.windows.iter().any(|w| ToplevelId::Xdg(w.0.id) == *id) {
+                if !self.windows.iter().any(|w| ToplevelId::Xdg(w.0.id) == *id)
+                    && !layer_map.layers().any(|l| ToplevelId::Layer(l.0.id) == *id)
+                {
                     Some(*w)
                 } else {
                     None
@@ -424,6 +452,23 @@ impl Space {
                 let loc = window_loc(window, &self.id);
                 damage.extend(window.accumulated_damage().into_iter().map(|mut rect| {
                     rect.loc += loc;
+                    rect
+                }));
+            }
+        }
+        for layer in layer_map.layers() {
+            let geo = layer_map.layer_geometry(layer);
+            let old_geo = state.last_state.get(&ToplevelId::Layer(layer.0.id)).cloned();
+
+            // layer moved or resized
+            if old_geo.map(|old_geo| old_geo != geo).unwrap_or(false) {
+                // Add damage for the old position of the layer
+                damage.push(old_geo.unwrap());
+                damage.push(geo);
+            } else {
+                let location = geo.loc;
+                damage.extend(layer.accumulated_damage().into_iter().map(|mut rect| {
+                    rect.loc += location;
                     rect
                 }));
             }
@@ -485,7 +530,39 @@ impl Space {
                         .collect::<Vec<_>>(),
                 )?;
 
-                // Then re-draw all window overlapping with a damage rect.
+                // Then re-draw all windows & layers overlapping with a damage rect.
+
+                for layer in layer_map
+                    .layers_on(WlrLayer::Background)
+                    .chain(layer_map.layers_on(WlrLayer::Bottom))
+                {
+                    let lgeo = layer_map.layer_geometry(layer);
+                    if damage.iter().any(|geo| lgeo.overlaps(*geo)) {
+                        let layer_damage = damage
+                            .iter()
+                            .filter(|geo| geo.overlaps(lgeo))
+                            .map(|geo| geo.intersection(lgeo))
+                            .map(|geo| Rectangle::from_loc_and_size(geo.loc - lgeo.loc, geo.size))
+                            .collect::<Vec<_>>();
+                        slog::trace!(
+                            self.logger,
+                            "Rendering layer at {:?} with damage {:#?}",
+                            lgeo,
+                            damage
+                        );
+                        draw_layer(
+                            renderer,
+                            frame,
+                            layer,
+                            state.render_scale,
+                            lgeo.loc,
+                            &layer_damage,
+                            &self.logger,
+                        )?;
+                        layer_state(self.id, layer).drawn = true;
+                    }
+                }
+
                 for window in self.windows.iter() {
                     let wgeo = window_rect_with_popups(window, &self.id);
                     let mut loc = window_loc(window, &self.id);
@@ -516,6 +593,37 @@ impl Space {
                     }
                 }
 
+                for layer in layer_map
+                    .layers_on(WlrLayer::Top)
+                    .chain(layer_map.layers_on(WlrLayer::Overlay))
+                {
+                    let lgeo = layer_map.layer_geometry(layer);
+                    if damage.iter().any(|geo| lgeo.overlaps(*geo)) {
+                        let layer_damage = damage
+                            .iter()
+                            .filter(|geo| geo.overlaps(lgeo))
+                            .map(|geo| geo.intersection(lgeo))
+                            .map(|geo| Rectangle::from_loc_and_size(geo.loc - lgeo.loc, geo.size))
+                            .collect::<Vec<_>>();
+                        slog::trace!(
+                            self.logger,
+                            "Rendering layer at {:?} with damage {:#?}",
+                            lgeo,
+                            damage
+                        );
+                        draw_layer(
+                            renderer,
+                            frame,
+                            layer,
+                            state.render_scale,
+                            lgeo.loc,
+                            &layer_damage,
+                            &self.logger,
+                        )?;
+                        layer_state(self.id, layer).drawn = true;
+                    }
+                }
+
                 Result::<(), R::Error>::Ok(())
             },
         ) {
@@ -534,6 +642,10 @@ impl Space {
                 let wgeo = window_rect_with_popups(window, &self.id);
                 (ToplevelId::Xdg(window.0.id), wgeo)
             })
+            .chain(layer_map.layers().map(|layer| {
+                let lgeo = layer_map.layer_geometry(layer);
+                (ToplevelId::Layer(layer.0.id), lgeo)
+            }))
             .collect();
         state.old_damage.push_front(new_damage);
 
@@ -548,6 +660,18 @@ impl Space {
             }
         }) {
             window.send_frame(time);
+        }
+
+        for output in self.outputs.iter() {
+            let map = layer_map_for_output(output);
+            for layer in map.layers().filter(|l| {
+                all || {
+                    let mut state = layer_state(self.id, l);
+                    std::mem::replace(&mut state.drawn, false)
+                }
+            }) {
+                layer.send_frame(time);
+            }
         }
     }
 }

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -47,6 +47,7 @@ where
     }
     fn geometry(&self, space_id: usize) -> Rectangle<i32, Logical>;
     fn accumulated_damage(&self, for_values: Option<(&Space, &Output)>) -> Vec<Rectangle<i32, Logical>>;
+    #[allow(clippy::too_many_arguments)]
     fn draw(
         &self,
         space_id: usize,

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -1,0 +1,141 @@
+use crate::{
+    backend::renderer::{Frame, ImportAll, Renderer, Texture},
+    desktop::{space::*, utils::*},
+    utils::{Logical, Point, Rectangle},
+    wayland::output::Output,
+};
+use std::any::{Any, TypeId};
+use wayland_server::protocol::wl_surface::WlSurface;
+
+pub trait RenderElement<R, F, E, T>
+where
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
+    F: Frame<Error = E, TextureId = T>,
+    E: std::error::Error,
+    T: Texture + 'static,
+    Self: Any + 'static,
+{
+    fn id(&self) -> usize;
+    #[doc(hidden)]
+    fn type_of(&self) -> TypeId {
+        std::any::Any::type_id(self)
+    }
+    fn geometry(&self) -> Rectangle<i32, Logical>;
+    fn accumulated_damage(&self, for_values: Option<(&Space, &Output)>) -> Vec<Rectangle<i32, Logical>>;
+    fn draw(
+        &self,
+        renderer: &mut R,
+        frame: &mut F,
+        scale: f64,
+        location: Point<i32, Logical>,
+        damage: &[Rectangle<i32, Logical>],
+        log: &slog::Logger,
+    ) -> Result<(), R::Error>;
+}
+
+pub(crate) trait SpaceElement<R, F, E, T>
+where
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
+    F: Frame<Error = E, TextureId = T>,
+    E: std::error::Error,
+    T: Texture,
+{
+    fn id(&self) -> usize;
+    fn type_of(&self) -> TypeId;
+    fn location(&self, space_id: usize) -> Point<i32, Logical> {
+        self.geometry(space_id).loc
+    }
+    fn geometry(&self, space_id: usize) -> Rectangle<i32, Logical>;
+    fn accumulated_damage(&self, for_values: Option<(&Space, &Output)>) -> Vec<Rectangle<i32, Logical>>;
+    fn draw(
+        &self,
+        space_id: usize,
+        renderer: &mut R,
+        frame: &mut F,
+        scale: f64,
+        location: Point<i32, Logical>,
+        damage: &[Rectangle<i32, Logical>],
+        log: &slog::Logger,
+    ) -> Result<(), R::Error>;
+}
+
+impl<R, F, E, T> SpaceElement<R, F, E, T> for Box<dyn RenderElement<R, F, E, T>>
+where
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll + 'static,
+    F: Frame<Error = E, TextureId = T> + 'static,
+    E: std::error::Error + 'static,
+    T: Texture + 'static,
+{
+    fn id(&self) -> usize {
+        (&**self as &dyn RenderElement<R, F, E, T>).id()
+    }
+    fn type_of(&self) -> TypeId {
+        (&**self as &dyn RenderElement<R, F, E, T>).type_of()
+    }
+    fn geometry(&self, _space_id: usize) -> Rectangle<i32, Logical> {
+        (&**self as &dyn RenderElement<R, F, E, T>).geometry()
+    }
+    fn accumulated_damage(&self, for_values: Option<(&Space, &Output)>) -> Vec<Rectangle<i32, Logical>> {
+        (&**self as &dyn RenderElement<R, F, E, T>).accumulated_damage(for_values)
+    }
+    fn draw(
+        &self,
+        _space_id: usize,
+        renderer: &mut R,
+        frame: &mut F,
+        scale: f64,
+        location: Point<i32, Logical>,
+        damage: &[Rectangle<i32, Logical>],
+        log: &slog::Logger,
+    ) -> Result<(), R::Error> {
+        (&**self as &dyn RenderElement<R, F, E, T>).draw(renderer, frame, scale, location, damage, log)
+    }
+}
+
+#[derive(Debug)]
+pub struct SurfaceTree {
+    pub surface: WlSurface,
+    pub position: Point<i32, Logical>,
+}
+
+impl<R, F, E, T> RenderElement<R, F, E, T> for SurfaceTree
+where
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
+    F: Frame<Error = E, TextureId = T>,
+    E: std::error::Error,
+    T: Texture + 'static,
+{
+    fn id(&self) -> usize {
+        self.surface.as_ref().id() as usize
+    }
+
+    fn geometry(&self) -> Rectangle<i32, Logical> {
+        let mut bbox = bbox_from_surface_tree(&self.surface, (0, 0));
+        bbox.loc += self.position;
+        bbox
+    }
+
+    fn accumulated_damage(&self, for_values: Option<(&Space, &Output)>) -> Vec<Rectangle<i32, Logical>> {
+        damage_from_surface_tree(&self.surface, (0, 0), for_values)
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut R,
+        frame: &mut F,
+        scale: f64,
+        location: Point<i32, Logical>,
+        damage: &[Rectangle<i32, Logical>],
+        log: &slog::Logger,
+    ) -> Result<(), R::Error> {
+        crate::backend::renderer::utils::draw_surface_tree(
+            renderer,
+            frame,
+            &self.surface,
+            scale,
+            location,
+            damage,
+            log,
+        )
+    }
+}

--- a/src/desktop/space/layer.rs
+++ b/src/desktop/space/layer.rs
@@ -42,7 +42,7 @@ where
         TypeId::of::<LayerSurface>()
     }
 
-    fn geometry(&self, space_id: usize) -> Rectangle<i32, Logical> {
+    fn geometry(&self, _space_id: usize) -> Rectangle<i32, Logical> {
         let mut bbox = self.bbox_with_popups();
         let state = output_layer_state(self);
         bbox.loc += state.location;

--- a/src/desktop/space/layer.rs
+++ b/src/desktop/space/layer.rs
@@ -1,0 +1,72 @@
+use crate::{
+    backend::renderer::{Frame, ImportAll, Renderer, Texture},
+    desktop::{
+        layer::{layer_state as output_layer_state, *},
+        space::{Space, SpaceElement},
+    },
+    utils::{Logical, Point, Rectangle},
+    wayland::output::Output,
+};
+use std::{
+    any::TypeId,
+    cell::{RefCell, RefMut},
+    collections::HashMap,
+};
+
+#[derive(Default)]
+pub struct LayerState {
+    pub drawn: bool,
+}
+
+type LayerUserdata = RefCell<HashMap<usize, LayerState>>;
+pub fn layer_state(space: usize, l: &LayerSurface) -> RefMut<'_, LayerState> {
+    let userdata = l.user_data();
+    userdata.insert_if_missing(LayerUserdata::default);
+    RefMut::map(userdata.get::<LayerUserdata>().unwrap().borrow_mut(), |m| {
+        m.entry(space).or_default()
+    })
+}
+
+impl<R, F, E, T> SpaceElement<R, F, E, T> for LayerSurface
+where
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
+    F: Frame<Error = E, TextureId = T>,
+    E: std::error::Error,
+    T: Texture + 'static,
+{
+    fn id(&self) -> usize {
+        self.0.id
+    }
+
+    fn type_of(&self) -> TypeId {
+        TypeId::of::<LayerSurface>()
+    }
+
+    fn geometry(&self, space_id: usize) -> Rectangle<i32, Logical> {
+        let mut bbox = self.bbox_with_popups();
+        let state = output_layer_state(self);
+        bbox.loc += state.location;
+        bbox
+    }
+
+    fn accumulated_damage(&self, for_values: Option<(&Space, &Output)>) -> Vec<Rectangle<i32, Logical>> {
+        self.accumulated_damage(for_values)
+    }
+
+    fn draw(
+        &self,
+        space_id: usize,
+        renderer: &mut R,
+        frame: &mut F,
+        scale: f64,
+        location: Point<i32, Logical>,
+        damage: &[Rectangle<i32, Logical>],
+        log: &slog::Logger,
+    ) -> Result<(), R::Error> {
+        let res = draw_layer(renderer, frame, self, scale, location, damage, log);
+        if res.is_ok() {
+            layer_state(space_id, self).drawn = true;
+        }
+        res
+    }
+}

--- a/src/desktop/space/layer.rs
+++ b/src/desktop/space/layer.rs
@@ -63,7 +63,7 @@ where
         damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,
     ) -> Result<(), R::Error> {
-        let res = draw_layer(renderer, frame, self, scale, location, damage, log);
+        let res = draw_layer_surface(renderer, frame, self, scale, location, damage, log);
         if res.is_ok() {
             layer_state(space_id, self).drawn = true;
         }

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -498,7 +498,7 @@ impl Space {
         }
 
         let output_transform: Transform = output.current_transform().into();
-        if let Err(err) = renderer.render(
+        let res = renderer.render(
             output_transform
                 .transform_size(output_size)
                 .to_f64()
@@ -559,7 +559,9 @@ impl Space {
 
                 Result::<(), R::Error>::Ok(())
             },
-        ) {
+        );
+
+        if let Err(err) = res {
             // if the rendering errors on us, we need to be prepared, that this whole buffer was partially updated and thus now unusable.
             // thus clean our old states before returning
             state.old_damage = VecDeque::new();

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -30,7 +30,6 @@ use self::window::*;
 
 crate::utils::ids::id_gen!(next_space_id, SPACE_ID, SPACE_IDS);
 
-// TODO: Maybe replace UnmanagedResource if nothing else comes up?
 #[derive(Debug, thiserror::Error)]
 pub enum SpaceError {
     #[error("Window is not mapped to this space")]
@@ -43,10 +42,11 @@ pub struct Space {
     // in z-order, back to front
     windows: IndexSet<Window>,
     outputs: Vec<Output>,
-    // TODO:
-    //layers: Vec<Layer>,
     logger: ::slog::Logger,
 }
+
+pub type DynamicRenderElements<R> =
+    Box<dyn RenderElement<R, <R as Renderer>::Frame, <R as Renderer>::Error, <R as Renderer>::TextureId>>;
 
 impl Drop for Space {
     fn drop(&mut self) {
@@ -382,9 +382,7 @@ impl Space {
         output: &Output,
         age: usize,
         clear_color: [f32; 4],
-        custom_elements: &[Box<
-            dyn RenderElement<R, <R as Renderer>::Frame, <R as Renderer>::Error, <R as Renderer>::TextureId>,
-        >],
+        custom_elements: &[DynamicRenderElements<R>],
     ) -> Result<Option<Vec<Rectangle<i32, Logical>>>, RenderError<R>>
     where
         R: Renderer + ImportAll + 'static,

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     },
 };
 use indexmap::{IndexMap, IndexSet};
-use std::{cell::RefCell, collections::VecDeque};
+use std::{cell::RefCell, collections::VecDeque, fmt};
 use wayland_server::protocol::wl_surface::WlSurface;
 
 mod element;
@@ -682,7 +682,7 @@ impl Space {
 }
 
 /// Errors thrown by [`Space::render_output`]
-#[derive(Debug, thiserror::Error)]
+#[derive(thiserror::Error)]
 pub enum RenderError<R: Renderer> {
     /// The provided [`Renderer`] did return an error during an operation
     #[error(transparent)]
@@ -693,4 +693,14 @@ pub enum RenderError<R: Renderer> {
     /// The given [`Output`] is not mapped to this [`Space`].
     #[error("Output was not mapped to this space")]
     UnmappedOutput,
+}
+
+impl<R: Renderer> fmt::Debug for RenderError<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RenderError::Rendering(err) => fmt::Debug::fmt(err, f),
+            RenderError::OutputNoMode => f.write_str("Output has no active move"),
+            RenderError::UnmappedOutput => f.write_str("Output was not mapped to this space"),
+        }
+    }
 }

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -411,7 +411,7 @@ impl Space {
         custom_elements: &[Box<
             dyn RenderElement<R, <R as Renderer>::Frame, <R as Renderer>::Error, <R as Renderer>::TextureId>,
         >],
-    ) -> Result<bool, RenderError<R>>
+    ) -> Result<Option<Vec<Rectangle<i32, Logical>>>, RenderError<R>>
     where
         R: Renderer + ImportAll + 'static,
         R::TextureId: 'static,
@@ -520,7 +520,7 @@ impl Space {
         });
 
         if damage.is_empty() {
-            return Ok(false);
+            return Ok(None);
         }
 
         let output_transform: Transform = output.current_transform().into();
@@ -605,9 +605,9 @@ impl Space {
                 (ToplevelId::from(elem), geo)
             })
             .collect();
-        state.old_damage.push_front(new_damage);
+        state.old_damage.push_front(new_damage.clone());
 
-        Ok(true)
+        Ok(Some(new_damage))
     }
 
     pub fn send_frames(&self, all: bool, time: u32) {

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -70,25 +70,26 @@ impl Space {
     /// Map window and moves it to top of the stack
     ///
     /// This can safely be called on an already mapped window
-    pub fn map_window<P: Into<Point<i32, Logical>>>(&mut self, window: &Window, location: P) {
-        self.insert_window(window);
+    pub fn map_window<P: Into<Point<i32, Logical>>>(&mut self, window: &Window, location: P, activate: bool) {
+        self.insert_window(window, activate);
         window_state(self.id, window).location = location.into();
     }
 
-    pub fn raise_window(&mut self, window: &Window) {
+    pub fn raise_window(&mut self, window: &Window, activate: bool) {
         if self.windows.shift_remove(window) {
-            self.insert_window(window);
+            self.insert_window(window, activate);
         }
     }
 
-    fn insert_window(&mut self, window: &Window) {
+    fn insert_window(&mut self, window: &Window, activate: bool) {
         self.windows.insert(window.clone());
 
-        // TODO: should this be handled by us?
-        window.set_activated(true);
-        for w in self.windows.iter() {
-            if w != window {
-                w.set_activated(false);
+        if activate {
+            window.set_activated(true);
+            for w in self.windows.iter() {
+                if w != window {
+                    w.set_activated(false);
+                }
             }
         }
     }

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -136,10 +136,10 @@ impl Space {
         })
     }
 
-    /// Get a reference to the output under a given point, if any
-    pub fn output_under<P: Into<Point<f64, Logical>>>(&self, point: P) -> Option<&Output> {
+    /// Get a reference to the outputs under a given point
+    pub fn output_under<P: Into<Point<f64, Logical>>>(&self, point: P) -> impl Iterator<Item = &Output> {
         let point = point.into();
-        self.outputs.iter().rev().find(|o| {
+        self.outputs.iter().rev().filter(move |o| {
             let bbox = self.output_geometry(o);
             bbox.map(|bbox| bbox.to_f64().contains(point)).unwrap_or(false)
         })

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -215,11 +215,16 @@ impl Space {
             return None;
         }
 
+        let transform: Transform = o.current_transform().into();
         let state = output_state(self.id, o);
         o.current_mode().map(|mode| {
             Rectangle::from_loc_and_size(
                 state.location,
-                mode.size.to_f64().to_logical(state.render_scale).to_i32_round(),
+                transform
+                    .transform_size(mode.size)
+                    .to_f64()
+                    .to_logical(state.render_scale)
+                    .to_i32_round(),
             )
         })
     }

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -112,7 +112,7 @@ impl Space {
         }
     }
 
-    /// Unmap a [`Window`] from this space by.
+    /// Unmap a [`Window`] from this space.
     ///
     /// This function does nothing for already unmapped windows
     pub fn unmap_window(&mut self, window: &Window) {

--- a/src/desktop/space/output.rs
+++ b/src/desktop/space/output.rs
@@ -1,6 +1,6 @@
 use crate::{
     backend::renderer::{Frame, ImportAll, Renderer, Texture},
-    desktop::{space::SpaceElement, LayerSurface, Window},
+    desktop::space::SpaceElement,
     utils::{Logical, Point, Rectangle},
     wayland::output::Output,
 };
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use wayland_server::protocol::wl_surface::WlSurface;
 
 use std::{
-    any::{Any, TypeId},
+    any::TypeId,
     cell::{RefCell, RefMut},
     collections::{HashMap, VecDeque},
 };

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -97,7 +97,7 @@ where
         damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,
     ) -> Result<(), R::Error> {
-        let res = draw_window(renderer, frame, &self, scale, location, damage, log);
+        let res = draw_window(renderer, frame, self, scale, location, damage, log);
         if res.is_ok() {
             window_state(space_id, self).drawn = true;
         }

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -1,0 +1,106 @@
+use crate::{
+    backend::renderer::{Frame, ImportAll, Renderer, Texture},
+    desktop::{
+        space::{Space, SpaceElement},
+        window::{draw_window, Window},
+    },
+    utils::{Logical, Point, Rectangle},
+    wayland::output::Output,
+};
+use std::{
+    any::TypeId,
+    cell::{RefCell, RefMut},
+    collections::HashMap,
+};
+
+#[derive(Default)]
+pub struct WindowState {
+    pub location: Point<i32, Logical>,
+    pub drawn: bool,
+}
+
+pub type WindowUserdata = RefCell<HashMap<usize, WindowState>>;
+pub fn window_state(space: usize, w: &Window) -> RefMut<'_, WindowState> {
+    let userdata = w.user_data();
+    userdata.insert_if_missing(WindowUserdata::default);
+    RefMut::map(userdata.get::<WindowUserdata>().unwrap().borrow_mut(), |m| {
+        m.entry(space).or_default()
+    })
+}
+
+pub fn window_geo(window: &Window, space_id: &usize) -> Rectangle<i32, Logical> {
+    let loc = window_loc(window, space_id);
+    let mut wgeo = window.geometry();
+    wgeo.loc = loc;
+    wgeo
+}
+
+pub fn window_rect(window: &Window, space_id: &usize) -> Rectangle<i32, Logical> {
+    let loc = window_loc(window, space_id);
+    let mut wgeo = window.bbox();
+    wgeo.loc += loc;
+    wgeo
+}
+
+pub fn window_rect_with_popups(window: &Window, space_id: &usize) -> Rectangle<i32, Logical> {
+    let loc = window_loc(window, space_id);
+    let mut wgeo = window.bbox_with_popups();
+    wgeo.loc += loc;
+    wgeo
+}
+
+pub fn window_loc(window: &Window, space_id: &usize) -> Point<i32, Logical> {
+    window
+        .user_data()
+        .get::<RefCell<HashMap<usize, WindowState>>>()
+        .unwrap()
+        .borrow()
+        .get(space_id)
+        .unwrap()
+        .location
+}
+
+impl<R, F, E, T> SpaceElement<R, F, E, T> for Window
+where
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
+    F: Frame<Error = E, TextureId = T>,
+    E: std::error::Error,
+    T: Texture + 'static,
+{
+    fn id(&self) -> usize {
+        self.0.id
+    }
+
+    fn type_of(&self) -> TypeId {
+        TypeId::of::<Window>()
+    }
+
+    fn location(&self, space_id: usize) -> Point<i32, Logical> {
+        window_loc(self, &space_id)
+    }
+
+    fn geometry(&self, space_id: usize) -> Rectangle<i32, Logical> {
+        window_rect_with_popups(self, &space_id)
+    }
+
+    fn accumulated_damage(&self, for_values: Option<(&Space, &Output)>) -> Vec<Rectangle<i32, Logical>> {
+        self.accumulated_damage(for_values)
+    }
+
+    fn draw(
+        &self,
+        space_id: usize,
+        renderer: &mut R,
+        frame: &mut F,
+        scale: f64,
+        location: Point<i32, Logical>,
+        damage: &[Rectangle<i32, Logical>],
+        log: &slog::Logger,
+    ) -> Result<(), R::Error> {
+        let res = draw_window(renderer, frame, &self, scale, location, damage, log);
+        if res.is_ok() {
+            window_state(space_id, self).drawn = true;
+        }
+        res
+    }
+}

--- a/src/desktop/utils.rs
+++ b/src/desktop/utils.rs
@@ -21,7 +21,8 @@ impl SurfaceState {
             .map(|dims| dims.to_logical(self.buffer_scale))
     }
 
-    fn contains_point(&self, attrs: &SurfaceAttributes, point: Point<f64, Logical>) -> bool {
+    fn contains_point<P: Into<Point<f64, Logical>>>(&self, attrs: &SurfaceAttributes, point: P) -> bool {
+        let point = point.into();
         let size = match self.size() {
             None => return false, // If the surface has no size, it can't have an input region.
             Some(size) => size,

--- a/src/desktop/utils.rs
+++ b/src/desktop/utils.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use wayland_server::protocol::wl_surface;
 
-use std::{cell::RefCell, sync::Arc};
+use std::cell::RefCell;
 
 impl SurfaceState {
     /// Returns the size of the surface.
@@ -96,8 +96,10 @@ pub fn damage_from_surface_tree<P>(
 where
     P: Into<Point<i32, Logical>>,
 {
+    use super::space::SpaceOutputTuple;
+
     let mut damage = Vec::new();
-    let key = key.map(|(space, output)| (space.id, Arc::as_ptr(&output.inner) as *const ()));
+    let key = key.map(|x| SpaceOutputTuple::from(x).owned_hash());
     with_surface_tree_upward(
         surface,
         location.into(),

--- a/src/desktop/utils.rs
+++ b/src/desktop/utils.rs
@@ -1,14 +1,18 @@
 use crate::{
     backend::renderer::utils::SurfaceState,
+    desktop::Space,
     utils::{Logical, Point, Rectangle, Size},
-    wayland::compositor::{
-        with_surface_tree_downward, with_surface_tree_upward, Damage, SubsurfaceCachedState,
-        SurfaceAttributes, TraversalAction,
+    wayland::{
+        compositor::{
+            with_surface_tree_downward, with_surface_tree_upward, Damage, SubsurfaceCachedState,
+            SurfaceAttributes, TraversalAction,
+        },
+        output::Output,
     },
 };
 use wayland_server::protocol::wl_surface;
 
-use std::cell::RefCell;
+use std::{cell::RefCell, sync::Arc};
 
 impl SurfaceState {
     /// Returns the size of the surface.
@@ -86,11 +90,13 @@ where
 pub fn damage_from_surface_tree<P>(
     surface: &wl_surface::WlSurface,
     location: P,
+    key: Option<(&Space, &Output)>,
 ) -> Vec<Rectangle<i32, Logical>>
 where
     P: Into<Point<i32, Logical>>,
 {
     let mut damage = Vec::new();
+    let key = key.map(|(space, output)| (space.id, Arc::as_ptr(&output.inner) as *const ()));
     with_surface_tree_upward(
         surface,
         location.into(),
@@ -98,7 +104,11 @@ where
             let mut location = *location;
             if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
                 let data = data.borrow();
-                if data.texture.is_none() {
+                if key
+                    .as_ref()
+                    .map(|key| !data.damage_seen.contains(key))
+                    .unwrap_or(true)
+                {
                     if states.role == Some("subsurface") {
                         let current = states.cached_state.current::<SubsurfaceCachedState>();
                         location += current.location;
@@ -110,10 +120,14 @@ where
         |_surface, states, location| {
             let mut location = *location;
             if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
-                let data = data.borrow();
+                let mut data = data.borrow_mut();
                 let attributes = states.cached_state.current::<SurfaceAttributes>();
 
-                if data.texture.is_none() {
+                if key
+                    .as_ref()
+                    .map(|key| !data.damage_seen.contains(key))
+                    .unwrap_or(true)
+                {
                     if states.role == Some("subsurface") {
                         let current = states.cached_state.current::<SubsurfaceCachedState>();
                         location += current.location;
@@ -127,6 +141,10 @@ where
                         rect.loc += location;
                         rect
                     }));
+
+                    if let Some(key) = key {
+                        data.damage_seen.insert(key);
+                    }
                 }
             }
         },

--- a/src/desktop/utils.rs
+++ b/src/desktop/utils.rs
@@ -1,0 +1,199 @@
+use crate::{
+    backend::renderer::utils::SurfaceState,
+    utils::{Logical, Point, Rectangle, Size},
+    wayland::compositor::{
+        with_surface_tree_downward, with_surface_tree_upward, Damage, SubsurfaceCachedState,
+        SurfaceAttributes, TraversalAction,
+    },
+};
+use wayland_server::protocol::wl_surface;
+
+use std::cell::RefCell;
+
+impl SurfaceState {
+    /// Returns the size of the surface.
+    pub fn size(&self) -> Option<Size<i32, Logical>> {
+        self.buffer_dimensions
+            .map(|dims| dims.to_logical(self.buffer_scale))
+    }
+
+    fn contains_point(&self, attrs: &SurfaceAttributes, point: Point<f64, Logical>) -> bool {
+        let size = match self.size() {
+            None => return false, // If the surface has no size, it can't have an input region.
+            Some(size) => size,
+        };
+
+        let rect = Rectangle {
+            loc: (0, 0).into(),
+            size,
+        }
+        .to_f64();
+
+        // The input region is always within the surface itself, so if the surface itself doesn't contain the
+        // point we can return false.
+        if !rect.contains(point) {
+            return false;
+        }
+
+        // If there's no input region, we're done.
+        if attrs.input_region.is_none() {
+            return true;
+        }
+
+        attrs
+            .input_region
+            .as_ref()
+            .unwrap()
+            .contains(point.to_i32_floor())
+    }
+}
+
+pub fn bbox_from_surface_tree<P>(surface: &wl_surface::WlSurface, location: P) -> Rectangle<i32, Logical>
+where
+    P: Into<Point<i32, Logical>>,
+{
+    let location = location.into();
+    let mut bounding_box = Rectangle::from_loc_and_size(location, (0, 0));
+    with_surface_tree_downward(
+        surface,
+        location,
+        |_, states, loc: &Point<i32, Logical>| {
+            let mut loc = *loc;
+            let data = states.data_map.get::<RefCell<SurfaceState>>();
+
+            if let Some(size) = data.and_then(|d| d.borrow().size()) {
+                if states.role == Some("subsurface") {
+                    let current = states.cached_state.current::<SubsurfaceCachedState>();
+                    loc += current.location;
+                }
+
+                // Update the bounding box.
+                bounding_box = bounding_box.merge(Rectangle::from_loc_and_size(loc, size));
+
+                TraversalAction::DoChildren(loc)
+            } else {
+                // If the parent surface is unmapped, then the child surfaces are hidden as
+                // well, no need to consider them here.
+                TraversalAction::SkipChildren
+            }
+        },
+        |_, _, _| {},
+        |_, _, _| true,
+    );
+    bounding_box
+}
+
+pub fn damage_from_surface_tree<P>(
+    surface: &wl_surface::WlSurface,
+    location: P,
+) -> Vec<Rectangle<i32, Logical>>
+where
+    P: Into<Point<i32, Logical>>,
+{
+    let mut damage = Vec::new();
+    with_surface_tree_upward(
+        surface,
+        location.into(),
+        |_surface, states, location| {
+            let mut location = *location;
+            if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
+                let data = data.borrow();
+                if data.texture.is_none() {
+                    if states.role == Some("subsurface") {
+                        let current = states.cached_state.current::<SubsurfaceCachedState>();
+                        location += current.location;
+                    }
+                }
+            }
+            TraversalAction::DoChildren(location)
+        },
+        |_surface, states, location| {
+            let mut location = *location;
+            if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
+                let data = data.borrow();
+                let attributes = states.cached_state.current::<SurfaceAttributes>();
+
+                if data.texture.is_none() {
+                    if states.role == Some("subsurface") {
+                        let current = states.cached_state.current::<SubsurfaceCachedState>();
+                        location += current.location;
+                    }
+
+                    damage.extend(attributes.damage.iter().map(|dmg| {
+                        let mut rect = match dmg {
+                            Damage::Buffer(rect) => rect.to_logical(attributes.buffer_scale),
+                            Damage::Surface(rect) => *rect,
+                        };
+                        rect.loc += location;
+                        rect
+                    }));
+                }
+            }
+        },
+        |_, _, _| true,
+    );
+    damage
+}
+
+pub fn under_from_surface_tree<P>(
+    surface: &wl_surface::WlSurface,
+    point: Point<f64, Logical>,
+    location: P,
+) -> Option<(wl_surface::WlSurface, Point<i32, Logical>)>
+where
+    P: Into<Point<i32, Logical>>,
+{
+    let found = RefCell::new(None);
+    with_surface_tree_downward(
+        surface,
+        location.into(),
+        |wl_surface, states, location: &Point<i32, Logical>| {
+            let mut location = *location;
+            let data = states.data_map.get::<RefCell<SurfaceState>>();
+
+            if states.role == Some("subsurface") {
+                let current = states.cached_state.current::<SubsurfaceCachedState>();
+                location += current.location;
+            }
+
+            let contains_the_point = data
+                .map(|data| {
+                    data.borrow()
+                        .contains_point(&*states.cached_state.current(), point - location.to_f64())
+                })
+                .unwrap_or(false);
+            if contains_the_point {
+                *found.borrow_mut() = Some((wl_surface.clone(), location));
+            }
+
+            TraversalAction::DoChildren(location)
+        },
+        |_, _, _| {},
+        |_, _, _| {
+            // only continue if the point is not found
+            found.borrow().is_none()
+        },
+    );
+    found.into_inner()
+}
+
+pub fn send_frames_surface_tree(surface: &wl_surface::WlSurface, time: u32) {
+    with_surface_tree_downward(
+        surface,
+        (),
+        |_, _, &()| TraversalAction::DoChildren(()),
+        |_surf, states, &()| {
+            // the surface may not have any user_data if it is a subsurface and has not
+            // yet been commited
+            for callback in states
+                .cached_state
+                .current::<SurfaceAttributes>()
+                .frame_callbacks
+                .drain(..)
+            {
+                callback.done(time);
+            }
+        },
+        |_, _, &()| true,
+    );
+}

--- a/src/desktop/utils.rs
+++ b/src/desktop/utils.rs
@@ -49,7 +49,7 @@ impl SurfaceState {
             .input_region
             .as_ref()
             .unwrap()
-            .contains(point.to_i32_floor())
+            .contains(point.to_i32_round())
     }
 }
 

--- a/src/desktop/utils.rs
+++ b/src/desktop/utils.rs
@@ -1,3 +1,5 @@
+//! Helper functions to ease dealing with surface trees
+
 use crate::{
     backend::renderer::utils::SurfaceState,
     desktop::Space,
@@ -53,6 +55,9 @@ impl SurfaceState {
     }
 }
 
+/// Returns the bounding box of a given surface and all its subsurfaces.
+///
+/// - `location` can be set to offset the returned bounding box.
 pub fn bbox_from_surface_tree<P>(surface: &wl_surface::WlSurface, location: P) -> Rectangle<i32, Logical>
 where
     P: Into<Point<i32, Logical>>,
@@ -88,6 +93,12 @@ where
     bounding_box
 }
 
+/// Returns the damage rectangles of the current buffer for a given surface and its subsurfaces.
+///
+/// - `location` can be set to offset the returned bounding box.
+/// - if a `key` is set the damage is only returned on the first call with the given key values.
+///   Subsequent calls will return an empty vector until the buffer is updated again and new
+///   damage values may be retrieved.
 pub fn damage_from_surface_tree<P>(
     surface: &wl_surface::WlSurface,
     location: P,
@@ -155,6 +166,10 @@ where
     damage
 }
 
+/// Returns the (sub-)surface under a given position given a surface, if any.
+///
+/// - `point` has to be the position to query, relative to (0, 0) of the given surface + `location`.
+/// - `location` can be used to offset the returned point.
 pub fn under_from_surface_tree<P>(
     surface: &wl_surface::WlSurface,
     point: Point<f64, Logical>,
@@ -197,6 +212,7 @@ where
     found.into_inner()
 }
 
+/// Sends frame callbacks for a surface and its subsurfaces with the given `time`.
 pub fn send_frames_surface_tree(surface: &wl_surface::WlSurface, time: u32) {
     with_surface_tree_downward(
         surface,

--- a/src/desktop/utils.rs
+++ b/src/desktop/utils.rs
@@ -109,11 +109,10 @@ where
                     .as_ref()
                     .map(|key| !data.damage_seen.contains(key))
                     .unwrap_or(true)
+                    && states.role == Some("subsurface")
                 {
-                    if states.role == Some("subsurface") {
-                        let current = states.cached_state.current::<SubsurfaceCachedState>();
-                        location += current.location;
-                    }
+                    let current = states.cached_state.current::<SubsurfaceCachedState>();
+                    location += current.location;
                 }
             }
             TraversalAction::DoChildren(location)

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -1,0 +1,510 @@
+use crate::{
+    backend::renderer::{buffer_dimensions, Frame, ImportAll, Renderer, Texture},
+    utils::{Logical, Physical, Point, Rectangle, Size},
+    wayland::{
+        compositor::{
+            add_commit_hook, is_sync_subsurface, with_states, with_surface_tree_downward,
+            with_surface_tree_upward, BufferAssignment, Damage, SubsurfaceCachedState, SurfaceAttributes,
+            TraversalAction,
+        },
+        shell::xdg::{SurfaceCachedState, ToplevelSurface},
+    },
+};
+use std::{
+    cell::RefCell,
+    collections::HashSet,
+    hash::{Hash, Hasher},
+    rc::Rc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    },
+};
+use wayland_commons::user_data::UserDataMap;
+use wayland_protocols::xdg_shell::server::xdg_toplevel;
+use wayland_server::protocol::{wl_buffer, wl_surface};
+
+static WINDOW_ID: AtomicUsize = AtomicUsize::new(0);
+lazy_static::lazy_static! {
+    static ref WINDOW_IDS: Mutex<HashSet<usize>> = Mutex::new(HashSet::new());
+}
+
+fn next_window_id() -> usize {
+    let mut ids = WINDOW_IDS.lock().unwrap();
+    if ids.len() == usize::MAX {
+        // Theoretically the code below wraps around correctly,
+        // but that is hard to detect and might deadlock.
+        // Maybe make this a debug_assert instead?
+        panic!("Out of window ids");
+    }
+
+    let mut id = WINDOW_ID.fetch_add(1, Ordering::SeqCst);
+    while ids.iter().any(|k| *k == id) {
+        id = WINDOW_ID.fetch_add(1, Ordering::SeqCst);
+    }
+
+    ids.insert(id);
+    id
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Kind {
+    Xdg(ToplevelSurface),
+    #[cfg(feature = "xwayland")]
+    X11(X11Surface),
+}
+
+// Big TODO
+#[derive(Debug, Clone)]
+pub struct X11Surface {
+    surface: wl_surface::WlSurface,
+}
+
+impl std::cmp::PartialEq for X11Surface {
+    fn eq(&self, other: &Self) -> bool {
+        self.alive() && other.alive() && self.surface == other.surface
+    }
+}
+
+impl X11Surface {
+    pub fn alive(&self) -> bool {
+        self.surface.as_ref().is_alive()
+    }
+
+    pub fn get_surface(&self) -> Option<&wl_surface::WlSurface> {
+        if self.alive() {
+            Some(&self.surface)
+        } else {
+            None
+        }
+    }
+}
+
+impl Kind {
+    pub fn alive(&self) -> bool {
+        match *self {
+            Kind::Xdg(ref t) => t.alive(),
+            #[cfg(feature = "xwayland")]
+            Kind::X11(ref t) => t.alive(),
+        }
+    }
+
+    pub fn get_surface(&self) -> Option<&wl_surface::WlSurface> {
+        match *self {
+            Kind::Xdg(ref t) => t.get_surface(),
+            #[cfg(feature = "xwayland")]
+            Kind::X11(ref t) => t.get_surface(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct SurfaceState {
+    buffer_dimensions: Option<Size<i32, Physical>>,
+    buffer_scale: i32,
+    buffer: Option<wl_buffer::WlBuffer>,
+    texture: Option<Box<dyn std::any::Any + 'static>>,
+}
+
+fn surface_commit(surface: &wl_surface::WlSurface) {
+    if !is_sync_subsurface(surface) {
+        with_surface_tree_upward(
+            surface,
+            (),
+            |_, _, _| TraversalAction::DoChildren(()),
+            |_surf, states, _| {
+                states
+                    .data_map
+                    .insert_if_missing(|| RefCell::new(SurfaceState::default()));
+                let mut data = states
+                    .data_map
+                    .get::<RefCell<SurfaceState>>()
+                    .unwrap()
+                    .borrow_mut();
+                data.update_buffer(&mut *states.cached_state.current::<SurfaceAttributes>());
+            },
+            |_, _, _| true,
+        );
+    }
+}
+
+impl SurfaceState {
+    pub fn update_buffer(&mut self, attrs: &mut SurfaceAttributes) {
+        match attrs.buffer.take() {
+            Some(BufferAssignment::NewBuffer { buffer, .. }) => {
+                // new contents
+                self.buffer_dimensions = buffer_dimensions(&buffer);
+                self.buffer_scale = attrs.buffer_scale;
+                if let Some(old_buffer) = std::mem::replace(&mut self.buffer, Some(buffer)) {
+                    if &old_buffer != self.buffer.as_ref().unwrap() {
+                        old_buffer.release();
+                    }
+                }
+                self.texture = None;
+            }
+            Some(BufferAssignment::Removed) => {
+                // remove the contents
+                self.buffer_dimensions = None;
+                if let Some(buffer) = self.buffer.take() {
+                    buffer.release();
+                };
+                self.texture = None;
+            }
+            None => {}
+        }
+    }
+
+    /// Returns the size of the surface.
+    pub fn size(&self) -> Option<Size<i32, Logical>> {
+        self.buffer_dimensions
+            .map(|dims| dims.to_logical(self.buffer_scale))
+    }
+
+    fn contains_point(&self, attrs: &SurfaceAttributes, point: Point<f64, Logical>) -> bool {
+        let size = match self.size() {
+            None => return false, // If the surface has no size, it can't have an input region.
+            Some(size) => size,
+        };
+
+        let rect = Rectangle {
+            loc: (0, 0).into(),
+            size,
+        }
+        .to_f64();
+
+        // The input region is always within the surface itself, so if the surface itself doesn't contain the
+        // point we can return false.
+        if !rect.contains(point) {
+            return false;
+        }
+
+        // If there's no input region, we're done.
+        if attrs.input_region.is_none() {
+            return true;
+        }
+
+        attrs
+            .input_region
+            .as_ref()
+            .unwrap()
+            .contains(point.to_i32_floor())
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct WindowInner {
+    pub(super) id: usize,
+    toplevel: Kind,
+    user_data: UserDataMap,
+}
+
+impl Drop for WindowInner {
+    fn drop(&mut self) {
+        WINDOW_IDS.lock().unwrap().remove(&self.id);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Window(pub(super) Rc<WindowInner>);
+
+impl PartialEq for Window {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.id == other.0.id
+    }
+}
+
+impl Eq for Window {}
+
+impl Hash for Window {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.id.hash(state);
+    }
+}
+
+impl Window {
+    pub fn new(toplevel: Kind) -> Window {
+        let id = next_window_id();
+
+        // TODO: Do we want this? For new lets add Window::commit
+        //add_commit_hook(toplevel.get_surface().unwrap(), surface_commit);
+
+        Window(Rc::new(WindowInner {
+            id,
+            toplevel,
+            user_data: UserDataMap::new(),
+        }))
+    }
+
+    /// Returns the geometry of this window.
+    pub fn geometry(&self) -> Rectangle<i32, Logical> {
+        // It's the set geometry with the full bounding box as the fallback.
+        with_states(self.0.toplevel.get_surface().unwrap(), |states| {
+            states.cached_state.current::<SurfaceCachedState>().geometry
+        })
+        .unwrap()
+        .unwrap_or_else(|| self.bbox())
+    }
+
+    /// A bounding box over this window and its children.
+    // TODO: Cache and document when to trigger updates. If possible let space do it
+    pub fn bbox(&self) -> Rectangle<i32, Logical> {
+        let mut bounding_box = Rectangle::from_loc_and_size((0, 0), (0, 0));
+        if let Some(wl_surface) = self.0.toplevel.get_surface() {
+            with_surface_tree_downward(
+                wl_surface,
+                (0, 0).into(),
+                |_, states, loc: &Point<i32, Logical>| {
+                    let mut loc = *loc;
+                    let data = states.data_map.get::<RefCell<SurfaceState>>();
+
+                    if let Some(size) = data.and_then(|d| d.borrow().size()) {
+                        if states.role == Some("subsurface") {
+                            let current = states.cached_state.current::<SubsurfaceCachedState>();
+                            loc += current.location;
+                        }
+
+                        // Update the bounding box.
+                        bounding_box = bounding_box.merge(Rectangle::from_loc_and_size(loc, size));
+
+                        TraversalAction::DoChildren(loc)
+                    } else {
+                        // If the parent surface is unmapped, then the child surfaces are hidden as
+                        // well, no need to consider them here.
+                        TraversalAction::SkipChildren
+                    }
+                },
+                |_, _, _| {},
+                |_, _, _| true,
+            );
+        }
+        bounding_box
+    }
+
+    /// Activate/Deactivate this window
+    // TODO: Add more helpers for Maximize? Minimize? Fullscreen? I dunno
+    pub fn set_activated(&self, active: bool) -> bool {
+        match self.0.toplevel {
+            Kind::Xdg(ref t) => t
+                .with_pending_state(|state| {
+                    if active {
+                        state.states.set(xdg_toplevel::State::Activated)
+                    } else {
+                        state.states.unset(xdg_toplevel::State::Activated)
+                    }
+                })
+                .unwrap_or(false),
+            #[cfg(feature = "xwayland")]
+            Kind::X11(ref t) => unimplemented!(),
+        }
+    }
+
+    /// Commit any changes to this window
+    pub fn configure(&self) {
+        match self.0.toplevel {
+            Kind::Xdg(ref t) => t.send_configure(),
+            #[cfg(feature = "xwayland")]
+            Kind::X11(ref t) => unimplemented!(),
+        }
+    }
+
+    /// Sends the frame callback to all the subsurfaces in this
+    /// window that requested it
+    pub fn send_frame(&self, time: u32) {
+        if let Some(wl_surface) = self.0.toplevel.get_surface() {
+            with_surface_tree_downward(
+                wl_surface,
+                (),
+                |_, _, &()| TraversalAction::DoChildren(()),
+                |_surf, states, &()| {
+                    // the surface may not have any user_data if it is a subsurface and has not
+                    // yet been commited
+                    for callback in states
+                        .cached_state
+                        .current::<SurfaceAttributes>()
+                        .frame_callbacks
+                        .drain(..)
+                    {
+                        callback.done(time);
+                    }
+                },
+                |_, _, &()| true,
+            );
+        }
+    }
+
+    /// Finds the topmost surface under this point if any and returns it together with the location of this
+    /// surface.
+    pub fn surface_under(
+        &self,
+        point: Point<f64, Logical>,
+    ) -> Option<(wl_surface::WlSurface, Point<i32, Logical>)> {
+        let found = RefCell::new(None);
+        if let Some(wl_surface) = self.0.toplevel.get_surface() {
+            with_surface_tree_downward(
+                wl_surface,
+                (0, 0).into(),
+                |wl_surface, states, location: &Point<i32, Logical>| {
+                    let mut location = *location;
+                    let data = states.data_map.get::<RefCell<SurfaceState>>();
+
+                    if states.role == Some("subsurface") {
+                        let current = states.cached_state.current::<SubsurfaceCachedState>();
+                        location += current.location;
+                    }
+
+                    let contains_the_point = data
+                        .map(|data| {
+                            data.borrow()
+                                .contains_point(&*states.cached_state.current(), point - location.to_f64())
+                        })
+                        .unwrap_or(false);
+                    if contains_the_point {
+                        *found.borrow_mut() = Some((wl_surface.clone(), location));
+                    }
+
+                    TraversalAction::DoChildren(location)
+                },
+                |_, _, _| {},
+                |_, _, _| {
+                    // only continue if the point is not found
+                    found.borrow().is_none()
+                },
+            );
+        }
+        found.into_inner()
+    }
+
+    pub fn toplevel(&self) -> &Kind {
+        &self.0.toplevel
+    }
+
+    pub fn user_data(&self) -> &UserDataMap {
+        &self.0.user_data
+    }
+
+    /// Has to be called on commit - Window handles the buffer for you
+    pub fn commit(surface: &wl_surface::WlSurface) {
+        surface_commit(surface)
+    }
+}
+
+// TODO: This is basically `draw_surface_tree` from anvil.
+// Can we move this somewhere, where it is also usable for other things then windows?
+// Maybe add this as a helper function for surfaces to `backend::renderer`?
+// How do we handle SurfaceState in that case? Like we need a closure to
+// store and retrieve textures for arbitrary surface trees? Or leave this to the
+// compositor, but that feels like a lot of unnecessary code dublication.
+
+// TODO: This does not handle ImportAll errors properly and uses only one texture slot.
+// This means it is *not* compatible with MultiGPU setups at all.
+// Current plan is to make sure it does not crash at least in that case and later add
+// A `MultiGpuManager` that opens gpus automatically, creates renderers for them,
+// implements `Renderer` and `ImportAll` itself and dispatches everything accordingly,
+// even copying buffers if necessary. This abstraction will likely also handle dmabuf-
+// protocol(s) (and maybe explicit sync?). Then this function will be fine and all the
+// gore of handling multiple gpus will be hidden away for most if not all cases.
+
+// TODO: This function does not crop or scale windows to fit into a space.
+// How do we want to handle this? Add an additional size property to a window?
+// Let the user specify the max size and the method to handle it?
+
+pub fn draw_window<R, E, F, T>(
+    renderer: &mut R,
+    frame: &mut F,
+    window: &Window,
+    scale: f64,
+    location: Point<i32, Logical>,
+    log: &slog::Logger,
+) -> Result<(), R::Error>
+where
+    R: Renderer<Error = E, TextureId = T, Frame = F> + ImportAll,
+    F: Frame<Error = E, TextureId = T>,
+    E: std::error::Error,
+    T: Texture + 'static,
+{
+    let mut result = Ok(());
+    if let Some(surface) = window.0.toplevel.get_surface() {
+        with_surface_tree_upward(
+            surface,
+            location,
+            |_surface, states, location| {
+                let mut location = *location;
+                if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
+                    let mut data = data.borrow_mut();
+                    let attributes = states.cached_state.current::<SurfaceAttributes>();
+                    // Import a new buffer if necessary
+                    if data.texture.is_none() {
+                        if let Some(buffer) = data.buffer.as_ref() {
+                            let damage = attributes
+                                .damage
+                                .iter()
+                                .map(|dmg| match dmg {
+                                    Damage::Buffer(rect) => *rect,
+                                    // TODO also apply transformations
+                                    Damage::Surface(rect) => rect.to_buffer(attributes.buffer_scale),
+                                })
+                                .collect::<Vec<_>>();
+
+                            match renderer.import_buffer(buffer, Some(states), &damage) {
+                                Some(Ok(m)) => {
+                                    data.texture = Some(Box::new(m));
+                                }
+                                Some(Err(err)) => {
+                                    slog::warn!(log, "Error loading buffer: {}", err);
+                                }
+                                None => {
+                                    slog::error!(log, "Unknown buffer format for: {:?}", buffer);
+                                }
+                            }
+                        }
+                    }
+                    // Now, should we be drawn ?
+                    if data.texture.is_some() {
+                        // if yes, also process the children
+                        if states.role == Some("subsurface") {
+                            let current = states.cached_state.current::<SubsurfaceCachedState>();
+                            location += current.location;
+                        }
+                        TraversalAction::DoChildren(location)
+                    } else {
+                        // we are not displayed, so our children are neither
+                        TraversalAction::SkipChildren
+                    }
+                } else {
+                    // we are not displayed, so our children are neither
+                    TraversalAction::SkipChildren
+                }
+            },
+            |_surface, states, location| {
+                let mut location = *location;
+                if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
+                    let mut data = data.borrow_mut();
+                    let buffer_scale = data.buffer_scale;
+                    let attributes = states.cached_state.current::<SurfaceAttributes>();
+                    if let Some(texture) = data.texture.as_mut().and_then(|x| x.downcast_mut::<T>()) {
+                        // we need to re-extract the subsurface offset, as the previous closure
+                        // only passes it to our children
+                        if states.role == Some("subsurface") {
+                            let current = states.cached_state.current::<SubsurfaceCachedState>();
+                            location += current.location;
+                        }
+                        // TODO: Take wp_viewporter into account
+                        if let Err(err) = frame.render_texture_at(
+                            texture,
+                            location.to_f64().to_physical(scale).to_i32_round(),
+                            buffer_scale,
+                            scale,
+                            attributes.buffer_transform.into(),
+                            1.0,
+                        ) {
+                            result = Err(err);
+                        }
+                    }
+                }
+            },
+            |_, _, _| true,
+        );
+    }
+
+    result
+}

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -99,7 +99,7 @@ impl Kind {
 }
 
 #[derive(Default)]
-struct SurfaceState {
+pub(super) struct SurfaceState {
     buffer_dimensions: Option<Size<i32, Physical>>,
     buffer_scale: i32,
     buffer: Option<wl_buffer::WlBuffer>,

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -1,9 +1,10 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, Frame, ImportAll, Renderer, Texture},
-    desktop::{utils::*, PopupManager},
+    desktop::{utils::*, PopupManager, Space},
     utils::{Logical, Point, Rectangle},
     wayland::{
         compositor::with_states,
+        output::Output,
         shell::xdg::{SurfaceCachedState, ToplevelSurface},
     },
 };
@@ -245,17 +246,20 @@ impl Window {
     }
 
     /// Damage of all the surfaces of this window
-    pub(super) fn accumulated_damage(&self) -> Vec<Rectangle<i32, Logical>> {
+    pub(super) fn accumulated_damage(
+        &self,
+        for_values: Option<(&Space, &Output)>,
+    ) -> Vec<Rectangle<i32, Logical>> {
         let mut damage = Vec::new();
         if let Some(surface) = self.0.toplevel.get_surface() {
-            damage.extend(damage_from_surface_tree(surface, (0, 0)));
+            damage.extend(damage_from_surface_tree(surface, (0, 0), for_values));
             for (popup, location) in PopupManager::popups_for_surface(surface)
                 .ok()
                 .into_iter()
                 .flatten()
             {
                 if let Some(surface) = popup.get_surface() {
-                    let popup_damage = damage_from_surface_tree(surface, location);
+                    let popup_damage = damage_from_surface_tree(surface, location, for_values);
                     damage.extend(popup_damage);
                 }
             }

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -1,20 +1,13 @@
 use crate::{
-    backend::renderer::{
-        utils::{draw_surface_tree, SurfaceState},
-        Frame, ImportAll, Renderer, Texture,
-    },
-    desktop::PopupManager,
-    utils::{Logical, Point, Rectangle, Size},
+    backend::renderer::{utils::draw_surface_tree, Frame, ImportAll, Renderer, Texture},
+    desktop::{utils::*, PopupManager},
+    utils::{Logical, Point, Rectangle},
     wayland::{
-        compositor::{
-            with_states, with_surface_tree_downward, with_surface_tree_upward, Damage, SubsurfaceCachedState,
-            SurfaceAttributes, TraversalAction,
-        },
+        compositor::with_states,
         shell::xdg::{SurfaceCachedState, ToplevelSurface},
     },
 };
 use std::{
-    cell::RefCell,
     collections::HashSet,
     hash::{Hash, Hasher},
     rc::Rc,
@@ -25,7 +18,7 @@ use std::{
 };
 use wayland_commons::user_data::UserDataMap;
 use wayland_protocols::xdg_shell::server::xdg_toplevel;
-use wayland_server::protocol::{wl_buffer, wl_surface};
+use wayland_server::protocol::wl_surface;
 
 static WINDOW_ID: AtomicUsize = AtomicUsize::new(0);
 lazy_static::lazy_static! {
@@ -98,44 +91,6 @@ impl Kind {
             #[cfg(feature = "xwayland")]
             Kind::X11(ref t) => t.get_surface(),
         }
-    }
-}
-
-impl SurfaceState {
-    /// Returns the size of the surface.
-    pub fn size(&self) -> Option<Size<i32, Logical>> {
-        self.buffer_dimensions
-            .map(|dims| dims.to_logical(self.buffer_scale))
-    }
-
-    fn contains_point(&self, attrs: &SurfaceAttributes, point: Point<f64, Logical>) -> bool {
-        let size = match self.size() {
-            None => return false, // If the surface has no size, it can't have an input region.
-            Some(size) => size,
-        };
-
-        let rect = Rectangle {
-            loc: (0, 0).into(),
-            size,
-        }
-        .to_f64();
-
-        // The input region is always within the surface itself, so if the surface itself doesn't contain the
-        // point we can return false.
-        if !rect.contains(point) {
-            return false;
-        }
-
-        // If there's no input region, we're done.
-        if attrs.input_region.is_none() {
-            return true;
-        }
-
-        attrs
-            .input_region
-            .as_ref()
-            .unwrap()
-            .contains(point.to_i32_floor())
     }
 }
 
@@ -315,154 +270,6 @@ impl Window {
     pub fn user_data(&self) -> &UserDataMap {
         &self.0.user_data
     }
-}
-
-fn damage_from_surface_tree<P>(surface: &wl_surface::WlSurface, location: P) -> Vec<Rectangle<i32, Logical>>
-where
-    P: Into<Point<i32, Logical>>,
-{
-    let mut damage = Vec::new();
-    with_surface_tree_upward(
-        surface,
-        location.into(),
-        |_surface, states, location| {
-            let mut location = *location;
-            if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
-                let data = data.borrow();
-                if data.texture.is_none() {
-                    if states.role == Some("subsurface") {
-                        let current = states.cached_state.current::<SubsurfaceCachedState>();
-                        location += current.location;
-                    }
-                    return TraversalAction::DoChildren(location);
-                }
-            }
-            TraversalAction::SkipChildren
-        },
-        |_surface, states, location| {
-            let mut location = *location;
-            if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
-                let data = data.borrow();
-                let attributes = states.cached_state.current::<SurfaceAttributes>();
-
-                if data.texture.is_none() {
-                    if states.role == Some("subsurface") {
-                        let current = states.cached_state.current::<SubsurfaceCachedState>();
-                        location += current.location;
-                    }
-
-                    damage.extend(attributes.damage.iter().map(|dmg| {
-                        let mut rect = match dmg {
-                            Damage::Buffer(rect) => rect.to_logical(attributes.buffer_scale),
-                            Damage::Surface(rect) => *rect,
-                        };
-                        rect.loc += location;
-                        rect
-                    }));
-                }
-            }
-        },
-        |_, _, _| true,
-    );
-    damage
-}
-
-fn bbox_from_surface_tree<P>(surface: &wl_surface::WlSurface, location: P) -> Rectangle<i32, Logical>
-where
-    P: Into<Point<i32, Logical>>,
-{
-    let location = location.into();
-    let mut bounding_box = Rectangle::from_loc_and_size(location, (0, 0));
-    with_surface_tree_downward(
-        surface,
-        location,
-        |_, states, loc: &Point<i32, Logical>| {
-            let mut loc = *loc;
-            let data = states.data_map.get::<RefCell<SurfaceState>>();
-
-            if let Some(size) = data.and_then(|d| d.borrow().size()) {
-                if states.role == Some("subsurface") {
-                    let current = states.cached_state.current::<SubsurfaceCachedState>();
-                    loc += current.location;
-                }
-
-                // Update the bounding box.
-                bounding_box = bounding_box.merge(Rectangle::from_loc_and_size(loc, size));
-
-                TraversalAction::DoChildren(loc)
-            } else {
-                // If the parent surface is unmapped, then the child surfaces are hidden as
-                // well, no need to consider them here.
-                TraversalAction::SkipChildren
-            }
-        },
-        |_, _, _| {},
-        |_, _, _| true,
-    );
-    bounding_box
-}
-
-pub fn under_from_surface_tree<P>(
-    surface: &wl_surface::WlSurface,
-    point: Point<f64, Logical>,
-    location: P,
-) -> Option<(wl_surface::WlSurface, Point<i32, Logical>)>
-where
-    P: Into<Point<i32, Logical>>,
-{
-    let found = RefCell::new(None);
-    with_surface_tree_downward(
-        surface,
-        location.into(),
-        |wl_surface, states, location: &Point<i32, Logical>| {
-            let mut location = *location;
-            let data = states.data_map.get::<RefCell<SurfaceState>>();
-
-            if states.role == Some("subsurface") {
-                let current = states.cached_state.current::<SubsurfaceCachedState>();
-                location += current.location;
-            }
-
-            let contains_the_point = data
-                .map(|data| {
-                    data.borrow()
-                        .contains_point(&*states.cached_state.current(), point - location.to_f64())
-                })
-                .unwrap_or(false);
-            if contains_the_point {
-                *found.borrow_mut() = Some((wl_surface.clone(), location));
-            }
-
-            TraversalAction::DoChildren(location)
-        },
-        |_, _, _| {},
-        |_, _, _| {
-            // only continue if the point is not found
-            found.borrow().is_none()
-        },
-    );
-    found.into_inner()
-}
-
-fn send_frames_surface_tree(surface: &wl_surface::WlSurface, time: u32) {
-    with_surface_tree_downward(
-        surface,
-        (),
-        |_, _, &()| TraversalAction::DoChildren(()),
-        |_surf, states, &()| {
-            // the surface may not have any user_data if it is a subsurface and has not
-            // yet been commited
-            for callback in states
-                .cached_state
-                .current::<SurfaceAttributes>()
-                .frame_callbacks
-                .drain(..)
-            {
-                callback.done(time);
-            }
-        },
-        |_, _, &()| true,
-    );
 }
 
 pub fn draw_window<R, E, F, T>(

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -260,10 +260,7 @@ impl Window {
     }
 
     /// Damage of all the surfaces of this window
-    pub(super) fn accumulated_damage(
-        &self,
-        for_values: Option<(&Space, &Output)>,
-    ) -> Vec<Rectangle<i32, Logical>> {
+    pub fn accumulated_damage(&self, for_values: Option<(&Space, &Output)>) -> Vec<Rectangle<i32, Logical>> {
         let mut damage = Vec::new();
         if let Some(surface) = self.0.toplevel.get_surface() {
             damage.extend(

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -266,15 +266,20 @@ impl Window {
     ) -> Vec<Rectangle<i32, Logical>> {
         let mut damage = Vec::new();
         if let Some(surface) = self.0.toplevel.get_surface() {
-            damage.extend(damage_from_surface_tree(surface, (0, 0), for_values));
+            damage.extend(
+                damage_from_surface_tree(surface, (0, 0), for_values)
+                    .into_iter()
+                    .flat_map(|rect| rect.intersection(self.bbox())),
+            );
             for (popup, location) in PopupManager::popups_for_surface(surface)
                 .ok()
                 .into_iter()
                 .flatten()
             {
                 if let Some(surface) = popup.get_surface() {
+                    let bbox = bbox_from_surface_tree(surface, location);
                     let popup_damage = damage_from_surface_tree(surface, location, for_values);
-                    damage.extend(popup_damage);
+                    damage.extend(popup_damage.into_iter().flat_map(|rect| rect.intersection(bbox)));
                 }
             }
         }

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -105,9 +105,6 @@ impl Window {
     pub fn new(toplevel: Kind) -> Window {
         let id = next_window_id();
 
-        // TODO: Do we want this? For new lets add Window::commit
-        //add_commit_hook(toplevel.get_surface().unwrap(), surface_commit);
-
         Window(Rc::new(WindowInner {
             id,
             toplevel,
@@ -127,7 +124,6 @@ impl Window {
     }
 
     /// A bounding box over this window and its children.
-    // TODO: Cache and document when to trigger updates. If possible let space do it
     pub fn bbox(&self) -> Rectangle<i32, Logical> {
         if self.0.toplevel.get_surface().is_some() {
             self.0.bbox.get()
@@ -154,7 +150,6 @@ impl Window {
     }
 
     /// Activate/Deactivate this window
-    // TODO: Add more helpers for Maximize? Minimize? Fullscreen? I dunno
     pub fn set_activated(&self, active: bool) -> bool {
         match self.0.toplevel {
             Kind::Xdg(ref t) => t

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -221,10 +221,11 @@ impl Window {
 
     /// Finds the topmost surface under this point if any and returns it together with the location of this
     /// surface.
-    pub fn surface_under(
+    pub fn surface_under<P: Into<Point<f64, Logical>>>(
         &self,
-        point: Point<f64, Logical>,
+        point: P,
     ) -> Option<(wl_surface::WlSurface, Point<i32, Logical>)> {
+        let point = point.into();
         if let Some(surface) = self.0.toplevel.get_surface() {
             for (popup, location) in PopupManager::popups_for_surface(surface)
                 .ok()
@@ -276,12 +277,12 @@ impl Window {
     }
 }
 
-pub fn draw_window<R, E, F, T>(
+pub fn draw_window<R, E, F, T, P>(
     renderer: &mut R,
     frame: &mut F,
     window: &Window,
     scale: f64,
-    location: Point<i32, Logical>,
+    location: P,
     damage: &[Rectangle<i32, Logical>],
     log: &slog::Logger,
 ) -> Result<(), R::Error>
@@ -290,7 +291,9 @@ where
     F: Frame<Error = E, TextureId = T>,
     E: std::error::Error,
     T: Texture + 'static,
+    P: Into<Point<i32, Logical>>,
 {
+    let location = location.into();
     if let Some(surface) = window.toplevel().get_surface() {
         draw_surface_tree(renderer, frame, surface, scale, location, damage, log)?;
         for (popup, p_location) in PopupManager::popups_for_surface(surface)

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -129,7 +129,7 @@ impl Window {
     /// A bounding box over this window and its children.
     // TODO: Cache and document when to trigger updates. If possible let space do it
     pub fn bbox(&self) -> Rectangle<i32, Logical> {
-        if let Some(surface) = self.0.toplevel.get_surface() {
+        if self.0.toplevel.get_surface().is_some() {
             self.0.bbox.get()
         } else {
             Rectangle::from_loc_and_size((0, 0), (0, 0))
@@ -167,7 +167,7 @@ impl Window {
                 })
                 .unwrap_or(false),
             #[cfg(feature = "xwayland")]
-            Kind::X11(ref t) => unimplemented!(),
+            Kind::X11(ref _t) => unimplemented!(),
         }
     }
 
@@ -176,7 +176,7 @@ impl Window {
         match self.0.toplevel {
             Kind::Xdg(ref t) => t.send_configure(),
             #[cfg(feature = "xwayland")]
-            Kind::X11(ref t) => unimplemented!(),
+            Kind::X11(ref _t) => unimplemented!(),
         }
     }
 

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -171,7 +171,8 @@ impl Window {
                 .flatten()
             {
                 if let Some(surface) = popup.get_surface() {
-                    bounding_box = bounding_box.merge(bbox_from_surface_tree(surface, location));
+                    let offset = self.geometry().loc + location - popup.geometry().loc;
+                    bounding_box = bounding_box.merge(bbox_from_surface_tree(surface, offset));
                 }
             }
         }
@@ -245,9 +246,10 @@ impl Window {
                 .into_iter()
                 .flatten()
             {
+                let offset = self.geometry().loc + location - popup.geometry().loc;
                 if let Some(result) = popup
                     .get_surface()
-                    .and_then(|surface| under_from_surface_tree(surface, point, location))
+                    .and_then(|surface| under_from_surface_tree(surface, point, offset))
                 {
                     return Some(result);
                 }
@@ -274,8 +276,9 @@ impl Window {
                 .flatten()
             {
                 if let Some(surface) = popup.get_surface() {
-                    let bbox = bbox_from_surface_tree(surface, location);
-                    let popup_damage = damage_from_surface_tree(surface, location, for_values);
+                    let offset = self.geometry().loc + location - popup.geometry().loc;
+                    let bbox = bbox_from_surface_tree(surface, offset);
+                    let popup_damage = damage_from_surface_tree(surface, offset, for_values);
                     damage.extend(popup_damage.into_iter().flat_map(|rect| rect.intersection(bbox)));
                 }
             }
@@ -317,23 +320,16 @@ where
             .flatten()
         {
             if let Some(surface) = popup.get_surface() {
+                let offset = window.geometry().loc + p_location - popup.geometry().loc;
                 let damage = damage
                     .iter()
                     .cloned()
                     .map(|mut geo| {
-                        geo.loc -= p_location;
+                        geo.loc -= offset;
                         geo
                     })
                     .collect::<Vec<_>>();
-                draw_surface_tree(
-                    renderer,
-                    frame,
-                    surface,
-                    scale,
-                    location + p_location,
-                    &damage,
-                    log,
-                )?;
+                draw_surface_tree(renderer, frame, surface, scale, location + offset, &damage, log)?;
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@
 pub extern crate nix;
 
 pub mod backend;
+#[cfg(feature = "desktop")]
+pub mod desktop;
 pub mod utils;
 #[cfg(feature = "wayland_frontend")]
 pub mod wayland;

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -297,6 +297,23 @@ impl<N: Coordinate, Kind> Point<N, Kind> {
 }
 
 impl<N: Coordinate, Kind> Point<N, Kind> {
+    /// Constrain this [`Point`] within a [`Rectangle`] with the same coordinates
+    ///
+    /// The [`Point`] returned is guaranteed to be not smaller than the [`Rectangle`]
+    /// location and not greater than the [`Rectangle`] size.
+    #[inline]
+    pub fn constrain(self, rect: impl Into<Rectangle<N, Kind>>) -> Point<N, Kind> {
+        let rect = rect.into();
+
+        Point {
+            x: self.x.max(rect.loc.x).min(rect.size.w),
+            y: self.y.max(rect.loc.y).min(rect.size.h),
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<N: Coordinate, Kind> Point<N, Kind> {
     /// Convert the underlying numerical type to f64 for floating point manipulations
     #[inline]
     pub fn to_f64(self) -> Point<f64, Kind> {
@@ -538,6 +555,20 @@ impl<N: Coordinate, Kind> Size<N, Kind> {
         Point {
             x: self.w,
             y: self.h,
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<N: Coordinate, Kind> Size<N, Kind> {
+    /// Restrict this [`Size`] to min and max [`Size`] with the same coordinates
+    pub fn clamp(self, min: impl Into<Size<N, Kind>>, max: impl Into<Size<N, Kind>>) -> Size<N, Kind> {
+        let min = min.into();
+        let max = max.into();
+
+        Size {
+            w: self.w.max(min.w).min(max.w),
+            h: self.h.max(min.h).min(max.h),
             _kind: std::marker::PhantomData,
         }
     }

--- a/src/utils/ids.rs
+++ b/src/utils/ids.rs
@@ -1,0 +1,37 @@
+macro_rules! id_gen {
+    ($func_name:ident, $id_name:ident, $ids_name:ident) => {
+        static $id_name: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        lazy_static::lazy_static! {
+            static ref $ids_name: std::sync::Mutex<std::collections::HashSet<usize>> =
+                std::sync::Mutex::new(std::collections::HashSet::new());
+        }
+
+        fn $func_name() -> usize {
+            let mut ids = $ids_name.lock().unwrap();
+            if ids.len() == usize::MAX {
+                panic!("Out of ids");
+            }
+
+            let id = loop {
+                let new_id = $id_name.fetch_update(
+                    std::sync::atomic::Ordering::SeqCst,
+                    std::sync::atomic::Ordering::SeqCst,
+                    |mut id| {
+                        while ids.iter().any(|k| *k == id) {
+                            id += 1;
+                        }
+                        Some(id)
+                    },
+                );
+                if let Ok(id) = new_id {
+                    break id;
+                }
+            };
+
+            ids.insert(id);
+            id
+        }
+    };
+}
+
+pub(crate) use id_gen;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub mod signaling;
 #[cfg(feature = "x11rb_event_source")]
 pub mod x11rb;
 
+pub(crate) mod ids;
 pub mod user_data;
 
 pub use self::geometry::{Buffer, Coordinate, Logical, Physical, Point, Raw, Rectangle, Size};

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub mod signaling;
 #[cfg(feature = "x11rb_event_source")]
 pub mod x11rb;
 
+#[cfg(feature = "desktop")]
 pub(crate) mod ids;
 pub mod user_data;
 

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -449,7 +449,7 @@ mod tests {
     #[test]
     fn region_attributes_empty() {
         let region = RegionAttributes { rects: vec![] };
-        assert_eq!(region.contains((0, 0)), false);
+        assert!(!region.contains((0, 0)));
     }
 
     #[test]
@@ -458,7 +458,7 @@ mod tests {
             rects: vec![(RectangleKind::Add, Rectangle::from_loc_and_size((0, 0), (10, 10)))],
         };
 
-        assert_eq!(region.contains((0, 0)), true);
+        assert!(region.contains((0, 0)));
     }
 
     #[test]
@@ -473,8 +473,8 @@ mod tests {
             ],
         };
 
-        assert_eq!(region.contains((0, 0)), false);
-        assert_eq!(region.contains((5, 5)), true);
+        assert!(!region.contains((0, 0)));
+        assert!(region.contains((5, 5)));
     }
 
     #[test]
@@ -490,8 +490,8 @@ mod tests {
             ],
         };
 
-        assert_eq!(region.contains((0, 0)), false);
-        assert_eq!(region.contains((5, 5)), true);
-        assert_eq!(region.contains((2, 2)), true);
+        assert!(!region.contains((0, 0)));
+        assert!(region.contains((5, 5)));
+        assert!(region.contains((2, 2)));
     }
 }

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -100,7 +100,7 @@ pub struct PhysicalProperties {
 }
 
 #[derive(Debug)]
-struct Inner {
+pub(crate) struct Inner {
     name: String,
     log: ::slog::Logger,
     instances: Vec<WlOutput>,
@@ -170,7 +170,7 @@ impl Inner {
 /// about any change in the properties of this output.
 #[derive(Debug, Clone)]
 pub struct Output {
-    inner: InnerType,
+    pub(crate) inner: InnerType,
 }
 
 impl Output {
@@ -272,6 +272,11 @@ impl Output {
     /// Returns the currently advertised transformation of the output
     pub fn current_transform(&self) -> Transform {
         self.inner.0.lock().unwrap().transform
+    }
+
+    /// Returns the currenly advertised scale of the output
+    pub fn current_scale(&self) -> i32 {
+        self.inner.0.lock().unwrap().scale
     }
 
     /// Returns the name of the output

--- a/src/wayland/output/xdg.rs
+++ b/src/wayland/output/xdg.rs
@@ -159,7 +159,7 @@ where
                     output: wl_output,
                 } => {
                     let output = Output::from_resource(&wl_output).unwrap();
-                    let mut inner = output.inner.lock().unwrap();
+                    let mut inner = output.inner.0.lock().unwrap();
 
                     if inner.xdg_output.is_none() {
                         inner.xdg_output = Some(XdgOutput::new(&inner, log.clone()));

--- a/src/wayland/shell/wlr_layer/types.rs
+++ b/src/wayland/shell/wlr_layer/types.rs
@@ -50,7 +50,7 @@ impl Default for Layer {
 /// - some applications are not interested in keyboard events
 ///   and not allowing them to be focused can improve the desktop experience
 /// - some applications will want to take exclusive keyboard focus.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyboardInteractivity {
     /// This value indicates that this surface is not interested in keyboard events
     /// and the compositor should never assign it the keyboard focus.

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -18,6 +18,7 @@ use smithay::{
             Client, Display,
         },
     },
+    utils::Rectangle,
     wayland::{
         output::{Mode, PhysicalProperties},
         seat::CursorImageStatus,
@@ -103,7 +104,10 @@ pub fn run(channel: Channel<WlcsEvent>) {
 
             renderer
                 .render((800, 600).into(), Transform::Normal, |renderer, frame| {
-                    frame.clear([0.8, 0.8, 0.9, 1.0])?;
+                    frame.clear(
+                        [0.8, 0.8, 0.9, 1.0],
+                        &[Rectangle::from_loc_and_size((0, 0), (800, 600))],
+                    )?;
 
                     // draw the windows
                     draw_windows(

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -97,7 +97,7 @@ impl Frame for DummyFrame {
     type Error = SwapBuffersError;
     type TextureId = DummyTexture;
 
-    fn clear(&mut self, _color: [f32; 4]) -> Result<(), Self::Error> {
+    fn clear(&mut self, _color: [f32; 4], _damage: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -106,6 +106,7 @@ impl Frame for DummyFrame {
         _texture: &Self::TextureId,
         _src: Rectangle<i32, Buffer>,
         _dst: Rectangle<f64, Physical>,
+        _damage: &[Rectangle<i32, Physical>],
         _src_transform: Transform,
         _alpha: f32,
     ) -> Result<(), Self::Error> {


### PR DESCRIPTION
First draft of #363.

## Notable changes:
- Makes existing `Output` more versitile
- Adds `Window` abstraction
- Adds `Space` abstraction
- Adds drawing helpers (`Space::render_output` and `draw_window`)
- Very rough anvil implementation

## Things missing:

### space
- [x] xdg-popup handling
- [x] layer-shell support
- [x] track/call output enter/leave for windows
- [x] damage tracking is currently not used for damage of surfaces themselves (instead always the whole window is damaged). This obviously leaves a lot of performance/efficiency gains on the table. 
  - [x] ~~this needs some kind of boolean for each window (was_moved/dirty) to track, which windows should be rendered in full and then this needs to be passed to draw_window to render only with surface damage.~~
  - [x] we actually need to add the accumulated damage of all window surface, because surfaces can be transcluent and we therefor need to render everything that overlaps with the surface damage. Was done in f80b6ba.
  - [x] ~~solution is incomplete, we need to properly track this for multiple outputs/spaces.~~ done
- ~~has no max size and it is awkward to add because it enforces a strict order of:~~
  - updating the size of windows
  - and remapping outputs if necessary
  - and updating the size of the space
  - e.g. If we change the space size and want to remap the outputs and then re-arrange the windows. Should the first two steps error, because we do now have non-accessible windows? Does the operation itself still succeed? Or do we need an api to do all of this atomically?
- ~~we can properly add `MoveGrab` and `ResizeGrab` to smithay directly and add some helpers to use them with spaces~~ tbd in a later pr

### window
- ~~has no max-size (which would also be nice for rendering)~~ will be part of a follow-up PR
- ~~`draw_window` does not play well with multi-gpu setups~~ (will be implemented in a later PR)
- [x] cache bbox
- ~~xwayland support~~ will be part of a larger effort to better support xwayland in smithay

### anvil
- [x] udev backend is not updated at all
- [x] winit makes now use of damage tracking ~~winit backend does not make use of damage-tracking. I think we should not bother. Lets deprecate winit for 0.4 with less features and also add a wayland-backend before 0.4 as an alternative.~~
- [x] render layers again
- [x] render cursors again
- [x] render fps again
- [x] handle fullscreen surfaces
- ~~implement little workspace effect or something similar to show how the desktop abstraction can be temporarily avoided for fancy stuff before resuming efficient rendering.~~ (implemented later)

## Open questions:
- [x] Figure out how to draw external stuff without breaking damage-tracking. Let compositors `map` arbitrary elements with textures? Maybe we can have a trait that can also work for windows and layers? (probably not layers though, since they map to outputs.)
- ~~Figure out a way to atomically update the size and the position of a window (wait for ack on size and next buffer before updating the position). I want to get this rid on first try, because otherwise this feels really bad for tiling. I have no good idea yet how to do that, so suggestions are **very** welcome~~ tbd after wayland-rs 0.30
- ~~Figure out an API to support the size-constraints envisioned by @vberger s first proposal (see #363)~~

My focus obviously was implementing damage-tracking and seeing if that works. I also took some inspiration from the code I wrote for fireplace. So please give feedback for ... well *everything*. I think the api was easy enough to implement for anvil, but it could likely be better.