### PR TITLE
0.30 buffer management

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -13,7 +13,7 @@ use smithay::{
     reexports::wayland_server::Display,
     utils::{Rectangle, Transform},
     wayland::{
-        buffer::{BufferHandler, ManagedBuffer},
+        buffer::{Buffer, BufferHandler},
         compositor::{
             with_surface_tree_downward, CompositorHandler, CompositorState, SurfaceAttributes,
             TraversalAction,
@@ -32,7 +32,7 @@ use wayland_server::{
 };
 
 impl BufferHandler for App {
-    fn buffer_destroyed(&mut self, _buffer: &ManagedBuffer) {}
+    fn buffer_destroyed(&mut self, _buffer: &Buffer) {}
 }
 
 impl XdgShellHandler for App {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -13,6 +13,7 @@ use smithay::{
     reexports::wayland_server::Display,
     utils::{Rectangle, Transform},
     wayland::{
+        buffer::{BufferHandler, ManagedBuffer},
         compositor::{
             with_surface_tree_downward, CompositorHandler, CompositorState, SurfaceAttributes,
             TraversalAction,
@@ -29,6 +30,10 @@ use wayland_server::{
     socket::ListeningSocket,
     DisplayHandle,
 };
+
+impl BufferHandler for App {
+    fn buffer_destroyed(&mut self, _buffer: &ManagedBuffer) {}
+}
 
 impl XdgShellHandler for App {
     fn xdg_shell_state(&mut self) -> &mut XdgShellState {

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -16,10 +16,13 @@ use wayland_server::{protocol::wl_buffer::WlBuffer, Display};
 use wayland_sys::server::wl_display;
 
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
-use crate::backend::egl::{BufferAccessError, EGLBuffer, Format};
+use crate::{
+    backend::egl::{BufferAccessError, EGLBuffer, Format},
+    wayland::buffer::Buffer,
+};
 use crate::{
     backend::{
-        allocator::{dmabuf::Dmabuf, Buffer, Format as DrmFormat, Fourcc, Modifier},
+        allocator::{dmabuf::Dmabuf, Buffer as _, Format as DrmFormat, Fourcc, Modifier},
         egl::{
             context::{GlAttributes, PixelFormatRequirements},
             ffi,
@@ -919,11 +922,10 @@ impl EGLBufferReader {
     pub fn egl_buffer_dimensions(
         &self,
         dh: &mut wayland_server::DisplayHandle<'_>,
-        buffer: &WlBuffer,
+        buffer: &Buffer,
     ) -> Option<crate::utils::Size<i32, crate::utils::Buffer>> {
-        use wayland_server::Resource;
         if dh.get_object_data(buffer.id()).is_err() {
-            debug!(self.logger, "Suplied buffer is no longer alive");
+            debug!(self.logger, "Supplied buffer is no longer alive");
             return None;
         }
 

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -33,19 +33,18 @@ use crate::backend::egl::{
     EGLContext, EGLSurface, MakeCurrentError,
 };
 use crate::backend::SwapBuffersError;
-use crate::utils::{Buffer, Physical, Rectangle, Size, Transform};
+use crate::utils::{Buffer as BufferCoord, Physical, Rectangle, Size, Transform};
 
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
 use super::ImportEgl;
 #[cfg(feature = "wayland_frontend")]
 use super::{ImportDmaWl, ImportMemWl};
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
-use crate::backend::egl::{display::EGLBufferReader, Format as EGLFormat};
+use crate::backend::egl::{self, display::EGLBufferReader, EGLError, Format as EGLFormat};
 #[cfg(feature = "wayland_frontend")]
-use wayland_server::{
-    protocol::{wl_buffer, wl_shm},
-    DisplayHandle,
-};
+use crate::wayland::buffer::Buffer;
+#[cfg(feature = "wayland_frontend")]
+use wayland_server::protocol::wl_shm;
 
 use slog::{debug, error, info, o, trace, warn};
 
@@ -95,7 +94,7 @@ impl Gles2Texture {
     pub unsafe fn from_raw(
         renderer: &Gles2Renderer,
         tex: ffi::types::GLuint,
-        size: Size<i32, Buffer>,
+        size: Size<i32, BufferCoord>,
     ) -> Gles2Texture {
         Gles2Texture(Rc::new(Gles2TextureInternal {
             texture: tex,
@@ -122,7 +121,7 @@ struct Gles2TextureInternal {
     texture_kind: usize,
     is_external: bool,
     y_inverted: bool,
-    size: Size<i32, Buffer>,
+    size: Size<i32, BufferCoord>,
     egl_images: Option<Vec<EGLImage>>,
     destruction_callback_sender: Sender<CleanupResource>,
 }
@@ -157,7 +156,7 @@ impl Texture for Gles2Texture {
     fn height(&self) -> u32 {
         self.0.size.h as u32
     }
-    fn size(&self) -> Size<i32, Buffer> {
+    fn size(&self) -> Size<i32, BufferCoord> {
         self.0.size
     }
 }
@@ -166,7 +165,7 @@ impl Texture for Gles2Texture {
 #[derive(Debug)]
 pub struct Gles2Mapping {
     pbo: ffi::types::GLuint,
-    size: Size<i32, Buffer>,
+    size: Size<i32, BufferCoord>,
     mapping: AtomicPtr<nix::libc::c_void>,
     destruction_callback_sender: Sender<CleanupResource>,
 }
@@ -178,7 +177,7 @@ impl Texture for Gles2Mapping {
     fn height(&self) -> u32 {
         self.size.h as u32
     }
-    fn size(&self) -> Size<i32, Buffer> {
+    fn size(&self) -> Size<i32, BufferCoord> {
         self.size
     }
 }
@@ -767,22 +766,13 @@ impl Gles2Renderer {
 impl ImportMemWl for Gles2Renderer {
     fn import_shm_buffer(
         &mut self,
-        dh: &mut DisplayHandle<'_>,
-        buffer: &wl_buffer::WlBuffer,
+        buffer: &Buffer,
         surface: Option<&crate::wayland::compositor::SurfaceData>,
-        damage: &[Rectangle<i32, Buffer>],
+        damage: &[Rectangle<i32, BufferCoord>],
     ) -> Result<Gles2Texture, Gles2Error> {
-        use crate::wayland::{
-            buffer::ManagedBuffer,
-            shm::{with_buffer_contents, BufferAccessError},
-        };
+        use crate::wayland::shm::with_buffer_contents;
 
-        let buffer = match ManagedBuffer::from_buffer(buffer, dh) {
-            Ok(buffer) => buffer,
-            Err(_) => return Err(Gles2Error::BufferAccessError(BufferAccessError::NotManaged)),
-        };
-
-        with_buffer_contents(&buffer, |slice, data| {
+        with_buffer_contents(buffer, |slice, data| {
             self.make_current()?;
 
             let offset = data.offset as i32;
@@ -900,7 +890,7 @@ impl ImportMem for Gles2Renderer {
     fn import_memory(
         &mut self,
         data: &[u8],
-        size: Size<i32, Buffer>,
+        size: Size<i32, BufferCoord>,
         flipped: bool,
     ) -> Result<Gles2Texture, Gles2Error> {
         self.make_current()?;
@@ -950,7 +940,7 @@ impl ImportMem for Gles2Renderer {
         &mut self,
         texture: &<Self as Renderer>::TextureId,
         data: &[u8],
-        region: Rectangle<i32, Buffer>,
+        region: Rectangle<i32, BufferCoord>,
     ) -> Result<(), <Self as Renderer>::Error> {
         self.make_current()?;
 
@@ -1011,9 +1001,9 @@ impl ImportEgl for Gles2Renderer {
     fn import_egl_buffer(
         &mut self,
         dh: &mut wayland_server::DisplayHandle<'_>,
-        buffer: &wl_buffer::WlBuffer,
+        buffer: &Buffer,
         _surface: Option<&crate::wayland::compositor::SurfaceData>,
-        _damage: &[Rectangle<i32, Buffer>],
+        _damage: &[Rectangle<i32, BufferCoord>],
     ) -> Result<Gles2Texture, Gles2Error> {
         if !self.extensions.iter().any(|ext| ext == "GL_OES_EGL_image") {
             return Err(Gles2Error::GLExtensionNotSupported(&["GL_OES_EGL_image"]));
@@ -1032,11 +1022,15 @@ impl ImportEgl for Gles2Renderer {
         // will never be cleaned up.
         self.make_current()?;
 
+        let buffer = buffer.buffer(dh).map_err(|_| {
+            Gles2Error::EGLBufferAccessError(egl::BufferAccessError::NotManaged(EGLError::BadParameter))
+        })?;
+
         let egl = self
             .egl_reader
             .as_ref()
             .unwrap()
-            .egl_buffer_contents(dh, buffer)
+            .egl_buffer_contents(dh, &buffer)
             .map_err(Gles2Error::EGLBufferAccessError)?;
 
         let tex = self.import_egl_image(egl.image(0).unwrap(), egl.format == EGLFormat::External, None)?;
@@ -1064,7 +1058,7 @@ impl ImportDma for Gles2Renderer {
     fn import_dmabuf(
         &mut self,
         buffer: &Dmabuf,
-        _damage: Option<&[Rectangle<i32, Buffer>]>,
+        _damage: Option<&[Rectangle<i32, BufferCoord>]>,
     ) -> Result<Gles2Texture, Gles2Error> {
         use crate::backend::allocator::Buffer;
         if !self.extensions.iter().any(|ext| ext == "GL_OES_EGL_image") {
@@ -1166,7 +1160,7 @@ impl ExportMem for Gles2Renderer {
 
     fn copy_framebuffer(
         &mut self,
-        region: Rectangle<i32, Buffer>,
+        region: Rectangle<i32, BufferCoord>,
     ) -> Result<Self::TextureMapping, Self::Error> {
         self.make_current()?;
         let mut pbo = 0;
@@ -1200,7 +1194,7 @@ impl ExportMem for Gles2Renderer {
     fn copy_texture(
         &mut self,
         texture: &Self::TextureId,
-        region: Rectangle<i32, Buffer>,
+        region: Rectangle<i32, BufferCoord>,
     ) -> Result<Self::TextureMapping, Self::Error> {
         let mut pbo = 0;
         let old_target = self.target.take();
@@ -1320,7 +1314,7 @@ impl ExportDma for Gles2Renderer {
         res
     }
 
-    fn export_framebuffer(&mut self, size: Size<i32, Buffer>) -> Result<Dmabuf, Gles2Error> {
+    fn export_framebuffer(&mut self, size: Size<i32, BufferCoord>) -> Result<Dmabuf, Gles2Error> {
         self.make_current()?;
 
         if !self
@@ -1537,7 +1531,7 @@ impl Bind<Gles2Texture> for Gles2Renderer {
 }
 
 impl Offscreen<Gles2Texture> for Gles2Renderer {
-    fn create_buffer(&mut self, size: Size<i32, Buffer>) -> Result<Gles2Texture, Gles2Error> {
+    fn create_buffer(&mut self, size: Size<i32, BufferCoord>) -> Result<Gles2Texture, Gles2Error> {
         self.make_current()?;
         let tex = unsafe {
             let mut tex = 0;
@@ -1597,7 +1591,7 @@ impl Bind<Gles2Renderbuffer> for Gles2Renderer {
 }
 
 impl Offscreen<Gles2Renderbuffer> for Gles2Renderer {
-    fn create_buffer(&mut self, size: Size<i32, Buffer>) -> Result<Gles2Renderbuffer, Gles2Error> {
+    fn create_buffer(&mut self, size: Size<i32, BufferCoord>) -> Result<Gles2Renderbuffer, Gles2Error> {
         self.make_current()?;
         unsafe {
             let mut rbo = 0;
@@ -1959,7 +1953,7 @@ impl Frame for Gles2Frame {
     fn render_texture_from_to(
         &mut self,
         texture: &Self::TextureId,
-        src: Rectangle<i32, Buffer>,
+        src: Rectangle<i32, BufferCoord>,
         dest: Rectangle<f64, Physical>,
         damage: &[Rectangle<f64, Physical>],
         transform: Transform,

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -10,16 +10,13 @@
 use std::collections::HashSet;
 use std::error::Error;
 
-use crate::utils::{Buffer, Physical, Point, Rectangle, Size, Transform};
+use crate::utils::{Buffer as BufferCoord, Physical, Point, Rectangle, Size, Transform};
 
 #[cfg(feature = "wayland_frontend")]
-use crate::wayland::{buffer::ManagedBuffer, compositor::SurfaceData};
+use crate::wayland::{buffer::Buffer, compositor::SurfaceData};
 use cgmath::Matrix3;
 #[cfg(feature = "wayland_frontend")]
-use wayland_server::{
-    protocol::{wl_buffer, wl_shm},
-    DisplayHandle, Resource,
-};
+use wayland_server::protocol::wl_shm;
 
 #[cfg(feature = "renderer_gl")]
 pub mod gles2;
@@ -108,7 +105,7 @@ pub trait Unbind: Renderer {
 /// A two dimensional texture
 pub trait Texture {
     /// Size of the texture plane
-    fn size(&self) -> Size<i32, Buffer> {
+    fn size(&self) -> Size<i32, BufferCoord> {
         Size::from((self.width() as i32, self.height() as i32))
     }
 
@@ -157,7 +154,7 @@ pub trait Frame {
     ) -> Result<(), Self::Error> {
         self.render_texture_from_to(
             texture,
-            Rectangle::from_loc_and_size(Point::<i32, Buffer>::from((0, 0)), texture.size()),
+            Rectangle::from_loc_and_size(Point::<i32, BufferCoord>::from((0, 0)), texture.size()),
             Rectangle::from_loc_and_size(
                 pos,
                 texture
@@ -178,7 +175,7 @@ pub trait Frame {
     fn render_texture_from_to(
         &mut self,
         texture: &Self::TextureId,
-        src: Rectangle<i32, Buffer>,
+        src: Rectangle<i32, BufferCoord>,
         dst: Rectangle<f64, Physical>,
         damage: &[Rectangle<f64, Physical>],
         src_transform: Transform,
@@ -233,7 +230,7 @@ pub trait Offscreen<Target>: Renderer + Bind<Target> {
     /// This call *may* fail, if (but not limited to):
     /// - The maximum amount of framebuffers for this renderer would be exceeded
     /// - The size is too large for a framebuffer
-    fn create_buffer(&mut self, size: Size<i32, Buffer>) -> Result<Target, <Self as Renderer>::Error>;
+    fn create_buffer(&mut self, size: Size<i32, BufferCoord>) -> Result<Target, <Self as Renderer>::Error>;
 }
 
 /// Trait for Renderers supporting importing wl_buffers using shared memory.
@@ -256,10 +253,9 @@ pub trait ImportMemWl: ImportMem {
     /// with an empty list `&[]`, the renderer is allowed to not update the texture at all.
     fn import_shm_buffer(
         &mut self,
-        dh: &mut DisplayHandle<'_>,
-        buffer: &wl_buffer::WlBuffer,
+        buffer: &Buffer,
         surface: Option<&crate::wayland::compositor::SurfaceData>,
-        damage: &[Rectangle<i32, Buffer>],
+        damage: &[Rectangle<i32, BufferCoord>],
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>;
 
     /// Returns supported formats for shared memory buffers.
@@ -291,7 +287,7 @@ pub trait ImportMem: Renderer {
     fn import_memory(
         &mut self,
         data: &[u8],
-        size: Size<i32, Buffer>,
+        size: Size<i32, BufferCoord>,
         flipped: bool,
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>;
 
@@ -312,7 +308,7 @@ pub trait ImportMem: Renderer {
         &mut self,
         texture: &<Self as Renderer>::TextureId,
         data: &[u8],
-        region: Rectangle<i32, Buffer>,
+        region: Rectangle<i32, BufferCoord>,
     ) -> Result<(), <Self as Renderer>::Error>;
 }
 
@@ -366,9 +362,9 @@ pub trait ImportEgl: Renderer {
     fn import_egl_buffer(
         &mut self,
         dh: &mut wayland_server::DisplayHandle<'_>,
-        buffer: &wl_buffer::WlBuffer,
+        buffer: &Buffer,
         surface: Option<&crate::wayland::compositor::SurfaceData>,
-        damage: &[Rectangle<i32, Buffer>],
+        damage: &[Rectangle<i32, BufferCoord>],
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>;
 }
 
@@ -388,15 +384,16 @@ pub trait ImportDmaWl: ImportDma {
     /// to avoid relying on implementation details, keep the buffer alive, until you destroyed this texture again.
     fn import_dma_buffer(
         &mut self,
-        buffer: &wl_buffer::WlBuffer,
+        _buffer: &Buffer,
         surface: Option<&crate::wayland::compositor::SurfaceData>,
-        damage: &[Rectangle<i32, Buffer>],
+        _damage: &[Rectangle<i32, BufferCoord>],
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error> {
         let _ = surface;
-        let dmabuf = buffer
-            .data::<Dmabuf>()
-            .expect("import_dma_buffer without checking buffer type?");
-        self.import_dmabuf(dmabuf, Some(damage))
+        // let dmabuf = buffer
+        //     .data::<Dmabuf>()
+        //     .expect("import_dma_buffer without checking buffer type?");
+        // self.import_dmabuf(dmabuf, Some(damage))
+        todo!("Dma")
     }
 }
 
@@ -421,7 +418,7 @@ pub trait ImportDma: Renderer {
     fn import_dmabuf(
         &mut self,
         dmabuf: &Dmabuf,
-        damage: Option<&[Rectangle<i32, Buffer>]>,
+        damage: Option<&[Rectangle<i32, BufferCoord>]>,
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>;
 }
 
@@ -452,9 +449,9 @@ pub trait ImportAll: Renderer {
     fn import_buffer(
         &mut self,
         dh: &mut wayland_server::DisplayHandle<'_>,
-        buffer: &wl_buffer::WlBuffer,
+        buffer: &Buffer,
         surface: Option<&crate::wayland::compositor::SurfaceData>,
-        damage: &[Rectangle<i32, Buffer>],
+        damage: &[Rectangle<i32, BufferCoord>],
     ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>>;
 }
 
@@ -468,12 +465,12 @@ impl<R: Renderer + ImportMemWl + ImportEgl + ImportDmaWl> ImportAll for R {
     fn import_buffer(
         &mut self,
         dh: &mut wayland_server::DisplayHandle<'_>,
-        buffer: &wl_buffer::WlBuffer,
+        buffer: &Buffer,
         surface: Option<&SurfaceData>,
-        damage: &[Rectangle<i32, Buffer>],
+        damage: &[Rectangle<i32, BufferCoord>],
     ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>> {
         match buffer_type(dh, buffer) {
-            Some(BufferType::Shm) => Some(self.import_shm_buffer(dh, buffer, surface, damage)),
+            Some(BufferType::Shm) => Some(self.import_shm_buffer(buffer, surface, damage)),
             Some(BufferType::Egl) => Some(self.import_egl_buffer(dh, buffer, surface, damage)),
             Some(BufferType::Dma) => Some(self.import_dma_buffer(buffer, surface, damage)),
             _ => None,
@@ -489,12 +486,12 @@ impl<R: Renderer + ImportMemWl + ImportDmaWl> ImportAll for R {
     fn import_buffer(
         &mut self,
         dh: &mut wayland_server::DisplayHandle<'_>,
-        buffer: &wl_buffer::WlBuffer,
+        buffer: &Buffer,
         surface: Option<&SurfaceData>,
-        damage: &[Rectangle<i32, Buffer>],
+        damage: &[Rectangle<i32, BufferCoord>],
     ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>> {
         match buffer_type(dh, buffer) {
-            Some(BufferType::Shm) => Some(self.import_shm_buffer(dh, buffer, surface, damage)),
+            Some(BufferType::Shm) => Some(self.import_shm_buffer(buffer, surface, damage)),
             Some(BufferType::Dma) => Some(self.import_dma_buffer(buffer, surface, damage)),
             _ => None,
         }
@@ -516,7 +513,7 @@ pub trait ExportMem: Renderer {
     /// - There is not enough space to create the mapping
     fn copy_framebuffer(
         &mut self,
-        region: Rectangle<i32, Buffer>,
+        region: Rectangle<i32, BufferCoord>,
     ) -> Result<Self::TextureMapping, <Self as Renderer>::Error>;
     /// Copies the contents of the passed texture.
     /// *Note*: This function may change or invalidate the current bind.
@@ -529,7 +526,7 @@ pub trait ExportMem: Renderer {
     fn copy_texture(
         &mut self,
         texture: &Self::TextureId,
-        region: Rectangle<i32, Buffer>,
+        region: Rectangle<i32, BufferCoord>,
     ) -> Result<Self::TextureMapping, Self::Error>;
     /// Returns a read-only pointer to a previously created texture mapping.
     ///
@@ -553,7 +550,10 @@ pub trait ExportDma: Renderer {
     /// - The framebuffer is not readable
     /// - The size is larger than the framebuffer
     /// - There is not enough space to create a copy
-    fn export_framebuffer(&mut self, size: Size<i32, Buffer>) -> Result<Dmabuf, <Self as Renderer>::Error>;
+    fn export_framebuffer(
+        &mut self,
+        size: Size<i32, BufferCoord>,
+    ) -> Result<Dmabuf, <Self as Renderer>::Error>;
     /// Exports the given texture as a dmabuf.
     ///
     /// This operation is not destructive, the contents of the texture keep being valid.
@@ -585,37 +585,27 @@ pub enum BufferType {
 /// Returns `None` if the type is not known to smithay
 /// or otherwise not supported (e.g. not initialized using one of smithays [`crate::wayland`]-handlers).
 #[cfg(feature = "wayland_frontend")]
-pub fn buffer_type(
-    dh: &mut wayland_server::DisplayHandle<'_>,
-    buffer: &wl_buffer::WlBuffer,
-) -> Option<BufferType> {
-    #[allow(clippy::single_match)] // TODO: Dma
-    match ManagedBuffer::from_buffer(buffer, dh) {
-        Ok(buffer) => {
-            // TODO: Dma
-            // if buffer.data::<Dmabuf>().is_some() {
-            //     return Some(BufferType::Dma);
-            // }
+pub fn buffer_type(_dh: &mut wayland_server::DisplayHandle<'_>, buffer: &Buffer) -> Option<BufferType> {
+    // TODO: Dma
+    // if buffer.data::<Dmabuf>().is_some() {
+    //     return Some(BufferType::Dma);
+    // }
 
-            if crate::wayland::shm::with_buffer_contents(&buffer, |_, _| ()).is_ok() {
-                return Some(BufferType::Shm);
-            }
-        }
+    if crate::wayland::shm::with_buffer_contents(buffer, |_, _| ()).is_ok() {
+        return Some(BufferType::Shm);
+    }
 
-        Err(_) => {
-            // Not managed, check if this is an EGLBuffer
-            #[cfg(all(feature = "backend_egl", feature = "use_system_lib"))]
-            if BUFFER_READER
-                .lock()
-                .unwrap()
-                .as_ref()
-                .and_then(|x| x.upgrade())
-                .and_then(|x| x.egl_buffer_dimensions(dh, buffer))
-                .is_some()
-            {
-                return Some(BufferType::Egl);
-            }
-        }
+    // Not managed, check if this is an EGLBuffer
+    #[cfg(all(feature = "backend_egl", feature = "use_system_lib"))]
+    if BUFFER_READER
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|x| x.upgrade())
+        .and_then(|x| x.egl_buffer_dimensions(_dh, buffer))
+        .is_some()
+    {
+        return Some(BufferType::Egl);
     }
 
     None
@@ -626,21 +616,19 @@ pub fn buffer_type(
 /// *Note*: This will only return dimensions for buffer types known to smithay (see [`buffer_type`])
 #[cfg(feature = "wayland_frontend")]
 pub fn buffer_dimensions(
-    dh: &mut wayland_server::DisplayHandle<'_>,
-    buffer: &wl_buffer::WlBuffer,
-) -> Option<Size<i32, Buffer>> {
+    _dh: &mut wayland_server::DisplayHandle<'_>,
+    buffer: &Buffer,
+) -> Option<Size<i32, BufferCoord>> {
     #[allow(unused_imports)] // TODO: Dma
     use crate::{backend::allocator::Buffer, wayland::shm};
 
-    match ManagedBuffer::from_buffer(buffer, dh) {
-        Ok(buffer) => {
-            // TODO: Dma
-            // if let Some(buf) = buffer.data::<Dmabuf>() {
-            //     return Some((buf.width() as i32, buf.height() as i32).into());
-            // }
+    // TODO: Dma
+    // if let Some(buf) = buffer.data::<Dmabuf>() {
+    //     return Some((buf.width() as i32, buf.height() as i32).into());
+    // }
 
-            shm::with_buffer_contents(&buffer, |_, data| (data.width, data.height).into()).ok()
-        }
+    match shm::with_buffer_contents(buffer, |_, data| (data.width, data.height).into()) {
+        Ok(data) => Some(data),
 
         Err(_) => {
             // Not managed, check if this is an EGLBuffer
@@ -650,7 +638,7 @@ pub fn buffer_dimensions(
                 .unwrap()
                 .as_ref()
                 .and_then(|x| x.upgrade())
-                .and_then(|x| x.egl_buffer_dimensions(dh, buffer))
+                .and_then(|x| x.egl_buffer_dimensions(_dh, buffer))
             {
                 return Some(dim);
             }

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -13,12 +13,12 @@ use std::error::Error;
 use crate::utils::{Buffer, Physical, Point, Rectangle, Size, Transform};
 
 #[cfg(feature = "wayland_frontend")]
-use crate::wayland::compositor::SurfaceData;
+use crate::wayland::{buffer::ManagedBuffer, compositor::SurfaceData};
 use cgmath::Matrix3;
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::{
     protocol::{wl_buffer, wl_shm},
-    Resource,
+    DisplayHandle, Resource,
 };
 
 #[cfg(feature = "renderer_gl")]
@@ -256,6 +256,7 @@ pub trait ImportMemWl: ImportMem {
     /// with an empty list `&[]`, the renderer is allowed to not update the texture at all.
     fn import_shm_buffer(
         &mut self,
+        dh: &mut DisplayHandle<'_>,
         buffer: &wl_buffer::WlBuffer,
         surface: Option<&crate::wayland::compositor::SurfaceData>,
         damage: &[Rectangle<i32, Buffer>],
@@ -472,7 +473,7 @@ impl<R: Renderer + ImportMemWl + ImportEgl + ImportDmaWl> ImportAll for R {
         damage: &[Rectangle<i32, Buffer>],
     ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>> {
         match buffer_type(dh, buffer) {
-            Some(BufferType::Shm) => Some(self.import_shm_buffer(buffer, surface, damage)),
+            Some(BufferType::Shm) => Some(self.import_shm_buffer(dh, buffer, surface, damage)),
             Some(BufferType::Egl) => Some(self.import_egl_buffer(dh, buffer, surface, damage)),
             Some(BufferType::Dma) => Some(self.import_dma_buffer(buffer, surface, damage)),
             _ => None,
@@ -493,7 +494,7 @@ impl<R: Renderer + ImportMemWl + ImportDmaWl> ImportAll for R {
         damage: &[Rectangle<i32, Buffer>],
     ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>> {
         match buffer_type(dh, buffer) {
-            Some(BufferType::Shm) => Some(self.import_shm_buffer(buffer, surface, damage)),
+            Some(BufferType::Shm) => Some(self.import_shm_buffer(dh, buffer, surface, damage)),
             Some(BufferType::Dma) => Some(self.import_dma_buffer(buffer, surface, damage)),
             _ => None,
         }
@@ -585,28 +586,36 @@ pub enum BufferType {
 /// or otherwise not supported (e.g. not initialized using one of smithays [`crate::wayland`]-handlers).
 #[cfg(feature = "wayland_frontend")]
 pub fn buffer_type(
-    // Note: this variable is only used if the inner [cfg()] is triggered
-    _dh: &mut wayland_server::DisplayHandle<'_>,
+    dh: &mut wayland_server::DisplayHandle<'_>,
     buffer: &wl_buffer::WlBuffer,
 ) -> Option<BufferType> {
-    if buffer.data::<Dmabuf>().is_some() {
-        return Some(BufferType::Dma);
-    }
+    #[allow(clippy::single_match)] // TODO: Dma
+    match ManagedBuffer::from_buffer(buffer, dh) {
+        Ok(buffer) => {
+            // TODO: Dma
+            // if buffer.data::<Dmabuf>().is_some() {
+            //     return Some(BufferType::Dma);
+            // }
 
-    #[cfg(all(feature = "backend_egl", feature = "use_system_lib"))]
-    if BUFFER_READER
-        .lock()
-        .unwrap()
-        .as_ref()
-        .and_then(|x| x.upgrade())
-        .and_then(|x| x.egl_buffer_dimensions(_dh, buffer))
-        .is_some()
-    {
-        return Some(BufferType::Egl);
-    }
+            if crate::wayland::shm::with_buffer_contents(&buffer, |_, _| ()).is_ok() {
+                return Some(BufferType::Shm);
+            }
+        }
 
-    if crate::wayland::shm::with_buffer_contents(buffer, |_, _| ()).is_ok() {
-        return Some(BufferType::Shm);
+        Err(_) => {
+            // Not managed, check if this is an EGLBuffer
+            #[cfg(all(feature = "backend_egl", feature = "use_system_lib"))]
+            if BUFFER_READER
+                .lock()
+                .unwrap()
+                .as_ref()
+                .and_then(|x| x.upgrade())
+                .and_then(|x| x.egl_buffer_dimensions(dh, buffer))
+                .is_some()
+            {
+                return Some(BufferType::Egl);
+            }
+        }
     }
 
     None
@@ -617,26 +626,36 @@ pub fn buffer_type(
 /// *Note*: This will only return dimensions for buffer types known to smithay (see [`buffer_type`])
 #[cfg(feature = "wayland_frontend")]
 pub fn buffer_dimensions(
-    // Note: this variable is only used if the inner [cfg()] is triggered
-    _dh: &mut wayland_server::DisplayHandle<'_>,
+    dh: &mut wayland_server::DisplayHandle<'_>,
     buffer: &wl_buffer::WlBuffer,
 ) -> Option<Size<i32, Buffer>> {
-    use crate::backend::allocator::Buffer;
+    #[allow(unused_imports)] // TODO: Dma
+    use crate::{backend::allocator::Buffer, wayland::shm};
 
-    if let Some(buf) = buffer.data::<Dmabuf>() {
-        return Some((buf.width() as i32, buf.height() as i32).into());
+    match ManagedBuffer::from_buffer(buffer, dh) {
+        Ok(buffer) => {
+            // TODO: Dma
+            // if let Some(buf) = buffer.data::<Dmabuf>() {
+            //     return Some((buf.width() as i32, buf.height() as i32).into());
+            // }
+
+            shm::with_buffer_contents(&buffer, |_, data| (data.width, data.height).into()).ok()
+        }
+
+        Err(_) => {
+            // Not managed, check if this is an EGLBuffer
+            #[cfg(all(feature = "backend_egl", feature = "use_system_lib"))]
+            if let Some(dim) = BUFFER_READER
+                .lock()
+                .unwrap()
+                .as_ref()
+                .and_then(|x| x.upgrade())
+                .and_then(|x| x.egl_buffer_dimensions(dh, buffer))
+            {
+                return Some(dim);
+            }
+
+            None
+        }
     }
-
-    #[cfg(all(feature = "backend_egl", feature = "use_system_lib"))]
-    if let Some(dim) = BUFFER_READER
-        .lock()
-        .unwrap()
-        .as_ref()
-        .and_then(|x| x.upgrade())
-        .and_then(|x| x.egl_buffer_dimensions(_dh, buffer))
-    {
-        return Some(dim);
-    }
-
-    crate::wayland::shm::with_buffer_contents(buffer, |_, data| (data.width, data.height).into()).ok()
 }

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -44,7 +44,7 @@ impl SurfaceState {
             Some(BufferAssignment::NewBuffer { buffer, .. }) => {
                 // new contents
                 self.buffer_dimensions = {
-                    let buffer = Buffer::from_buffer(&buffer, dh);
+                    let buffer = Buffer::from_wl(&buffer, dh);
 
                     buffer_dimensions(dh, &buffer)
                 };
@@ -222,7 +222,7 @@ where
                 let buffer_damage = data.damage_since(last_commit.copied());
                 if let Entry::Vacant(e) = data.textures.entry(texture_id) {
                     if let Some(buffer) = data.buffer.as_ref() {
-                        let buffer = Buffer::from_buffer(buffer, dh);
+                        let buffer = Buffer::from_wl(buffer, dh);
 
                         match renderer.import_buffer(dh, &buffer, Some(states), &buffer_damage) {
                             Some(Ok(m)) => {

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -2,10 +2,13 @@
 
 use crate::{
     backend::renderer::{buffer_dimensions, Frame, ImportAll, Renderer},
-    utils::{Buffer, Logical, Point, Rectangle, Size, Transform},
-    wayland::compositor::{
-        is_sync_subsurface, with_surface_tree_upward, BufferAssignment, Damage, SubsurfaceCachedState,
-        SurfaceAttributes, SurfaceData, TraversalAction,
+    utils::{Buffer as BufferCoord, Logical, Point, Rectangle, Size, Transform},
+    wayland::{
+        buffer::Buffer,
+        compositor::{
+            is_sync_subsurface, with_surface_tree_upward, BufferAssignment, Damage, SubsurfaceCachedState,
+            SurfaceAttributes, SurfaceData, TraversalAction,
+        },
     },
 };
 use std::collections::VecDeque;
@@ -22,11 +25,11 @@ use wayland_server::{
 #[derive(Default)]
 pub(crate) struct SurfaceState {
     pub(crate) commit_count: usize,
-    pub(crate) buffer_dimensions: Option<Size<i32, Buffer>>,
+    pub(crate) buffer_dimensions: Option<Size<i32, BufferCoord>>,
     pub(crate) buffer_scale: i32,
     pub(crate) buffer_transform: Transform,
     pub(crate) buffer: Option<WlBuffer>,
-    pub(crate) damage: VecDeque<Vec<Rectangle<i32, Buffer>>>,
+    pub(crate) damage: VecDeque<Vec<Rectangle<i32, BufferCoord>>>,
     pub(crate) renderer_seen: HashMap<(TypeId, usize), usize>,
     pub(crate) textures: HashMap<(TypeId, usize), Box<dyn std::any::Any>>,
     // #[cfg(feature = "desktop")]
@@ -40,7 +43,11 @@ impl SurfaceState {
         match attrs.buffer.take() {
             Some(BufferAssignment::NewBuffer { buffer, .. }) => {
                 // new contents
-                self.buffer_dimensions = buffer_dimensions(dh, &buffer);
+                self.buffer_dimensions = {
+                    let buffer = Buffer::from_buffer(&buffer, dh);
+
+                    buffer_dimensions(dh, &buffer)
+                };
 
                 // #[cfg(feature = "desktop")]
                 // if self.buffer_scale != attrs.buffer_scale
@@ -75,7 +82,7 @@ impl SurfaceState {
                             self.buffer_dimensions.unwrap(),
                         ))
                     })
-                    .collect::<Vec<Rectangle<i32, Buffer>>>();
+                    .collect::<Vec<Rectangle<i32, BufferCoord>>>();
                 buffer_damage.dedup();
                 self.damage.push_front(buffer_damage);
                 self.damage.truncate(MAX_DAMAGE);
@@ -94,7 +101,7 @@ impl SurfaceState {
         }
     }
 
-    pub(crate) fn damage_since(&self, commit: Option<usize>) -> Vec<Rectangle<i32, Buffer>> {
+    pub(crate) fn damage_since(&self, commit: Option<usize>) -> Vec<Rectangle<i32, BufferCoord>> {
         // on overflow the wrapping_sub should end up
         let recent_enough = commit
             // if commit > commit_count we have overflown, in that case the following map might result
@@ -215,7 +222,9 @@ where
                 let buffer_damage = data.damage_since(last_commit.copied());
                 if let Entry::Vacant(e) = data.textures.entry(texture_id) {
                     if let Some(buffer) = data.buffer.as_ref() {
-                        match renderer.import_buffer(dh, buffer, Some(states), &buffer_damage) {
+                        let buffer = Buffer::from_buffer(buffer, dh);
+
+                        match renderer.import_buffer(dh, &buffer, Some(states), &buffer_damage) {
                             Some(Ok(m)) => {
                                 e.insert(Box::new(m));
                                 data.renderer_seen.insert(texture_id, data.commit_count);

--- a/src/wayland/buffer/mod.rs
+++ b/src/wayland/buffer/mod.rs
@@ -1,0 +1,156 @@
+//! Buffer management utilities.
+//!
+//! This module provides the [`Buffer`] type to represent a [`WlBuffer`] managed by Smithay and data
+//! associated with said buffer. This module has a dual purpose. This module provides a way for the compositor
+//! to be told when a client has destroyed a buffer. The other purpose is to provide a way for specific types
+//! of [`WlBuffer`] to abstractly associate some data with the protocol object without conflicting
+//! [`Dispatch`](crate::reexports::wayland_server::Dispatch) implementations.
+//!
+//! Unlike most delegate types found in other modules of the wayland frontend, this module has no `delegate`
+//! macro by design.
+
+use std::{any::Any, sync::Arc};
+
+use wayland_server::{
+    backend::{protocol::Message, ClientId, Handle, InvalidId, ObjectData, ObjectId},
+    protocol::wl_buffer::WlBuffer,
+    DataInit, DisplayHandle, New, Resource,
+};
+
+use crate::utils::UnmanagedResource;
+
+/// Handler trait for associating data with a [`WlBuffer`].
+///
+/// This trait primarily allows compositors to be told when a buffer is destroyed.
+///
+/// # For buffer abstractions
+///
+/// Buffer abstractions (such as [`shm`](crate::wayland::shm)) should require this trait bound in dispatch
+/// requirements to ensure access to the [`BufferManager`].
+pub trait BufferHandler {
+    /// Returns a reference to the buffer manager.
+    fn buffer_manager(&self) -> &BufferManager;
+
+    /// Called when the client has destroyed the buffer.
+    ///
+    /// At this point the buffer is no longer usable by Smithay.
+    fn buffer_destroyed(&mut self, buffer: &Buffer);
+}
+
+/// The buffer manager.
+///
+/// This type allows a [`WlBuffer`] to have data associated and managed by Smithay.
+#[derive(Debug)]
+pub struct BufferManager(());
+
+impl BufferManager {
+    /// Initializes the buffer manager.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> BufferManager {
+        BufferManager(())
+    }
+
+    /// Initializes a buffer, associating some user data with the buffer. This function causes the buffer to
+    /// managed by Smithay.
+    ///
+    /// The data associated with the buffer may obtained using [`BufferManager::buffer_data`].
+    pub fn init_buffer<D, T>(&self, init: &mut DataInit<'_, D>, buffer: New<WlBuffer>, data: T) -> Buffer
+    where
+        D: BufferHandler + 'static,
+        T: Send + Sync + 'static,
+    {
+        let data = Arc::new(BufferData { data: Box::new(data) });
+        let buffer = init.custom_init(buffer, data.clone());
+
+        Buffer {
+            buffer: buffer.id(),
+            data,
+        }
+    }
+}
+
+/// A wrapper around a [`WlBuffer`] managed by Smithay.
+#[derive(Debug, Clone)]
+pub struct Buffer {
+    buffer: ObjectId,
+    data: Arc<BufferData>,
+}
+
+impl PartialEq for Buffer {
+    fn eq(&self, other: &Self) -> bool {
+        self.buffer == other.buffer
+    }
+}
+
+impl Buffer {
+    /// Creates a [`Buffer`] from a [`WlBuffer`].
+    ///
+    /// This function returns [`Err`] if the buffer is not managed by Smithay (such as an EGL buffer).
+    pub fn from_buffer(buffer: &WlBuffer, dh: &mut DisplayHandle<'_>) -> Result<Buffer, UnmanagedResource> {
+        let data = dh
+            .get_object_data(buffer.id())
+            .map_err(|_| UnmanagedResource)?
+            .downcast::<BufferData>()
+            .map_err(|_| UnmanagedResource)?;
+
+        Ok(Buffer {
+            buffer: buffer.id(),
+            data,
+        })
+    }
+
+    /// Returns a reference to the underlying [`WlBuffer`].
+    pub fn buffer(&self, dh: &mut DisplayHandle<'_>) -> Result<WlBuffer, InvalidId> {
+        WlBuffer::from_id(dh, self.buffer.clone())
+    }
+
+    /// Sends a `release` event, indicating the buffer is no longer in use by the compositor, meaning the
+    /// client is free to reuse or destroy the buffer.
+    pub fn release(&self, dh: &mut DisplayHandle<'_>) -> Result<(), InvalidId> {
+        self.buffer(dh)?.release(dh);
+        Ok(())
+    }
+
+    /// Returns the data associated with the buffer.
+    ///
+    /// This function is intended for abstractions to obtain the buffer data they store. Users should use the
+    /// functions provided by the buffer abstractions to obtain the data. For example, data associated with an
+    /// shm buffer should be obtained using [`with_buffer_contents`](crate::wayland::shm::with_buffer_contents)
+    /// instead of specifying the type of the data in the `T` generic for this function.
+    pub fn buffer_data<T>(&self) -> Option<&T>
+    where
+        T: Send + Sync + 'static,
+    {
+        <dyn Any>::downcast_ref::<T>(&*self.data.data)
+    }
+}
+
+#[derive(Debug)]
+struct BufferData {
+    data: Box<(dyn Any + Send + Sync + 'static)>,
+}
+
+impl<D> ObjectData<D> for BufferData
+where
+    D: BufferHandler + 'static,
+{
+    fn request(
+        self: Arc<Self>,
+        _: &mut Handle<D>,
+        data: &mut D,
+        _: ClientId,
+        msg: Message<ObjectId>,
+    ) -> Option<Arc<dyn ObjectData<D>>> {
+        // WlBuffer has a single request which is a destructor.
+        assert_eq!(msg.opcode, 0);
+
+        data.buffer_destroyed(&Buffer {
+            buffer: msg.sender_id,
+            data: self,
+        });
+
+        None
+    }
+
+    fn destroyed(&self, _: &mut D, _: ClientId, _: ObjectId) {}
+}

--- a/src/wayland/buffer/mod.rs
+++ b/src/wayland/buffer/mod.rs
@@ -55,7 +55,7 @@ impl Buffer {
     }
 
     /// Creates a [`Buffer`] from a [`WlBuffer`].
-    pub fn from_buffer(buffer: &WlBuffer, dh: &mut DisplayHandle<'_>) -> Buffer {
+    pub fn from_wl(buffer: &WlBuffer, dh: &mut DisplayHandle<'_>) -> Buffer {
         match dh.get_object_data(buffer.id()) {
             Ok(data) => {
                 match data.downcast::<BufferData>() {

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -54,6 +54,7 @@
 
 use std::sync::atomic::{AtomicU32, Ordering};
 
+pub mod buffer;
 pub mod compositor;
 // pub mod data_device;
 // pub mod dmabuf;

--- a/src/wayland/shm/handlers.rs
+++ b/src/wayland/shm/handlers.rs
@@ -1,5 +1,5 @@
 use crate::wayland::{
-    buffer::{BufferHandler, ManagedBuffer},
+    buffer::{Buffer, BufferHandler},
     shm::ShmBufferUserData,
 };
 
@@ -179,7 +179,7 @@ where
                             },
                         };
 
-                        ManagedBuffer::init_buffer(data_init, buffer, data);
+                        Buffer::init_buffer(data_init, buffer, data);
                     }
 
                     WEnum::Unknown(unknown) => {

--- a/src/wayland/shm/handlers.rs
+++ b/src/wayland/shm/handlers.rs
@@ -1,12 +1,16 @@
+use crate::wayland::{
+    buffer::{BufferHandler, ManagedBuffer},
+    shm::ShmBufferUserData,
+};
+
 use super::{
     pool::{Pool, ResizeError},
-    BufferData, ShmState,
+    BufferData, ShmPoolUserData, ShmState,
 };
 
 use std::sync::Arc;
 use wayland_server::{
     protocol::{
-        wl_buffer::{self, WlBuffer},
         wl_shm::{self, WlShm},
         wl_shm_pool::{self, WlShmPool},
     },
@@ -96,22 +100,13 @@ where
  * wl_shm_pool
  */
 
-/// User data of WlShmPool
-#[derive(Debug)]
-pub struct ShmPoolUserData {
-    inner: Arc<Pool>,
-}
-
 impl DelegateDispatchBase<WlShmPool> for ShmState {
     type UserData = ShmPoolUserData;
 }
 
 impl<D> DelegateDispatch<WlShmPool, D> for ShmState
 where
-    D: Dispatch<WlShmPool, UserData = ShmPoolUserData>
-        + Dispatch<WlBuffer, UserData = ShmBufferUserData>
-        + AsRef<ShmState>
-        + 'static,
+    D: Dispatch<WlShmPool, UserData = ShmPoolUserData> + BufferHandler + AsRef<ShmState> + 'static,
 {
     fn request(
         state: &mut D,
@@ -184,7 +179,7 @@ where
                             },
                         };
 
-                        data_init.init(buffer, data);
+                        ManagedBuffer::init_buffer(data_init, buffer, data);
                     }
 
                     WEnum::Unknown(unknown) => {
@@ -215,37 +210,5 @@ where
 
             _ => unreachable!(),
         }
-    }
-}
-
-/*
- * wl_buffer
- */
-
-/// User data of shm WlBuffer
-#[derive(Debug)]
-pub struct ShmBufferUserData {
-    pub(crate) pool: Arc<Pool>,
-    pub(crate) data: BufferData,
-}
-
-impl DelegateDispatchBase<WlBuffer> for ShmState {
-    type UserData = ShmBufferUserData;
-}
-
-impl<D> DelegateDispatch<WlBuffer, D> for ShmState
-where
-    D: Dispatch<WlBuffer, UserData = ShmBufferUserData>,
-    D: 'static,
-{
-    fn request(
-        _state: &mut D,
-        _client: &wayland_server::Client,
-        _pool: &WlBuffer,
-        _request: wl_buffer::Request,
-        _data: &Self::UserData,
-        _dh: &mut DisplayHandle<'_>,
-        _data_init: &mut DataInit<'_, D>,
-    ) {
     }
 }


### PR DESCRIPTION
This adds a way for multiple types of WlBuffer to coexist. The interesting part of this is the `ManagedBuffer` type which statically asserts a buffer is managed by Smithay.

This is done in two commits:
- introducing the `buffer` module
- porting shm to use `buffer` module along with renderer changes.