### PR TITLE
utils: correctly increment ids on first call

### DIFF
--- a/src/utils/ids.rs
+++ b/src/utils/ids.rs
@@ -20,6 +20,7 @@ macro_rules! id_gen {
                         while ids.iter().any(|k| *k == id) {
                             id += 1;
                         }
+                        id += 1;
                         Some(id)
                     },
                 );


### PR DESCRIPTION
`fetch_update` returns the previous value, resulting in the current code assigning the id `0` twice.