### PR TITLE
0.30: Update Seat to allow data passing

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -90,8 +90,8 @@ impl ShmHandler for App {
     }
 }
 
-impl SeatHandler for App {
-    fn seat_state(&mut self) -> &mut SeatState {
+impl SeatHandler<Self> for App {
+    fn seat_state(&mut self) -> &mut SeatState<Self> {
         &mut self.seat_state
     }
 }
@@ -100,7 +100,7 @@ struct App {
     compositor_state: CompositorState,
     xdg_shell_state: XdgShellState,
     shm_state: ShmState,
-    seat_state: SeatState,
+    seat_state: SeatState<Self>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -270,5 +270,5 @@ delegate_dispatch!(App: [WlShm, WlShmPool, WlBuffer] => ShmState);
 // Wl Seat
 //
 
-delegate_global_dispatch!(App: [WlSeat] => SeatState);
-delegate_dispatch!(App: [WlSeat, WlPointer, WlKeyboard] => SeatState);
+delegate_global_dispatch!(App: [WlSeat] => SeatState<App>);
+delegate_dispatch!(App: [WlSeat, WlPointer, WlKeyboard] => SeatState<App>);

--- a/examples/seat.rs
+++ b/examples/seat.rs
@@ -11,11 +11,11 @@ use wayland_server::socket::ListeningSocket;
 use wayland_server::{delegate_dispatch, delegate_global_dispatch};
 
 struct App {
-    seat_state: SeatState,
+    seat_state: SeatState<Self>,
 }
 
-impl SeatHandler for App {
-    fn seat_state(&mut self) -> &mut SeatState {
+impl SeatHandler<Self> for App {
+    fn seat_state(&mut self) -> &mut SeatState<Self> {
         &mut self.seat_state
     }
 }
@@ -77,5 +77,5 @@ impl ClientData<App> for ClientState {
     }
 }
 
-delegate_global_dispatch!(App: [WlSeat] => SeatState);
-delegate_dispatch!(App: [WlSeat, WlPointer, WlKeyboard] => SeatState);
+delegate_global_dispatch!(App: [WlSeat] => SeatState<App>);
+delegate_dispatch!(App: [WlSeat, WlPointer, WlKeyboard] => SeatState<App>);

--- a/src/wayland/seat/keyboard/mod.rs
+++ b/src/wayland/seat/keyboard/mod.rs
@@ -513,8 +513,7 @@ impl KeyboardHandle {
 
     /// Check if keyboard has focus
     pub fn is_focused(&self) -> bool {
-        todo!("is_focused");
-        // self.arc.internal.borrow_mut().focus.is_some()
+        self.arc.internal.lock().unwrap().focus.is_some()
     }
 
     /// Register a new keyboard to this handler

--- a/src/wayland/seat/keyboard/mod.rs
+++ b/src/wayland/seat/keyboard/mod.rs
@@ -569,14 +569,14 @@ pub struct KeyboardUserData {
     pub(crate) handle: Option<KeyboardHandle>,
 }
 
-impl DelegateDispatchBase<WlKeyboard> for SeatState {
+impl<T> DelegateDispatchBase<WlKeyboard> for SeatState<T> {
     type UserData = KeyboardUserData;
 }
 
-impl<D> DelegateDispatch<WlKeyboard, D> for SeatState
+impl<T, D> DelegateDispatch<WlKeyboard, D> for SeatState<T>
 where
     D: 'static + Dispatch<WlKeyboard, UserData = KeyboardUserData>,
-    D: SeatHandler,
+    D: SeatHandler<T>,
 {
     fn request(
         _state: &mut D,

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -26,21 +26,21 @@ pub use grab::{GrabStartData, PointerGrab};
 mod cursor_image;
 pub use cursor_image::{CursorImageAttributes, CursorImageStatus, CURSOR_IMAGE_ROLE};
 
-mod axis_frame;
-pub use axis_frame::AxisFrame;
+mod events;
+pub use events::{AxisFrame, ButtonEvent, MotionEvent};
 
-struct PointerInternal {
+struct PointerInternal<T> {
     known_pointers: Vec<WlPointer>,
     focus: Option<(WlSurface, Point<i32, Logical>)>,
     pending_focus: Option<(WlSurface, Point<i32, Logical>)>,
     location: Point<f64, Logical>,
-    grab: GrabStatus,
+    grab: GrabStatus<T>,
     pressed_buttons: Vec<u32>,
     image_callback: Box<dyn FnMut(CursorImageStatus) + Send + Sync>,
 }
 
 // image_callback does not implement debug, so we have to impl Debug manually
-impl fmt::Debug for PointerInternal {
+impl<T> fmt::Debug for PointerInternal<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PointerInternal")
             .field("known_pointers", &self.known_pointers)
@@ -54,7 +54,7 @@ impl fmt::Debug for PointerInternal {
     }
 }
 
-impl PointerInternal {
+impl<T> PointerInternal<T> {
     fn new(image_callback: Box<dyn FnMut(CursorImageStatus) + Send + Sync>) -> Self {
         Self {
             known_pointers: Vec::new(),
@@ -67,7 +67,7 @@ impl PointerInternal {
         }
     }
 
-    fn set_grab<G: PointerGrab + 'static>(
+    fn set_grab<G: PointerGrab<T> + 'static>(
         &mut self,
         dh: &mut DisplayHandle<'_>,
         serial: Serial,
@@ -164,7 +164,7 @@ impl PointerInternal {
 
     fn with_grab<F>(&mut self, dh: &mut DisplayHandle<'_>, f: F)
     where
-        F: FnOnce(&mut DisplayHandle<'_>, PointerInnerHandle<'_>, &mut dyn PointerGrab),
+        F: FnOnce(&mut DisplayHandle<'_>, PointerInnerHandle<'_, T>, &mut dyn PointerGrab<T>),
     {
         let mut grab = ::std::mem::replace(&mut self.grab, GrabStatus::Borrowed);
         match grab {
@@ -203,11 +203,11 @@ impl PointerInternal {
 /// When sending events using this handle, they will be intercepted by a pointer
 /// grab if any is active. See the [`PointerGrab`] trait for details.
 #[derive(Debug)]
-pub struct PointerHandle {
-    inner: Arc<Mutex<PointerInternal>>,
+pub struct PointerHandle<T> {
+    inner: Arc<Mutex<PointerInternal<T>>>,
 }
 
-impl Clone for PointerHandle {
+impl<T> Clone for PointerHandle<T> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -215,8 +215,8 @@ impl Clone for PointerHandle {
     }
 }
 
-impl PointerHandle {
-    pub(crate) fn new<F>(cb: F) -> PointerHandle
+impl<T> PointerHandle<T> {
+    pub(crate) fn new<F>(cb: F) -> PointerHandle<T>
     where
         F: FnMut(CursorImageStatus) + Send + Sync + 'static,
     {
@@ -233,7 +233,7 @@ impl PointerHandle {
     /// Change the current grab on this pointer to the provided grab
     ///
     /// Overwrites any current grab.
-    pub fn set_grab<G: PointerGrab + 'static>(
+    pub fn set_grab<G: PointerGrab<T> + 'static>(
         &self,
         dh: &mut DisplayHandle<'_>,
         grab: G,
@@ -283,18 +283,11 @@ impl PointerHandle {
     ///
     /// This will internally take care of notifying the appropriate client objects
     /// of enter/motion/leave events.
-    pub fn motion(
-        &self,
-        dh: &mut DisplayHandle<'_>,
-        location: Point<f64, Logical>,
-        focus: Option<(WlSurface, Point<i32, Logical>)>,
-        serial: Serial,
-        time: u32,
-    ) {
+    pub fn motion(&self, data: &mut T, dh: &mut DisplayHandle<'_>, event: &MotionEvent) {
         let mut inner = self.inner.lock().unwrap();
-        inner.pending_focus = focus.clone();
+        inner.pending_focus = event.focus.clone();
         inner.with_grab(dh, move |dh, mut handle, grab| {
-            grab.motion(dh, &mut handle, location, focus, serial, time);
+            grab.motion(data, dh, &mut handle, event);
         });
     }
 
@@ -302,37 +295,30 @@ impl PointerHandle {
     ///
     /// This will internally send the appropriate button event to the client
     /// objects matching with the currently focused surface.
-    pub fn button(
-        &self,
-        dh: &mut DisplayHandle<'_>,
-        button: u32,
-        state: ButtonState,
-        serial: Serial,
-        time: u32,
-    ) {
+    pub fn button(&self, data: &mut T, dh: &mut DisplayHandle<'_>, event: &ButtonEvent) {
         let mut inner = self.inner.lock().unwrap();
-        match state {
+        match event.state {
             ButtonState::Pressed => {
-                inner.pressed_buttons.push(button);
+                inner.pressed_buttons.push(event.button);
             }
             ButtonState::Released => {
-                inner.pressed_buttons.retain(|b| *b != button);
+                inner.pressed_buttons.retain(|b| *b != event.button);
             }
             _ => unreachable!(),
         }
         inner.with_grab(dh, |dh, mut handle, grab| {
-            grab.button(dh, &mut handle, button, state, serial, time);
+            grab.button(data, dh, &mut handle, event);
         });
     }
 
-    // /// Start an axis frame
-    // ///
-    // /// A single frame will group multiple scroll events as if they happened in the same instance.
-    // pub fn axis(&self, details: AxisFrame) {
-    //     self.inner.borrow_mut().with_grab(|mut handle, grab| {
-    //         grab.axis(&mut handle, details);
-    //     });
-    // }
+    /// Start an axis frame
+    ///
+    /// A single frame will group multiple scroll events as if they happened in the same instance.
+    pub fn axis(&self, data: &mut T, dh: &mut DisplayHandle<'_>, details: AxisFrame) {
+        self.inner.lock().unwrap().with_grab(dh, |dh, mut handle, grab| {
+            grab.axis(data, dh, &mut handle, details);
+        });
+    }
 
     /// Access the current location of this pointer in the global space
     pub fn current_location(&self) -> Point<f64, Logical> {
@@ -343,15 +329,15 @@ impl PointerHandle {
 /// This inner handle is accessed from inside a pointer grab logic, and directly
 /// sends event to the client
 #[derive(Debug)]
-pub struct PointerInnerHandle<'a> {
-    inner: &'a mut PointerInternal,
+pub struct PointerInnerHandle<'a, T> {
+    inner: &'a mut PointerInternal<T>,
 }
 
-impl<'a> PointerInnerHandle<'a> {
+impl<'a, T> PointerInnerHandle<'a, T> {
     /// Change the current grab on this pointer to the provided grab
     ///
     /// Overwrites any current grab.
-    pub fn set_grab<G: PointerGrab + 'static>(
+    pub fn set_grab<G: PointerGrab<T> + 'static>(
         &mut self,
         dh: &mut DisplayHandle<'_>,
         serial: Serial,
@@ -473,19 +459,20 @@ impl<'a> PointerInnerHandle<'a> {
 
 /// User data for pointer
 #[derive(Debug)]
-pub struct PointerUserData {
-    pub(crate) handle: Option<PointerHandle>,
+pub struct PointerUserData<T> {
+    pub(crate) handle: Option<PointerHandle<T>>,
 }
 
-impl DelegateDispatchBase<WlPointer> for SeatState {
-    type UserData = PointerUserData;
+impl<T: 'static> DelegateDispatchBase<WlPointer> for SeatState<T> {
+    type UserData = PointerUserData<T>;
 }
 
-impl<D> DelegateDispatch<WlPointer, D> for SeatState
+impl<T, D> DelegateDispatch<WlPointer, D> for SeatState<T>
 where
-    D: Dispatch<WlPointer, UserData = PointerUserData>,
-    D: SeatHandler,
+    D: Dispatch<WlPointer, UserData = PointerUserData<T>>,
+    D: SeatHandler<T>,
     D: 'static,
+    T: 'static,
 {
     fn request(
         _state: &mut D,

--- a/src/wayland/seat/pointer/events.rs
+++ b/src/wayland/seat/pointer/events.rs
@@ -1,4 +1,46 @@
-use wayland_server::protocol::wl_pointer::{Axis, AxisSource};
+use wayland_server::protocol::{
+    wl_pointer::{Axis, AxisSource, ButtonState},
+    wl_surface::WlSurface,
+};
+
+use crate::{
+    utils::{Logical, Point},
+    wayland::Serial,
+};
+
+/// Pointer motion event
+#[derive(Debug, Clone)]
+pub struct MotionEvent {
+    /// Location of the pointer in compositor space
+    pub location: Point<f64, Logical>,
+    /// Currently focused surface
+    pub focus: Option<(WlSurface, Point<i32, Logical>)>,
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+}
+
+/// Pointer button event
+
+/// Mouse button click and release notifications.
+/// The location of the click is given by the last motion or enter event.
+#[derive(Debug, Clone, Copy)]
+pub struct ButtonEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp with millisecond granularity, with an undefined base.
+    pub time: u32,
+    /// Button that produced the event
+    ///
+    /// The button is a button code as defined in the
+    /// Linux kernel's linux/input-event-codes.h header file, e.g. BTN_LEFT.
+    ///
+    /// Any 16-bit button code value is reserved for future additions to the kernel's event code list. All other button codes above 0xFFFF are currently undefined but may be used in future versions of this protocol.
+    pub button: u32,
+    /// Physical state of the button
+    pub state: ButtonState,
+}
 
 /// A frame of pointer axis events.
 ///

--- a/src/wayland/seat/pointer/grab.rs
+++ b/src/wayland/seat/pointer/grab.rs
@@ -21,6 +21,10 @@ use super::{
 /// This trait is the interface to intercept regular pointer events and change them as needed, its
 /// interface mimics the [`PointerHandle`] interface.
 ///
+/// Any interactions with [`PointerHandle`] should be done using [`PointerInnerHandle`],
+/// as handle is borrowed/locked before grab methods are called,
+/// so calling methods on [`PointerHandle`] would result in a deadlock.
+///
 /// If your logic decides that the grab should end, both [`PointerInnerHandle`] and [`PointerHandle`] have
 /// a method to change it.
 ///


### PR DESCRIPTION
- Allows users to pass arbitrary data into grabs
- Implements `is_focused` method
- Implements `from_resource`  (Useful for potential multiseat support)
- Implements `user_data` method (I believe some yet unported modules will make use of it)