### PR TITLE
Apply transformations correctly

### DIFF
--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -13,7 +13,7 @@ use smithay::{
             Display,
         },
     },
-    utils::{Logical, Physical, Point, Rectangle, Size},
+    utils::{Buffer, Logical, Point, Rectangle, Size, Transform},
     wayland::{
         compositor::{
             compositor_init, is_sync_subsurface, with_states, with_surface_tree_upward, BufferAssignment,
@@ -947,8 +947,9 @@ pub struct SurfaceData {
     pub texture: Option<Box<dyn std::any::Any + 'static>>,
     pub geometry: Option<Rectangle<i32, Logical>>,
     pub resize_state: ResizeState,
-    pub buffer_dimensions: Option<Size<i32, Physical>>,
+    pub buffer_dimensions: Option<Size<i32, Buffer>>,
     pub buffer_scale: i32,
+    pub buffer_transform: Transform,
 }
 
 impl SurfaceData {
@@ -958,6 +959,7 @@ impl SurfaceData {
                 // new contents
                 self.buffer_dimensions = buffer_dimensions(&buffer);
                 self.buffer_scale = attrs.buffer_scale;
+                self.buffer_transform = attrs.buffer_transform.into();
                 if let Some(old_buffer) = std::mem::replace(&mut self.buffer, Some(buffer)) {
                     old_buffer.release();
                 }
@@ -976,7 +978,7 @@ impl SurfaceData {
     /// Returns the size of the surface.
     pub fn size(&self) -> Option<Size<i32, Logical>> {
         self.buffer_dimensions
-            .map(|dims| dims.to_logical(self.buffer_scale))
+            .map(|dims| dims.to_logical(self.buffer_scale, self.buffer_transform))
     }
 
     /// Checks if the surface's input region contains the point.

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -20,7 +20,7 @@ use smithay::{
         libinput::{LibinputInputBackend, LibinputSessionInterface},
         renderer::{
             gles2::{Gles2Renderer, Gles2Texture},
-            Bind, Frame, Renderer, Transform,
+            Bind, Frame, Renderer,
         },
         session::{auto::AutoSession, Session, Signal as SessionSignal},
         udev::{UdevBackend, UdevEvent},
@@ -50,7 +50,7 @@ use smithay::{
     },
     utils::{
         signaling::{Linkable, SignalToken, Signaler},
-        Logical, Point, Rectangle,
+        Logical, Point, Rectangle, Transform,
     },
     wayland::{
         output::{Mode, PhysicalProperties},

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -9,7 +9,7 @@ use smithay::{
 };
 use smithay::{
     backend::{
-        renderer::{Renderer, Transform},
+        renderer::Renderer,
         winit::{self, WinitEvent},
         SwapBuffersError,
     },
@@ -17,6 +17,7 @@ use smithay::{
         calloop::EventLoop,
         wayland_server::{protocol::wl_output, Display},
     },
+    utils::Transform,
     wayland::{
         output::{Mode, PhysicalProperties},
         seat::CursorImageStatus,

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -11,7 +11,7 @@ use smithay::{backend::renderer::ImportDma, wayland::dmabuf::init_dmabuf_global}
 use smithay::{
     backend::{
         egl::{EGLContext, EGLDisplay},
-        renderer::{gles2::Gles2Renderer, Bind, ImportEgl, Renderer, Transform, Unbind},
+        renderer::{gles2::Gles2Renderer, Bind, ImportEgl, Renderer, Unbind},
         x11::{WindowBuilder, X11Backend, X11Event, X11Surface},
         SwapBuffersError,
     },
@@ -20,6 +20,7 @@ use smithay::{
         gbm,
         wayland_server::{protocol::wl_output, Display},
     },
+    utils::Transform,
     wayland::{
         output::{Mode, PhysicalProperties},
         seat::CursorImageStatus,

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -839,7 +839,7 @@ impl EGLBufferReader {
     pub fn egl_buffer_dimensions(
         &self,
         buffer: &WlBuffer,
-    ) -> Option<crate::utils::Size<i32, crate::utils::Physical>> {
+    ) -> Option<crate::utils::Size<i32, crate::utils::Buffer>> {
         if !buffer.as_ref().is_alive() {
             debug!(self.logger, "Suplied buffer is no longer alive");
             return None;

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1295,13 +1295,19 @@ impl Frame for Gles2Frame {
                 let rect_constrained_loc = rect
                     .loc
                     .constrain(Rectangle::from_extemities((0f64, 0f64), dest.size.to_point()));
-                let rect_clamped_size = rect.size.clamp((0f64, 0f64), dest.size);
+                let rect_clamped_size = rect.size.clamp(
+                    (0f64, 0f64),
+                    (dest.size.to_point() - rect_constrained_loc).to_size(),
+                );
+
+                let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+                let rect_transformed = self.transformation().transform_rect_in(rect, &dest.size);
 
                 [
-                    (rect_constrained_loc.x / dest.size.w) as f32,
-                    (rect_constrained_loc.y / dest.size.h) as f32,
-                    (rect_clamped_size.w / dest.size.w) as f32,
-                    (rect_clamped_size.h / dest.size.h) as f32,
+                    (rect_transformed.loc.x / dest.size.w) as f32,
+                    (rect_transformed.loc.y / dest.size.h) as f32,
+                    (rect_transformed.size.w / dest.size.w) as f32,
+                    (rect_transformed.size.h / dest.size.h) as f32,
                 ]
             })
             .flatten()

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -13,7 +13,7 @@ use cgmath::{prelude::*, Matrix3, Vector2, Vector3};
 mod shaders;
 mod version;
 
-use super::{Bind, Frame, Renderer, Texture, TextureFilter, Transform, Unbind};
+use super::{Bind, Frame, Renderer, Texture, TextureFilter, Unbind};
 use crate::backend::allocator::{
     dmabuf::{Dmabuf, WeakDmabuf},
     Format,
@@ -23,7 +23,7 @@ use crate::backend::egl::{
     EGLContext, EGLSurface, MakeCurrentError,
 };
 use crate::backend::SwapBuffersError;
-use crate::utils::{Buffer, Physical, Rectangle, Size};
+use crate::utils::{Buffer, Physical, Rectangle, Size, Transform};
 
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
 use super::ImportEgl;
@@ -1250,7 +1250,7 @@ impl Frame for Gles2Frame {
         texture: &Self::TextureId,
         src: Rectangle<i32, Buffer>,
         dest: Rectangle<f64, Physical>,
-        damage: &[Rectangle<i32, Physical>],
+        damage: &[Rectangle<i32, Buffer>],
         transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error> {
@@ -1266,7 +1266,7 @@ impl Frame for Gles2Frame {
             assert_eq!(mat, mat * transform.invert().matrix());
             assert_eq!(transform.matrix(), Matrix3::<f32>::identity());
         }
-        mat = mat * transform.invert().matrix();
+        mat = mat * transform.matrix();
         mat = mat * Matrix3::from_translation(Vector2::new(-0.5, -0.5));
 
         // this matrix should be regular, we can expect invert to succeed
@@ -1290,24 +1290,24 @@ impl Frame for Gles2Frame {
         let damage = damage
             .iter()
             .map(|rect| {
+                let src = src.size.to_f64();
                 let rect = rect.to_f64();
 
                 let rect_constrained_loc = rect
                     .loc
-                    .constrain(Rectangle::from_extemities((0f64, 0f64), dest.size.to_point()));
-                let rect_clamped_size = rect.size.clamp(
-                    (0f64, 0f64),
-                    (dest.size.to_point() - rect_constrained_loc).to_size(),
-                );
+                    .constrain(Rectangle::from_extemities((0f64, 0f64), src.to_point()));
+                let rect_clamped_size = rect
+                    .size
+                    .clamp((0f64, 0f64), (src.to_point() - rect_constrained_loc).to_size());
 
                 let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
-                let rect_transformed = self.transformation().transform_rect_in(rect, &dest.size);
+                let rect_transformed = self.transformation().transform_rect_in(rect, &src);
 
                 [
-                    (rect_transformed.loc.x / dest.size.w) as f32,
-                    (rect_transformed.loc.y / dest.size.h) as f32,
-                    (rect_transformed.size.w / dest.size.w) as f32,
-                    (rect_transformed.size.h / dest.size.h) as f32,
+                    (rect_transformed.loc.x / src.w) as f32,
+                    (rect_transformed.loc.y / src.h) as f32,
+                    (rect_transformed.size.w / src.w) as f32,
+                    (rect_transformed.size.h / src.h) as f32,
                 ]
             })
             .flatten()

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -2,12 +2,12 @@
 //! rendering helpers to add custom elements or different clients to a space.
 
 use crate::{
-    backend::renderer::{utils::SurfaceState, Frame, ImportAll, Renderer, Transform},
+    backend::renderer::{utils::SurfaceState, Frame, ImportAll, Renderer},
     desktop::{
         layer::{layer_map_for_output, LayerSurface},
         window::Window,
     },
-    utils::{Logical, Point, Rectangle},
+    utils::{Logical, Point, Rectangle, Transform},
     wayland::{
         compositor::{
             get_parent, is_sync_subsurface, with_surface_tree_downward, SubsurfaceCachedState,
@@ -372,7 +372,7 @@ impl Space {
                         |wl_surface, states, &loc| {
                             let data = states.data_map.get::<RefCell<SurfaceState>>();
 
-                            if let Some(size) = data.and_then(|d| d.borrow().size()) {
+                            if let Some(size) = data.and_then(|d| d.borrow().surface_size()) {
                                 let surface_rectangle = Rectangle { loc, size };
 
                                 if output_geometry.overlaps(surface_rectangle) {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,7 +10,7 @@ pub mod x11rb;
 pub(crate) mod ids;
 pub mod user_data;
 
-pub use self::geometry::{Buffer, Coordinate, Logical, Physical, Point, Raw, Rectangle, Size};
+pub use self::geometry::{Buffer, Coordinate, Logical, Physical, Point, Raw, Rectangle, Size, Transform};
 
 /// This resource is not managed by Smithay
 #[derive(Debug)]

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -5,7 +5,7 @@ use std::{
 
 use smithay::{
     backend::{
-        renderer::{Frame, Renderer, Transform},
+        renderer::{Frame, Renderer},
         SwapBuffersError,
     },
     reexports::{
@@ -18,7 +18,7 @@ use smithay::{
             Client, Display,
         },
     },
-    utils::Rectangle,
+    utils::{Rectangle, Transform},
     wayland::{
         output::{Mode, PhysicalProperties},
         seat::CursorImageStatus,

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -3,11 +3,11 @@ use std::cell::Cell;
 use smithay::{
     backend::{
         allocator::dmabuf::Dmabuf,
-        renderer::{Frame, ImportDma, ImportShm, Renderer, Texture, TextureFilter, Transform},
+        renderer::{Frame, ImportDma, ImportShm, Renderer, Texture, TextureFilter},
         SwapBuffersError,
     },
     reexports::wayland_server::protocol::wl_buffer,
-    utils::{Buffer, Physical, Rectangle, Size},
+    utils::{Buffer, Physical, Rectangle, Size, Transform},
     wayland::compositor::SurfaceData,
 };
 
@@ -106,7 +106,7 @@ impl Frame for DummyFrame {
         _texture: &Self::TextureId,
         _src: Rectangle<i32, Buffer>,
         _dst: Rectangle<f64, Physical>,
-        _damage: &[Rectangle<i32, Physical>],
+        _damage: &[Rectangle<i32, Buffer>],
         _src_transform: Transform,
         _alpha: f32,
     ) -> Result<(), Self::Error> {


### PR DESCRIPTION
Damage values for rendered textures on transformed outputs are currently off, because we calculate the positions in the cpu before uploading them to the gpu in opengl coordinate space.

The first commit simply applies the transformation beforehand.

The second fixes a slight mistake in the Transform::matrices and then finally applies buffer-transformations correctly instead.
To do that it:
- Moves `Transform` into utils::geometry
- Changes conversion from and into buffer-coordinates to take
  `Transform` arguments.
- `Renderer` take `Buffer`-space instead of `Physical` (so render-space) damage now
- buffer_transform is taken into account everywhere