### PR TITLE
fix setting the parent of a ToplevelSurface

### DIFF
--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1169,15 +1169,14 @@ impl ToplevelSurface {
     /// The parent must be another toplevel equivalent surface.
     ///
     /// If the parent is `None`, the parent-child relationship is removed.
-    pub fn set_parent(&self, parent: Option<wl_surface::WlSurface>) -> bool {
+    pub fn set_parent(&self, parent: Option<&wl_surface::WlSurface>) -> bool {
         if let Some(parent) = parent {
-            if !is_toplevel_equivalent(&parent) {
+            if !is_toplevel_equivalent(parent) {
                 return false;
             }
         }
 
-        // Unset the parent
-        xdg_handlers::set_parent(&self.shell_surface, None);
+        xdg_handlers::set_parent(&self.shell_surface, parent.cloned());
 
         true
     }

--- a/src/wayland/xdg_foreign/mod.rs
+++ b/src/wayland/xdg_foreign/mod.rs
@@ -447,7 +447,7 @@ fn imported_implementation(
                 .map(|export| export.surface.clone())
                 .unwrap();
 
-            toplevel_surface.set_parent(Some(imported_parent));
+            toplevel_surface.set_parent(Some(&imported_parent));
         }
 
         _ => unreachable!(),


### PR DESCRIPTION
`set_parent` of `ToplevelSurface` always removed the current parent, this PR fixes that.