### PR TITLE
Replace redundant Result/Error typealiases

### DIFF
--- a/src/backend/session/dbus/logind.rs
+++ b/src/backend/session/dbus/logind.rs
@@ -49,8 +49,7 @@ use nix::{
 };
 use std::{
     cell::RefCell,
-    fmt,
-    io::Error as IoError,
+    fmt, io,
     os::unix::io::RawFd,
     path::Path,
     rc::{Rc, Weak},
@@ -502,10 +501,10 @@ pub enum Error {
     FailedDbusConnection(#[source] dbus::Error),
     /// Failed to get session from logind
     #[error("Failed to get session from logind")]
-    FailedToGetSession(#[source] IoError),
+    FailedToGetSession(#[source] io::Error),
     /// Failed to get seat from logind
     #[error("Failed to get seat from logind")]
-    FailedToGetSeat(#[source] IoError),
+    FailedToGetSeat(#[source] io::Error),
     /// Failed to get vt from logind
     #[error("Failed to get vt from logind")]
     FailedToGetVT,

--- a/src/backend/session/direct.rs
+++ b/src/backend/session/direct.rs
@@ -55,7 +55,7 @@ use nix::{
     libc::c_int,
     sys::stat::{dev_t, fstat, major, minor, Mode},
     unistd::{close, dup},
-    Error as NixError, Result as NixResult,
+    Error as NixError,
 };
 use std::{
     fmt,
@@ -348,14 +348,14 @@ impl DirectSession {
 impl Session for DirectSession {
     type Error = NixError;
 
-    fn open(&mut self, path: &Path, flags: OFlag) -> NixResult<RawFd> {
+    fn open(&mut self, path: &Path, flags: OFlag) -> nix::Result<RawFd> {
         debug!(self.logger, "Opening device: {:?}", path);
         let fd = open(path, flags, Mode::empty())?;
         trace!(self.logger, "Fd num: {:?}", fd);
         Ok(fd)
     }
 
-    fn close(&mut self, fd: RawFd) -> NixResult<()> {
+    fn close(&mut self, fd: RawFd) -> nix::Result<()> {
         debug!(self.logger, "Closing device: {:?}", fd);
         close(fd)
     }
@@ -369,7 +369,7 @@ impl Session for DirectSession {
         String::from("seat0")
     }
 
-    fn change_vt(&mut self, vt_num: i32) -> NixResult<()> {
+    fn change_vt(&mut self, vt_num: i32) -> nix::Result<()> {
         unsafe { tty::vt_activate(self.tty, vt_num).map(|_| ()) }
     }
 }

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -41,8 +41,7 @@ use nix::sys::stat::{dev_t, stat};
 use std::{
     collections::HashMap,
     ffi::OsString,
-    fmt,
-    io::Result as IoResult,
+    fmt, io,
     os::unix::io::{AsRawFd, RawFd},
     path::{Path, PathBuf},
 };
@@ -88,7 +87,7 @@ impl UdevBackend {
     /// ## Arguments
     /// `seat`    - system seat which should be bound
     /// `logger`  - slog Logger to be used by the backend and its `DrmDevices`.
-    pub fn new<L, S: AsRef<str>>(seat: S, logger: L) -> IoResult<UdevBackend>
+    pub fn new<L, S: AsRef<str>>(seat: S, logger: L) -> io::Result<UdevBackend>
     where
         L: Into<Option<::slog::Logger>>,
     {
@@ -233,7 +232,7 @@ pub enum UdevEvent {
 ///
 /// Might be used for filtering of [`UdevEvent::Added`] or for manual
 /// [`DrmDevice`](crate::backend::drm::DrmDevice) initialization.
-pub fn primary_gpu<S: AsRef<str>>(seat: S) -> IoResult<Option<PathBuf>> {
+pub fn primary_gpu<S: AsRef<str>>(seat: S) -> io::Result<Option<PathBuf>> {
     let mut enumerator = Enumerator::new()?;
     enumerator.match_subsystem("drm")?;
     enumerator.match_sysname("card[0-9]*")?;
@@ -267,7 +266,7 @@ pub fn primary_gpu<S: AsRef<str>>(seat: S) -> IoResult<Option<PathBuf>> {
 ///
 /// Might be used for manual  [`DrmDevice`](crate::backend::drm::DrmDevice)
 /// initialization.
-pub fn all_gpus<S: AsRef<str>>(seat: S) -> IoResult<Vec<PathBuf>> {
+pub fn all_gpus<S: AsRef<str>>(seat: S) -> io::Result<Vec<PathBuf>> {
     let mut enumerator = Enumerator::new()?;
     enumerator.match_subsystem("drm")?;
     enumerator.match_sysname("card[0-9]*")?;
@@ -285,7 +284,7 @@ pub fn all_gpus<S: AsRef<str>>(seat: S) -> IoResult<Vec<PathBuf>> {
 }
 
 /// Returns the loaded driver for a device named by it's [`dev_t`](::nix::sys::stat::dev_t).
-pub fn driver(dev: dev_t) -> IoResult<Option<OsString>> {
+pub fn driver(dev: dev_t) -> io::Result<Option<OsString>> {
     let mut enumerator = Enumerator::new()?;
     enumerator.match_subsystem("drm")?;
     enumerator.match_sysname("card[0-9]*")?;

--- a/src/utils/x11rb.rs
+++ b/src/utils/x11rb.rs
@@ -4,7 +4,7 @@
 //! backend in a compositor.
 
 use std::{
-    io::Result as IOResult,
+    io,
     sync::Arc,
     thread::{spawn, JoinHandle},
 };
@@ -109,7 +109,7 @@ impl EventSource for X11Source {
         readiness: Readiness,
         token: Token,
         mut callback: C,
-    ) -> IOResult<PostAction>
+    ) -> io::Result<PostAction>
     where
         C: FnMut(Self::Event, &mut Self::Metadata) -> Self::Ret,
     {
@@ -125,7 +125,7 @@ impl EventSource for X11Source {
         }
     }
 
-    fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> IOResult<()> {
+    fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> io::Result<()> {
         if let Some(channel) = &mut self.channel {
             channel.register(poll, factory)?;
         }
@@ -133,7 +133,7 @@ impl EventSource for X11Source {
         Ok(())
     }
 
-    fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> IOResult<()> {
+    fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> io::Result<()> {
         if let Some(channel) = &mut self.channel {
             channel.reregister(poll, factory)?;
         }
@@ -141,7 +141,7 @@ impl EventSource for X11Source {
         Ok(())
     }
 
-    fn unregister(&mut self, poll: &mut Poll) -> IOResult<()> {
+    fn unregister(&mut self, poll: &mut Poll) -> io::Result<()> {
         if let Some(channel) = &mut self.channel {
             channel.unregister(poll)?;
         }

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -5,7 +5,7 @@ use std::{
     cell::RefCell,
     default::Default,
     fmt,
-    io::{Error as IoError, Seek, Write},
+    io::{self, Seek, Write},
     ops::Deref as _,
     os::unix::io::AsRawFd,
     rc::Rc,
@@ -264,7 +264,7 @@ pub enum Error {
     BadKeymap,
     /// Smithay could not create a tempfile to share the keymap with clients
     #[error("Failed to create tempfile to share the keymap: {0}")]
-    IoError(IoError),
+    IoError(io::Error),
 }
 
 /// Create a keyboard handler from a set of RMLVO rules

--- a/src/xwayland/x11_sockets.rs
+++ b/src/xwayland/x11_sockets.rs
@@ -5,7 +5,7 @@ use std::{
 
 use slog::{debug, info, warn};
 
-use nix::{errno::Errno, sys::socket, Result as NixResult};
+use nix::{errno::Errno, sys::socket};
 
 /// Find a free X11 display slot and setup
 pub(crate) fn prepare_x11_sockets(log: ::slog::Logger) -> Result<(X11Lock, [UnixStream; 2]), std::io::Error> {
@@ -112,7 +112,7 @@ impl Drop for X11Lock {
 /// Open the two unix sockets an X server listens on
 ///
 /// Should only be done after the associated lockfile is acquired!
-fn open_x11_sockets_for_display(display: u32) -> NixResult<[UnixStream; 2]> {
+fn open_x11_sockets_for_display(display: u32) -> nix::Result<[UnixStream; 2]> {
     let path = format!("/tmp/.X11-unix/X{}", display);
     let _ = ::std::fs::remove_file(&path);
     // We know this path is not to long, these unwrap cannot fail
@@ -124,7 +124,7 @@ fn open_x11_sockets_for_display(display: u32) -> NixResult<[UnixStream; 2]> {
 }
 
 /// Open an unix socket for listening and bind it to given path
-fn open_socket(addr: socket::UnixAddr) -> NixResult<UnixStream> {
+fn open_socket(addr: socket::UnixAddr) -> nix::Result<UnixStream> {
     // create an unix stream socket
     let fd = socket::socket(
         socket::AddressFamily::Unix,

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -42,7 +42,7 @@ use std::{
     any::Any,
     cell::RefCell,
     env,
-    io::{Read, Result as IOResult},
+    io::{self, Read},
     os::unix::{
         io::{AsRawFd, IntoRawFd, RawFd},
         net::UnixStream,
@@ -368,7 +368,7 @@ fn spawn_xwayland(
     wayland_socket: UnixStream,
     wm_socket: UnixStream,
     listen_sockets: &[UnixStream],
-) -> IOResult<ChildStdout> {
+) -> io::Result<ChildStdout> {
     let mut command = Command::new("sh");
 
     // We use output stream to communicate because FD is easier to handle than exit code.
@@ -422,7 +422,7 @@ fn spawn_xwayland(
 ///
 /// This means that the `Fd` will *not* be automatically
 /// closed when we `exec()` into XWayland
-fn unset_cloexec(fd: RawFd) -> IOResult<()> {
+fn unset_cloexec(fd: RawFd) -> io::Result<()> {
     use nix::fcntl::{fcntl, FcntlArg, FdFlag};
     fcntl(fd, FcntlArg::F_SETFD(FdFlag::empty()))?;
     Ok(())


### PR DESCRIPTION
Specifically, aliases to io::Error, io::Result and nix::Result