### PR TITLE
EGL and Gles2 cleanups and additions

### DIFF
--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -264,6 +264,13 @@ impl EGLContext {
     pub fn user_data(&self) -> &UserDataMap {
         &*self.user_data
     }
+
+    /// Get a raw handle to the underlying context.
+    ///
+    /// The pointer will become invalid, when this struct is destroyed.
+    pub fn get_context_handle(&self) -> ffi::egl::types::EGLContext {
+        self.context
+    }
 }
 
 impl Drop for EGLContext {

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -1,12 +1,21 @@
 //! EGL context related structs
-use std::collections::HashSet;
-use std::os::raw::c_int;
-use std::sync::atomic::Ordering;
+use std::{
+    collections::HashSet,
+    os::raw::c_int,
+    sync::{atomic::Ordering, Arc},
+};
 
 use super::{ffi, wrap_egl_call, Error, MakeCurrentError};
-use crate::backend::allocator::Format as DrmFormat;
-use crate::backend::egl::display::{EGLDisplay, PixelFormat};
-use crate::backend::egl::EGLSurface;
+use crate::{
+    backend::{
+        allocator::Format as DrmFormat,
+        egl::{
+            display::{EGLDisplay, PixelFormat},
+            EGLSurface,
+        },
+    },
+    utils::user_data::UserDataMap,
+};
 
 use slog::{info, o, trace};
 
@@ -17,6 +26,7 @@ pub struct EGLContext {
     pub(crate) display: EGLDisplay,
     config_id: ffi::egl::types::EGLConfig,
     pixel_format: Option<PixelFormat>,
+    user_data: Arc<UserDataMap>,
 }
 // EGLContexts can be moved between threads safely
 unsafe impl Send for EGLContext {}
@@ -162,6 +172,11 @@ impl EGLContext {
             display: display.clone(),
             config_id,
             pixel_format,
+            user_data: if let Some(shared) = shared {
+                shared.user_data.clone()
+            } else {
+                Arc::new(UserDataMap::default())
+            },
         })
     }
 
@@ -240,6 +255,14 @@ impl EGLContext {
     /// Returns a list of formats for dmabufs that can be used as textures.
     pub fn dmabuf_texture_formats(&self) -> &HashSet<DrmFormat> {
         &self.display.dmabuf_import_formats
+    }
+
+    /// Retrieve user_data associated with this context
+    ///
+    /// *Note:* UserData is shared between shared context, if constructed with
+    /// [`new_shared`](EGLContext::new_shared) or [`new_shared_with_config`](EGLContext::new_shared_with_config).
+    pub fn user_data(&self) -> &UserDataMap {
+        &*self.user_data
     }
 }
 

--- a/src/backend/egl/device.rs
+++ b/src/backend/egl/device.rs
@@ -173,7 +173,9 @@ impl EGLDevice {
     }
 
     /// Returns the pointer to the raw [`EGLDevice`].
-    pub fn inner(&self) -> *const c_void {
+    ///
+    /// The pointer will become invalid, when this struct is destroyed.
+    pub fn get_device_handle(&self) -> *const c_void {
         self.inner
     }
 }

--- a/src/backend/egl/surface.rs
+++ b/src/backend/egl/surface.rs
@@ -172,6 +172,16 @@ impl EGLSurface {
     pub fn resize(&self, width: i32, height: i32, dx: i32, dy: i32) -> bool {
         self.native.resize(width, height, dx, dy)
     }
+
+    /// Get a raw handle to the underlying surface
+    ///
+    /// *Note*: The surface might get dynamically recreated during swap-buffers
+    /// causing the pointer to become invalid.
+    ///
+    /// The pointer will become invalid, when this struct is destroyed.
+    pub fn get_surface_handle(&self) -> ffi::egl::types::EGLSurface {
+        self.surface.load(Ordering::SeqCst)
+    }
 }
 
 impl Drop for EGLSurface {

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1428,4 +1428,9 @@ impl Gles2Frame {
 
         Ok(())
     }
+
+    /// Projection matrix for this frame
+    pub fn projection(&self) -> &[f32; 9] {
+        self.current_projection.as_ref()
+    }
 }

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1017,12 +1017,25 @@ impl Drop for Gles2Renderer {
 }
 
 impl Gles2Renderer {
+    /// Get access to the underlying [`EGLContext`].
+    ///
+    /// *Note*: Modifying the context state, might result in rendering issues.
+    /// The context state is considerd an implementation detail
+    /// and no guarantee is made about what can or cannot be changed.
+    /// To make sure a certain modification does not interfere with
+    /// the renderer's behaviour, check the source.
+    pub fn egl_context(&self) -> &EGLContext {
+        &self.egl
+    }
+
     /// Run custom code in the GL context owned by this renderer.
     ///
-    /// *Note*: Any changes to the GL state should be restored at the end of this function.
-    /// Otherwise this can lead to rendering errors while using functions of this renderer.
-    /// Relying on any state set by the renderer may break on any smithay update as the
-    /// details about how this renderer works are considered an implementation detail.
+    /// The OpenGL state of the renderer is considered an implementation detail
+    /// and no guarantee is made about what can or cannot be changed,
+    /// as such you should reset everything you change back to its previous value
+    /// or check the source code of the version of Smithay you are using to ensure
+    /// your changes don't interfere with the renderer's behavior.
+    /// Doing otherwise can lead to rendering errors while using other functions of this renderer.
     pub fn with_context<F, R>(&mut self, func: F) -> Result<R, Gles2Error>
     where
         F: FnOnce(&mut Self, &ffi::Gles2) -> R,

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -186,6 +186,7 @@ pub struct Gles2Renderer {
 /// Handle to the currently rendered frame during [`Gles2Renderer::render`](Renderer::render)
 pub struct Gles2Frame {
     current_projection: Matrix3<f32>,
+    transform: Transform,
     gl: ffi::Gles2,
     tex_programs: [Gles2TexProgram; shaders::FRAGMENT_COUNT],
     solid_program: Gles2SolidProgram,
@@ -1129,6 +1130,7 @@ impl Renderer for Gles2Renderer {
             solid_program: self.solid_program.clone(),
             // output transformation passed in by the user
             current_projection: flip180 * transform.matrix() * renderer,
+            transform,
             vbos: self.vbos,
             size,
         };
@@ -1317,6 +1319,10 @@ impl Frame for Gles2Frame {
             .collect::<Vec<_>>();
 
         self.render_texture(texture, mat, Some(&damage), tex_verts, alpha)
+    }
+
+    fn transformation(&self) -> Transform {
+        self.transform
     }
 }
 

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -108,6 +108,36 @@ impl Transform {
             size
         }
     }
+
+    /// Transforms a rectangle inside an area of a given size by applying this transformation
+    pub fn transform_rect_in<N: Coordinate, Kind>(
+        &self,
+        rect: Rectangle<N, Kind>,
+        area: &Size<N, Kind>,
+    ) -> Rectangle<N, Kind> {
+        let size = self.transform_size(rect.size);
+
+        let loc = match *self {
+            Transform::Normal => rect.loc,
+            Transform::_90 => (area.h - rect.loc.y - rect.size.h, rect.loc.x).into(),
+            Transform::_180 => (
+                area.w - rect.loc.x - rect.size.w,
+                area.h - rect.loc.y - rect.size.h,
+            )
+                .into(),
+            Transform::_270 => (rect.loc.y, area.w - rect.loc.x - rect.size.w).into(),
+            Transform::Flipped => (area.w - rect.loc.x - rect.size.w, rect.loc.y).into(),
+            Transform::Flipped90 => (rect.loc.y, rect.loc.x).into(),
+            Transform::Flipped180 => (rect.loc.x, area.h - rect.loc.y - rect.size.h).into(),
+            Transform::Flipped270 => (
+                area.h - rect.loc.y - rect.size.h,
+                area.w - rect.loc.x - rect.size.w,
+            )
+                .into(),
+        };
+
+        Rectangle::from_loc_and_size(loc, size)
+    }
 }
 
 #[cfg(feature = "wayland_frontend")]
@@ -529,4 +559,103 @@ pub fn buffer_dimensions(buffer: &wl_buffer::WlBuffer) -> Option<Size<i32, Physi
     }
 
     crate::wayland::shm::with_buffer_contents(buffer, |_, data| (data.width, data.height).into()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Transform;
+    use crate::utils::{Logical, Rectangle, Size};
+
+    #[test]
+    fn transform_rect_ident() {
+        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let size = Size::from((70, 90));
+        let transform = Transform::Normal;
+
+        assert_eq!(rect, transform.transform_rect_in(rect, &size))
+    }
+
+    #[test]
+    fn transform_rect_90() {
+        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let size = Size::from((70, 90));
+        let transform = Transform::_90;
+
+        assert_eq!(
+            Rectangle::from_loc_and_size((30, 10), (40, 30)),
+            transform.transform_rect_in(rect, &size)
+        )
+    }
+
+    #[test]
+    fn transform_rect_180() {
+        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let size = Size::from((70, 90));
+        let transform = Transform::_180;
+
+        assert_eq!(
+            Rectangle::from_loc_and_size((30, 30), (30, 40)),
+            transform.transform_rect_in(rect, &size)
+        )
+    }
+
+    #[test]
+    fn transform_rect_270() {
+        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let size = Size::from((70, 90));
+        let transform = Transform::_270;
+
+        assert_eq!(
+            Rectangle::from_loc_and_size((20, 30), (40, 30)),
+            transform.transform_rect_in(rect, &size)
+        )
+    }
+
+    #[test]
+    fn transform_rect_f() {
+        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let size = Size::from((70, 90));
+        let transform = Transform::Flipped;
+
+        assert_eq!(
+            Rectangle::from_loc_and_size((30, 20), (30, 40)),
+            transform.transform_rect_in(rect, &size)
+        )
+    }
+
+    #[test]
+    fn transform_rect_f90() {
+        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let size = Size::from((70, 80));
+        let transform = Transform::Flipped90;
+
+        assert_eq!(
+            Rectangle::from_loc_and_size((20, 10), (40, 30)),
+            transform.transform_rect_in(rect, &size)
+        )
+    }
+
+    #[test]
+    fn transform_rect_f180() {
+        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let size = Size::from((70, 90));
+        let transform = Transform::Flipped180;
+
+        assert_eq!(
+            Rectangle::from_loc_and_size((10, 30), (30, 40)),
+            transform.transform_rect_in(rect, &size)
+        )
+    }
+
+    #[test]
+    fn transform_rect_f270() {
+        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let size = Size::from((70, 90));
+        let transform = Transform::Flipped270;
+
+        assert_eq!(
+            Rectangle::from_loc_and_size((30, 30), (40, 30)),
+            transform.transform_rect_in(rect, &size)
+        )
+    }
 }

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -219,6 +219,9 @@ pub trait Frame {
         src_transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error>;
+
+    /// Output transformation that is applied to this frame
+    fn transformation(&self) -> Transform;
 }
 
 /// Abstraction of commonly used rendering operations for compositors.

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -112,6 +112,10 @@ impl Frame for DummyFrame {
     ) -> Result<(), Self::Error> {
         Ok(())
     }
+
+    fn transformation(&self) -> Transform {
+        Transform::Normal
+    }
 }
 
 pub struct DummyTexture {


### PR DESCRIPTION
Best reviewed on a commit-by-commit basis.

Addresses some short-comings I found implementing smithay-egui.

6e1f6ab1f3e4d3e705c55c51d6c17d09b6f39068 makes it possible to attach user_data to an `EGLContext`. Given that GL-resources like textures or buffers are local to a context, this is the obvious place to store them.

e0ad187411cbcb4e7d7586b9676c47a07069686f makes it possible to retrieve the `EGLContext` of a `Gles2Renderer` to actually access the user_data from downstream.

7ac8872a5ebac9cf8a6570da3ccaa4199dbe1751 and 07bf1e563955c00b2ec50bb51e48ce1c1562f577 expose rendering specifics of the `Gles2Frame`, that make it easier to correctly orientate and size externally drawn content.

04f6434b76c9ac0d2d1d7ed10873c9673005cbf3 allows downstream to retrieve the raw-egl handles, if they want to. We already supported that for the `EGLDevice` and `EGLDisplay` anyway, and this is useful for example to hook up RenderDoc.

08df10c958bc73181e5ce5ee7dfa63669c5174cf fixes up the existing texture filtering code of the `Gles2Renderer`, which was previously not applied correctly.

29b0b2b1bdad43bdc1e8a017880a565f4ca34aa2 fixes resizing the window of the winit-backend in anvil, which broke with #423.

Finally 864b379 adds a utility function to transform `Rectangle`s and some tests.