### PR TITLE
desktop: Take xdg geometry location into acount

### DIFF
--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -33,7 +33,7 @@ pub fn window_state(space: usize, w: &Window) -> RefMut<'_, WindowState> {
 pub fn window_geo(window: &Window, space_id: &usize) -> Rectangle<i32, Logical> {
     let loc = window_loc(window, space_id);
     let mut wgeo = window.geometry();
-    wgeo.loc = loc;
+    wgeo.loc += loc;
     wgeo
 }
 


### PR DESCRIPTION
What is the definition of `geometry` in desktop abstraction terms? My understanding was that it should work like xdg geometry, but looking at the code it erases location of xdg toplevels in relation to root position.
So the geometry does not align with window contents:
![image](https://user-images.githubusercontent.com/20758186/153101460-22c8069d-c51e-4bab-ac12-4c73981a444a.png)

So using `+=` seems to fix the problem.