### PR TITLE
disable clippy non-send-fields-in-send-ty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,12 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features "test_all_features" -- -D warnings
+          args: --features "test_all_features" -- -D warnings -A clippy::non-send-fields-in-send-ty
       - name: Clippy Anvil
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --manifest-path "./anvil/Cargo.toml" --features "test_all_features" -- -D warnings
+          args: --manifest-path "./anvil/Cargo.toml" --features "test_all_features" -- -D warnings -A clippy::non-send-fields-in-send-ty
   
   check-minimal:
     env:


### PR DESCRIPTION
This PR disables the new [non_send_fields_in_send_ty](https://rust-lang.github.io/rust-clippy/master/index.html#non_send_fields_in_send_ty) clippy warning for now.

As written in [rust-clippy/issues/8045#issuecomment-1013301645](https://github.com/rust-lang/rust-clippy/issues/8045#issuecomment-1013301645) this lint will be moved back to nursery in 1.58.1. 
Apparently this was done for `Nightly` and `Beta`, but not for `Stable`. see:  [rust-clippy/issues/8045#issuecomment-1010392770](https://github.com/rust-lang/rust-clippy/issues/8045#issuecomment-1010392770)