### PR TITLE
Allow checking if KeyboardHandle is focused on a surface

### DIFF
--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -469,6 +469,11 @@ impl KeyboardHandle {
             .unwrap_or(false)
     }
 
+    /// Check if keyboard has focus
+    pub fn is_focused(&self) -> bool {
+        self.arc.internal.borrow_mut().focus.is_some()
+    }
+
     /// Register a new keyboard to this handler
     ///
     /// The keymap will automatically be sent to it


### PR DESCRIPTION
This PR add a simple function to KeyboardHandle with allows checking if they is currently a focused surface with grabs the keyboard.
Motivation behind it is when writing a WM with internal build in shell for example by using imgui keyboard events routed to it needs to be omitted if the Keyboard is focused on a surface. 