### PR TITLE
Fix surface-damage indefinitely accumulating

### DIFF
--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -5,11 +5,10 @@ use crate::{
     utils::{Buffer, Logical, Point, Rectangle, Size, Transform},
     wayland::compositor::{
         is_sync_subsurface, with_surface_tree_upward, BufferAssignment, Damage, SubsurfaceCachedState,
-        SurfaceAttributes, TraversalAction,
+        SurfaceAttributes, SurfaceData, TraversalAction,
     },
 };
-#[cfg(feature = "desktop")]
-use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::{
     any::TypeId,
     cell::RefCell,
@@ -19,14 +18,19 @@ use wayland_server::protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface};
 
 #[derive(Default)]
 pub(crate) struct SurfaceState {
+    pub(crate) commit_count: usize,
     pub(crate) buffer_dimensions: Option<Size<i32, Buffer>>,
     pub(crate) buffer_scale: i32,
     pub(crate) buffer_transform: Transform,
     pub(crate) buffer: Option<WlBuffer>,
+    pub(crate) damage: VecDeque<Vec<Rectangle<i32, Buffer>>>,
+    pub(crate) renderer_seen: HashMap<(TypeId, usize), usize>,
     pub(crate) textures: HashMap<(TypeId, usize), Box<dyn std::any::Any>>,
     #[cfg(feature = "desktop")]
-    pub(crate) damage_seen: HashSet<crate::desktop::space::SpaceOutputHash>,
+    pub(crate) space_seen: HashMap<crate::desktop::space::SpaceOutputHash, usize>,
 }
+
+const MAX_DAMAGE: usize = 4;
 
 impl SurfaceState {
     pub fn update_buffer(&mut self, attrs: &mut SurfaceAttributes) {
@@ -34,16 +38,44 @@ impl SurfaceState {
             Some(BufferAssignment::NewBuffer { buffer, .. }) => {
                 // new contents
                 self.buffer_dimensions = buffer_dimensions(&buffer);
+
+                #[cfg(feature = "desktop")]
+                if self.buffer_scale != attrs.buffer_scale
+                    || self.buffer_transform != attrs.buffer_transform.into()
+                {
+                    self.reset_space_damage();
+                }
                 self.buffer_scale = attrs.buffer_scale;
                 self.buffer_transform = attrs.buffer_transform.into();
+
                 if let Some(old_buffer) = std::mem::replace(&mut self.buffer, Some(buffer)) {
                     if &old_buffer != self.buffer.as_ref().unwrap() {
                         old_buffer.release();
                     }
                 }
                 self.textures.clear();
-                #[cfg(feature = "desktop")]
-                self.damage_seen.clear();
+                self.commit_count = self.commit_count.wrapping_add(1);
+                let mut buffer_damage = attrs
+                    .damage
+                    .drain(..)
+                    .flat_map(|dmg| {
+                        match dmg {
+                            Damage::Buffer(rect) => rect,
+                            Damage::Surface(rect) => rect.to_buffer(
+                                self.buffer_scale,
+                                self.buffer_transform,
+                                &self.surface_size().unwrap(),
+                            ),
+                        }
+                        .intersection(Rectangle::from_loc_and_size(
+                            (0, 0),
+                            self.buffer_dimensions.unwrap(),
+                        ))
+                    })
+                    .collect::<Vec<Rectangle<i32, Buffer>>>();
+                buffer_damage.dedup();
+                self.damage.push_front(buffer_damage);
+                self.damage.truncate(MAX_DAMAGE);
             }
             Some(BufferAssignment::Removed) => {
                 // remove the contents
@@ -52,11 +84,42 @@ impl SurfaceState {
                     buffer.release();
                 };
                 self.textures.clear();
-                #[cfg(feature = "desktop")]
-                self.damage_seen.clear();
+                self.commit_count = self.commit_count.wrapping_add(1);
+                self.damage.clear();
             }
             None => {}
         }
+    }
+
+    pub(crate) fn damage_since(&self, commit: Option<usize>) -> Vec<Rectangle<i32, Buffer>> {
+        // on overflow the wrapping_sub should end up
+        let recent_enough = commit
+            // if commit > commit_count we have overflown, in that case the following map might result
+            // in a false-positive, if commit is still very large. So we force false in those cases.
+            // That will result in a potentially sub-optimal full damage every usize::MAX frames,
+            // which is acceptable.
+            .filter(|commit| *commit <= self.commit_count)
+            .map(|commit| self.commit_count.wrapping_sub(self.damage.len()) <= commit)
+            .unwrap_or(false);
+        if recent_enough {
+            self.damage
+                .iter()
+                .take(self.commit_count.wrapping_sub(commit.unwrap()))
+                .fold(Vec::new(), |mut acc, elem| {
+                    acc.extend(elem);
+                    acc
+                })
+        } else {
+            self.buffer_dimensions
+                .as_ref()
+                .map(|size| vec![Rectangle::from_loc_and_size((0, 0), *size)])
+                .unwrap_or_else(Vec::new)
+        }
+    }
+
+    #[cfg(feature = "desktop")]
+    pub fn reset_space_damage(&mut self) {
+        self.space_seen.clear();
     }
 
     /// Returns the size of the surface.
@@ -117,37 +180,40 @@ where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
 {
-    let mut result = Ok(());
+    import_surface_tree_and(renderer, surface, log, (0, 0).into(), |_, _, _| {})
+}
+
+fn import_surface_tree_and<F, R>(
+    renderer: &mut R,
+    surface: &WlSurface,
+    log: &slog::Logger,
+    location: Point<i32, Logical>,
+    processor: F,
+) -> Result<(), <R as Renderer>::Error>
+where
+    R: Renderer + ImportAll,
+    <R as Renderer>::TextureId: 'static,
+    F: FnMut(&WlSurface, &SurfaceData, &Point<i32, Logical>),
+{
     let texture_id = (TypeId::of::<<R as Renderer>::TextureId>(), renderer.id());
+    let mut result = Ok(());
     with_surface_tree_upward(
         surface,
-        (),
-        |_surface, states, _| {
+        location,
+        |_surface, states, location| {
+            let mut location = *location;
             if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
                 let mut data_ref = data.borrow_mut();
                 let data = &mut *data_ref;
-                let attributes = states.cached_state.current::<SurfaceAttributes>();
-                // Import a new buffer if available
-                let surface_size = data.surface_size();
+                // Import a new buffer if necessary
+                let last_commit = data.renderer_seen.get(&texture_id);
+                let buffer_damage = data.damage_since(last_commit.copied());
                 if let Entry::Vacant(e) = data.textures.entry(texture_id) {
                     if let Some(buffer) = data.buffer.as_ref() {
-                        let surface_size = surface_size.unwrap();
-                        let buffer_damage = attributes
-                            .damage
-                            .iter()
-                            .map(|dmg| match dmg {
-                                Damage::Buffer(rect) => *rect,
-                                Damage::Surface(rect) => rect.to_buffer(
-                                    attributes.buffer_scale,
-                                    attributes.buffer_transform.into(),
-                                    &surface_size,
-                                ),
-                            })
-                            .collect::<Vec<_>>();
-
                         match renderer.import_buffer(buffer, Some(states), &buffer_damage) {
                             Some(Ok(m)) => {
                                 e.insert(Box::new(m));
+                                data.renderer_seen.insert(texture_id, data.commit_count);
                             }
                             Some(Err(err)) => {
                                 slog::warn!(log, "Error loading buffer: {}", err);
@@ -159,9 +225,14 @@ where
                         }
                     }
                 }
-                // Now, was the import successful?
+                // Now, should we be drawn ?
                 if data.textures.contains_key(&texture_id) {
-                    TraversalAction::DoChildren(())
+                    // if yes, also process the children
+                    if states.role == Some("subsurface") {
+                        let current = states.cached_state.current::<SubsurfaceCachedState>();
+                        location += current.location;
+                    }
+                    TraversalAction::DoChildren(location)
                 } else {
                     // we are not displayed, so our children are neither
                     TraversalAction::SkipChildren
@@ -171,10 +242,9 @@ where
                 TraversalAction::SkipChildren
             }
         },
-        |_, _, _| {},
+        processor,
         |_, _, _| true,
     );
-
     result
 }
 
@@ -200,119 +270,59 @@ where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
 {
-    let mut result = Ok(());
     let texture_id = (TypeId::of::<<R as Renderer>::TextureId>(), renderer.id());
-    with_surface_tree_upward(
-        surface,
-        location,
-        |_surface, states, location| {
-            let mut location = *location;
-            if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
-                let mut data_ref = data.borrow_mut();
-                let data = &mut *data_ref;
-                let attributes = states.cached_state.current::<SurfaceAttributes>();
-                // Import a new buffer if necessary
-                let surface_size = data.surface_size();
-                if let Entry::Vacant(e) = data.textures.entry(texture_id) {
-                    if let Some(buffer) = data.buffer.as_ref() {
-                        let surface_size = surface_size.unwrap();
-                        let buffer_damage = attributes
-                            .damage
-                            .iter()
-                            .map(|dmg| match dmg {
-                                Damage::Buffer(rect) => *rect,
-                                Damage::Surface(rect) => rect.to_buffer(
-                                    attributes.buffer_scale,
-                                    attributes.buffer_transform.into(),
-                                    &surface_size,
-                                ),
-                            })
-                            .collect::<Vec<_>>();
-
-                        match renderer.import_buffer(buffer, Some(states), &buffer_damage) {
-                            Some(Ok(m)) => {
-                                e.insert(Box::new(m));
-                            }
-                            Some(Err(err)) => {
-                                slog::warn!(log, "Error loading buffer: {}", err);
-                            }
-                            None => {
-                                slog::error!(log, "Unknown buffer format for: {:?}", buffer);
-                            }
-                        }
-                    }
+    let mut result = Ok(());
+    let _ = import_surface_tree_and(renderer, surface, log, location, |_surface, states, location| {
+        let mut location = *location;
+        if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
+            let mut data = data.borrow_mut();
+            let dimensions = data.surface_size();
+            let buffer_scale = data.buffer_scale;
+            let attributes = states.cached_state.current::<SurfaceAttributes>();
+            if let Some(texture) = data
+                .textures
+                .get_mut(&texture_id)
+                .and_then(|x| x.downcast_mut::<<R as Renderer>::TextureId>())
+            {
+                let dimensions = dimensions.unwrap();
+                // we need to re-extract the subsurface offset, as the previous closure
+                // only passes it to our children
+                let mut surface_offset = (0, 0).into();
+                if states.role == Some("subsurface") {
+                    let current = states.cached_state.current::<SubsurfaceCachedState>();
+                    surface_offset = current.location;
+                    location += current.location;
                 }
-                // Now, should we be drawn ?
-                if data.textures.contains_key(&texture_id) {
-                    // if yes, also process the children
-                    if states.role == Some("subsurface") {
-                        let current = states.cached_state.current::<SubsurfaceCachedState>();
-                        location += current.location;
-                    }
-                    TraversalAction::DoChildren(location)
-                } else {
-                    // we are not displayed, so our children are neither
-                    TraversalAction::SkipChildren
-                }
-            } else {
-                // we are not displayed, so our children are neither
-                TraversalAction::SkipChildren
-            }
-        },
-        |_surface, states, location| {
-            let mut location = *location;
-            if let Some(data) = states.data_map.get::<RefCell<SurfaceState>>() {
-                let mut data = data.borrow_mut();
-                let dimensions = data.surface_size();
-                let buffer_scale = data.buffer_scale;
-                let attributes = states.cached_state.current::<SurfaceAttributes>();
-                if let Some(texture) = data
-                    .textures
-                    .get_mut(&texture_id)
-                    .and_then(|x| x.downcast_mut::<<R as Renderer>::TextureId>())
-                {
-                    let dimensions = dimensions.unwrap();
-                    // we need to re-extract the subsurface offset, as the previous closure
-                    // only passes it to our children
-                    let mut surface_offset = (0, 0).into();
-                    if states.role == Some("subsurface") {
-                        let current = states.cached_state.current::<SubsurfaceCachedState>();
-                        surface_offset = current.location;
-                        location += current.location;
-                    }
 
-                    let damage = damage
-                        .iter()
-                        .cloned()
-                        // first move the damage by the surface offset in logical space
-                        .map(|mut geo| {
-                            // make the damage relative to the surfaec
-                            geo.loc -= surface_offset;
-                            geo
-                        })
-                        // then clamp to surface size again in logical space
-                        .flat_map(|geo| geo.intersection(Rectangle::from_loc_and_size((0, 0), dimensions)))
-                        // lastly transform it into physical space
-                        .map(|geo| geo.to_f64().to_physical(scale))
-                        .collect::<Vec<_>>();
+                let damage = damage
+                    .iter()
+                    .cloned()
+                    // first move the damage by the surface offset in logical space
+                    .map(|mut geo| {
+                        // make the damage relative to the surfaec
+                        geo.loc -= surface_offset;
+                        geo
+                    })
+                    // then clamp to surface size again in logical space
+                    .flat_map(|geo| geo.intersection(Rectangle::from_loc_and_size((0, 0), dimensions)))
+                    // lastly transform it into physical space
+                    .map(|geo| geo.to_f64().to_physical(scale))
+                    .collect::<Vec<_>>();
 
-                    // TODO: Take wp_viewporter into account
-                    if let Err(err) = frame.render_texture_at(
-                        texture,
-                        location.to_f64().to_physical(scale),
-                        buffer_scale,
-                        scale,
-                        attributes.buffer_transform.into(),
-                        &damage,
-                        1.0,
-                    ) {
-                        result = Err(err);
-                    }
+                // TODO: Take wp_viewporter into account
+                if let Err(err) = frame.render_texture_at(
+                    texture,
+                    location.to_f64().to_physical(scale),
+                    buffer_scale,
+                    scale,
+                    attributes.buffer_transform.into(),
+                    &damage,
+                    1.0,
+                ) {
+                    result = Err(err);
                 }
             }
-        },
-        |_, _, _| true,
-    );
-
+        }
+    });
     result
 }

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -103,7 +103,7 @@ use wayland_server::{
 
 /// Description of a part of a surface that
 /// should be considered damaged and needs to be redrawn
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Damage {
     /// A rectangle containing the damaged zone, in surface coordinates
     Surface(Rectangle<i32, Logical>),


### PR DESCRIPTION
wayland/compositor is designed to expect downstream to drain/clear
the accumulated damage from `SurfaceData` on commit. To handle
multiple renderers the renderer/utils module did not do that, causing
damage to pile up indefinitely. This is obviously wrong, so this commit
attempts to fix this, by accumulating damage into `SurfaceState`
(clearing `SurfaceData` in the process) and keeping at most four commits
of damage for different renderers to consume.