### PR TITLE
desktop: allow to retrieve the surface under a point

### DIFF
--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -410,6 +410,7 @@ impl EGLDisplay {
     }
 
     /// Exports an [`EGLImage`] as a [`Dmabuf`]
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn create_dmabuf_from_image(
         &self,
         image: EGLImage,
@@ -435,6 +436,8 @@ impl EGLDisplay {
         let mut num_planes: nix::libc::c_int = 0;
         let mut modifier: ffi::egl::types::EGLuint64KHR = 0;
         if unsafe {
+            // TODO: clippy warns us here that we might dereference a raw pointer in a non unsafe public function
+            // For now we add a allow rule, but this should be addressed in the future
             ffi::egl::ExportDMABUFImageQueryMESA(
                 **self.display,
                 image,
@@ -450,6 +453,8 @@ impl EGLDisplay {
         let mut strides: Vec<ffi::egl::types::EGLint> = Vec::with_capacity(num_planes as usize);
         let mut offsets: Vec<ffi::egl::types::EGLint> = Vec::with_capacity(num_planes as usize);
         unsafe {
+            // TODO: clippy warns us here that we might dereference a raw pointer in a non unsafe public function
+            // For now we add a allow rule, but this should be addressed in the future
             if ffi::egl::ExportDMABUFImageMESA(
                 **self.display,
                 image,

--- a/src/desktop/utils.rs
+++ b/src/desktop/utils.rs
@@ -174,7 +174,9 @@ where
     damage
 }
 
-/// Returns the (sub-)surface under a given position given a surface, if any.
+/// Returns the topmost (sub-)surface under a given position matching the input regions of the surface.
+///
+/// In case no surface input region matches the point [`None`] is returned.
 ///
 /// - `point` has to be the position to query, relative to (0, 0) of the given surface + `location`.
 /// - `location` can be used to offset the returned point.

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -240,8 +240,10 @@ impl Window {
         }
     }
 
-    /// Finds the topmost surface under this point if any and returns it together with the location of this
-    /// surface.
+    /// Finds the topmost surface under this point matching the input regions of the surface and returns
+    /// it together with the location of this surface.
+    ///
+    /// In case no surface input region matches the point [`None`] is returned.
     ///
     /// - `point` should be relative to (0,0) of the window.
     pub fn surface_under<P: Into<Point<f64, Logical>>>(

--- a/src/utils/signaling.rs
+++ b/src/utils/signaling.rs
@@ -166,7 +166,7 @@ impl<S> SignalInner<S> {
                     // Send the message, cleaning up defunct callbacks in the process
                     guard.retain(|weak| {
                         if let Some(cb) = Weak::upgrade(weak) {
-                            (&mut *cb.borrow_mut())(&event);
+                            (*cb.borrow_mut())(&event);
                             true
                         } else {
                             false

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -137,7 +137,7 @@ impl SurfaceImplem {
                 }
                 PrivateSurfaceData::commit(&surface);
                 trace!(self.log, "Calling user implementation for wl_surface.commit");
-                (&mut *user_impl)(surface, ddata);
+                (*user_impl)(surface, ddata);
             }
             wl_surface::Request::SetBufferTransform { transform } => {
                 PrivateSurfaceData::with_states(&surface, |states| {

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -212,7 +212,7 @@ impl PointerGrab for DnDGrab {
                     source.cancelled();
                 }
             }
-            (&mut *self.callback.borrow_mut())(super::DataDeviceEvent::DnDDropped {
+            (*self.callback.borrow_mut())(super::DataDeviceEvent::DnDDropped {
                 seat: self.seat.clone(),
             });
             self.icon = None;
@@ -323,7 +323,7 @@ fn implement_dnd_data_offer(
                 let source_actions = with_source_metadata(&source, |meta| meta.dnd_action)
                     .unwrap_or_else(|_| DndAction::empty());
                 let possible_actions = source_actions & dnd_actions;
-                data.chosen_action = (&mut *action_choice.borrow_mut())(possible_actions, preferred_action);
+                data.chosen_action = (*action_choice.borrow_mut())(possible_actions, preferred_action);
                 // check that the user provided callback respects that one precise action should be chosen
                 debug_assert!(
                     [DndAction::None, DndAction::Move, DndAction::Copy, DndAction::Ask]

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -228,10 +228,7 @@ impl SeatData {
                                 debug!(log, "Denying a wl_data_offer.receive with invalid source.");
                                 let _ = ::nix::unistd::close(fd);
                             } else {
-                                (&mut *callback.borrow_mut())(DataDeviceEvent::SendSelection {
-                                    mime_type,
-                                    fd,
-                                });
+                                (*callback.borrow_mut())(DataDeviceEvent::SendSelection { mime_type, fd });
                             }
                         }
                     });
@@ -448,7 +445,7 @@ where
                         }
                     }
                     // The StartDrag is in response to a pointer implicit grab, all is good
-                    (&mut *callback.borrow_mut())(DataDeviceEvent::DnDStarted {
+                    (*callback.borrow_mut())(DataDeviceEvent::DnDStarted {
                         source: source.clone(),
                         icon: icon.clone(),
                         seat: seat.clone(),
@@ -481,7 +478,7 @@ where
                     .unwrap_or(false)
                 {
                     let seat_data = seat.user_data().get::<RefCell<SeatData>>().unwrap();
-                    (&mut *callback.borrow_mut())(DataDeviceEvent::NewSelection(source.clone()));
+                    (*callback.borrow_mut())(DataDeviceEvent::NewSelection(source.clone()));
                     // The client has kbd focus, it can set the selection
                     seat_data
                         .borrow_mut()

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -207,9 +207,9 @@ where
                 }
             }
             let mut callback = self.callback.borrow_mut();
-            (&mut *callback)(ServerDndEvent::Dropped);
+            (*callback)(ServerDndEvent::Dropped);
             if !validated {
-                (&mut *callback)(ServerDndEvent::Cancelled);
+                (*callback)(ServerDndEvent::Cancelled);
             }
             // in all cases abandon the drop
             // no more buttons are pressed, release the grab
@@ -258,7 +258,7 @@ where
             Request::Receive { mime_type, fd } => {
                 // check if the source and associated mime type is still valid
                 if metadata.mime_types.contains(&mime_type) && data.active {
-                    (&mut *callback.borrow_mut())(ServerDndEvent::Send { mime_type, fd });
+                    (*callback.borrow_mut())(ServerDndEvent::Send { mime_type, fd });
                 }
             }
             Request::Destroy => {}
@@ -291,7 +291,7 @@ where
                     );
                     return;
                 }
-                (&mut *callback.borrow_mut())(ServerDndEvent::Finished);
+                (*callback.borrow_mut())(ServerDndEvent::Finished);
                 data.active = false;
             }
             Request::SetActions {
@@ -311,14 +311,14 @@ where
                     return;
                 }
                 let possible_actions = metadata.dnd_action & dnd_actions;
-                data.chosen_action = (&mut *action_choice.borrow_mut())(possible_actions, preferred_action);
+                data.chosen_action = (*action_choice.borrow_mut())(possible_actions, preferred_action);
                 // check that the user provided callback respects that one precise action should be chosen
                 debug_assert!(
                     [DndAction::None, DndAction::Move, DndAction::Copy, DndAction::Ask]
                         .contains(&data.chosen_action)
                 );
                 offer.action(data.chosen_action);
-                (&mut *callback.borrow_mut())(ServerDndEvent::Action(data.chosen_action));
+                (*callback.borrow_mut())(ServerDndEvent::Action(data.chosen_action));
             }
             _ => unreachable!(),
         }

--- a/src/wayland/shell/legacy/wl_handlers.rs
+++ b/src/wayland/shell/legacy/wl_handlers.rs
@@ -51,7 +51,7 @@ pub(crate) fn implement_shell<Impl>(
             .known_surfaces
             .push(make_handle(&shell_surface));
         let mut imp = implementation.borrow_mut();
-        (&mut *imp)(
+        (*imp)(
             ShellRequest::NewShellSurface {
                 surface: make_handle(&shell_surface),
             },
@@ -113,7 +113,7 @@ where
                 })
                 .unwrap();
                 if valid {
-                    (&mut *user_impl)(
+                    (*user_impl)(
                         ShellRequest::Pong {
                             surface: make_handle(&shell_surface),
                         },
@@ -123,7 +123,7 @@ where
             }
             Request::Move { seat, serial } => {
                 let serial = Serial::from(serial);
-                (&mut *user_impl)(
+                (*user_impl)(
                     ShellRequest::Move {
                         surface: make_handle(&shell_surface),
                         serial,
@@ -134,7 +134,7 @@ where
             }
             Request::Resize { seat, serial, edges } => {
                 let serial = Serial::from(serial);
-                (&mut *user_impl)(
+                (*user_impl)(
                     ShellRequest::Resize {
                         surface: make_handle(&shell_surface),
                         serial,
@@ -144,14 +144,14 @@ where
                     dispatch_data,
                 )
             }
-            Request::SetToplevel => (&mut *user_impl)(
+            Request::SetToplevel => (*user_impl)(
                 ShellRequest::SetKind {
                     surface: make_handle(&shell_surface),
                     kind: ShellSurfaceKind::Toplevel,
                 },
                 dispatch_data,
             ),
-            Request::SetTransient { parent, x, y, flags } => (&mut *user_impl)(
+            Request::SetTransient { parent, x, y, flags } => (*user_impl)(
                 ShellRequest::SetKind {
                     surface: make_handle(&shell_surface),
                     kind: ShellSurfaceKind::Transient {
@@ -166,7 +166,7 @@ where
                 method,
                 framerate,
                 output,
-            } => (&mut *user_impl)(
+            } => (*user_impl)(
                 ShellRequest::SetKind {
                     surface: make_handle(&shell_surface),
                     kind: ShellSurfaceKind::Fullscreen {
@@ -186,7 +186,7 @@ where
                 flags,
             } => {
                 let serial = Serial::from(serial);
-                (&mut *user_impl)(
+                (*user_impl)(
                     ShellRequest::SetKind {
                         surface: make_handle(&shell_surface),
                         kind: ShellSurfaceKind::Popup {
@@ -200,7 +200,7 @@ where
                     dispatch_data,
                 )
             }
-            Request::SetMaximized { output } => (&mut *user_impl)(
+            Request::SetMaximized { output } => (*user_impl)(
                 ShellRequest::SetKind {
                     surface: make_handle(&shell_surface),
                     kind: ShellSurfaceKind::Maximized { output },

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -120,7 +120,7 @@ pub(super) fn layer_shell_implementation(
             data.shell_state.lock().unwrap().known_layers.push(handle.clone());
 
             let mut user_impl = data.user_impl.borrow_mut();
-            (&mut *user_impl)(
+            (*user_impl)(
                 LayerShellRequest::NewLayerSurface {
                     surface: handle,
                     output,
@@ -265,7 +265,7 @@ fn layer_surface_implementation(
             };
 
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(
+            (*user_impl)(
                 LayerShellRequest::AckConfigure {
                     surface: data.wl_surface.clone(),
                     configure,

--- a/src/wayland/shell/xdg/decoration.rs
+++ b/src/wayland/shell/xdg/decoration.rs
@@ -100,7 +100,7 @@ where
                                     wl_surface: data.wl_surface.clone(),
                                 };
 
-                                (&mut *cb.borrow_mut())(
+                                (*cb.borrow_mut())(
                                     XdgDecorationRequest::NewToplevelDecoration {
                                         toplevel: toplevel.clone(),
                                     },
@@ -110,7 +110,7 @@ where
                                 let cb = cb.clone();
                                 id.quick_assign(move |_, request, ddata| match request {
                                     zxdg_toplevel_decoration_v1::Request::SetMode { mode } => {
-                                        (&mut *cb.borrow_mut())(
+                                        (*cb.borrow_mut())(
                                             XdgDecorationRequest::SetMode {
                                                 toplevel: toplevel.clone(),
                                                 mode,
@@ -119,7 +119,7 @@ where
                                         );
                                     }
                                     zxdg_toplevel_decoration_v1::Request::UnsetMode => {
-                                        (&mut *cb.borrow_mut())(
+                                        (*cb.borrow_mut())(
                                             XdgDecorationRequest::UnsetMode {
                                                 toplevel: toplevel.clone(),
                                             },

--- a/src/wayland/shell/xdg/xdg_handlers.rs
+++ b/src/wayland/shell/xdg/xdg_handlers.rs
@@ -30,7 +30,7 @@ pub(crate) fn implement_wm_base(
         client_data: Mutex::new(make_shell_client_data()),
     });
     let mut user_impl = shell_data.user_impl.borrow_mut();
-    (&mut *user_impl)(
+    (*user_impl)(
         XdgRequest::NewClient {
             client: make_shell_client(&shell),
         },
@@ -95,7 +95,7 @@ fn wm_implementation(
             };
             if valid {
                 let mut user_impl = data.shell_data.user_impl.borrow_mut();
-                (&mut *user_impl)(
+                (*user_impl)(
                     XdgRequest::ClientPong {
                         client: make_shell_client(&shell),
                     },
@@ -272,7 +272,7 @@ fn xdg_surface_implementation(
 
             let handle = make_toplevel_handle(&id);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(XdgRequest::NewToplevel { surface: handle }, dispatch_data);
+            (*user_impl)(XdgRequest::NewToplevel { surface: handle }, dispatch_data);
         }
         xdg_surface::Request::GetPopup {
             id,
@@ -348,7 +348,7 @@ fn xdg_surface_implementation(
 
             let handle = make_popup_handle(&id);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(
+            (*user_impl)(
                 XdgRequest::NewPopup {
                     surface: handle,
                     positioner: positioner_data,
@@ -453,7 +453,7 @@ fn xdg_surface_implementation(
             };
 
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(
+            (*user_impl)(
                 XdgRequest::AckConfigure {
                     surface: surface.clone(),
                     configure,
@@ -600,7 +600,7 @@ fn toplevel_implementation(
             let handle = make_toplevel_handle(&toplevel);
             let serial = Serial::from(serial);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(
+            (*user_impl)(
                 XdgRequest::ShowWindowMenu {
                     surface: handle,
                     seat,
@@ -615,7 +615,7 @@ fn toplevel_implementation(
             let handle = make_toplevel_handle(&toplevel);
             let serial = Serial::from(serial);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(
+            (*user_impl)(
                 XdgRequest::Move {
                     surface: handle,
                     seat,
@@ -629,7 +629,7 @@ fn toplevel_implementation(
             let handle = make_toplevel_handle(&toplevel);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
             let serial = Serial::from(serial);
-            (&mut *user_impl)(
+            (*user_impl)(
                 XdgRequest::Resize {
                     surface: handle,
                     seat,
@@ -652,17 +652,17 @@ fn toplevel_implementation(
         xdg_toplevel::Request::SetMaximized => {
             let handle = make_toplevel_handle(&toplevel);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(XdgRequest::Maximize { surface: handle }, dispatch_data);
+            (*user_impl)(XdgRequest::Maximize { surface: handle }, dispatch_data);
         }
         xdg_toplevel::Request::UnsetMaximized => {
             let handle = make_toplevel_handle(&toplevel);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(XdgRequest::UnMaximize { surface: handle }, dispatch_data);
+            (*user_impl)(XdgRequest::UnMaximize { surface: handle }, dispatch_data);
         }
         xdg_toplevel::Request::SetFullscreen { output } => {
             let handle = make_toplevel_handle(&toplevel);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(
+            (*user_impl)(
                 XdgRequest::Fullscreen {
                     surface: handle,
                     output,
@@ -673,14 +673,14 @@ fn toplevel_implementation(
         xdg_toplevel::Request::UnsetFullscreen => {
             let handle = make_toplevel_handle(&toplevel);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(XdgRequest::UnFullscreen { surface: handle }, dispatch_data);
+            (*user_impl)(XdgRequest::UnFullscreen { surface: handle }, dispatch_data);
         }
         xdg_toplevel::Request::SetMinimized => {
             // This has to be handled by the compositor, may not be
             // supported and just ignored
             let handle = make_toplevel_handle(&toplevel);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
-            (&mut *user_impl)(XdgRequest::Minimize { surface: handle }, dispatch_data);
+            (*user_impl)(XdgRequest::Minimize { surface: handle }, dispatch_data);
         }
         _ => unreachable!(),
     }
@@ -757,7 +757,7 @@ fn xdg_popup_implementation(
             let handle = make_popup_handle(&popup);
             let mut user_impl = data.shell_data.user_impl.borrow_mut();
             let serial = Serial::from(serial);
-            (&mut *user_impl)(
+            (*user_impl)(
                 XdgRequest::Grab {
                     surface: handle,
                     seat,
@@ -777,7 +777,7 @@ fn xdg_popup_implementation(
                 .unwrap()
                 .borrow();
 
-            (&mut *user_impl)(
+            (*user_impl)(
                 XdgRequest::RePosition {
                     surface: handle,
                     positioner: positioner_data,


### PR DESCRIPTION
This PR changes the input handling to always use the input region(s) to find the surface under a point.
Using the window bounding box blocks clicking through drop shadows and using the window geometry
is wrong as it will block input on decorations (breaking move and resize).