### PR TITLE
Add client touch capability support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `MouseButton` is now non-exhaustive.
 - Remove `Other` and add `Forward` and `Back` variants to `MouseButton`. Use the new `PointerButtonEvent::button_code` in place of `Other`.
 - `GrabStartData` has been renamed to `PointerGrabStartData`
+- Added `TouchHandle` for Wayland client touch support (see `Seat::get_touch`)
+- **[Breaking]**: The `slot` method on touch events no longer returns an `Option` and multi-touch capability is thus opaque to the compositor
 
 #### Backends
 
@@ -61,10 +63,10 @@
 #### Backends
 
 - New `x11` backend to run the compositor as an X11 client. Enabled through the `backend_x11` feature.
-- `x11rb` event source integration used in anvil's XWayland implementation is now part of smithay at `utils::x11rb`. Enabled through the `x11rb_event_source` feature. 
+- `x11rb` event source integration used in anvil's XWayland implementation is now part of smithay at `utils::x11rb`. Enabled through the `x11rb_event_source` feature.
 - `KeyState`, `MouseButton`, `ButtonState` and `Axis` in `backend::input` now derive `Hash`.
 - New `DrmNode` type in drm backend. This is primarily for use a backend which needs to run as client inside another session.
-- The button code for a `PointerButtonEvent` may now be obtained using `PointerButtonEvent::button_code`. 
+- The button code for a `PointerButtonEvent` may now be obtained using `PointerButtonEvent::button_code`.
 - `Renderer` now allows texture filtering methods to be set.
 - `backend::renderer` has a new `utils`-module that can take care of client buffer management for you.
 - `EGLSurface::buffer_age` can be used to query the surface buffer age.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@
 - `MouseButton` is now non-exhaustive.
 - Remove `Other` and add `Forward` and `Back` variants to `MouseButton`. Use the new `PointerButtonEvent::button_code` in place of `Other`.
 - `GrabStartData` has been renamed to `PointerGrabStartData`
-- Added `TouchHandle` for Wayland client touch support (see `Seat::get_touch`)
-- **[Breaking]**: The `slot` method on touch events no longer returns an `Option` and multi-touch capability is thus opaque to the compositor
+- The `slot` method on touch events no longer returns an `Option` and multi-touch capability is thus opaque to the compositor
 
 #### Backends
 
@@ -59,6 +58,7 @@
 - Added a `KeyboardGrab` similar to the existing `PointerGrab`
 - `wayland::output::Output` now has a `current_scale` method to quickly retrieve its set scale.
 - `wayland::shell::wlr_layer::KeyboardInteractivity` now implements `PartialEq` and `Eq`.
+- Added `TouchHandle` for Wayland client touch support (see `Seat::get_touch`)
 
 #### Backends
 

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -347,9 +347,9 @@ impl From<Option<u32>> for TouchSlot {
     }
 }
 
-impl Into<i32> for TouchSlot {
-    fn into(self) -> i32 {
-        self.id.map(|id| id as i32).unwrap_or(-1)
+impl From<TouchSlot> for i32 {
+    fn from(slot: TouchSlot) -> i32 {
+        slot.id.map(|id| id as i32).unwrap_or(-1)
     }
 }
 

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -336,22 +336,27 @@ impl<B: InputBackend> PointerMotionAbsoluteEvent<B> for UnusedEvent {
 /// Touch events are grouped by slots, usually to identify different
 /// fingers on a multi-touch enabled input device. Events should only
 /// be interpreted in the context of other events on the same slot.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TouchSlot {
-    id: u64,
+    id: Option<u32>,
 }
 
-#[cfg(any(feature = "backend_winit", feature = "backend_libinput"))]
-impl TouchSlot {
-    pub(crate) fn new(id: u64) -> Self {
-        TouchSlot { id }
+impl From<Option<u32>> for TouchSlot {
+    fn from(id: Option<u32>) -> Self {
+        Self { id }
+    }
+}
+
+impl Into<i32> for TouchSlot {
+    fn into(self) -> i32 {
+        self.id.map(|id| id as i32).unwrap_or(-1)
     }
 }
 
 /// Trait for touch events starting at a given position.
 pub trait TouchDownEvent<B: InputBackend>: Event<B> {
-    /// [`TouchSlot`], if the device has multi-touch capabilities
-    fn slot(&self) -> Option<TouchSlot>;
+    /// Multi-touch slot identifier.
+    fn slot(&self) -> TouchSlot;
 
     /// Touch position in the device's native coordinate space
     ///
@@ -390,7 +395,7 @@ pub trait TouchDownEvent<B: InputBackend>: Event<B> {
 }
 
 impl<B: InputBackend> TouchDownEvent<B> for UnusedEvent {
-    fn slot(&self) -> Option<TouchSlot> {
+    fn slot(&self) -> TouchSlot {
         match *self {}
     }
 
@@ -413,8 +418,8 @@ impl<B: InputBackend> TouchDownEvent<B> for UnusedEvent {
 
 /// Trait for touch events regarding movement on the screen
 pub trait TouchMotionEvent<B: InputBackend>: Event<B> {
-    /// [`TouchSlot`], if the device has multi-touch capabilities
-    fn slot(&self) -> Option<TouchSlot>;
+    /// Multi-touch slot identifier.
+    fn slot(&self) -> TouchSlot;
 
     /// Touch position in the device's native coordinate space
     ///
@@ -453,7 +458,7 @@ pub trait TouchMotionEvent<B: InputBackend>: Event<B> {
 }
 
 impl<B: InputBackend> TouchMotionEvent<B> for UnusedEvent {
-    fn slot(&self) -> Option<TouchSlot> {
+    fn slot(&self) -> TouchSlot {
         match *self {}
     }
 
@@ -476,24 +481,24 @@ impl<B: InputBackend> TouchMotionEvent<B> for UnusedEvent {
 
 /// Trait for touch events finishing.
 pub trait TouchUpEvent<B: InputBackend>: Event<B> {
-    /// [`TouchSlot`], if the device has multi-touch capabilities
-    fn slot(&self) -> Option<TouchSlot>;
+    /// Multi-touch slot identifier.
+    fn slot(&self) -> TouchSlot;
 }
 
 impl<B: InputBackend> TouchUpEvent<B> for UnusedEvent {
-    fn slot(&self) -> Option<TouchSlot> {
+    fn slot(&self) -> TouchSlot {
         match *self {}
     }
 }
 
 /// Trait for touch events canceling the chain
 pub trait TouchCancelEvent<B: InputBackend>: Event<B> {
-    /// [`TouchSlot`], if the device has multi-touch capabilities
-    fn slot(&self) -> Option<TouchSlot>;
+    /// Multi-touch slot identifier.
+    fn slot(&self) -> TouchSlot;
 }
 
 impl<B: InputBackend> TouchCancelEvent<B> for UnusedEvent {
-    fn slot(&self) -> Option<TouchSlot> {
+    fn slot(&self) -> TouchSlot {
         match *self {}
     }
 }

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -256,8 +256,8 @@ impl backend::Event<LibinputInputBackend> for event::touch::TouchDownEvent {
 }
 
 impl backend::TouchDownEvent<LibinputInputBackend> for event::touch::TouchDownEvent {
-    fn slot(&self) -> Option<backend::TouchSlot> {
-        event::touch::TouchEventSlot::slot(self).map(|x| backend::TouchSlot::new(x as u64))
+    fn slot(&self) -> backend::TouchSlot {
+        event::touch::TouchEventSlot::slot(self).into()
     }
 
     fn x(&self) -> f64 {
@@ -288,8 +288,8 @@ impl backend::Event<LibinputInputBackend> for event::touch::TouchMotionEvent {
 }
 
 impl backend::TouchMotionEvent<LibinputInputBackend> for event::touch::TouchMotionEvent {
-    fn slot(&self) -> Option<backend::TouchSlot> {
-        event::touch::TouchEventSlot::slot(self).map(|x| backend::TouchSlot::new(x as u64))
+    fn slot(&self) -> backend::TouchSlot {
+        event::touch::TouchEventSlot::slot(self).into()
     }
 
     fn x(&self) -> f64 {
@@ -320,8 +320,8 @@ impl backend::Event<LibinputInputBackend> for event::touch::TouchUpEvent {
 }
 
 impl backend::TouchUpEvent<LibinputInputBackend> for event::touch::TouchUpEvent {
-    fn slot(&self) -> Option<backend::TouchSlot> {
-        event::touch::TouchEventSlot::slot(self).map(|x| backend::TouchSlot::new(x as u64))
+    fn slot(&self) -> backend::TouchSlot {
+        event::touch::TouchEventSlot::slot(self).into()
     }
 }
 
@@ -336,8 +336,8 @@ impl backend::Event<LibinputInputBackend> for event::touch::TouchCancelEvent {
 }
 
 impl backend::TouchCancelEvent<LibinputInputBackend> for event::touch::TouchCancelEvent {
-    fn slot(&self) -> Option<backend::TouchSlot> {
-        event::touch::TouchEventSlot::slot(self).map(|x| backend::TouchSlot::new(x as u64))
+    fn slot(&self) -> backend::TouchSlot {
+        event::touch::TouchEventSlot::slot(self).into()
     }
 }
 

--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -224,8 +224,8 @@ impl Event<WinitInput> for WinitTouchStartedEvent {
 }
 
 impl TouchDownEvent<WinitInput> for WinitTouchStartedEvent {
-    fn slot(&self) -> Option<TouchSlot> {
-        Some(TouchSlot::new(self.id))
+    fn slot(&self) -> TouchSlot {
+        Some(self.id as u32).into()
     }
 
     fn x(&self) -> f64 {
@@ -271,8 +271,8 @@ impl Event<WinitInput> for WinitTouchMovedEvent {
 }
 
 impl TouchMotionEvent<WinitInput> for WinitTouchMovedEvent {
-    fn slot(&self) -> Option<TouchSlot> {
-        Some(TouchSlot::new(self.id))
+    fn slot(&self) -> TouchSlot {
+        Some(self.id as u32).into()
     }
 
     fn x(&self) -> f64 {
@@ -316,8 +316,8 @@ impl Event<WinitInput> for WinitTouchEndedEvent {
 }
 
 impl TouchUpEvent<WinitInput> for WinitTouchEndedEvent {
-    fn slot(&self) -> Option<TouchSlot> {
-        Some(TouchSlot::new(self.id))
+    fn slot(&self) -> TouchSlot {
+        Some(self.id as u32).into()
     }
 }
 
@@ -339,8 +339,8 @@ impl Event<WinitInput> for WinitTouchCancelledEvent {
 }
 
 impl TouchCancelEvent<WinitInput> for WinitTouchCancelledEvent {
-    fn slot(&self) -> Option<TouchSlot> {
-        Some(TouchSlot::new(self.id))
+    fn slot(&self) -> TouchSlot {
+        Some(self.id as u32).into()
     }
 }
 

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -93,6 +93,9 @@ impl Inner {
         if self.keyboard.is_some() {
             caps |= wl_seat::Capability::Keyboard;
         }
+        if self.touch.is_some() {
+            caps |= wl_seat::Capability::Touch;
+        }
         caps
     }
 

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -1,0 +1,184 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::rc::Rc;
+
+use wayland_server::protocol::wl_touch::WlTouch;
+use wayland_server::{Filter, Main};
+
+use crate::backend::input::TouchSlot;
+use crate::utils::{Logical, Point};
+use crate::wayland::seat::wl_surface::WlSurface;
+use crate::wayland::SERIAL_COUNTER;
+
+/// An handle to a touch handler.
+///
+/// It can be cloned and all clones manipulate the same internal state.
+///
+/// This handle gives you access to an interface to send touch events to your
+/// clients.
+#[derive(Debug, Clone)]
+pub struct TouchHandle {
+    inner: Rc<RefCell<TouchInternal>>,
+}
+
+impl TouchHandle {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+
+    /// Register a new touch handle to this handler
+    ///
+    /// This should be done first, before anything else is done with this touch handle.
+    pub(crate) fn new_touch(&self, touch: WlTouch) {
+        self.inner.borrow_mut().known_handles.push(touch);
+    }
+
+    /// Notify clients about new touch points.
+    pub fn down(
+        &mut self,
+        time: u32,
+        surface: &WlSurface,
+        surface_offset: Point<i32, Logical>,
+        slot: TouchSlot,
+        location: Point<f64, Logical>,
+    ) {
+        self.inner
+            .borrow_mut()
+            .down(time, surface, surface_offset, slot, location);
+    }
+
+    /// Notify clients about touch point removal.
+    pub fn up(&self, time: u32, slot: TouchSlot) {
+        self.inner.borrow_mut().up(time, slot);
+    }
+
+    /// Notify clients about touch motion.
+    pub fn motion(&self, time: u32, slot: TouchSlot, location: Point<f64, Logical>) {
+        self.inner.borrow_mut().motion(time, slot, location);
+    }
+
+    /// Notify clients about touch shape changes.
+    pub fn shape(&self, slot: TouchSlot, major: f64, minor: f64) {
+        self.inner.borrow_mut().shape(slot, major, minor);
+    }
+
+    /// Notify clients about touch shape orientation.
+    pub fn orientation(&self, slot: TouchSlot, orientation: f64) {
+        self.inner.borrow_mut().orientation(slot, orientation);
+    }
+
+    /// Notify clients about touch cancellation.
+    ///
+    /// This should be sent by the compositor when the currently active touch
+    /// slot was recognized as a gesture.
+    pub fn cancel(&self) {
+        self.inner.borrow_mut().cancel();
+    }
+}
+
+/// Touch-slot focused Wayland client state.
+#[derive(Default, Debug)]
+struct TouchFocus {
+    surface_offset: Point<f64, Logical>,
+    handles: Vec<WlTouch>,
+}
+
+#[derive(Default, Debug)]
+struct TouchInternal {
+    known_handles: Vec<WlTouch>,
+    focus: HashMap<TouchSlot, TouchFocus>,
+}
+
+impl TouchInternal {
+    fn down(
+        &mut self,
+        time: u32,
+        surface: &WlSurface,
+        surface_offset: Point<i32, Logical>,
+        slot: TouchSlot,
+        location: Point<f64, Logical>,
+    ) {
+        // Update focused client state.
+        let focus = self.focus.entry(slot).or_default();
+        focus.surface_offset = surface_offset.to_f64();
+        focus.handles.clear();
+
+        // Select all WlTouch instances associated to the active WlSurface.
+        for handle in &self.known_handles {
+            if handle.as_ref().same_client_as(surface.as_ref()) {
+                focus.handles.push(handle.clone());
+            }
+        }
+
+        let (x, y) = (location - focus.surface_offset).into();
+        let serial = SERIAL_COUNTER.next_serial().into();
+        self.with_focused_handles(slot, |handle| {
+            handle.down(serial, time, surface, slot.into(), x, y)
+        });
+    }
+
+    fn up(&self, time: u32, slot: TouchSlot) {
+        let serial = SERIAL_COUNTER.next_serial().into();
+        self.with_focused_handles(slot, |handle| handle.up(serial, time, slot.into()));
+    }
+
+    fn motion(&self, time: u32, slot: TouchSlot, location: Point<f64, Logical>) {
+        let focus = match self.focus.get(&slot) {
+            Some(slot) => slot,
+            None => return,
+        };
+
+        let (x, y) = (location - focus.surface_offset).into();
+        self.with_focused_handles(slot, |handle| handle.motion(time, slot.into(), x, y));
+    }
+
+    fn shape(&self, slot: TouchSlot, major: f64, minor: f64) {
+        self.with_focused_handles(slot, |handle| handle.shape(slot.into(), major, minor));
+    }
+
+    fn orientation(&self, slot: TouchSlot, orientation: f64) {
+        self.with_focused_handles(slot, |handle| handle.orientation(slot.into(), orientation));
+    }
+
+    // TODO: In theory doesn't need to be sent for WlTouch that isn't in the focus hashmap?
+    fn cancel(&self) {
+        for handle in &self.known_handles {
+            handle.cancel();
+        }
+    }
+
+    // TODO: Document this also sends frame every time.
+    #[inline]
+    fn with_focused_handles<F>(&self, slot: TouchSlot, mut f: F)
+    where
+        F: FnMut(&WlTouch),
+    {
+        if let Some(focus) = self.focus.get(&slot) {
+            for handle in &focus.handles {
+                f(handle);
+                handle.frame();
+            }
+        }
+    }
+}
+
+pub(crate) fn implement_touch(touch: Main<WlTouch>, handle: Option<&TouchHandle>) -> WlTouch {
+    // The sole `Release` request is already handled by our destructor.
+    touch.quick_assign(|_touch, _request, _data| {});
+
+    // Remove from touch handles on destroy.
+    if let Some(handle) = handle {
+        let inner = handle.inner.clone();
+        touch.assign_destructor(Filter::new(move |touch: WlTouch, _, _| {
+            inner
+                .borrow_mut()
+                .known_handles
+                .retain(|t| !t.as_ref().equals(touch.as_ref()))
+        }));
+    }
+
+    touch.deref().clone()
+}

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -135,11 +135,19 @@ impl TouchInternal {
     }
 
     fn shape(&self, slot: TouchSlot, major: f64, minor: f64) {
-        self.with_focused_handles(slot, |handle| handle.shape(slot.into(), major, minor));
+        self.with_focused_handles(slot, |handle| {
+            if handle.as_ref().version() >= 6 {
+                handle.shape(slot.into(), major, minor);
+            }
+        });
     }
 
     fn orientation(&self, slot: TouchSlot, orientation: f64) {
-        self.with_focused_handles(slot, |handle| handle.orientation(slot.into(), orientation));
+        self.with_focused_handles(slot, |handle| {
+            if handle.as_ref().version() >= 6 {
+                handle.orientation(slot.into(), orientation);
+            }
+        });
     }
 
     // TODO: In theory doesn't need to be sent for WlTouch that isn't in the focus hashmap?


### PR DESCRIPTION
While Smithay already supports libinput's touch events, it did not
support forwarding touch events to clients yet.

This patch implements a new `TouchHandle`, which can be acquired from
`Seat::get_touch`.