### PR TITLE
resolve new clippy lints

### DIFF
--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -87,7 +87,7 @@ pub fn run_winit(log: Logger) {
     let data = WinitData {
         #[cfg(feature = "debug")]
         fps_texture: import_bitmap(
-            &mut renderer.borrow_mut().renderer(),
+            renderer.borrow_mut().renderer(),
             &image::io::Reader::with_format(std::io::Cursor::new(FPS_NUMBERS_PNG), image::ImageFormat::Png)
                 .decode()
                 .unwrap()

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -70,6 +70,7 @@ impl<A: AsRawFd + 'static> Drop for FdWrapper<A> {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum DrmDeviceInternal<A: AsRawFd + 'static> {
     Atomic(AtomicDrmDevice<A>),
     Legacy(LegacyDrmDevice<A>),

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -36,6 +36,7 @@ pub struct DrmSurface<A: AsRawFd + 'static> {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum DrmSurfaceInternal<A: AsRawFd + 'static> {
     Atomic(AtomicDrmSurface<A>),
     Legacy(LegacyDrmSurface<A>),

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -199,7 +199,7 @@ impl EGLNativeDisplay for EGLDevice {
 
 /// Trait for types returning valid surface pointers for initializing egl
 ///
-/// ## Unsafety
+/// ## Safety
 ///
 /// The returned [`NativeWindowType`](ffi::NativeWindowType) must be valid for EGL
 /// and there is no way to test that.

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -244,16 +244,10 @@ pub enum RectangleKind {
 /// This struct contains an ordered `Vec` containing the rectangles defining
 /// a region. They should be added or subtracted in this order to compute the
 /// actual contents of the region.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct RegionAttributes {
     /// List of rectangle part of this region
     pub rects: Vec<(RectangleKind, Rectangle<i32, Logical>)>,
-}
-
-impl Default for RegionAttributes {
-    fn default() -> RegionAttributes {
-        RegionAttributes { rects: Vec::new() }
-    }
 }
 
 impl RegionAttributes {

--- a/src/wayland/compositor/transaction.rs
+++ b/src/wayland/compositor/transaction.rs
@@ -61,18 +61,10 @@ pub enum BlockerState {
     Cancelled,
 }
 
+#[derive(Default)]
 struct TransactionState {
     surfaces: Vec<(WlSurface, Serial)>,
     blockers: Vec<Box<dyn Blocker + Send>>,
-}
-
-impl Default for TransactionState {
-    fn default() -> Self {
-        TransactionState {
-            surfaces: Vec::new(),
-            blockers: Vec::new(),
-        }
-    }
 }
 
 impl TransactionState {
@@ -213,19 +205,11 @@ impl Transaction {
 }
 
 // This queue should be per-client
+#[derive(Default)]
 pub(crate) struct TransactionQueue {
     transactions: Vec<Transaction>,
     // we keep the hashset around to reuse allocations
     seen_surfaces: HashSet<u32>,
-}
-
-impl Default for TransactionQueue {
-    fn default() -> Self {
-        TransactionQueue {
-            transactions: Vec::new(),
-            seen_surfaces: HashSet::new(),
-        }
-    }
 }
 
 impl TransactionQueue {

--- a/src/wayland/explicit_synchronization/mod.rs
+++ b/src/wayland/explicit_synchronization/mod.rs
@@ -87,7 +87,7 @@ impl ExplicitBufferRelease {
 ///
 /// When processing the current state, [`Option::take`] the values from it. Otherwise they'll be
 /// treated as unused and released when overwritten by the next client commit.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ExplicitSyncState {
     /// An acquire `dma_fence` object, that you should wait on before accessing the contents of the
     /// buffer associated with the surface.
@@ -95,15 +95,6 @@ pub struct ExplicitSyncState {
     /// A buffer release object, that you should use to signal the client when you are done using the
     /// buffer associated with the surface.
     pub release: Option<ExplicitBufferRelease>,
-}
-
-impl Default for ExplicitSyncState {
-    fn default() -> Self {
-        ExplicitSyncState {
-            acquire: None,
-            release: None,
-        }
-    }
 }
 
 impl Cacheable for ExplicitSyncState {

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -346,7 +346,7 @@ impl Output {
 
     /// This function allows to run a [FnMut] on every
     /// [WlOutput] matching the same [Client] as provided
-    pub fn with_client_outputs<F>(&self, client: Client, mut f: F)
+    pub fn with_client_outputs<F>(&self, client: Client, f: F)
     where
         F: FnMut(&WlOutput),
     {
@@ -359,7 +359,7 @@ impl Output {
                 Some(output_client) => output_client.equals(&client),
                 None => false,
             })
-            .for_each(|output| f(output))
+            .for_each(f)
     }
 
     /// Sends `wl_surface.enter` for the provided surface

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -66,7 +66,7 @@ impl ModifiersState {
 /// For details, see the [documentation at xkbcommon.org][docs].
 ///
 /// [docs]: https://xkbcommon.org/doc/current/structxkb__rule__names.html
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct XkbConfig<'a> {
     /// The rules file to use.
     ///
@@ -84,18 +84,6 @@ pub struct XkbConfig<'a> {
     /// preferences, like which key combinations are used for switching layouts, or which key is the
     /// Compose key.
     pub options: Option<String>,
-}
-
-impl<'a> Default for XkbConfig<'a> {
-    fn default() -> Self {
-        Self {
-            rules: "",
-            model: "",
-            layout: "",
-            variant: "",
-            options: None,
-        }
-    }
 }
 
 struct KbdInternal {

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -388,7 +388,7 @@ xdg_role!(
 );
 
 /// Represents the state of the popup
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PopupState {
     /// The positioner state can be used by the compositor
     /// to calculate the best placement for the popup.
@@ -406,15 +406,6 @@ pub struct PopupState {
     /// The position is relative to the window geometry as defined by
     /// xdg_surface.set_window_geometry of the parent surface.
     pub geometry: Rectangle<i32, Logical>,
-}
-
-impl Default for PopupState {
-    fn default() -> Self {
-        Self {
-            geometry: Default::default(),
-            positioner: Default::default(),
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -598,7 +589,7 @@ impl PositionerState {
 }
 
 /// State of a regular toplevel surface
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct ToplevelState {
     /// The suggested size of the surface
     pub size: Option<Size<i32, Logical>>,
@@ -611,17 +602,6 @@ pub struct ToplevelState {
 
     /// The xdg decoration mode of the surface
     pub decoration_mode: Option<zxdg_toplevel_decoration_v1::Mode>,
-}
-
-impl Default for ToplevelState {
-    fn default() -> Self {
-        ToplevelState {
-            fullscreen_output: None,
-            states: Default::default(),
-            size: None,
-            decoration_mode: None,
-        }
-    }
 }
 
 impl Clone for ToplevelState {
@@ -641,7 +621,7 @@ impl Clone for ToplevelState {
 /// having the same `xdg_toplevel::State` multiple times
 /// and simplifies setting and un-setting a particularly
 /// `xdg_toplevel::State`
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct ToplevelStateSet {
     states: Vec<xdg_toplevel::State>,
 }
@@ -711,12 +691,6 @@ impl ToplevelStateSet {
     }
 }
 
-impl Default for ToplevelStateSet {
-    fn default() -> Self {
-        Self { states: Vec::new() }
-    }
-}
-
 impl IntoIterator for ToplevelStateSet {
     type Item = xdg_toplevel::State;
     type IntoIter = std::vec::IntoIter<Self::Item>;
@@ -733,7 +707,7 @@ impl From<ToplevelStateSet> for Vec<xdg_toplevel::State> {
 }
 
 /// Represents the client pending state
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct SurfaceCachedState {
     /// Holds the double-buffered geometry that may be specified
     /// by xdg_surface.set_window_geometry.
@@ -752,16 +726,6 @@ pub struct SurfaceCachedState {
     /// This is only relevant for xdg_toplevel, and will always be
     /// `(0, 0)` for xdg_popup.
     pub max_size: Size<i32, Logical>,
-}
-
-impl Default for SurfaceCachedState {
-    fn default() -> Self {
-        Self {
-            geometry: None,
-            min_size: Default::default(),
-            max_size: Default::default(),
-        }
-    }
 }
 
 impl Cacheable for SurfaceCachedState {


### PR DESCRIPTION
Rust 1.57.0 means new clippy lints.

Many of the new warnings are manual `default::Default` impls.