### PR TITLE
desktop: Replace window_geo with window_location

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -199,7 +199,7 @@ impl<Backend> AnvilState<Backend> {
 
             if let Some(window) = space.window_under(self.pointer_location).cloned() {
                 space.raise_window(&window, true);
-                let window_loc = space.window_geometry(&window).unwrap().loc;
+                let window_loc = space.window_location(&window).unwrap();
                 let surface = window
                     .surface_under(
                         self.pointer_location - window_loc.to_f64(),
@@ -262,7 +262,7 @@ impl<Backend> AnvilState<Backend> {
                 )
                 .map(|(s, loc)| (s, loc + layer_loc));
         } else if let Some(window) = space.window_under(pos) {
-            let window_loc = space.window_geometry(window).unwrap().loc;
+            let window_loc = space.window_location(window).unwrap();
             under = window
                 .surface_under(pos - window_loc.to_f64(), WindowSurfaceType::ALL)
                 .map(|(s, loc)| (s, loc + window_loc));

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -162,13 +162,13 @@ impl Space {
         })
     }
 
-    /// Returns the geometry of a [`Window`] including its relative position inside the Space.
-    pub fn window_geometry(&self, w: &Window) -> Option<Rectangle<i32, Logical>> {
+    /// Returns the location of a [`Window`] inside the Space.
+    pub fn window_location(&self, w: &Window) -> Option<Point<i32, Logical>> {
         if !self.windows.contains(w) {
             return None;
         }
 
-        Some(window_geo(w, &self.id))
+        Some(window_loc(w, &self.id))
     }
 
     /// Returns the bounding box of a [`Window`] including its relative position inside the Space.

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -30,13 +30,6 @@ pub fn window_state(space: usize, w: &Window) -> RefMut<'_, WindowState> {
     })
 }
 
-pub fn window_geo(window: &Window, space_id: &usize) -> Rectangle<i32, Logical> {
-    let loc = window_loc(window, space_id);
-    let mut wgeo = window.geometry();
-    wgeo.loc = loc;
-    wgeo
-}
-
 pub fn window_rect(window: &Window, space_id: &usize) -> Rectangle<i32, Logical> {
     let loc = window_loc(window, space_id);
     let mut wgeo = window.bbox();


### PR DESCRIPTION
Followup to  #491

As discussed on matrix, window_geo is being removed in favor of calling window.geometry() and doing any coordinate space calculations manually. 