### PR TITLE
do not release the buffer if old == new

### DIFF
--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -189,7 +189,14 @@ impl Cacheable for SurfaceAttributes {
             if let Some(BufferAssignment::NewBuffer { buffer, .. }) =
                 std::mem::replace(&mut into.buffer, self.buffer)
             {
-                buffer.release();
+                let new_buffer = into.buffer.as_ref().and_then(|b| match b {
+                    BufferAssignment::Removed => None,
+                    BufferAssignment::NewBuffer { buffer, .. } => Some(buffer),
+                });
+
+                if Some(&buffer) != new_buffer {
+                    buffer.release();
+                }
             }
         }
         into.buffer_scale = self.buffer_scale;


### PR DESCRIPTION
If the same buffer is attached multiple times to a sync subsurface without a commit on the parent in between releasing the old buffer will also release the new buffer.
After that the buffer will be dead and all access, including importing the buffer content will fail.
This can be observed by running foot:

```
...
[3145960.831]  -> wl_subcompositor@6.get_subsurface(new id wl_subsurface@37, wl_surface@36, wl_surface@19)
[3145960.838]  -> wl_subsurface@37.set_sync()
...
[3145962.725]  -> wl_surface@19.attach(wl_buffer@39, 0, 0)
[3145962.734]  -> wl_surface@19.damage_buffer(0, 0, 700, 26)
[3145962.741]  -> wl_surface@19.set_buffer_scale(1)
[3145962.744]  -> wl_compositor@5.create_region(new id wl_region@47)
[3145962.751]  -> wl_region@47.add(0, 0, 700, 26)
[3145962.758]  -> wl_surface@19.set_opaque_region(wl_region@47)
[3145962.761]  -> wl_region@47.destroy()
[3145962.762]  -> wl_surface@19.commit()
[3145962.763]  -> wl_surface@19.attach(wl_buffer@39, 0, 0)
[3145962.769]  -> wl_surface@19.damage_buffer(0, 0, 700, 26)
[3145962.778]  -> wl_surface@19.set_buffer_scale(1)
[3145962.782]  -> wl_surface@19.commit()
...
```