### PR TITLE
swapchain: Don't force release of submitted buffers

### DIFF
--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -213,7 +213,6 @@ where
     pub fn frame_submitted(&mut self) -> Result<(), Error> {
         if let Some(mut pending) = self.pending_fb.take() {
             std::mem::swap(&mut pending, &mut self.current_fb);
-            self.swapchain.submitted(pending);
             if self.queued_fb.is_some() {
                 self.submit()?;
             }
@@ -233,6 +232,7 @@ where
             self.drm.page_flip([(fb, self.drm.plane())].iter(), true)
         };
         if flip.is_ok() {
+            self.swapchain.submitted(&slot);
             self.pending_fb = Some(slot);
         }
         flip.map_err(Error::DrmError)

--- a/src/backend/x11/surface.rs
+++ b/src/backend/x11/surface.rs
@@ -123,7 +123,7 @@ impl X11Surface {
 
             // Now present the current buffer
             let _ = pixmap.present(&*connection, window.as_ref())?;
-            self.swapchain.submitted(next);
+            self.swapchain.submitted(&next);
 
             // Flush the connection after presenting to the window to ensure we don't run out of buffer space in the X11 connection.
             let _ = connection.flush();


### PR DESCRIPTION
Previously a buffer could only be marked of submitted, when it should also be released.

This breaks damage tracking in the `GbmBufferedSurface`, because for drm-operations we need to keep the buffer alive until it was actually scanned-out, but also need to increase the age after rendering is done for the next buffer to have the correct value.