### PR TITLE
rewind the keymap file before passing it to clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 
 - `Multicache::has()` now correctly does what is expected of it
 - `xdg_shell` had an issue where it was possible that configured state gets overwritten before it was acked/committed.
+- `wl_keyboard` rewind the `keymap` file before passing it to the client
 
 #### Backends
 

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -5,7 +5,7 @@ use std::{
     cell::RefCell,
     default::Default,
     fmt,
-    io::{Error as IoError, Write},
+    io::{Error as IoError, Seek, Write},
     ops::Deref as _,
     os::unix::io::AsRawFd,
     rc::Rc,
@@ -481,6 +481,7 @@ impl KeyboardHandle {
         let ret = tempfile().and_then(|mut f| {
             f.write_all(self.arc.keymap.as_bytes())?;
             f.flush()?;
+            f.rewind()?;
             kbd.keymap(
                 KeymapFormat::XkbV1,
                 f.as_raw_fd(),


### PR DESCRIPTION
This fixes clients reading the keymap from the `fd` directly to a string instead of using a memory map.