### PR TITLE
Fix use_mode when trying to apply higher resolution then the current one 

### DIFF
--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -354,7 +354,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
                 source,
             })?;
 
-        let test_fb = self.create_test_buffer(pending.mode.size())?;
+        let test_fb = self.create_test_buffer(mode.size())?;
         let req = self.build_request(
             &mut pending.connectors.iter(),
             &mut [].iter(),

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -309,8 +309,11 @@ where
     /// Fails if the mode is not compatible with the underlying
     /// [`crtc`](drm::control::crtc) or any of the
     /// pending [`connector`](drm::control::connector)s.
-    pub fn use_mode(&self, mode: Mode) -> Result<(), Error> {
-        self.drm.use_mode(mode).map_err(Error::DrmError)
+    pub fn use_mode(&mut self, mode: Mode) -> Result<(), Error> {
+        self.drm.use_mode(mode).map_err(Error::DrmError)?;
+        let (w, h) = mode.size();
+        self.swapchain.resize(w as _, h as _);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Current use_mode implementation fails when the user tries to set a mode with higher resolution the the initial output mode.
The issue is cased by two places:
- the test_buffer uses the previous mode size, so when a new mode tries to commit on it and has higher resolution it fails with ENOSPC. This is fixed by the "make use_mode use the new mode size on test_buffer 9a7cd23" commit
-  after the test is successful the real buffer will reject the new pending mode on next commit unless resize on swapchain is called. This is fixed by the "call resize after applying new pending model 5ce5a8a" commit.