### PR TITLE
Fix error due to unknown DRM rotation property

### DIFF
--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -862,11 +862,9 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
                 self.plane_prop_handle(primary, "CRTC_H")?,
                 property::Value::UnsignedRange(mode.size().1 as u64),
             );
-            req.add_property(
-                primary,
-                self.plane_prop_handle(primary, "rotation")?,
-                property::Value::Bitmask(1u64),
-            );
+            if let Ok(prop) = self.plane_prop_handle(primary, "rotation") {
+                req.add_property(primary, prop, property::Value::Bitmask(1u64));
+            }
         }
 
         // and finally the others
@@ -913,11 +911,9 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
                 self.plane_prop_handle(plane_info.handle, "CRTC_H")?,
                 property::Value::UnsignedRange(plane_info.h as u64),
             );
-            req.add_property(
-                plane_info.handle,
-                self.plane_prop_handle(plane_info.handle, "rotation")?,
-                property::Value::Bitmask(1u64),
-            );
+            if let Ok(prop) = self.plane_prop_handle(plane_info.handle, "rotation") {
+                req.add_property(plane_info.handle, prop, property::Value::Bitmask(1u64));
+            }
         }
 
         Ok(req)


### PR DESCRIPTION
This resolves a regression introduced in 6260e46, which could lead to
compositors not finding any viable GPU due to their lack of the
`rotation` property.

Since this property is only set to ensure it has a sane default value,
it should not be necessary on devices where it is not present at all.

Fixes #536.