### PR TITLE
Refine compositor API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["gui"]
 features = ["test_all_features"]
 
 [workspace]
-# members = [ "anvil", "wlcs_anvil" ]
+ members = [ "anvil", "wlcs_anvil" ]
 
 [dependencies]
 appendlist = "1.4"

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -68,7 +68,7 @@ impl SurfaceState {
 /// `draw_*` helpers of the [desktop module](`crate::desktop`) will
 /// become usable for surfaces handled this way.
 pub fn on_commit_buffer_handler(dh: &mut DisplayHandle<'_>, surface: &WlSurface) {
-    if !is_sync_subsurface(dh, surface) {
+    if !is_sync_subsurface(surface) {
         with_surface_tree_upward(
             surface,
             (),

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -228,15 +228,12 @@ where
                 });
             }
             wl_surface::Request::Commit => {
-                PrivateSurfaceData::invoke_commit_hooks(handle, surface);
-
-                // is_alive check
-                if handle.object_info(surface.id()).is_err() {
-                    // the client was killed by a hook, abort
-                    return;
-                }
+                PrivateSurfaceData::invoke_pre_commit_hooks(handle, surface);
 
                 PrivateSurfaceData::commit(surface, handle);
+
+                PrivateSurfaceData::invoke_post_commit_hooks(handle, surface);
+
                 trace!(
                     state.compositor_state().log,
                     "Calling user implementation for wl_surface.commit"

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -329,50 +329,29 @@ pub fn with_surface_tree_downward<F1, F2, F3, T>(
 /// Retrieve the parent of this surface
 ///
 /// Returns `None` is this surface is a root surface
-pub fn get_parent(dh: &mut DisplayHandle<'_>, surface: &WlSurface) -> Option<WlSurface> {
-    if dh.object_info(surface.id()).is_err() {
-        return None;
-    }
+pub fn get_parent(surface: &WlSurface) -> Option<WlSurface> {
     PrivateSurfaceData::get_parent(surface)
 }
 
 /// Retrieve the children of this surface
-pub fn get_children(dh: &mut DisplayHandle<'_>, surface: &WlSurface) -> Vec<WlSurface> {
-    if dh.object_info(surface.id()).is_err() {
-        return Vec::new();
-    }
+pub fn get_children(surface: &WlSurface) -> Vec<WlSurface> {
     PrivateSurfaceData::get_children(surface)
 }
 
 /// Check if this subsurface is a synchronized subsurface
-///
-/// Returns false if the surface is already dead
-pub fn is_sync_subsurface(dh: &mut DisplayHandle<'_>, surface: &WlSurface) -> bool {
-    if dh.object_info(surface.id()).is_err() {
-        return false;
-    }
+pub fn is_sync_subsurface(surface: &WlSurface) -> bool {
     self::handlers::is_effectively_sync(surface)
 }
 
 /// Get the current role of this surface
-pub fn get_role(dh: &mut DisplayHandle<'_>, surface: &WlSurface) -> Option<&'static str> {
-    if dh.object_info(surface.id()).is_err() {
-        return None;
-    }
+pub fn get_role(surface: &WlSurface) -> Option<&'static str> {
     PrivateSurfaceData::get_role(surface)
 }
 
 /// Register that this surface has given role
 ///
 /// Fails if the surface already has a role.
-pub fn give_role(
-    dh: &mut DisplayHandle<'_>,
-    surface: &WlSurface,
-    role: &'static str,
-) -> Result<(), AlreadyHasRole> {
-    if dh.object_info(surface.id()).is_err() {
-        return Ok(());
-    }
+pub fn give_role(surface: &WlSurface, role: &'static str) -> Result<(), AlreadyHasRole> {
     PrivateSurfaceData::set_role(surface, role)
 }
 
@@ -405,14 +384,7 @@ pub fn get_region_attributes(region: &wl_region::WlRegion) -> RegionAttributes {
 /// Register a commit hook to be invoked on surface commit
 ///
 /// For its precise semantics, see module-level documentation.
-pub fn add_commit_hook(
-    dh: &mut DisplayHandle<'_>,
-    surface: &WlSurface,
-    hook: fn(&mut DisplayHandle<'_>, &WlSurface),
-) {
-    if dh.object_info(surface.id()).is_err() {
-        return;
-    }
+pub fn add_commit_hook(surface: &WlSurface, hook: fn(&mut DisplayHandle<'_>, &WlSurface)) {
     PrivateSurfaceData::add_commit_hook(surface, hook)
 }
 

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -381,11 +381,26 @@ pub fn get_region_attributes(region: &wl_region::WlRegion) -> RegionAttributes {
     }
 }
 
-/// Register a commit hook to be invoked on surface commit
+/// Register a pre-commit hook to be invoked on surface commit
 ///
-/// For its precise semantics, see module-level documentation.
-pub fn add_commit_hook(surface: &WlSurface, hook: fn(&mut DisplayHandle<'_>, &WlSurface)) {
-    PrivateSurfaceData::add_commit_hook(surface, hook)
+/// It'll be invoked on surface commit, *before* the new state is merged into the current state.
+pub fn add_pre_commit_hook(surface: &WlSurface, hook: fn(&mut DisplayHandle<'_>, &WlSurface)) {
+    PrivateSurfaceData::add_pre_commit_hook(surface, hook)
+}
+
+/// Register a post-commit hook to be invoked on surface commit
+///
+/// It'll be invoked on surface commit, *after* the new state is merged into the current state.
+pub fn add_post_commit_hook(surface: &WlSurface, hook: fn(&mut DisplayHandle<'_>, &WlSurface)) {
+    PrivateSurfaceData::add_post_commit_hook(surface, hook)
+}
+
+/// Register a destruction hook to be invoked on surface destruction
+///
+/// It'll be invoked when the surface is destroyed (either explicitly by the client or on
+/// client disconnect).
+pub fn add_destruction_hook(surface: &WlSurface, hook: fn(&SurfaceData)) {
+    PrivateSurfaceData::add_destruction_hook(surface, hook)
 }
 
 /// Handler trait for compositor

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -2,7 +2,6 @@ use crate::wayland::Serial;
 
 use super::{
     cache::MultiCache,
-    get_children,
     handlers::{is_effectively_sync, SurfaceUserData},
     transaction::PendingTransaction,
     SurfaceData,
@@ -172,7 +171,7 @@ impl PrivateSurfaceData {
 
     pub fn commit(surface: &WlSurface, dh: &mut DisplayHandle<'_>) {
         let is_sync = is_effectively_sync(surface);
-        let children = get_children(dh, surface);
+        let children = PrivateSurfaceData::get_children(surface);
         let my_data_mutex = &surface.data::<SurfaceUserData>().unwrap().inner;
         let mut my_data = my_data_mutex.lock().unwrap();
         // commit our state

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -472,8 +472,8 @@ where
                             match surface {
                                 Some(surface) => {
                                     // tolerate re-using the same surface
-                                    if compositor::give_role(dh, &surface, CURSOR_IMAGE_ROLE).is_err()
-                                        && compositor::get_role(dh, &surface) != Some(CURSOR_IMAGE_ROLE)
+                                    if compositor::give_role(&surface, CURSOR_IMAGE_ROLE).is_err()
+                                        && compositor::get_role(&surface) != Some(CURSOR_IMAGE_ROLE)
                                     {
                                         pointer.post_error(
                                             dh,

--- a/src/wayland/shell/mod.rs
+++ b/src/wayland/shell/mod.rs
@@ -17,7 +17,7 @@
 use super::Serial;
 use crate::wayland::compositor;
 use thiserror::Error;
-use wayland_server::{protocol::wl_surface::WlSurface, DisplayHandle};
+use wayland_server::protocol::wl_surface::WlSurface;
 
 // pub mod legacy;
 pub mod xdg;
@@ -38,11 +38,10 @@ pub enum PingError {
 
 /// Returns true if the surface is toplevel equivalent.
 ///
-/// This is method checks if the surface roles is one of `wl_shell_surface`, `xdg_toplevel`
-/// or `zxdg_toplevel`.
-pub fn is_toplevel_equivalent(dh: &mut DisplayHandle<'_>, surface: &WlSurface) -> bool {
+/// This is method checks if the surface roles is `wl_shell_surface` or `xdg_toplevel`
+pub fn is_toplevel_equivalent(surface: &WlSurface) -> bool {
     // (z)xdg_toplevel and wl_shell_surface are toplevel like, so verify if the roles match.
-    let role = compositor::get_role(dh, surface);
+    let role = compositor::get_role(surface);
 
     matches!(
         role,

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -84,7 +84,7 @@ where
                     }
                 };
 
-                if compositor::give_role(dh, &wl_surface, LAYER_SURFACE_ROLE).is_err() {
+                if compositor::give_role(&wl_surface, LAYER_SURFACE_ROLE).is_err() {
                     shell.post_error(
                         dh,
                         zwlr_layer_shell_v1::Error::Role,
@@ -110,7 +110,7 @@ where
                 })
                 .unwrap();
 
-                compositor::add_commit_hook(dh, &wl_surface, |dh, surface| {
+                compositor::add_commit_hook(&wl_surface, |dh, surface| {
                     compositor::with_states(surface, |states| {
                         let mut guard = states
                             .data_map

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -110,7 +110,7 @@ where
                 })
                 .unwrap();
 
-                compositor::add_commit_hook(&wl_surface, |dh, surface| {
+                compositor::add_pre_commit_hook(&wl_surface, |dh, surface| {
                     compositor::with_states(surface, |states| {
                         let mut guard = states
                             .data_map

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -89,7 +89,7 @@ where
                 })
                 .unwrap();
 
-                compositor::add_commit_hook(surface, super::super::ToplevelSurface::commit_hook);
+                compositor::add_pre_commit_hook(surface, super::super::ToplevelSurface::commit_hook);
 
                 let toplevel = data_init.init(
                     id,
@@ -165,7 +165,7 @@ where
                 })
                 .unwrap();
 
-                compositor::add_commit_hook(surface, super::super::PopupSurface::commit_hook);
+                compositor::add_pre_commit_hook(surface, super::super::PopupSurface::commit_hook);
 
                 let popup = data_init.init(
                     id,

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -75,7 +75,7 @@ where
                 let surface = &data.wl_surface;
                 let shell = &data.wm_base;
 
-                if compositor::give_role(dh, surface, XDG_TOPLEVEL_ROLE).is_err() {
+                if compositor::give_role(surface, XDG_TOPLEVEL_ROLE).is_err() {
                     shell.post_error(dh, xdg_wm_base::Error::Role, "Surface already has a role.");
                     return;
                 }
@@ -89,7 +89,7 @@ where
                 })
                 .unwrap();
 
-                compositor::add_commit_hook(dh, surface, super::super::ToplevelSurface::commit_hook);
+                compositor::add_commit_hook(surface, super::super::ToplevelSurface::commit_hook);
 
                 let toplevel = data_init.init(
                     id,
@@ -145,7 +145,7 @@ where
                     }),
                     ..Default::default()
                 };
-                if compositor::give_role(dh, surface, XDG_POPUP_ROLE).is_err() {
+                if compositor::give_role(surface, XDG_POPUP_ROLE).is_err() {
                     shell.post_error(dh, xdg_wm_base::Error::Role, "Surface already has a role.");
                     return;
                 }
@@ -165,7 +165,7 @@ where
                 })
                 .unwrap();
 
-                compositor::add_commit_hook(dh, surface, super::super::PopupSurface::commit_hook);
+                compositor::add_commit_hook(surface, super::super::PopupSurface::commit_hook);
 
                 let popup = data_init.init(
                     id,
@@ -204,7 +204,7 @@ where
                 // which is a protocol error.
                 let surface = &data.wl_surface;
 
-                let role = compositor::get_role(dh, surface);
+                let role = compositor::get_role(surface);
 
                 if role.is_none() {
                     xdg_surface.post_error(
@@ -236,7 +236,7 @@ where
                 // Check the role of the surface, this can be either xdg_toplevel
                 // or xdg_popup. If none of the role matches the xdg_surface has no role set
                 // which is a protocol error.
-                if compositor::get_role(dh, surface).is_none() {
+                if compositor::get_role(surface).is_none() {
                     xdg_surface.post_error(
                         dh,
                         xdg_surface::Error::NotConstructed,

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1145,9 +1145,9 @@ impl ToplevelSurface {
     /// The parent must be another toplevel equivalent surface.
     ///
     /// If the parent is `None`, the parent-child relationship is removed.
-    pub fn set_parent(&self, dh: &mut DisplayHandle<'_>, parent: Option<wl_surface::WlSurface>) -> bool {
+    pub fn set_parent(&self, parent: Option<wl_surface::WlSurface>) -> bool {
         if let Some(parent) = parent {
-            if !is_toplevel_equivalent(dh, &parent) {
+            if !is_toplevel_equivalent(&parent) {
                 return false;
             }
         }


### PR DESCRIPTION
Remove unneeded liveness checks and introduce pro/post commit hooks as well as destruction hooks for surfaces.