### PR TITLE
gles: Don't apply output transformations to buffer damage

### DIFF
--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1301,13 +1301,11 @@ impl Frame for Gles2Frame {
                     .clamp((0f64, 0f64), (src.to_point() - rect_constrained_loc).to_size());
 
                 let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
-                let rect_transformed = self.transformation().transform_rect_in(rect, &src);
-
                 [
-                    (rect_transformed.loc.x / src.w) as f32,
-                    (rect_transformed.loc.y / src.h) as f32,
-                    (rect_transformed.size.w / src.w) as f32,
-                    (rect_transformed.size.h / src.h) as f32,
+                    (rect.loc.x / src.w) as f32,
+                    (rect.loc.y / src.h) as f32,
+                    (rect.size.w / src.w) as f32,
+                    (rect.size.h / src.h) as f32,
                 ]
             })
             .flatten()


### PR DESCRIPTION
Ok, this PR is awkward right after #466.

The first commit added a transformation, that I am removing now, because the second fixed the underlying issue, causing the previous commit to cause the bug it fixed previously...

To sum it up, because damage is now buffer based instead of surface based, we don't need to translate the damage in the renderer anymore, the shader does this for us. As a result the winit-backend (which needs a Transform of Flipped180) is broken again, while I didn't notice this, when testing the buffer-transfomations on the x11-backend...

Now both are applied fine (output and buffer transforms).