### PR TITLE
deps: Update drm-rs and gbm-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ cgmath = "0.18.0"
 dbus = { version = "0.9.0", optional = true }
 downcast-rs = "1.2.0"
 drm-fourcc = "^2.1.1"
-drm = { version = "0.5.0", optional = true }
-drm-ffi = { version = "0.2.0", optional = true }
-gbm = { version = "0.7.0", optional = true, default-features = false, features = ["drm-support"] }
+drm = { version = "0.6.1", optional = true }
+drm-ffi = { version = "0.2.1", optional = true }
+gbm = { version = "0.8.0", optional = true, default-features = false, features = ["drm-support"] }
 input = { version = "0.7", default-features = false, features=["libinput_1_14"], optional = true }
 indexmap = { version = "1.7", optional = true }
 lazy_static = "1"

--- a/src/backend/drm/device/atomic.rs
+++ b/src/backend/drm/device/atomic.rs
@@ -242,7 +242,7 @@ impl<A: AsRawFd + 'static> AtomicDrmDevice<A> {
             req.add_property(*crtc, *mode_prop, property::Value::Unknown(0));
         }
         self.fd
-            .atomic_commit(&[AtomicCommitFlags::AllowModeset], req)
+            .atomic_commit(AtomicCommitFlags::ALLOW_MODESET, req)
             .map_err(|source| Error::Access {
                 errmsg: "Failed to disable connectors",
                 dev: self.fd.dev_path(),
@@ -282,7 +282,7 @@ impl<A: AsRawFd + 'static> Drop for AtomicDrmDevice<A> {
             add_multiple_props(&mut req, &self.old_state.2);
             add_multiple_props(&mut req, &self.old_state.3);
 
-            if let Err(err) = self.fd.atomic_commit(&[AtomicCommitFlags::AllowModeset], req) {
+            if let Err(err) = self.fd.atomic_commit(AtomicCommitFlags::ALLOW_MODESET, req) {
                 error!(self.logger, "Failed to restore previous state. Error: {}", err);
             }
         }

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -249,7 +249,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
             )?;
             self.fd
                 .atomic_commit(
-                    &[AtomicCommitFlags::AllowModeset, AtomicCommitFlags::TestOnly],
+                    AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
                     req,
                 )
                 .map_err(|_| Error::TestFailed(self.crtc))?;
@@ -287,7 +287,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         )?;
         self.fd
             .atomic_commit(
-                &[AtomicCommitFlags::AllowModeset, AtomicCommitFlags::TestOnly],
+                AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
                 req,
             )
             .map_err(|_| Error::TestFailed(self.crtc))?;
@@ -327,7 +327,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
 
         self.fd
             .atomic_commit(
-                &[AtomicCommitFlags::AllowModeset, AtomicCommitFlags::TestOnly],
+                AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
                 req,
             )
             .map_err(|_| Error::TestFailed(self.crtc))?;
@@ -367,7 +367,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         if let Err(err) = self
             .fd
             .atomic_commit(
-                &[AtomicCommitFlags::AllowModeset, AtomicCommitFlags::TestOnly],
+                AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
                 req,
             )
             .map_err(|_| Error::TestFailed(self.crtc))
@@ -428,7 +428,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         )?;
         self.fd
             .atomic_commit(
-                &[AtomicCommitFlags::AllowModeset, AtomicCommitFlags::TestOnly],
+                AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
                 req,
             )
             .map_err(|_| Error::TestFailed(self.crtc))?;
@@ -502,7 +502,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
             if let Err(err) = self
                 .fd
                 .atomic_commit(
-                    &[AtomicCommitFlags::AllowModeset, AtomicCommitFlags::TestOnly],
+                    AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
                     req.clone(),
                 )
                 .map_err(|_| Error::TestFailed(self.crtc))
@@ -530,21 +530,18 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
             .fd
             .atomic_commit(
                 if event {
-                    &[
-                        // on the atomic api we can modeset and trigger a page_flip event on the same call!
-                        AtomicCommitFlags::PageFlipEvent,
-                        AtomicCommitFlags::AllowModeset,
-                        // we also *should* not need to wait for completion, like with `set_crtc`,
-                        // because we have tested this exact commit already, so we do not expect any errors later down the line.
-                        //
-                        // but there is always an exception and `amdgpu` can fail in interesting ways with this flag set...
-                        // https://gitlab.freedesktop.org/drm/amd/-/issues?scope=all&utf8=%E2%9C%93&state=opened&search=drm_atomic_helper_wait_for_flip_done
-                        //
-                        // so we skip this flag:
-                        // AtomicCommitFlags::Nonblock,
-                    ]
+                    // on the atomic api we can modeset and trigger a page_flip event on the same call!
+                    AtomicCommitFlags::PAGE_FLIP_EVENT | AtomicCommitFlags::ALLOW_MODESET
+                    // we also *should* not need to wait for completion, like with `set_crtc`,
+                    // because we have tested this exact commit already, so we do not expect any errors later down the line.
+                    //
+                    // but there is always an exception and `amdgpu` can fail in interesting ways with this flag set...
+                    // https://gitlab.freedesktop.org/drm/amd/-/issues?scope=all&utf8=%E2%9C%93&state=opened&search=drm_atomic_helper_wait_for_flip_done
+                    //
+                    // so we skip this flag:
+                    // AtomicCommitFlags::Nonblock,
                 } else {
-                    &[AtomicCommitFlags::AllowModeset]
+                    AtomicCommitFlags::ALLOW_MODESET
                 },
                 req,
             )
@@ -588,9 +585,9 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         self.fd
             .atomic_commit(
                 if event {
-                    &[AtomicCommitFlags::PageFlipEvent, AtomicCommitFlags::Nonblock]
+                    AtomicCommitFlags::PAGE_FLIP_EVENT | AtomicCommitFlags::NONBLOCK
                 } else {
-                    &[AtomicCommitFlags::Nonblock]
+                    AtomicCommitFlags::NONBLOCK
                 },
                 req,
             )
@@ -638,7 +635,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         let result = self
             .fd
             .atomic_commit(
-                &[AtomicCommitFlags::AllowModeset, AtomicCommitFlags::TestOnly],
+                AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
                 req,
             )
             .is_ok();
@@ -676,7 +673,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         let result = self
             .fd
             .atomic_commit(
-                &[AtomicCommitFlags::AllowModeset, AtomicCommitFlags::TestOnly],
+                AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
                 req,
             )
             .is_ok();
@@ -937,7 +934,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
 
         let result = self
             .fd
-            .atomic_commit(&[AtomicCommitFlags::Nonblock], req)
+            .atomic_commit(AtomicCommitFlags::NONBLOCK, req)
             .map_err(|source| Error::Access {
                 errmsg: "Failed to commit on clear_plane",
                 dev: self.fd.dev_path(),
@@ -1029,7 +1026,7 @@ impl<A: AsRawFd + 'static> Drop for AtomicDrmSurface<A> {
 
         req.add_property(self.crtc, *active_prop, property::Value::Boolean(false));
         req.add_property(self.crtc, *mode_prop, property::Value::Unknown(0));
-        if let Err(err) = self.fd.atomic_commit(&[AtomicCommitFlags::AllowModeset], req) {
+        if let Err(err) = self.fd.atomic_commit(AtomicCommitFlags::ALLOW_MODESET, req) {
             warn!(self.logger, "Unable to disable connectors: {}", err);
         }
     }

--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -289,18 +289,13 @@ impl<A: AsRawFd + 'static> LegacyDrmSurface<A> {
             // this will result in wasting a frame, because this flip will need to wait
             // for `set_crtc`, but is necessary to drive the event loop and thus provide
             // a more consistent api.
-            ControlDevice::page_flip(
-                &*self.fd,
-                self.crtc,
-                framebuffer,
-                &[PageFlipFlags::PageFlipEvent],
-                None,
-            )
-            .map_err(|source| Error::Access {
-                errmsg: "Failed to queue page flip",
-                dev: self.fd.dev_path(),
-                source,
-            })?;
+            ControlDevice::page_flip(&*self.fd, self.crtc, framebuffer, PageFlipFlags::EVENT, None).map_err(
+                |source| Error::Access {
+                    errmsg: "Failed to queue page flip",
+                    dev: self.fd.dev_path(),
+                    source,
+                },
+            )?;
         }
 
         Ok(())
@@ -318,9 +313,9 @@ impl<A: AsRawFd + 'static> LegacyDrmSurface<A> {
             self.crtc,
             framebuffer,
             if event {
-                &[PageFlipFlags::PageFlipEvent]
+                PageFlipFlags::EVENT
             } else {
-                &[]
+                PageFlipFlags::empty()
             },
             None,
         )


### PR DESCRIPTION
Basically the only thing different for the current version of drm-rs is, that it uses the bitflags-crate now.

But it also brings some new function, which might be interesting for downstream (much less to smithay itself), so we should care to update.