### PR TITLE
0.30: Introduce IsAlive trait

### DIFF
--- a/src/utils/alive_tracker.rs
+++ b/src/utils/alive_tracker.rs
@@ -17,11 +17,6 @@ impl Default for AliveTracker {
 }
 
 impl AliveTracker {
-    /// Create new alive tracker
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Notify the tracker that object is dead
     pub fn destroy_notify(&self) {
         self.is_alive.store(false, Ordering::Release);

--- a/src/utils/alive_tracker.rs
+++ b/src/utils/alive_tracker.rs
@@ -1,0 +1,40 @@
+//! Utilities to track object's life cycle
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Util to track wayland object's life time
+#[derive(Debug)]
+pub struct AliveTracker {
+    is_alive: AtomicBool,
+}
+
+impl Default for AliveTracker {
+    fn default() -> Self {
+        Self {
+            is_alive: AtomicBool::new(true),
+        }
+    }
+}
+
+impl AliveTracker {
+    /// Create new alive tracker
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Notify the tracker that object is dead
+    pub fn destroy_notify(&self) {
+        self.is_alive.store(false, Ordering::Release);
+    }
+
+    /// Check if object is alive
+    pub fn alive(&self) -> bool {
+        self.is_alive.load(Ordering::Acquire)
+    }
+}
+
+/// Trait that is implemented on wayland objects tracked by Smithay
+pub trait IsAlive {
+    /// Check if object is alive
+    fn alive(&self) -> bool;
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,7 +11,9 @@ pub(crate) mod ids;
 pub mod user_data;
 
 #[cfg(feature = "wayland_frontend")]
-pub mod alive_tracker;
+pub(crate) mod alive_tracker;
+#[cfg(feature = "wayland_frontend")]
+pub use self::alive_tracker::IsAlive;
 
 pub use self::geometry::{Buffer, Coordinate, Logical, Physical, Point, Raw, Rectangle, Size, Transform};
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,6 +10,9 @@ pub mod x11rb;
 pub(crate) mod ids;
 pub mod user_data;
 
+#[cfg(feature = "wayland_frontend")]
+pub mod alive_tracker;
+
 pub use self::geometry::{Buffer, Coordinate, Logical, Physical, Point, Raw, Rectangle, Size, Transform};
 
 /// This resource is not managed by Smithay

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -38,7 +38,7 @@ use wayland_server::{
 };
 
 use crate::{
-    utils::{Logical, Size},
+    utils::{alive_tracker::IsAlive, Logical, Size},
     wayland::{
         compositor::{self, Cacheable},
         Serial, SERIAL_COUNTER,
@@ -211,6 +211,11 @@ impl std::cmp::PartialEq for LayerSurface {
 }
 
 impl LayerSurface {
+    /// Checks if the surface is still alive
+    pub fn alive(&self) -> bool {
+        self.wl_surface.alive() && self.shell_surface.alive()
+    }
+
     /// Gets the current pending state for a configure
     ///
     /// Returns `Some` if either no initial configure has been sent or

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use crate::utils::alive_tracker::{AliveTracker, IsAlive};
 use crate::{
     utils::Rectangle,
     wayland::{
@@ -99,6 +100,7 @@ where
                         xdg_surface: xdg_surface.clone(),
                         wm_base: data.wm_base.clone(),
                         decoration: Default::default(),
+                        alive_tracker: Default::default(),
                     },
                 );
 
@@ -174,6 +176,7 @@ where
                         xdg_surface: xdg_surface.clone(),
                         wm_base: data.wm_base.clone(),
                         decoration: Default::default(),
+                        alive_tracker: Default::default(),
                     },
                 );
 
@@ -347,4 +350,20 @@ pub struct XdgShellSurfaceUserData {
     pub(crate) wm_base: xdg_wm_base::XdgWmBase,
     pub(crate) xdg_surface: xdg_surface::XdgSurface,
     pub(crate) decoration: Mutex<Option<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1>>,
+
+    pub(crate) alive_tracker: AliveTracker,
+}
+
+impl IsAlive for XdgToplevel {
+    fn alive(&self) -> bool {
+        let data: &XdgShellSurfaceUserData = self.data().unwrap();
+        data.alive_tracker.alive()
+    }
+}
+
+impl IsAlive for XdgPopup {
+    fn alive(&self) -> bool {
+        let data: &XdgShellSurfaceUserData = self.data().unwrap();
+        data.alive_tracker.alive()
+    }
 }

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -155,6 +155,8 @@ where
     }
 
     fn destroyed(_state: &mut D, _client_id: ClientId, object_id: ObjectId, data: &Self::UserData) {
+        data.alive_tracker.destroy_notify();
+
         if let Some(surface_data) = data.xdg_surface.data::<XdgSurfaceUserData>() {
             surface_data.has_active_role.store(false, Ordering::Release);
         }

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -61,6 +61,7 @@
 //! the subhandler you provided, or via methods on the [`ShellState`]
 //! that you are given (in an `Arc<Mutex<_>>`) as return value of the `init` function.
 
+use crate::utils::alive_tracker::IsAlive;
 use crate::utils::{user_data::UserDataMap, Logical, Point, Rectangle, Size};
 use crate::wayland::compositor;
 use crate::wayland::compositor::Cacheable;
@@ -888,6 +889,11 @@ impl std::cmp::PartialEq for ToplevelSurface {
 }
 
 impl ToplevelSurface {
+    /// Is the toplevel surface referred by this handle still alive?
+    pub fn alive(&self) -> bool {
+        self.wl_surface.alive() && self.shell_surface.alive()
+    }
+
     /// Supported XDG shell protocol version.
     pub fn version(&self) -> u32 {
         self.shell_surface.version()
@@ -1155,6 +1161,11 @@ impl std::cmp::PartialEq for PopupSurface {
 }
 
 impl PopupSurface {
+    /// Is the toplevel surface referred by this handle still alive?
+    pub fn alive(&self) -> bool {
+        self.wl_surface.alive() && self.shell_surface.alive()
+    }
+
     /// Gets a reference of the parent WlSurface of
     /// this popup.
     pub fn get_parent_surface(&self) -> Option<wl_surface::WlSurface> {


### PR DESCRIPTION
This introduces new IsAlive trait that we can use to implement `is_alive` check on any wayland object we want.  For now I implemented it for most common objects that users may want to alive check. 