### PR TITLE
x11: Don't use modifiers on old dri3 versions

### DIFF
--- a/src/backend/x11/mod.rs
+++ b/src/backend/x11/mod.rs
@@ -367,7 +367,12 @@ impl X11Handle {
             return Err(X11Error::InvalidWindow);
         }
 
-        let modifiers = modifiers.collect::<Vec<_>>();
+        let mut modifiers = modifiers.collect::<Vec<_>>();
+        // older dri3 versions do only support buffers with one plane.
+        // we need to make sure, we don't accidently allocate buffers with more.
+        if window.0.extensions.dri3 < Some((1, 2)) {
+            modifiers.retain(|modi| modi == &DrmModifier::Invalid || modi == &DrmModifier::Linear);
+        }
 
         let format = window.0.format;
         let size = window.size();


### PR DESCRIPTION
Older dri3 versions (< 1.2) do only support dmabufs with one plane.
Lets limit the modifiers early, if we detect that, so we do not end
up allocating buffers the interface does not accept.