### PR TITLE
reset surface damage if it gets unmapped

### DIFF
--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -186,6 +186,9 @@ impl Cacheable for SurfaceAttributes {
     }
     fn merge_into(self, into: &mut Self) {
         if self.buffer.is_some() {
+            if let Some(BufferAssignment::Removed) = &self.buffer {
+                into.damage.clear();
+            }
             if let Some(BufferAssignment::NewBuffer { buffer, .. }) =
                 std::mem::replace(&mut into.buffer, self.buffer)
             {


### PR DESCRIPTION
~If the client attaches a new buffer (either NIL or some new buffer) we should reset the current damage or we will end up
with wrong damage in case of sync subsurfaces where multiple attach/commits are called on the surface without a parent commit in between.~

If a surface gets unmapped by attaching a `NULL`  buffer we should also clear the pending damage.

fixes #494