### PR TITLE
Always send frame callbacks

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -776,7 +776,7 @@ impl AnvilState<UdevData> {
             // Send frame events so that client start drawing their next frame
             self.space
                 .borrow()
-                .send_frames(false, self.start_time.elapsed().as_millis() as u32);
+                .send_frames(self.start_time.elapsed().as_millis() as u32);
         }
     }
 }

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -272,7 +272,7 @@ pub fn run_winit(log: Logger) {
         state
             .space
             .borrow()
-            .send_frames(false, start_time.elapsed().as_millis() as u32);
+            .send_frames(start_time.elapsed().as_millis() as u32);
 
         if event_loop
             .dispatch(Some(Duration::from_millis(16)), &mut state)

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -290,7 +290,7 @@ pub fn run_x11(log: Logger) {
         }
 
         // Send frame events so that client start drawing their next frame
-        space.send_frames(false, start_time.elapsed().as_millis() as u32);
+        space.send_frames(start_time.elapsed().as_millis() as u32);
         std::mem::drop(space);
 
         if event_loop.dispatch(None, &mut state).is_err() {

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -26,7 +26,6 @@ mod popup;
 mod window;
 
 pub use self::element::*;
-use self::layer::*;
 use self::output::*;
 use self::window::*;
 
@@ -612,28 +611,14 @@ impl Space {
     }
 
     /// Sends the frame callback to mapped [`Window`]s and [`LayerSurface`]s.
-    ///
-    /// If `all` is set this will be send to `all` mapped surfaces.
-    /// Otherwise only windows and layers previously drawn during the
-    /// previous frame will be send frame events.
-    pub fn send_frames(&self, all: bool, time: u32) {
-        for window in self.windows.iter().filter(|w| {
-            all || {
-                let mut state = window_state(self.id, w);
-                std::mem::replace(&mut state.drawn, false)
-            }
-        }) {
+    pub fn send_frames(&self, time: u32) {
+        for window in self.windows.iter() {
             window.send_frame(time);
         }
 
         for output in self.outputs.iter() {
             let map = layer_map_for_output(output);
-            for layer in map.layers().filter(|l| {
-                all || {
-                    let mut state = layer_state(self.id, l);
-                    std::mem::replace(&mut state.drawn, false)
-                }
-            }) {
+            for layer in map.layers() {
                 layer.send_frame(time);
             }
         }

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -144,7 +144,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
         state
             .space
             .borrow()
-            .send_frames(false, state.start_time.elapsed().as_millis() as u32);
+            .send_frames(state.start_time.elapsed().as_millis() as u32);
 
         if event_loop
             .dispatch(Some(Duration::from_millis(16)), &mut state)


### PR DESCRIPTION
We need to always send frame callbacks, irregardless if the surface has been drawn or not. Some clients will just wait for the next frame callback to complete before updating their content.
For example firefox on a pointer axis event or when showing popup menus.