### PR TITLE
data_device: Pass seat to DnD events

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -167,7 +167,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                 DataDeviceEvent::DnDStarted { icon, .. } => {
                     *dnd_icon2.lock().unwrap() = icon;
                 }
-                DataDeviceEvent::DnDDropped => {
+                DataDeviceEvent::DnDDropped { .. } => {
                     *dnd_icon2.lock().unwrap() = None;
                 }
                 _ => {}

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -209,7 +209,9 @@ impl PointerGrab for DnDGrab {
                     source.cancelled();
                 }
             }
-            (&mut *self.callback.borrow_mut())(super::DataDeviceEvent::DnDDropped);
+            (&mut *self.callback.borrow_mut())(super::DataDeviceEvent::DnDDropped {
+                seat: self.seat.clone(),
+            });
             self.icon = None;
             // in all cases abandon the drop
             // no more buttons are pressed, release the grab

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -88,13 +88,18 @@ pub enum DataDeviceEvent {
         /// The icon the client requested to be used to be associated with the cursor icon
         /// during the drag'n'drop.
         icon: Option<wl_surface::WlSurface>,
+        /// The seat on which the DnD operation was started
+        seat: Seat,
     },
     /// The drag'n'drop action was finished by the user releasing the buttons
     ///
     /// At this point, any pointer icon should be removed.
     ///
     /// Note that this event will only be generated for client-initiated drag'n'drop session.
-    DnDDropped,
+    DnDDropped {
+        /// The seat on which the DnD action was finished.
+        seat: Seat,
+    },
     /// A client requested to read the server-set selection
     SendSelection {
         /// the requested mime type
@@ -445,6 +450,7 @@ where
                     (&mut *callback.borrow_mut())(DataDeviceEvent::DnDStarted {
                         source: source.clone(),
                         icon: icon.clone(),
+                        seat: seat.clone(),
                     });
                     let start_data = pointer.grab_start_data().unwrap();
                     pointer.set_grab(


### PR DESCRIPTION
Currently there is no way to know with which pointer a dnd-icon should be associated with.
(Anvil just uses it for all pointers, I think, but anvil also does not support multiple seats... so.)