### PR TITLE
Send popups and layers output enter/leave events as well

### DIFF
--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -103,16 +103,7 @@ impl LayerMap {
                 (),
                 |_, _, _| TraversalAction::DoChildren(()),
                 |wl_surface, _, _| {
-                    if self.surfaces.contains(wl_surface) {
-                        slog::trace!(
-                            self.logger,
-                            "surface ({:?}) leaving output {:?}",
-                            wl_surface,
-                            output.name()
-                        );
-                        output.leave(wl_surface);
-                        self.surfaces.retain(|s| s != wl_surface);
-                    }
+                    output_leave(&output, &mut self.surfaces, wl_surface, &self.logger);
                 },
                 |_, _, _| true,
             );
@@ -203,16 +194,7 @@ impl LayerMap {
                     (),
                     |_, _, _| TraversalAction::DoChildren(()),
                     |wl_surface, _, _| {
-                        if !surfaces_ref.contains(wl_surface) {
-                            slog::trace!(
-                                logger_ref,
-                                "surface ({:?}) entering output {:?}",
-                                wl_surface,
-                                output.name()
-                            );
-                            output.enter(wl_surface);
-                            surfaces_ref.push(wl_surface.clone());
-                        }
+                        output_enter(&output, surfaces_ref, wl_surface, logger_ref);
                     },
                     |_, _, _| true,
                 );

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -107,6 +107,23 @@ impl LayerMap {
                 },
                 |_, _, _| true,
             );
+            for (popup, _) in PopupManager::popups_for_surface(surface)
+                .ok()
+                .into_iter()
+                .flatten()
+            {
+                if let Some(surface) = popup.get_surface() {
+                    with_surface_tree_downward(
+                        surface,
+                        (),
+                        |_, _, _| TraversalAction::DoChildren(()),
+                        |wl_surface, _, _| {
+                            output_leave(&output, &mut self.surfaces, wl_surface, &self.logger);
+                        },
+                        |_, _, _| true,
+                    )
+                }
+            }
         }
     }
 
@@ -198,6 +215,23 @@ impl LayerMap {
                     },
                     |_, _, _| true,
                 );
+                for (popup, _) in PopupManager::popups_for_surface(surface)
+                    .ok()
+                    .into_iter()
+                    .flatten()
+                {
+                    if let Some(surface) = popup.get_surface() {
+                        with_surface_tree_downward(
+                            surface,
+                            (),
+                            |_, _, _| TraversalAction::DoChildren(()),
+                            |wl_surface, _, _| {
+                                output_enter(&output, surfaces_ref, wl_surface, logger_ref);
+                            },
+                            |_, _, _| true,
+                        )
+                    }
+                }
 
                 let data = with_states(surface, |states| {
                     *states.cached_state.current::<LayerSurfaceCachedState>()

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -102,7 +102,7 @@ pub struct PhysicalProperties {
 #[derive(Debug)]
 pub(crate) struct Inner {
     name: String,
-    log: ::slog::Logger,
+    pub(crate) log: ::slog::Logger,
     instances: Vec<WlOutput>,
     physical: PhysicalProperties,
     location: Point<i32, Logical>,


### PR DESCRIPTION
Currently we send neither popups or layers output enter or output leave events.
This series of commits tries to fix that and also refactors the logic of `Space::refresh` a bit to avoid adding too much duplicated code in the process.