### PR TITLE
Fix damage tracking with fractional output scale

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -188,7 +188,7 @@ where
                 })
                 .map(|mut x| {
                     x.loc = (0, 0).into();
-                    x.to_f64().to_physical(scale).to_i32_round()
+                    x.to_f64().to_physical(scale)
                 })
                 .collect::<Vec<_>>();
             frame.render_texture_from_to(

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -37,7 +37,10 @@ where
         renderer
             .render(mode.size, transform, |renderer, frame| {
                 let mut damage = window.accumulated_damage(None);
-                frame.clear(CLEAR_COLOR, &[Rectangle::from_loc_and_size((0, 0), mode.size)])?;
+                frame.clear(
+                    CLEAR_COLOR,
+                    &[Rectangle::from_loc_and_size((0, 0), mode.size).to_f64()],
+                )?;
                 draw_window(
                     renderer,
                     frame,

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -910,7 +910,10 @@ fn initial_render(
     renderer
         .render((1, 1).into(), Transform::Normal, |_, frame| {
             frame
-                .clear(CLEAR_COLOR, &[Rectangle::from_loc_and_size((0, 0), (1, 1))])
+                .clear(
+                    CLEAR_COLOR,
+                    &[Rectangle::from_loc_and_size((0.0, 0.0), (1.0, 1.0))],
+                )
                 .map_err(Into::<SwapBuffersError>::into)
         })
         .map_err(Into::<SwapBuffersError>::into)

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1823,7 +1823,7 @@ impl Frame for Gles2Frame {
     type Error = Gles2Error;
     type TextureId = Gles2Texture;
 
-    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<f64, Physical>]) -> Result<(), Self::Error> {
         if at.is_empty() {
             return Ok(());
         }
@@ -1948,7 +1948,7 @@ impl Frame for Gles2Frame {
         texture: &Self::TextureId,
         src: Rectangle<i32, Buffer>,
         dest: Rectangle<f64, Physical>,
-        damage: &[Rectangle<i32, Physical>],
+        damage: &[Rectangle<f64, Physical>],
         transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error> {
@@ -1999,7 +1999,6 @@ impl Frame for Gles2Frame {
             .iter()
             .flat_map(|rect| {
                 let dest_size = dest.size;
-                let rect = rect.to_f64();
 
                 let rect_constrained_loc = rect
                     .loc

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -136,7 +136,7 @@ pub trait Frame {
     ///
     /// This operation is only valid in between a `begin` and `finish`-call.
     /// If called outside this operation may error-out, do nothing or modify future rendering results in any way.
-    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error>;
+    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<f64, Physical>]) -> Result<(), Self::Error>;
 
     /// Render a texture to the current target as a flat 2d-plane at a given
     /// position and applying the given transformation with the given alpha value.
@@ -149,7 +149,7 @@ pub trait Frame {
         texture_scale: i32,
         output_scale: f64,
         src_transform: Transform,
-        damage: &[Rectangle<i32, Physical>],
+        damage: &[Rectangle<f64, Physical>],
         alpha: f32,
     ) -> Result<(), Self::Error> {
         self.render_texture_from_to(
@@ -161,8 +161,7 @@ pub trait Frame {
                     .size()
                     .to_logical(texture_scale, src_transform)
                     .to_f64()
-                    .to_physical(output_scale)
-                    .to_i32_round(),
+                    .to_physical(output_scale),
             ),
             damage,
             src_transform,
@@ -178,7 +177,7 @@ pub trait Frame {
         texture: &Self::TextureId,
         src: Rectangle<i32, Buffer>,
         dst: Rectangle<f64, Physical>,
-        damage: &[Rectangle<i32, Physical>],
+        damage: &[Rectangle<f64, Physical>],
         src_transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error>;

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -293,13 +293,13 @@ where
                         // then clamp to surface size again in logical space
                         .flat_map(|geo| geo.intersection(Rectangle::from_loc_and_size((0, 0), dimensions)))
                         // lastly transform it into physical space
-                        .map(|geo| geo.to_f64().to_physical(scale).to_i32_round())
+                        .map(|geo| geo.to_f64().to_physical(scale))
                         .collect::<Vec<_>>();
 
                     // TODO: Take wp_viewporter into account
                     if let Err(err) = frame.render_texture_at(
                         texture,
-                        location.to_f64().to_physical(scale).to_i32_round(),
+                        location.to_f64().to_physical(scale),
                         buffer_scale,
                         scale,
                         attributes.buffer_transform.into(),

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -545,7 +545,7 @@ impl Space {
                         // Map from global space to output space
                         .map(|geo| Rectangle::from_loc_and_size(geo.loc - output_geo.loc, geo.size))
                         // Map from logical to physical
-                        .map(|geo| geo.to_f64().to_physical(state.render_scale).to_i32_round())
+                        .map(|geo| geo.to_f64().to_physical(state.render_scale))
                         .collect::<Vec<_>>(),
                 )?;
                 // Then re-draw all windows & layers overlapping with a damage rect.
@@ -932,7 +932,7 @@ macro_rules! custom_elements_internal {
 /// # impl Frame for DummyFrame {
 /// #   type Error = SwapBuffersError;
 /// #   type TextureId = DummyTexture;
-/// #   fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> { Ok(()) }
+/// #   fn clear(&mut self, color: [f32; 4], at: &[Rectangle<f64, Physical>]) -> Result<(), Self::Error> { Ok(()) }
 /// #   #[allow(clippy::too_many_arguments)]
 /// #   fn render_texture_at(
 /// #       &mut self,
@@ -941,7 +941,7 @@ macro_rules! custom_elements_internal {
 /// #       texture_scale: i32,
 /// #       output_scale: f64,
 /// #       src_transform: Transform,
-/// #       damage: &[Rectangle<i32, Physical>],
+/// #       damage: &[Rectangle<f64, Physical>],
 /// #       alpha: f32,
 /// #   ) -> Result<(), Self::Error> {
 /// #       Ok(())
@@ -951,7 +951,7 @@ macro_rules! custom_elements_internal {
 /// #       texture: &Self::TextureId,
 /// #       src: Rectangle<i32, Buffer>,
 /// #       dst: Rectangle<f64, Physical>,
-/// #       damage: &[Rectangle<i32, Physical>],
+/// #       damage: &[Rectangle<f64, Physical>],
 /// #       src_transform: Transform,
 /// #       alpha: f32,
 /// #   ) -> Result<(), Self::Error> {

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -124,7 +124,7 @@ impl Frame for DummyFrame {
     type Error = SwapBuffersError;
     type TextureId = DummyTexture;
 
-    fn clear(&mut self, _color: [f32; 4], _damage: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+    fn clear(&mut self, _color: [f32; 4], _damage: &[Rectangle<f64, Physical>]) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -133,7 +133,7 @@ impl Frame for DummyFrame {
         _texture: &Self::TextureId,
         _src: Rectangle<i32, Buffer>,
         _dst: Rectangle<f64, Physical>,
-        _damage: &[Rectangle<i32, Physical>],
+        _damage: &[Rectangle<f64, Physical>],
         _src_transform: Transform,
         _alpha: f32,
     ) -> Result<(), Self::Error> {


### PR DESCRIPTION
Based on https://github.com/Smithay/smithay/pull/527

This PR changes the renderer damage including `clear` to use `f64` just like the `dst` already did.
The problem with damage tracking and fractional output scale is that rounding the `dst` and or `damage` will
result in mismatches with the damage provided to `clear`.