### PR TITLE
Add layer definition to RenderElement

### DIFF
--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -269,6 +269,11 @@ impl LayerMap {
     pub fn cleanup(&mut self) {
         self.layers.retain(|layer| layer.alive())
     }
+
+    /// Returns layers count
+    pub fn len(&self) -> usize {
+        self.layers.len()
+    }
 }
 
 #[derive(Debug, Default)]

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -271,6 +271,7 @@ impl LayerMap {
     }
 
     /// Returns layers count
+    #[allow(clippy::len_without_is_empty)] //we don't need is_empty on that struct for now, mark as allow
     pub fn len(&self) -> usize {
         self.layers.len()
     }

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -35,6 +35,7 @@ pub type DynamicRenderElements<R> =
 pub(super) type SpaceElem<R> =
     dyn SpaceElement<R, <R as Renderer>::Frame, <R as Renderer>::Error, <R as Renderer>::TextureId>;
 
+/// Helper struct for iterating over diffrent layers of `DynamicRenderElements`
 pub(super) struct DynamicRenderElementMap<'a, R: Renderer>(pub(super) &'a [DynamicRenderElements<R>]);
 
 impl<'a, R> DynamicRenderElementMap<'a, R>
@@ -44,30 +45,37 @@ where
     R::Error: 'static,
     R::Frame: 'static,
 {
+    /// Iterate over `DynamicRenderElements` with layer `RenderLayer::Bottom`
     pub fn iter_bottom(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
         self.iter_layer(RenderLayer::Bottom)
     }
 
+    /// Iterate over `DynamicRenderElements with layer `RenderLayer::AboveBackground`
     pub fn iter_above_background(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
         self.iter_layer(RenderLayer::AboveBackground)
     }
 
+    /// Iterate over `DynamicRenderElements` with layer `RenderLayer::BeforeWindows`
     pub fn iter_before_windows(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
         self.iter_layer(RenderLayer::BeforeWindows)
     }
 
+    /// Iterate over `DynamicRenderElements` with layer `RenderLayer::AfterWindows`
     pub fn iter_after_windows(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
         self.iter_layer(RenderLayer::AfterWindows)
     }
 
+    /// Iterate over `DynamicRenderElements` with layer `RenderLayer::BeforeOverlay`
     pub fn iter_before_overlay(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
         self.iter_layer(RenderLayer::BeforeOverlay)
     }
 
+    /// Iterate over `DynamicRenderElements` with layer `RenderLayer::Top`
     pub fn iter_top(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
         self.iter_layer(RenderLayer::Top)
     }
 
+    /// Iterate over `DynamicRenderElements` with provided `layer`
     pub fn iter_layer(&'a self, layer: RenderLayer) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
         Box::new(
             self.0

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -12,6 +12,7 @@ use wayland_server::protocol::wl_surface::WlSurface;
 
 /// Enum for indicating on with layer a render element schould be draw
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RenderLayer {
     /// Bellow every other elements
     Bottom,
@@ -25,6 +26,56 @@ pub enum RenderLayer {
     BeforeOverlay,
     /// Above anything else
     Top,
+}
+
+/// Elements rendered by [`Space::render_output`] in addition to windows, layers and popups.
+pub type DynamicRenderElements<R> =
+    Box<dyn RenderElement<R, <R as Renderer>::Frame, <R as Renderer>::Error, <R as Renderer>::TextureId>>;
+
+pub(super) type SpaceElem<R> =
+    dyn SpaceElement<R, <R as Renderer>::Frame, <R as Renderer>::Error, <R as Renderer>::TextureId>;
+
+pub(super) struct DynamicRenderElementMap<'a, R: Renderer>(pub(super) &'a [DynamicRenderElements<R>]);
+
+impl<'a, R> DynamicRenderElementMap<'a, R>
+where
+    R: Renderer + ImportAll + 'static,
+    R::TextureId: 'static,
+    R::Error: 'static,
+    R::Frame: 'static,
+{
+    pub fn iter_bottom(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
+        self.iter_layer(RenderLayer::Bottom)
+    }
+
+    pub fn iter_above_background(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
+        self.iter_layer(RenderLayer::AboveBackground)
+    }
+
+    pub fn iter_before_windows(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
+        self.iter_layer(RenderLayer::BeforeWindows)
+    }
+
+    pub fn iter_after_windows(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
+        self.iter_layer(RenderLayer::AfterWindows)
+    }
+
+    pub fn iter_before_overlay(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
+        self.iter_layer(RenderLayer::BeforeOverlay)
+    }
+
+    pub fn iter_top(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
+        self.iter_layer(RenderLayer::Top)
+    }
+
+    pub fn iter_layer(&'a self, layer: RenderLayer) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
+        Box::new(
+            self.0
+                .iter()
+                .filter(move |c| c.layer() == layer)
+                .map(|c| c as &SpaceElem<R>),
+        )
+    }
 }
 
 /// Trait for custom elements to be rendered during [`Space::render_output`].

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -20,14 +20,14 @@ pub enum RenderZindex {
     Bottom = 20,
     /// Default zindex for Windows
     Shell = 30,
-    /// Default zindex for Windows PopUps
-    PopUpsShell = 40,
     /// WlrLayer::Top default zindex
-    Top = 50,
+    Top = 40,
+    /// Default zindex for Windows PopUps
+    Popups = 50,
     /// Default Layer for RenderElements
-    Overlay = 80,
+    Overlay = 60,
     /// Default Layer for Overlay PopUp
-    PopUpsOverlay = 100,
+    PopupsOverlay = 70,
 }
 
 /// Elements rendered by [`Space::render_output`] in addition to windows, layers and popups.

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -10,6 +10,23 @@ use std::{
 };
 use wayland_server::protocol::wl_surface::WlSurface;
 
+/// Enum for indicating on with layer a render element schould be draw
+#[derive(Debug, PartialEq, Eq)]
+pub enum RenderLayer {
+    /// Bellow every other elements
+    Bottom,
+    /// Above WlrLayer::Background but bellow WlrLayer::Bottom
+    AboveBackground,
+    /// Right before programs windows are draw
+    BeforeWindows,
+    /// Right after programs windows are draw
+    AfterWindows,
+    /// Above WlrLayer::Top but bellow WlrLayer::Overlay
+    BeforeOverlay,
+    /// Above anything else
+    Top,
+}
+
 /// Trait for custom elements to be rendered during [`Space::render_output`].
 pub trait RenderElement<R, F, E, T>
 where
@@ -55,6 +72,11 @@ where
         damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,
     ) -> Result<(), R::Error>;
+
+    /// Returns they layer the elements schould be draw on, defaults to Top
+    fn layer(&self) -> RenderLayer {
+        RenderLayer::Top
+    }
 }
 
 pub(crate) trait SpaceElement<R, F, E, T>

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -11,21 +11,23 @@ use std::{
 use wayland_server::protocol::wl_surface::WlSurface;
 
 /// Indicates default values for some zindexs inside smithay
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum RenderZindex {
     /// WlrLayer::Background default zindex
     Background = 10,
     /// WlrLayer::Bottom default zindex
     Bottom = 20,
-    /// Not used yet?
-    Shell = 30,
     /// Default zindex for Windows
-    Top = 40,
+    Shell = 30,
+    /// Default zindex for Windows PopUps
+    PopUpsShell = 40,
+    /// WlrLayer::Top default zindex
+    Top = 50,
     /// Default Layer for RenderElements
-    Overlay = 50,
-    /// Default Layer for PopUps?
-    PopUp = 60,
+    Overlay = 80,
+    /// Default Layer for Overlay PopUp
+    PopUpsOverlay = 100,
 }
 
 /// Elements rendered by [`Space::render_output`] in addition to windows, layers and popups.

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -114,9 +114,7 @@ where
         damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,
     ) -> Result<(), R::Error>;
-    fn z_index(&self) -> u8; //{
-                             //    0
-                             //}
+    fn z_index(&self) -> u8;
 }
 
 impl<R, F, E, T> SpaceElement<R, F, E, T> for Box<dyn RenderElement<R, F, E, T>>

--- a/src/desktop/space/layer.rs
+++ b/src/desktop/space/layer.rs
@@ -5,13 +5,15 @@ use crate::{
         space::{Space, SpaceElement},
     },
     utils::{Logical, Point, Rectangle},
-    wayland::output::Output,
+    wayland::{output::Output, shell::wlr_layer::Layer},
 };
 use std::{
     any::TypeId,
     cell::{RefCell, RefMut},
     collections::HashMap,
 };
+
+use super::RenderZindex;
 
 #[derive(Default)]
 pub struct LayerState {
@@ -68,5 +70,20 @@ where
             layer_state(space_id, self).drawn = true;
         }
         res
+    }
+
+    fn z_index(&self) -> u8 {
+        if let Some(layer) = self.layer() {
+            let z_index = match layer {
+                Layer::Background => RenderZindex::Background,
+                Layer::Bottom => RenderZindex::Bottom,
+                Layer::Top => RenderZindex::Top,
+                Layer::Overlay => RenderZindex::Overlay,
+            };
+            z_index as u8
+        } else {
+            //TODO: what to do when layersurface doesn't have a layer?
+            0
+        }
     }
 }

--- a/src/desktop/space/layer.rs
+++ b/src/desktop/space/layer.rs
@@ -82,7 +82,6 @@ where
             };
             z_index as u8
         } else {
-            //TODO: what to do when layersurface doesn't have a layer?
             0
         }
     }

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -647,14 +647,14 @@ impl Space {
                         layer_map
                             .layers_on(WlrLayer::Top)
                             .map(|l| l as &SpaceElem<R>)
-                            .chain(
-                                custom_elements
-                                    .iter()
-                                    .filter(|c| c.layer() == RenderLayer::BeforeOverlay)
-                                    .map(|c| c as &SpaceElem<R>),
-                            )
-                            .chain(layer_map.layers_on(WlrLayer::Overlay).map(|l| l as &SpaceElem<R>)),
                     )
+                    .chain(
+                        custom_elements
+                            .iter()
+                            .filter(|c| c.layer() == RenderLayer::BeforeOverlay)
+                            .map(|c| c as &SpaceElem<R>),
+                    )
+                    .chain(layer_map.layers_on(WlrLayer::Overlay).map(|l| l as &SpaceElem<R>))
                     .chain(
                         custom_elements
                             .iter()

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -44,56 +44,6 @@ pub struct Space {
     logger: ::slog::Logger,
 }
 
-/// Elements rendered by [`Space::render_output`] in addition to windows, layers and popups.
-pub type DynamicRenderElements<R> =
-    Box<dyn RenderElement<R, <R as Renderer>::Frame, <R as Renderer>::Error, <R as Renderer>::TextureId>>;
-
-type SpaceElem<R> =
-    dyn SpaceElement<R, <R as Renderer>::Frame, <R as Renderer>::Error, <R as Renderer>::TextureId>;
-
-struct DynamicRenderElementMap<'a, R: Renderer>(&'a [DynamicRenderElements<R>]);
-
-impl<'a, R> DynamicRenderElementMap<'a, R>
-where
-    R: Renderer + ImportAll + 'static,
-    R::TextureId: 'static,
-    R::Error: 'static,
-    R::Frame: 'static,
-{
-    pub fn iter_bottom(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
-        self.iter_layer(RenderLayer::Bottom)
-    }
-
-    pub fn iter_above_background(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
-        self.iter_layer(RenderLayer::AboveBackground)
-    }
-
-    pub fn iter_before_windows(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
-        self.iter_layer(RenderLayer::BeforeWindows)
-    }
-
-    pub fn iter_after_windows(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
-        self.iter_layer(RenderLayer::AfterWindows)
-    }
-
-    pub fn iter_before_overlay(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
-        self.iter_layer(RenderLayer::BeforeOverlay)
-    }
-
-    pub fn iter_top(&'a self) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
-        self.iter_layer(RenderLayer::Top)
-    }
-
-    pub fn iter_layer(&'a self, layer: RenderLayer) -> Box<dyn Iterator<Item = &SpaceElem<R>> + 'a> {
-        Box::new(
-            self.0
-                .iter()
-                .filter(move |c| c.layer() == layer)
-                .map(|c| c as &SpaceElem<R>),
-        )
-    }
-}
-
 impl PartialEq for Space {
     fn eq(&self, other: &Space) -> bool {
         self.id == other.id

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -498,11 +498,11 @@ impl Space {
                 + layer_popups.len(),
         );
 
-        render_elements.extend(&mut custom_elements.iter().map(|l| l as &SpaceElem<R>));
-        render_elements.extend(&mut self.windows.iter().map(|l| l as &SpaceElem<R>));
-        render_elements.extend(&mut window_popups.iter().map(|l| l as &SpaceElem<R>));
-        render_elements.extend(&mut layer_map.layers().map(|l| l as &SpaceElem<R>));
-        render_elements.extend(&mut layer_popups.iter().map(|l| l as &SpaceElem<R>));
+        render_elements.extend(custom_elements.iter().map(|l| l as &SpaceElem<R>));
+        render_elements.extend(self.windows.iter().map(|l| l as &SpaceElem<R>));
+        render_elements.extend(window_popups.iter().map(|l| l as &SpaceElem<R>));
+        render_elements.extend(layer_map.layers().map(|l| l as &SpaceElem<R>));
+        render_elements.extend(layer_popups.iter().map(|l| l as &SpaceElem<R>));
 
         render_elements.sort_by_key(|e| e.z_index());
 

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -622,14 +622,14 @@ impl Space {
                         layer_map
                             .layers_on(WlrLayer::Background)
                             .map(|l| l as &SpaceElem<R>)
-                            .chain(
-                                custom_elements
-                                    .iter()
-                                    .filter(|c| c.layer() == RenderLayer::AboveBackground)
-                                    .map(|c| c as &SpaceElem<R>),
-                            )
-                            .chain(layer_map.layers_on(WlrLayer::Bottom).map(|l| l as &SpaceElem<R>)),
                     )
+                    .chain(
+                        custom_elements
+                            .iter()
+                            .filter(|c| c.layer() == RenderLayer::AboveBackground)
+                            .map(|c| c as &SpaceElem<R>),
+                    )
+                    .chain(layer_map.layers_on(WlrLayer::Bottom).map(|l| l as &SpaceElem<R>))
                     .chain(
                         custom_elements
                             .iter()

--- a/src/desktop/space/popup.rs
+++ b/src/desktop/space/popup.rs
@@ -18,6 +18,7 @@ use super::RenderZindex;
 pub struct RenderPopup {
     location: Point<i32, Logical>,
     popup: PopupKind,
+    parent_layer: RenderZindex,
 }
 
 impl Window {
@@ -41,6 +42,7 @@ impl Window {
                         RenderPopup {
                             location: offset,
                             popup,
+                            parent_layer: RenderZindex::Shell,
                         }
                     })
             })
@@ -72,6 +74,7 @@ impl LayerSurface {
                         RenderPopup {
                             location: offset,
                             popup,
+                            parent_layer: RenderZindex::Overlay,
                         }
                     })
             })
@@ -130,6 +133,10 @@ where
     }
 
     fn z_index(&self) -> u8 {
-        RenderZindex::PopUp as u8
+        match self.parent_layer {
+            RenderZindex::Shell => RenderZindex::PopUpsShell as u8,
+            RenderZindex::Overlay => RenderZindex::PopUpsOverlay as u8,
+            _ => 0, //Maybe better panic here? Or return u8::MAX?
+        }
     }
 }

--- a/src/desktop/space/popup.rs
+++ b/src/desktop/space/popup.rs
@@ -12,6 +12,8 @@ use crate::{
 };
 use std::any::TypeId;
 
+use super::RenderZindex;
+
 #[derive(Debug)]
 pub struct RenderPopup {
     location: Point<i32, Logical>,
@@ -125,5 +127,9 @@ where
     ) -> Result<(), R::Error> {
         // popups are special, we track them, but they render with their parents
         Ok(())
+    }
+
+    fn z_index(&self) -> u8 {
+        RenderZindex::PopUp as u8
     }
 }

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -107,6 +107,6 @@ where
     }
 
     fn z_index(&self) -> u8 {
-        RenderZindex::Top as u8
+        RenderZindex::Shell as u8
     }
 }

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -13,6 +13,8 @@ use std::{
     collections::HashMap,
 };
 
+use super::RenderZindex;
+
 #[derive(Default)]
 pub struct WindowState {
     pub location: Point<i32, Logical>,
@@ -102,5 +104,9 @@ where
             window_state(space_id, self).drawn = true;
         }
         res
+    }
+
+    fn z_index(&self) -> u8 {
+        RenderZindex::Top as u8
     }
 }


### PR DESCRIPTION
This PR add support for definition of layer a RenderElement passed to render_output should be draw on.
This is done via layer function in RenderElement trait, it should return a layer an element should be draw on.
A default implementation is provided which makes the element render on top of all other elements to preserve the current behavior and not introduce any braking changes.

Marking PR as draft because I hope some comments/suggestion for improvements, mostly probably for for the whole render loop chain got pretty scary.
Maybe add some simple functions is_top, is_above_background etc. to at least skip the `c.layer() == RenderLayer::AboveBackground`? 
Another option would be to wrap the `&[DynamicRenderElements<R>]` in a struct and add something similar to `layers_on`.
Thanks for any feedback :).

