### PR TITLE
Fixup for #419 and #421

### DIFF
--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -306,7 +306,9 @@ pub fn run_x11(log: Logger) {
                     }
 
                     // Submit the buffer
-                    backend_data.surface.submit();
+                    if let Err(err) = backend_data.surface.submit() {
+                        error!(log, "Error submitting buffer for display: {}", err);
+                    }
                 }
 
                 Err(err) => {


### PR DESCRIPTION
#419 and #421 brought buffer age support to the x11 backend.

However it is not utilized (yet) by anvil, causing two issues with the implementation to slip through.
#423 uncovered them and these two commits are cherry-picked from that PR to unblock further development of the X11 backend, while #423 is still in flux and will likely need a lot more time.