### PR TITLE
output: Expose all of its internal state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Remove `Other` and add `Forward` and `Back` variants to `MouseButton`. Use the new `PointerButtonEvent::button_code` in place of `Other`.
 - `GrabStartData` has been renamed to `PointerGrabStartData`
 - The `slot` method on touch events no longer returns an `Option` and multi-touch capability is thus opaque to the compositor
+- `wayland::output::Output` now is created separately from it's `Global` as reflected by [`Output::new`] and the new [`Output::create_global] method.
 
 #### Backends
 

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -459,8 +459,7 @@ fn scan_connectors(
             let output_name = format!("{}-{}", interface_short_name, connector_info.interface_id());
 
             let (phys_w, phys_h) = connector_info.size().unwrap_or((0, 0));
-            let (output, global) = Output::new(
-                display,
+            let output = Output::new(
                 output_name,
                 PhysicalProperties {
                     size: (phys_w as i32, phys_h as i32).into(),
@@ -470,6 +469,7 @@ fn scan_connectors(
                 },
                 None,
             );
+            let global = output.create_global(display);
             let position = (
                 space
                     .outputs()

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -130,8 +130,7 @@ pub fn run_winit(log: Logger) {
         refresh: 60_000,
     };
 
-    let (output, _global) = Output::new(
-        &mut *display.borrow_mut(),
+    let output = Output::new(
         OUTPUT_NAME.to_string(),
         PhysicalProperties {
             size: (0, 0).into(),
@@ -141,6 +140,7 @@ pub fn run_winit(log: Logger) {
         },
         log.clone(),
     );
+    let _global = output.create_global(&mut *display.borrow_mut());
     output.change_current_state(
         Some(mode),
         Some(wl_output::Transform::Flipped180),

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -152,8 +152,7 @@ pub fn run_x11(log: Logger) {
     };
 
     let mut state = AnvilState::init(display.clone(), event_loop.handle(), data, log.clone(), true);
-    let (output, _global) = Output::new(
-        &mut *display.borrow_mut(),
+    let output = Output::new(
         OUTPUT_NAME.to_string(),
         PhysicalProperties {
             size: (0, 0).into(),
@@ -163,6 +162,7 @@ pub fn run_x11(log: Logger) {
         },
         log.clone(),
     );
+    let _global = output.create_global(&mut *display.borrow_mut());
     output.change_current_state(Some(mode), None, None, Some((0, 0).into()));
     output.set_preferred(mode);
     state.space.borrow_mut().map_output(&output, 1.0, (0, 0));

--- a/src/wayland/output/xdg.rs
+++ b/src/wayland/output/xdg.rs
@@ -20,38 +20,33 @@ use crate::utils::{Logical, Physical, Point, Size};
 use super::{Mode, Output};
 
 #[derive(Debug)]
-struct Inner {
+pub(crate) struct Inner {
     name: String,
     description: String,
-    logical_position: Point<i32, Logical>,
+    pub(super) logical_position: Point<i32, Logical>,
 
-    physical_size: Option<Size<i32, Physical>>,
-    scale: i32,
+    pub(super) physical_size: Option<Size<i32, Physical>>,
+    pub(super) scale: i32,
 
     instances: Vec<ZxdgOutputV1>,
     _log: ::slog::Logger,
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct XdgOutput {
-    inner: Arc<Mutex<Inner>>,
+pub(crate) struct XdgOutput {
+    pub(crate) inner: Arc<Mutex<Inner>>,
 }
 
 impl XdgOutput {
     fn new(output: &super::Inner, log: ::slog::Logger) -> Self {
         trace!(log, "Creating new xdg_output"; "name" => &output.name);
 
-        let description = format!(
-            "{} - {} - {}",
-            output.physical.make, output.physical.model, output.name
-        );
-
         let physical_size = output.current_mode.map(|mode| mode.size);
 
         Self {
             inner: Arc::new(Mutex::new(Inner {
                 name: output.name.clone(),
-                description,
+                description: output.description.clone(),
                 logical_position: output.location,
 
                 physical_size,

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -80,8 +80,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
         refresh: 60_000,
     };
 
-    let (output, _global) = Output::new(
-        &mut *display.borrow_mut(),
+    let output = Output::new(
         OUTPUT_NAME.to_string(),
         PhysicalProperties {
             size: (0, 0).into(),
@@ -91,6 +90,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
         },
         logger.clone(),
     );
+    let _global = output.create_global(&mut *display.borrow_mut());
     output.change_current_state(Some(mode), None, None, Some((0, 0).into()));
     output.set_preferred(mode);
     state.space.borrow_mut().map_output(&output, 1.0, (0, 0));


### PR DESCRIPTION
As discussed on matrix, certain protocol implementations (e.g. wlr_output_management) are not desirable directly in smithay.

Still they might want to piggy-back on internal smitay types. This PR makes an attempt to make most of the state of `Output` accessible in some way and also decouples the `Output`-type from the existance of a matching `Global`.

See #558 for a example implementation, that makes use of these changes.

Any feedback on this approach is welcome.