### PR TITLE
space: Handle multiple overlapping rects when merging damage

### DIFF
--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -557,12 +557,15 @@ impl Space {
         damage.retain(|rect| rect.overlaps(output_geo));
         damage.retain(|rect| rect.size.h > 0 && rect.size.w > 0);
         // merge overlapping rectangles
-        damage = damage.into_iter().fold(Vec::new(), |mut new_damage, rect| {
-            if let Some(existing) = new_damage.iter_mut().find(|other| rect.overlaps(**other)) {
-                *existing = existing.merge(rect);
-            } else {
-                new_damage.push(rect);
+        damage = damage.into_iter().fold(Vec::new(), |new_damage, mut rect| {
+            // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
+            let (overlapping, mut new_damage): (Vec<_>, Vec<_>) =
+                new_damage.into_iter().partition(|other| other.overlaps(rect));
+
+            for overlap in overlapping {
+                rect = rect.merge(overlap);
             }
+            new_damage.push(rect);
             new_damage
         });
 


### PR DESCRIPTION
Thanks for @cmeissl for reporting and providing reproduction instructions.

This avoids double damage for the same region, when a rectangle is added to the damage that overlaps with two existing (previously) non-overlapping rectangles. The original code would merge the new rectangle into whichever other rectangle was returned first without visiting the rest of the damage-array. This leaves two overlapping rectangles behind, which can cause broken renderings, because rendering two instances of the same toplevel is problematic, when transparent regions are involved. E.g. stacked drop shadows.