### PR TITLE
drm: Use EventMetadata to pass on frame timings

### DIFF
--- a/examples/raw_drm.rs
+++ b/examples/raw_drm.rs
@@ -122,7 +122,7 @@ fn main() {
     let mut event_loop = EventLoop::<()>::try_new().unwrap();
     event_loop
         .handle()
-        .insert_source(device, move |event, _: &mut (), _: &mut ()| match event {
+        .insert_source(device, move |event, _: &mut _, _: &mut ()| match event {
             DrmEvent::VBlank(crtc) => vblank_handler.vblank(crtc),
             DrmEvent::Error(e) => panic!("{}", e),
         })

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -76,7 +76,7 @@ pub mod node;
 pub(self) mod session;
 pub(self) mod surface;
 
-pub use device::{DevPath, DrmDevice, DrmEvent};
+pub use device::{DevPath, DrmDevice, DrmEvent, EventMetadata as DrmEventMetadata, Time as DrmEventTime};
 pub use error::Error as DrmError;
 pub use node::{CreateDrmNodeError, DrmNode, NodeType};
 #[cfg(feature = "backend_gbm")]


### PR DESCRIPTION
For precise low-latency rendering it is important to now, when a frame event happened. We currently pass non of the timing related event fields from drm-rs to downstream. Lets make use of the calloop-Metadata to parse and change that.