### PR TITLE
0.30: Remove no longer needed alive checks

### DIFF
--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -425,7 +425,7 @@ pub fn init_shell<BackendData: Backend + 'static>(
                             .unwrap()
                             .0
                             .as_ref()
-                            .same_client_as(surface.get_surface().unwrap().as_ref())
+                            .same_client_as(surface.wl_surface().unwrap().as_ref())
                     {
                         return;
                     }
@@ -433,7 +433,7 @@ pub fn init_shell<BackendData: Backend + 'static>(
                     let space = state.space.clone();
                     let window = space
                         .borrow_mut()
-                        .window_for_surface(surface.get_surface().unwrap())
+                        .window_for_surface(surface.wl_surface().unwrap())
                         .unwrap()
                         .clone();
                     let mut initial_window_location = space.borrow().window_location(&window).unwrap();
@@ -501,7 +501,7 @@ pub fn init_shell<BackendData: Backend + 'static>(
                             .unwrap()
                             .0
                             .as_ref()
-                            .same_client_as(surface.get_surface().unwrap().as_ref())
+                            .same_client_as(surface.wl_surface().unwrap().as_ref())
                     {
                         return;
                     }
@@ -509,14 +509,14 @@ pub fn init_shell<BackendData: Backend + 'static>(
                     let space = state.space.clone();
                     let window = space
                         .borrow_mut()
-                        .window_for_surface(surface.get_surface().unwrap())
+                        .window_for_surface(surface.wl_surface().unwrap())
                         .unwrap()
                         .clone();
                     let geometry = window.geometry();
                     let loc = space.borrow().window_location(&window).unwrap();
                     let (initial_window_location, initial_window_size) = (loc, geometry.size);
 
-                    with_states(surface.get_surface().unwrap(), move |states| {
+                    with_states(surface.wl_surface().unwrap(), move |states| {
                         states
                             .data_map
                             .get::<RefCell<SurfaceData>>()
@@ -607,7 +607,7 @@ pub fn init_shell<BackendData: Backend + 'static>(
                     // NOTE: This is only one part of the solution. We can set the
                     // location and configure size here, but the surface should be rendered fullscreen
                     // independently from its buffer size
-                    let wl_surface = if let Some(surface) = surface.get_surface() {
+                    let wl_surface = if let Some(surface) = surface.wl_surface() {
                         surface
                     } else {
                         // If there is no underlying surface just ignore the request
@@ -675,7 +675,7 @@ pub fn init_shell<BackendData: Backend + 'static>(
                     // get the correct maximum size
                     let mut space = state.space.borrow_mut();
                     let window = space
-                        .window_for_surface(surface.get_surface().unwrap())
+                        .window_for_surface(surface.wl_surface().unwrap())
                         .unwrap()
                         .clone();
                     let output = &space.outputs_for_window(&window)[0];

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -59,11 +59,9 @@ impl XdgShellHandler for App {
 
         match request {
             XdgRequest::NewToplevel { surface } => {
-                surface
-                    .with_pending_state(dh, |state| {
-                        state.states.set(xdg_toplevel::State::Activated);
-                    })
-                    .unwrap();
+                surface.with_pending_state(|state| {
+                    state.states.set(xdg_toplevel::State::Activated);
+                });
                 surface.send_configure(dh);
             }
             XdgRequest::Move { .. } => {
@@ -155,7 +153,7 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
                     let dh = &mut display.handle();
                     state.xdg_shell_state.toplevel_surfaces(|surfaces| {
                         for surface in surfaces {
-                            let surface = surface.get_surface(dh).unwrap();
+                            let surface = surface.wl_surface();
                             keyboard.set_focus(dh, Some(surface), 0.into());
                         }
                     });
@@ -178,7 +176,7 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
                 state.xdg_shell_state.toplevel_surfaces(|surfaces| {
                     for surface in surfaces {
                         let dh = &mut display.handle();
-                        let surface = surface.get_surface(dh).unwrap();
+                        let surface = surface.wl_surface();
                         draw_surface_tree(
                             renderer,
                             frame,

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -389,8 +389,7 @@ where
 
                 super::with_states(&surface, |states| {
                     states.data_map.insert_if_missing_threadsafe(SubsurfaceState::new)
-                })
-                .unwrap();
+                });
             }
             wl_subcompositor::Request::Destroy => {}
             _ => unreachable!(),

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -91,7 +91,7 @@ pub use self::cache::{Cacheable, MultiCache};
 pub use self::handlers::SubsurfaceCachedState;
 use self::tree::PrivateSurfaceData;
 pub use self::tree::{AlreadyHasRole, TraversalAction};
-use crate::utils::{user_data::UserDataMap, Buffer, DeadResource, Logical, Point, Rectangle};
+use crate::utils::{user_data::UserDataMap, Buffer, Logical, Point, Rectangle};
 use wayland_server::backend::GlobalId;
 use wayland_server::protocol::wl_compositor::WlCompositor;
 use wayland_server::protocol::wl_subcompositor::WlSubcompositor;
@@ -356,18 +356,11 @@ pub fn give_role(surface: &WlSurface, role: &'static str) -> Result<(), AlreadyH
 }
 
 /// Access the states associated to this surface
-pub fn with_states<F, T>(
-    // dh: &mut DisplayHandle<'_, D>,
-    surface: &WlSurface,
-    f: F,
-) -> Result<T, DeadResource>
+pub fn with_states<F, T>(surface: &WlSurface, f: F) -> T
 where
     F: FnOnce(&SurfaceData) -> T,
 {
-    // if dh.object_info(surface.id()).is_err() {
-    //     return Err(DeadResource);
-    // }
-    Ok(PrivateSurfaceData::with_states(surface, f))
+    PrivateSurfaceData::with_states(surface, f)
 }
 
 /// Retrieve the metadata associated with a `wl_region`

--- a/src/wayland/compositor/transaction.rs
+++ b/src/wayland/compositor/transaction.rs
@@ -243,6 +243,7 @@ impl TransactionQueue {
             // if not, does this transaction depend on any previous transaction?
             if !skip {
                 for (s, _) in &self.transactions[i].surfaces {
+                    // TODO: is this alive check still needed?
                     if dh.object_info(s.id()).is_err() {
                         continue;
                     }
@@ -257,6 +258,7 @@ impl TransactionQueue {
                 // this transaction is not yet ready and should be skipped, add its surfaces to our
                 // seen list
                 for (s, _) in &self.transactions[i].surfaces {
+                    // TODO: is this alive check still needed?
                     if dh.object_info(s.id()).is_err() {
                         continue;
                     }

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -150,6 +150,7 @@ impl<T> PointerInternal<T> {
     {
         if let Some((ref focus, _)) = self.focus {
             focus.id();
+            // TODO: is this alive check still needed?
             // This is is_alive check
             if dh.object_info(focus.id()).is_err() {
                 return;
@@ -172,6 +173,7 @@ impl<T> PointerInternal<T> {
             GrabStatus::Active(_, ref mut handler) => {
                 // If this grab is associated with a surface that is no longer alive, discard it
                 if let Some((ref surface, _)) = handler.start_data().focus {
+                    // TODO: is this alive check still needed?
                     // This is is_alive check
                     if dh.object_info(surface.id()).is_err() {
                         self.grab = GrabStatus::None;
@@ -523,8 +525,7 @@ where
                                             .lock()
                                             .unwrap()
                                             .hotspot = (hotspot_x, hotspot_y).into();
-                                    })
-                                    .unwrap();
+                                    });
 
                                     (guard.image_callback)(CursorImageStatus::Image(surface));
                                 }

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -107,8 +107,7 @@ where
                         .insert_if_missing_threadsafe(|| Mutex::new(LayerSurfaceAttributes::new(id.clone())));
 
                     states.cached_state.pending::<LayerSurfaceCachedState>().layer = layer;
-                })
-                .unwrap();
+                });
 
                 compositor::add_pre_commit_hook(&wl_surface, |dh, surface| {
                     compositor::with_states(surface, |states| {
@@ -142,8 +141,7 @@ where
                         if let Some(state) = guard.last_acked.clone() {
                             guard.current = state;
                         }
-                    })
-                    .unwrap();
+                    });
                 });
 
                 let handle = super::LayerSurface {
@@ -273,8 +271,7 @@ where
                         .lock()
                         .unwrap()
                         .parent = Some(parent_surface);
-                })
-                .unwrap();
+                });
             }
             zwlr_layer_surface_v1::Request::AckConfigure { serial } => {
                 let serial = Serial::from(serial);
@@ -288,8 +285,7 @@ where
                         .lock()
                         .unwrap()
                         .ack_configure(serial)
-                })
-                .unwrap();
+                });
 
                 let configure = match found_configure {
                     Some(configure) => configure,
@@ -345,5 +341,4 @@ where
     compositor::with_states(&data.wl_surface, |states| {
         f(&mut *states.cached_state.pending::<LayerSurfaceCachedState>())
     })
-    .unwrap()
 }

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -86,8 +86,7 @@ where
                     states.data_map.insert_if_missing_threadsafe(|| {
                         Mutex::new(XdgToplevelSurfaceRoleAttributes::default())
                     })
-                })
-                .unwrap();
+                });
 
                 compositor::add_pre_commit_hook(surface, super::super::ToplevelSurface::commit_hook);
 
@@ -162,8 +161,7 @@ where
                         .unwrap()
                         .lock()
                         .unwrap() = attributes;
-                })
-                .unwrap();
+                });
 
                 compositor::add_pre_commit_hook(surface, super::super::PopupSurface::commit_hook);
 
@@ -226,8 +224,7 @@ where
                 compositor::with_states(surface, |states| {
                     states.cached_state.pending::<SurfaceCachedState>().geometry =
                         Some(Rectangle::from_loc_and_size((x, y), (width, height)));
-                })
-                .unwrap();
+                });
             }
             xdg_surface::Request::AckConfigure { serial } => {
                 let serial = Serial::from(serial);
@@ -277,8 +274,7 @@ where
                     } else {
                         Err(())
                     }
-                })
-                .unwrap();
+                });
 
                 let configure = match found_configure {
                     Ok(Some(configure)) => configure,

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -194,7 +194,6 @@ where
             .lock()
             .unwrap())
     })
-    .unwrap()
 }
 
 pub(super) fn make_toplevel_handle(
@@ -231,7 +230,6 @@ where
     compositor::with_states(&data.wl_surface, |states| {
         f(&mut *states.cached_state.pending::<SurfaceCachedState>())
     })
-    .unwrap()
 }
 
 pub fn send_toplevel_configure(


### PR DESCRIPTION
Those checks existed because old version of compositor module required alive checks, but that's no longer the case.