### PR TITLE
x11: rework api to be multi-window capable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `Present` was merged into the `X11Surface`
 - `X11Surface::buffer` now additionally returns the age of the buffer
 - `X11Surface` now has an explicit `submit` function
+- `X11Surface` is now multi-window capable.
 
 ### Additions
 

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -1,4 +1,9 @@
-use std::{cell::RefCell, rc::Rc, sync::atomic::Ordering, time::Duration};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::{atomic::Ordering, Arc, Mutex},
+    time::Duration,
+};
 
 use slog::Logger;
 #[cfg(feature = "egl")]
@@ -64,6 +69,7 @@ pub fn run_x11(log: Logger) {
     let device = gbm::Device::new(drm_node).expect("Failed to create gbm device");
     // Initialize EGL using the GBM device setup earlier.
     let egl = EGLDisplay::new(&device, log.clone()).expect("Failed to create EGLDisplay");
+    let device = Arc::new(Mutex::new(device));
     let context = EGLContext::new(&egl, log.clone()).expect("Failed to create EGLContext");
     let surface = X11Surface::new(
         &mut backend,

--- a/src/backend/x11/error.rs
+++ b/src/backend/x11/error.rs
@@ -25,9 +25,16 @@ pub enum X11Error {
     #[error("Creating the window failed")]
     CreateWindow(CreateWindowError),
 
-    /// An X11 surface already exists for this backend.
-    #[error("An X11 surface already exists for this backend")]
+    /// An X11 surface already exists for this window.
+    #[error("An X11 surface already exists for this window")]
     SurfaceExists,
+
+    /// An invalid window was used to create an X11 surface.
+    ///
+    /// This error will be risen if the window was destroyed or the window does not belong to the [`X11Handle`](super::X11Handle)
+    /// in use.
+    #[error("An invalid window was used to create an X11 surface")]
+    InvalidWindow,
 
     /// The X server is not capable of direct rendering.
     #[error("The X server is not capable of direct rendering")]


### PR DESCRIPTION
This should allow the X11 backend to create multiple windows.

I have not implemented the handling of secondary windows in anvil yet but the single primary window is tested as working.