### PR TITLE
0.30: update to alpha6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ slog-stdlog = { version = "4", optional = true }
 tempfile = { version = "3.0", optional = true }
 thiserror = "1.0.25"
 udev = { version = "0.6", optional = true }
-wayland-egl = { version = "0.30.0-alpha5", optional = true }
-wayland-protocols = { version = "0.30.0-alpha5", features = ["unstable_protocols", "server"], optional = true }
-wayland-server = { version = "0.30.0-alpha5", optional = true }
-wayland-sys = { version = "0.30.0-alpha5", optional = true }
-wayland-backend = { version = "0.1.0-alpha5", optional = true }
+wayland-egl = { version = "0.30.0-alpha6", optional = true }
+wayland-protocols = { version = "0.30.0-alpha6", features = ["unstable_protocols", "server"], optional = true }
+wayland-server = { version = "0.30.0-alpha6", optional = true }
+wayland-sys = { version = "0.30.0-alpha6", optional = true }
+wayland-backend = { version = "0.1.0-alpha6", optional = true }
 winit = { version = "0.26", optional = true }
 x11rb = { version = "0.9.0", optional = true }
 xkbcommon = "0.4.0"

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -198,13 +198,13 @@ impl EGLNativeDisplay for EGLDevice {
     }
 }
 
-/// Trait for types returning valid surface pointers for initializing egl
+/// Trait for types returning valid surface pointers for initializing egl.
 ///
 /// ## Safety
 ///
 /// The returned [`NativeWindowType`](ffi::NativeWindowType) must be valid for EGL
 /// and there is no way to test that.
-pub unsafe trait EGLNativeSurface: Send + Sync {
+pub unsafe trait EGLNativeSurface: Send {
     /// Create an EGLSurface from the internal native type.
     ///
     /// Must be able to deal with re-creation of existing resources,

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -449,6 +449,7 @@ impl CompositorState {
     }
 }
 
+#[allow(missing_docs)] // TODO
 #[macro_export]
 macro_rules! delegate_compositor {
     ($ty: ty) => {

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -406,6 +406,7 @@ pub struct SeatUserData<T> {
     seat: Arc<SeatRc<T>>,
 }
 
+#[allow(missing_docs)] // TODO
 #[macro_export]
 macro_rules! delegate_seat {
     ($ty: ty) => {

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1556,6 +1556,7 @@ pub enum XdgRequest {
     },
 }
 
+#[allow(missing_docs)] // TODO
 #[macro_export]
 macro_rules! delegate_xdg_shell {
     ($ty: ty) => {

--- a/src/wayland/shm/mod.rs
+++ b/src/wayland/shm/mod.rs
@@ -205,6 +205,7 @@ pub struct BufferData {
     pub format: wl_shm::Format,
 }
 
+#[allow(missing_docs)] // TODO
 #[macro_export]
 macro_rules! delegate_shm {
     ($ty: ty) => {


### PR DESCRIPTION
WlEglSurface is no longer Sync, so EGLNativeDisplay is only implemented for `Mutex<WlEglSurface>`.