### PR TITLE
Add support for popup grabs to desktop abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `PointerButtonEvent::button` now returns an `Option<MouseButton>`.
 - `MouseButton` is now non-exhaustive.
 - Remove `Other` and add `Forward` and `Back` variants to `MouseButton`. Use the new `PointerButtonEvent::button_code` in place of `Other`.
+- `GrabStartData` has been renamed to `PointerGrabStartData`
 
 #### Backends
 
@@ -49,6 +50,7 @@
 - Support for `xdg_wm_base` protocol version 3
 - Added the option to initialize the dmabuf global with a client filter
 - `wayland::output::Output` now has user data attached to it and more functions to query its properties
+- Added a `KeyboardGrab` similar to the existing `PointerGrab`
 
 #### Backends
 

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -19,7 +19,7 @@ use smithay::{
             compositor_init, is_sync_subsurface, with_states, with_surface_tree_upward, BufferAssignment,
             SurfaceAttributes, TraversalAction,
         },
-        seat::{AxisFrame, GrabStartData, PointerGrab, PointerInnerHandle, Seat},
+        seat::{AxisFrame, PointerGrab, PointerGrabStartData, PointerInnerHandle, Seat},
         shell::{
             legacy::{wl_shell_init, ShellRequest, ShellState as WlShellState, ShellSurfaceKind},
             wlr_layer::{LayerShellRequest, LayerSurfaceAttributes},
@@ -39,7 +39,7 @@ use crate::{
 };
 
 struct MoveSurfaceGrab {
-    start_data: GrabStartData,
+    start_data: PointerGrabStartData,
     window_map: Rc<RefCell<WindowMap>>,
     toplevel: SurfaceKind,
     initial_window_location: Point<i32, Logical>,
@@ -82,7 +82,7 @@ impl PointerGrab for MoveSurfaceGrab {
         handle.axis(details)
     }
 
-    fn start_data(&self) -> &GrabStartData {
+    fn start_data(&self) -> &PointerGrabStartData {
         &self.start_data
     }
 }
@@ -130,7 +130,7 @@ impl From<ResizeEdge> for xdg_toplevel::ResizeEdge {
 }
 
 struct ResizeSurfaceGrab {
-    start_data: GrabStartData,
+    start_data: PointerGrabStartData,
     toplevel: SurfaceKind,
     edges: ResizeEdge,
     initial_window_size: Size<i32, Logical>,
@@ -280,7 +280,7 @@ impl PointerGrab for ResizeSurfaceGrab {
         handle.axis(details)
     }
 
-    fn start_data(&self) -> &GrabStartData {
+    fn start_data(&self) -> &PointerGrabStartData {
         &self.start_data
     }
 }

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -21,6 +21,8 @@ use std::{
     sync::{Arc, Mutex, Weak},
 };
 
+use super::WindowSurfaceType;
+
 crate::utils::ids::id_gen!(next_layer_id, LAYER_ID, LAYER_IDS);
 
 /// Map of [`LayerSurface`]s on an [`Output`]
@@ -428,6 +430,7 @@ impl LayerSurface {
     pub fn surface_under<P: Into<Point<f64, Logical>>>(
         &self,
         point: P,
+        surface_type: WindowSurfaceType,
     ) -> Option<(WlSurface, Point<i32, Logical>)> {
         let point = point.into();
         if let Some(surface) = self.get_surface() {
@@ -438,13 +441,13 @@ impl LayerSurface {
             {
                 if let Some(result) = popup
                     .get_surface()
-                    .and_then(|surface| under_from_surface_tree(surface, point, location))
+                    .and_then(|surface| under_from_surface_tree(surface, point, location, surface_type))
                 {
                     return Some(result);
                 }
             }
 
-            under_from_surface_tree(surface, point, (0, 0))
+            under_from_surface_tree(surface, point, (0, 0), surface_type)
         } else {
             None
         }

--- a/src/desktop/popup/grab.rs
+++ b/src/desktop/popup/grab.rs
@@ -1,0 +1,501 @@
+use std::sync::{Arc, Mutex};
+
+use wayland_server::protocol::{wl_keyboard::KeyState, wl_pointer::ButtonState, wl_surface::WlSurface};
+
+use crate::{
+    utils::{DeadResource, Logical, Point},
+    wayland::{
+        compositor::get_role,
+        seat::{
+            AxisFrame, KeyboardGrab, KeyboardGrabStartData, KeyboardHandle, KeyboardInnerHandle, PointerGrab,
+            PointerGrabStartData, PointerInnerHandle,
+        },
+        shell::xdg::XDG_POPUP_ROLE,
+        Serial,
+    },
+};
+
+use thiserror::Error;
+
+use super::{PopupKind, PopupManager};
+
+/// Defines the possible errors that
+/// can be returned from [`PopupManager::grab_popup`]
+#[derive(Debug, Error)]
+pub enum PopupGrabError {
+    /// This resource has been destroyed and can no longer be used.
+    #[error(transparent)]
+    DeadResource(#[from] DeadResource),
+    /// The client tried to grab a popup after it's parent has been dismissed
+    #[error("the parent of the popup has been already dismissed")]
+    ParentDismissed,
+    /// The client tried to grab a popup after it has been mapped
+    #[error("tried to grab after being mapped")]
+    InvalidGrab,
+    /// The client tried to grab a popup which is not the topmost
+    #[error("popup was not created on the topmost popup")]
+    NotTheTopmostPopup,
+}
+
+/// Defines the possibly strategies
+/// for the [`PopupGrab::ungrab`] operation
+#[derive(Debug, Copy, Clone)]
+pub enum PopupUngrabStrategy {
+    /// Only ungrab the topmost popup
+    Topmost,
+    /// Ungrab all active popups
+    All,
+}
+
+#[derive(Debug, Default)]
+struct PopupGrabInternal {
+    serial: Option<Serial>,
+    active_grabs: Vec<(WlSurface, PopupKind)>,
+    dismissed_grabs: Vec<(WlSurface, PopupKind)>,
+}
+
+impl PopupGrabInternal {
+    fn alive(&self) -> bool {
+        !self.active_grabs.is_empty() || !self.dismissed_grabs.is_empty()
+    }
+
+    fn current_grab(&self) -> Option<&WlSurface> {
+        self.active_grabs
+            .iter()
+            .rev()
+            .find(|(_, p)| p.alive())
+            .map(|(s, _)| s)
+    }
+
+    fn is_dismissed(&self, surface: &WlSurface) -> bool {
+        self.dismissed_grabs.iter().any(|(s, _)| s == surface)
+    }
+
+    fn append_grab(&mut self, popup: &PopupKind) -> Result<(), DeadResource> {
+        let surface = popup.get_surface().ok_or(DeadResource)?;
+        self.active_grabs.push((surface.clone(), popup.clone()));
+        Ok(())
+    }
+
+    fn cleanup(&mut self) {
+        let mut i = 0;
+        while i < self.active_grabs.len() {
+            if !self.active_grabs[i].1.alive() {
+                let grab = self.active_grabs.remove(i);
+                self.dismissed_grabs.push(grab);
+            } else {
+                i += 1;
+            }
+        }
+
+        self.dismissed_grabs.retain(|(s, _)| s.as_ref().is_alive());
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct PopupGrabInner {
+    internal: Arc<Mutex<PopupGrabInternal>>,
+}
+
+impl PopupGrabInner {
+    pub(super) fn alive(&self) -> bool {
+        let guard = self.internal.lock().unwrap();
+        guard.alive()
+    }
+
+    fn current_grab(&self) -> Option<WlSurface> {
+        let guard = self.internal.lock().unwrap();
+        guard
+            .active_grabs
+            .iter()
+            .rev()
+            .find(|(_, p)| p.alive())
+            .map(|(s, _)| s)
+            .cloned()
+    }
+
+    pub(super) fn cleanup(&self) {
+        let mut guard = self.internal.lock().unwrap();
+        guard.cleanup();
+    }
+
+    pub(super) fn grab(&self, popup: &PopupKind, serial: Serial) -> Result<Option<Serial>, PopupGrabError> {
+        let parent = popup.parent().ok_or(DeadResource)?;
+        let parent_role = get_role(&parent);
+
+        self.cleanup();
+
+        let mut guard = self.internal.lock().unwrap();
+
+        match guard.current_grab() {
+            Some(grab) => {
+                if grab != &parent {
+                    // If the parent is a grabbing popup which has already been dismissed, this popup will be immediately dismissed.
+                    if guard.is_dismissed(&parent) {
+                        return Err(PopupGrabError::ParentDismissed);
+                    }
+
+                    // If the parent is a popup that did not take an explicit grab, an error will be raised.
+                    return Err(PopupGrabError::NotTheTopmostPopup);
+                }
+            }
+            None => {
+                if parent_role == Some(XDG_POPUP_ROLE) {
+                    return Err(PopupGrabError::NotTheTopmostPopup);
+                }
+            }
+        }
+
+        guard.append_grab(popup)?;
+
+        Ok(guard.serial.replace(serial))
+    }
+
+    fn ungrab(&self, root: &WlSurface, strategy: PopupUngrabStrategy) -> Option<WlSurface> {
+        let mut guard = self.internal.lock().unwrap();
+        let dismissed = match strategy {
+            PopupUngrabStrategy::Topmost => {
+                if let Some(grab) = guard.active_grabs.pop() {
+                    let dismissed = PopupManager::dismiss_popup(root, &grab.1);
+
+                    if dismissed.is_ok() {
+                        guard.dismissed_grabs.push(grab);
+                    }
+
+                    dismissed
+                } else {
+                    Ok(())
+                }
+            }
+            PopupUngrabStrategy::All => {
+                let grabs = guard.active_grabs.drain(..).collect::<Vec<_>>();
+
+                if let Some(grab) = grabs.first() {
+                    let dismissed = PopupManager::dismiss_popup(root, &grab.1);
+
+                    if dismissed.is_ok() {
+                        guard.dismissed_grabs.push(grab.clone());
+                        guard.dismissed_grabs.extend(grabs);
+                    }
+
+                    dismissed
+                } else {
+                    Ok(())
+                }
+            }
+        };
+
+        if dismissed.is_err() {
+            // If dismiss_popup returns Err(DeadResource) there is not much what
+            // can do about it here, we just remove all our grabs as they are dead now
+            // anyway. The pointer/keyboard grab will be unset automatically so we
+            // should be fine.
+            guard.active_grabs.drain(..);
+        }
+
+        guard.current_grab().cloned()
+    }
+}
+
+/// Represents the explicit grab a client requested for a popup
+///
+/// An explicit grab can be used by a client to redirect all keyboard
+/// input to a single popup. The focus of the keyboard will stay on
+/// the popup for as long as the grab is valid, that is as long as the
+/// compositor did not call [`ungrab`](PopupGrab::ungrab) or the client
+/// did not destroy the popup. A grab can be nested by requesting a grab
+/// on a popup who's parent is the currently grabbed popup. The grab will
+/// be returned to the parent after the popup has been dismissed.
+///
+/// This module also provides default implementations for [`KeyboardGrab`] and
+/// [`PointerGrab`] that implement the behavior described in the [`xdg-shell`](https://wayland.app/protocols/xdg-shell#xdg_popup:request:grab)
+/// specification. See [`PopupKeyboardGrab`] and [`PopupPointerGrab`] for more
+/// information on the default implementations.
+///
+/// In case the implemented behavior is not suited for your use-case the grab can be
+/// either decorated or a custom [`KeyboardGrab`]/[`PointerGrab`] can use the methods
+/// on the [`PopupGrab`] to implement a custom behavior.
+///
+/// One example would be to use a timer to automatically dismiss the popup after some
+/// timeout.
+///
+/// The grab is obtained by calling [`PopupManager::grap_popup`](super::PopupManager::grab_popup).
+#[derive(Debug, Clone)]
+pub struct PopupGrab {
+    root: WlSurface,
+    serial: Serial,
+    previous_serial: Option<Serial>,
+    toplevel_grab: PopupGrabInner,
+    keyboard_handle: Option<KeyboardHandle>,
+    keyboard_grab_start_data: KeyboardGrabStartData,
+    pointer_grab_start_data: PointerGrabStartData,
+}
+
+impl PopupGrab {
+    pub(super) fn new(
+        toplevel_popups: PopupGrabInner,
+        root: WlSurface,
+        serial: Serial,
+        previous_serial: Option<Serial>,
+        keyboard_handle: Option<KeyboardHandle>,
+    ) -> Self {
+        PopupGrab {
+            root: root.clone(),
+            serial,
+            previous_serial,
+            toplevel_grab: toplevel_popups,
+            keyboard_handle,
+            keyboard_grab_start_data: KeyboardGrabStartData {
+                // We set the focus to root as this will make
+                // sure the grab will stay alive until the
+                // toplevel is destroyed or the grab is unset
+                focus: Some(root.clone()),
+            },
+            pointer_grab_start_data: PointerGrabStartData {
+                button: 0,
+                // We set the focus to root as this will make
+                // sure the grab will stay alive until the
+                // toplevel is destroyed or the grab is unset
+                focus: Some((root, (0, 0).into())),
+                location: (0f64, 0f64).into(),
+            },
+        }
+    }
+
+    /// Returns the serial that was used to grab the popup
+    pub fn serial(&self) -> Serial {
+        self.serial
+    }
+
+    /// Returns the previous serial that was used to grab
+    /// the parent popup in case of nested grabs
+    pub fn previous_serial(&self) -> Option<Serial> {
+        self.previous_serial
+    }
+
+    /// Check if this grab has ended
+    ///
+    /// A grab has ended if either all popups
+    /// associated with the grab have been dismissed
+    /// by the server with [`PopupGrab::ungrab`] or by the client
+    /// by destroying the popup.
+    ///
+    /// This will also return [`false`] if the root
+    /// of the grab has been destroyed.
+    pub fn has_ended(&self) -> bool {
+        !self.root.as_ref().is_alive() || !self.toplevel_grab.alive()
+    }
+
+    /// Returns the current grabbed [`WlSurface`].
+    ///
+    /// If the grab has ended this will return the root surface
+    /// so that the client expected focus can be restored
+    pub fn current_grab(&self) -> Option<WlSurface> {
+        self.toplevel_grab
+            .current_grab()
+            .or_else(|| Some(self.root.clone()))
+    }
+
+    /// Ungrab and dismiss a popup
+    ///
+    /// This will dismiss either the topmost or all popups
+    /// according to the specified [`PopupUngrabStrategy`]
+    ///
+    /// Returns the new topmost popup in case of nested popups
+    /// or if the grab has ended the root surface
+    pub fn ungrab(&mut self, strategy: PopupUngrabStrategy) -> Option<WlSurface> {
+        self.toplevel_grab
+            .ungrab(&self.root, strategy)
+            .or_else(|| Some(self.root.clone()))
+    }
+
+    /// Convenience method for getting a [`KeyboardGrabStartData`] for this grab.
+    ///
+    /// The focus of the [`KeyboardGrabStartData`] will always be the root
+    /// of the popup grab, e.g. the surface of the toplevel, to make sure
+    /// the grab is not automatically unset.
+    pub fn keyboard_grab_start_data(&self) -> &KeyboardGrabStartData {
+        &self.keyboard_grab_start_data
+    }
+
+    /// Convenience method for getting a [`PointerGrabStartData`] for this grab.
+    ///
+    /// The focus of the [`PointerGrabStartData`] will always be the root
+    /// of the popup grab, e.g. the surface of the toplevel, to make sure
+    /// the grab is not automatically unset.
+    pub fn pointer_grab_start_data(&self) -> &PointerGrabStartData {
+        &self.pointer_grab_start_data
+    }
+
+    fn unset_keyboard_grab(&self, serial: Serial) {
+        if let Some(keyboard) = self.keyboard_handle.as_ref() {
+            if keyboard.is_grabbed()
+                && (keyboard.has_grab(self.serial)
+                    || keyboard.has_grab(self.previous_serial.unwrap_or(self.serial)))
+            {
+                keyboard.unset_grab();
+                keyboard.set_focus(Some(&self.root), serial);
+            }
+        }
+    }
+}
+
+/// Default implementation of a [`KeyboardGrab`] for [`PopupGrab`]
+///
+/// The [`PopupKeyboardGrab`] will keep the focus of the keyboard
+/// on the topmost popup until the grab has ended. If the
+/// grab has ended it will restore the focus on the root of the grab
+/// and unset the [`KeyboardGrab`]
+#[derive(Debug)]
+pub struct PopupKeyboardGrab {
+    popup_grab: PopupGrab,
+}
+
+impl PopupKeyboardGrab {
+    /// Create a [`PopupKeyboardGrab`] for the provided [`PopupGrab`]
+    pub fn new(popup_grab: &PopupGrab) -> Self {
+        PopupKeyboardGrab {
+            popup_grab: popup_grab.clone(),
+        }
+    }
+}
+
+impl KeyboardGrab for PopupKeyboardGrab {
+    fn input(
+        &mut self,
+        handle: &mut KeyboardInnerHandle<'_>,
+        keycode: u32,
+        key_state: KeyState,
+        modifiers: Option<(u32, u32, u32, u32)>,
+        serial: Serial,
+        time: u32,
+    ) {
+        // Check if the grab changed and update the focus
+        // If the grab has ended this will return the root
+        // surface to restore the client expected focus.
+        if let Some(surface) = self.popup_grab.current_grab() {
+            handle.set_focus(Some(&surface), serial);
+        }
+
+        if self.popup_grab.has_ended() {
+            handle.unset_grab(serial, false);
+        }
+
+        handle.input(keycode, key_state, modifiers, serial, time)
+    }
+
+    fn set_focus(&mut self, handle: &mut KeyboardInnerHandle<'_>, focus: Option<&WlSurface>, serial: Serial) {
+        // Ignore focus changes unless the grab has ended
+        if self.popup_grab.has_ended() {
+            handle.set_focus(focus, serial);
+            handle.unset_grab(serial, false);
+            return;
+        }
+
+        // Allow to set the focus to the current grab, this can
+        // happen if the user initially sets the focus to
+        // popup instead of relying on the grab behavior
+        if self.popup_grab.current_grab().as_ref() == focus {
+            handle.set_focus(focus, serial);
+        }
+    }
+
+    fn start_data(&self) -> &KeyboardGrabStartData {
+        self.popup_grab.keyboard_grab_start_data()
+    }
+}
+
+/// Default implementation of a [`PointerGrab`] for [`PopupGrab`]
+///
+/// The [`PopupPointerGrab`] will make sure that the pointer focus
+/// stays on the same client as the grabbed popup (similar to an
+/// "owner-events" grab in X11 parlance). If an input event happens
+/// outside of the grabbed [`WlSurface`] the popup will be dismissed
+/// and the grab ends. In case of a nested grab all parent grabs will
+/// also be dismissed.
+///
+/// If the grab has ended the pointer focus is restored and the
+/// [`PointerGrab`] is unset. Additional it will unset an active
+/// [`KeyboardGrab`] that matches the [`Serial`] of this grab and
+/// restore the keyboard focus like described in [`PopupKeyboardGrab`]
+#[derive(Debug)]
+pub struct PopupPointerGrab {
+    popup_grab: PopupGrab,
+}
+
+impl PopupPointerGrab {
+    /// Create a [`PopupPointerGrab`] for the provided [`PopupGrab`]
+    pub fn new(popup_grab: &PopupGrab) -> Self {
+        PopupPointerGrab {
+            popup_grab: popup_grab.clone(),
+        }
+    }
+}
+
+impl PointerGrab for PopupPointerGrab {
+    fn motion(
+        &mut self,
+        handle: &mut PointerInnerHandle<'_>,
+        location: Point<f64, Logical>,
+        focus: Option<(WlSurface, Point<i32, Logical>)>,
+        serial: Serial,
+        time: u32,
+    ) {
+        if self.popup_grab.has_ended() {
+            handle.unset_grab(serial, time);
+            self.popup_grab.unset_keyboard_grab(serial);
+            return;
+        }
+
+        // Check that the focus is of the same client as the grab
+        // If yes allow it, if not unset the focus.
+        let same_client = focus.as_ref().map(|(surface, _)| surface.as_ref().client())
+            == self
+                .popup_grab
+                .current_grab()
+                .map(|surface| surface.as_ref().client());
+
+        if same_client {
+            handle.motion(location, focus, serial, time);
+        } else {
+            handle.motion(location, None, serial, time);
+        }
+    }
+
+    fn button(
+        &mut self,
+        handle: &mut PointerInnerHandle<'_>,
+        button: u32,
+        state: ButtonState,
+        serial: Serial,
+        time: u32,
+    ) {
+        if self.popup_grab.has_ended() {
+            handle.unset_grab(serial, time);
+            handle.button(button, state, serial, time);
+            self.popup_grab.unset_keyboard_grab(serial);
+            return;
+        }
+
+        // Check if the the focused surface is still on the current grabbed surface,
+        // if not the popup will be dismissed
+        if state == ButtonState::Pressed
+            && handle.current_focus().map(|(surface, _)| surface) != self.popup_grab.current_grab().as_ref()
+        {
+            let _ = self.popup_grab.ungrab(PopupUngrabStrategy::All);
+            handle.unset_grab(serial, time);
+            handle.button(button, state, serial, time);
+            self.popup_grab.unset_keyboard_grab(serial);
+        }
+
+        handle.button(button, state, serial, time);
+    }
+
+    fn axis(&mut self, handle: &mut PointerInnerHandle<'_>, details: AxisFrame) {
+        handle.axis(details);
+    }
+
+    fn start_data(&self) -> &PointerGrabStartData {
+        self.popup_grab.pointer_grab_start_data()
+    }
+}

--- a/src/desktop/popup/mod.rs
+++ b/src/desktop/popup/mod.rs
@@ -1,0 +1,96 @@
+mod grab;
+mod manager;
+
+use std::sync::Mutex;
+
+pub use grab::*;
+pub use manager::*;
+use wayland_server::protocol::wl_surface::WlSurface;
+
+use crate::{
+    utils::{Logical, Point, Rectangle},
+    wayland::{
+        compositor::with_states,
+        shell::xdg::{PopupSurface, SurfaceCachedState, XdgPopupSurfaceRoleAttributes},
+    },
+};
+
+/// Represents a popup surface
+#[derive(Debug, Clone)]
+pub enum PopupKind {
+    /// xdg-shell [`PopupSurface`]
+    Xdg(PopupSurface),
+}
+
+impl PopupKind {
+    fn alive(&self) -> bool {
+        match *self {
+            PopupKind::Xdg(ref t) => t.alive(),
+        }
+    }
+
+    /// Retrieves the underlying [`WlSurface`]
+    pub fn get_surface(&self) -> Option<&WlSurface> {
+        match *self {
+            PopupKind::Xdg(ref t) => t.get_surface(),
+        }
+    }
+
+    fn parent(&self) -> Option<WlSurface> {
+        match *self {
+            PopupKind::Xdg(ref t) => t.get_parent_surface(),
+        }
+    }
+
+    /// Returns the surface geometry as set by the client using `xdg_surface::set_window_geometry`
+    pub fn geometry(&self) -> Rectangle<i32, Logical> {
+        let wl_surface = match self.get_surface() {
+            Some(s) => s,
+            None => return Rectangle::from_loc_and_size((0, 0), (0, 0)),
+        };
+
+        with_states(wl_surface, |states| {
+            states
+                .cached_state
+                .current::<SurfaceCachedState>()
+                .geometry
+                .unwrap_or_default()
+        })
+        .unwrap()
+    }
+
+    fn send_done(&self) {
+        if !self.alive() {
+            return;
+        }
+
+        match *self {
+            PopupKind::Xdg(ref t) => t.send_popup_done(),
+        }
+    }
+
+    fn location(&self) -> Point<i32, Logical> {
+        let wl_surface = match self.get_surface() {
+            Some(s) => s,
+            None => return (0, 0).into(),
+        };
+        with_states(wl_surface, |states| {
+            states
+                .data_map
+                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .current
+                .geometry
+        })
+        .unwrap_or_default()
+        .loc
+    }
+}
+
+impl From<PopupSurface> for PopupKind {
+    fn from(p: PopupSurface) -> PopupKind {
+        PopupKind::Xdg(p)
+    }
+}

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -8,7 +8,7 @@ use wayland_server::{
 use crate::{
     utils::{Logical, Point},
     wayland::{
-        seat::{AxisFrame, GrabStartData, PointerGrab, PointerInnerHandle, Seat},
+        seat::{AxisFrame, PointerGrab, PointerGrabStartData, PointerInnerHandle, Seat},
         Serial,
     },
 };
@@ -16,7 +16,7 @@ use crate::{
 use super::{with_source_metadata, DataDeviceData, SeatData};
 
 pub(crate) struct DnDGrab {
-    start_data: GrabStartData,
+    start_data: PointerGrabStartData,
     data_source: Option<wl_data_source::WlDataSource>,
     current_focus: Option<wl_surface::WlSurface>,
     pending_offers: Vec<wl_data_offer::WlDataOffer>,
@@ -29,7 +29,7 @@ pub(crate) struct DnDGrab {
 
 impl DnDGrab {
     pub(crate) fn new(
-        start_data: GrabStartData,
+        start_data: PointerGrabStartData,
         source: Option<wl_data_source::WlDataSource>,
         origin: wl_surface::WlSurface,
         seat: Seat,
@@ -222,7 +222,7 @@ impl PointerGrab for DnDGrab {
         handle.axis(details);
     }
 
-    fn start_data(&self) -> &GrabStartData {
+    fn start_data(&self) -> &PointerGrabStartData {
         &self.start_data
     }
 }

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -60,7 +60,7 @@ use slog::{debug, error, o};
 
 use crate::wayland::{
     compositor,
-    seat::{GrabStartData, Seat},
+    seat::{PointerGrabStartData, Seat},
     Serial,
 };
 
@@ -335,7 +335,7 @@ pub fn set_data_device_selection(seat: &Seat, mime_types: Vec<String>) {
 pub fn start_dnd<C>(
     seat: &Seat,
     serial: Serial,
-    start_data: GrabStartData,
+    start_data: PointerGrabStartData,
     metadata: SourceMetadata,
     callback: C,
 ) where

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -8,7 +8,7 @@ use wayland_server::{
 use crate::{
     utils::{Logical, Point},
     wayland::{
-        seat::{AxisFrame, GrabStartData, PointerGrab, PointerInnerHandle, Seat},
+        seat::{AxisFrame, PointerGrab, PointerGrabStartData, PointerInnerHandle, Seat},
         Serial,
     },
 };
@@ -42,7 +42,7 @@ pub enum ServerDndEvent {
 }
 
 pub(crate) struct ServerDnDGrab<C: 'static> {
-    start_data: GrabStartData,
+    start_data: PointerGrabStartData,
     metadata: super::SourceMetadata,
     current_focus: Option<wl_surface::WlSurface>,
     pending_offers: Vec<wl_data_offer::WlDataOffer>,
@@ -53,7 +53,7 @@ pub(crate) struct ServerDnDGrab<C: 'static> {
 
 impl<C: 'static> ServerDnDGrab<C> {
     pub(crate) fn new(
-        start_data: GrabStartData,
+        start_data: PointerGrabStartData,
         metadata: super::SourceMetadata,
         seat: Seat,
         callback: Rc<RefCell<C>>,
@@ -222,7 +222,7 @@ where
         handle.axis(details);
     }
 
-    fn start_data(&self) -> &GrabStartData {
+    fn start_data(&self) -> &PointerGrabStartData {
         &self.start_data
     }
 }

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -41,12 +41,12 @@ mod pointer;
 
 pub use self::{
     keyboard::{
-        keysyms, Error as KeyboardError, FilterResult, KeyboardHandle, Keysym, KeysymHandle, ModifiersState,
-        XkbConfig,
+        keysyms, Error as KeyboardError, FilterResult, GrabStartData as KeyboardGrabStartData, KeyboardGrab,
+        KeyboardHandle, KeyboardInnerHandle, Keysym, KeysymHandle, ModifiersState, XkbConfig,
     },
     pointer::{
-        AxisFrame, CursorImageAttributes, CursorImageStatus, GrabStartData, PointerGrab, PointerHandle,
-        PointerInnerHandle,
+        AxisFrame, CursorImageAttributes, CursorImageStatus, GrabStartData as PointerGrabStartData,
+        PointerGrab, PointerHandle, PointerInnerHandle,
     },
 };
 

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -677,16 +677,18 @@ impl PointerGrab for DefaultGrab {
         time: u32,
     ) {
         handle.button(button, state, serial, time);
-        handle.set_grab(
-            serial,
-            ClickGrab {
-                start_data: GrabStartData {
-                    focus: handle.current_focus().cloned(),
-                    button,
-                    location: handle.current_location(),
+        if state == ButtonState::Pressed {
+            handle.set_grab(
+                serial,
+                ClickGrab {
+                    start_data: GrabStartData {
+                        focus: handle.current_focus().cloned(),
+                        button,
+                        location: handle.current_location(),
+                    },
                 },
-            },
-        );
+            );
+        }
     }
     fn axis(&mut self, handle: &mut PointerInnerHandle<'_>, details: AxisFrame) {
         handle.axis(details);

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -383,6 +383,14 @@ xdg_role!(
         /// It is a protocol error to call commit on a wl_surface with
         /// the xdg_popup role when no parent is set.
         pub parent: Option<wl_surface::WlSurface>,
+
+        /// Defines if the surface has received at least one commit
+        ///
+        /// This can be used to check for protocol errors, like
+        /// checking if a popup requested a grab after it has been
+        /// mapped.
+        pub committed: bool,
+
         popup_handle: Option<xdg_popup::XdgPopup>
     }
 );
@@ -1399,6 +1407,7 @@ impl PopupSurface {
                 .unwrap()
                 .lock()
                 .unwrap();
+            attributes.committed = true;
             if attributes.initial_configure_sent {
                 if let Some(state) = attributes.last_acked {
                     if state != attributes.current {


### PR DESCRIPTION
The PR adds support for popup grabs to the desktop abstraction.

A popup grab is only allowed before the initial commit, to check for that protocol error the field `committed` 
has been added to the `XdgPopupSurfaceRoleAttributes`.

To support exclusive keyboard focus a `KeyboardGrab` similiar to the existing `PointerGrab` has been added.

During testing i found an issue with the current popup handling that prevents menu popups from working correctly.
If a popup has no grab it should not receive the keyboard focus, for that a `WindowSurfaceType` has been added
that can be used to filter the surfaces in `surfaces_under`.