### PR TITLE
Allow z-index of windows and surfacetree's to be overriden

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -52,7 +52,11 @@ pub fn draw_cursor(
             (0, 0).into()
         }
     };
-    SurfaceTree { surface, position }
+    SurfaceTree {
+        surface,
+        position,
+        z_index: 100, /* Cursor should always be on-top */
+    }
 }
 
 pub fn draw_dnd_icon(
@@ -69,6 +73,7 @@ pub fn draw_dnd_icon(
     SurfaceTree {
         surface,
         position: location.into(),
+        z_index: 100, /* Cursor should always be on-top */
     }
 }
 

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -190,6 +190,8 @@ pub struct SurfaceTree {
     pub surface: WlSurface,
     /// Position to draw add
     pub position: Point<i32, Logical>,
+    /// Z-Index to draw at
+    pub z_index: u8,
 }
 
 impl<R> RenderElement<R> for SurfaceTree
@@ -232,6 +234,10 @@ where
             damage,
             log,
         )
+    }
+
+    fn z_index(&self) -> u8 {
+        self.z_index
     }
 }
 

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -102,6 +102,6 @@ impl Window {
     }
 
     pub(super) fn elem_z_index(&self) -> u8 {
-        RenderZindex::Shell as u8
+        self.0.z_index.get().unwrap_or(RenderZindex::Shell as u8)
     }
 }

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -86,6 +86,7 @@ pub(super) struct WindowInner {
     pub(super) id: usize,
     toplevel: Kind,
     bbox: Cell<Rectangle<i32, Logical>>,
+    pub(super) z_index: Cell<Option<u8>>,
     user_data: UserDataMap,
 }
 
@@ -138,6 +139,7 @@ impl Window {
             toplevel,
             bbox: Cell::new(Rectangle::from_loc_and_size((0, 0), (0, 0))),
             user_data: UserDataMap::new(),
+            z_index: Cell::new(None),
         }))
     }
 
@@ -296,6 +298,18 @@ impl Window {
     /// Returns a [`UserDataMap`] to allow associating arbitrary data with this window.
     pub fn user_data(&self) -> &UserDataMap {
         &self.0.user_data
+    }
+
+    /// Overrides the default z-index of this window.
+    /// (Default is [`RenderZindex::Shell`](crate::desktop::space::RenderZindex))
+    pub fn override_z_index(&self, index: u8) {
+        self.0.z_index.set(Some(index));
+    }
+
+    /// Resets a previously overriden z-index to the default of
+    /// [`RenderZindex::Shell`](crate::desktop::space::RenderZindex).
+    pub fn clear_z_index(&self) {
+        self.0.z_index.take();
     }
 }
 


### PR DESCRIPTION
This adds the option to customize rendering order for two elements previously at fixed indices.

- `SurfaceTree`, which can be used to render any surface-type known or unknown to smithay and thus should be adjustable. E.g. anvil will use this to make sure the cursor always stays on top of everything.
- `Window` this is less obvious, but shell features like always-on-top windows can be implemented with this. This also allows windows to be ordered between each other without having to frequently raise windows to keep the relative order. E.g. tiling window managers might choose to have a floating window layer on top of the tiled windows, which could now be assigned `RenderZindex::Shell + 1` to accomplish this.