### PR TITLE
seat: Export KeysymHandle

### DIFF
--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -41,7 +41,8 @@ mod pointer;
 
 pub use self::{
     keyboard::{
-        keysyms, Error as KeyboardError, FilterResult, KeyboardHandle, Keysym, ModifiersState, XkbConfig,
+        keysyms, Error as KeyboardError, FilterResult, KeyboardHandle, Keysym, KeysymHandle, ModifiersState,
+        XkbConfig,
     },
     pointer::{
         AxisFrame, CursorImageAttributes, CursorImageStatus, GrabStartData, PointerGrab, PointerHandle,


### PR DESCRIPTION
An oversight, interesting Rust allows this, given it is part of the public api through the closure in `KeyboardHandle::input`.