### PR TITLE
winit: Fix returned buffer age

### DIFF
--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -874,6 +874,7 @@ impl Bind<Rc<EGLSurface>> for Gles2Renderer {
     fn bind(&mut self, surface: Rc<EGLSurface>) -> Result<(), Gles2Error> {
         self.unbind()?;
         self.target_surface = Some(surface);
+        self.make_current()?;
         Ok(())
     }
 }
@@ -881,9 +882,7 @@ impl Bind<Rc<EGLSurface>> for Gles2Renderer {
 impl Bind<Dmabuf> for Gles2Renderer {
     fn bind(&mut self, dmabuf: Dmabuf) -> Result<(), Gles2Error> {
         self.unbind()?;
-        unsafe {
-            self.egl.make_current()?;
-        }
+        self.make_current()?;
 
         // Free outdated buffer resources
         // TODO: Replace with `drain_filter` once it lands

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -302,7 +302,11 @@ impl WinitGraphicsBackend {
         Ok(())
     }
 
-    /// Retrieve the buffer age of the current backbuffer of the window
+    /// Retrieve the buffer age of the current backbuffer of the window.
+    ///
+    /// This will only return a meaningful value, if this `WinitGraphicsBackend`
+    /// is currently bound (by previously calling [`WinitGraphicsBackend::bind`]).
+    /// Otherwise the contents of the return value are undefined.
     pub fn buffer_age(&self) -> usize {
         if self.damage_tracking {
             self.egl.buffer_age() as usize

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -306,12 +306,15 @@ impl WinitGraphicsBackend {
     ///
     /// This will only return a meaningful value, if this `WinitGraphicsBackend`
     /// is currently bound (by previously calling [`WinitGraphicsBackend::bind`]).
-    /// Otherwise the contents of the return value are undefined.
-    pub fn buffer_age(&self) -> usize {
+    ///
+    /// Otherwise and on error this function returns `None`.
+    /// If you are using this value actively e.g. for damage-tracking you should
+    /// likely interpret an error just as if "0" was returned.
+    pub fn buffer_age(&self) -> Option<usize> {
         if self.damage_tracking {
-            self.egl.buffer_age() as usize
+            self.egl.buffer_age().map(|x| x as usize)
         } else {
-            0
+            Some(0)
         }
     }
 


### PR DESCRIPTION
Previously if the buffer age of a `WinitGraphicsBackend`s back buffer was queried, it would never return a defined value, because it's surface will never have been bound, because the `Renderer::bind`-call would deferr its `make_current` call until the actual rendering.

Additionally this PR adjusts the `WinitGraphicsBackend::buffer_age` docs to warn the user of this behavior. 