### PR TITLE
desktop: place a window relative to its geometry

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -257,9 +257,8 @@ impl<Backend> AnvilState<Backend> {
                     WindowSurfaceType::ALL,
                 )
                 .map(|(s, loc)| (s, loc + layer_loc));
-        } else if let Some((window, surface, location)) = space.surface_under(pos, WindowSurfaceType::ALL) {
-            let window_loc = space.window_location(&window).unwrap();
-            under = Some((surface, location + window_loc));
+        } else if let Some((_, surface, location)) = space.surface_under(pos, WindowSurfaceType::ALL) {
+            under = Some((surface, location));
         } else if let Some(layer) = layers
             .layer_under(WlrLayer::Bottom, pos)
             .or_else(|| layers.layer_under(WlrLayer::Background, pos))

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -124,7 +124,8 @@ impl Space {
     }
 
     /// Finds the topmost surface under this point if any and returns it
-    /// together with the location of this surface and its window.
+    /// together with the location of this surface relative to this space
+    /// and the window the surface belongs to.
     ///
     /// This is equivalent to iterating the windows in the space from
     /// top to bottom and calling [`Window::surface_under`] for each
@@ -139,7 +140,7 @@ impl Space {
     ) -> Option<(Window, WlSurface, Point<i32, Logical>)> {
         let point = point.into();
         for window in self.windows.iter().rev() {
-            let loc = window_loc(window, &self.id);
+            let loc = window.elem_location(self.id);
             let mut geo = window.bbox();
             geo.loc += loc;
 
@@ -148,7 +149,7 @@ impl Space {
             }
 
             if let Some((surface, location)) = window.surface_under(point - loc.to_f64(), surface_type) {
-                return Some((window.clone(), surface, location));
+                return Some((window.clone(), surface, location + loc));
             }
         }
 
@@ -159,7 +160,7 @@ impl Space {
     pub fn window_under<P: Into<Point<f64, Logical>>>(&self, point: P) -> Option<&Window> {
         let point = point.into();
         self.windows.iter().rev().find(|w| {
-            let loc = window_loc(w, &self.id);
+            let loc = w.elem_location(self.id);
             let mut geo = w.bbox();
             geo.loc += loc;
             geo.to_f64().contains(point)

--- a/src/desktop/space/popup.rs
+++ b/src/desktop/space/popup.rs
@@ -3,7 +3,7 @@ use crate::{
     desktop::{
         layer::LayerSurface,
         popup::{PopupKind, PopupManager},
-        space::{window_loc, Space},
+        space::Space,
         utils::{bbox_from_surface_tree, damage_from_surface_tree},
         window::Window,
     },
@@ -23,7 +23,7 @@ pub struct RenderPopup {
 
 impl Window {
     pub(super) fn popup_elements(&self, space_id: usize) -> impl Iterator<Item = RenderPopup> {
-        let loc = window_loc(self, &space_id) + self.geometry().loc;
+        let loc = self.elem_location(space_id) + self.geometry().loc;
         self.toplevel()
             .get_surface()
             .map(move |surface| {

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -65,11 +65,13 @@ impl Window {
     }
 
     pub(super) fn elem_location(&self, space_id: usize) -> Point<i32, Logical> {
-        window_loc(self, &space_id)
+        window_loc(self, &space_id) - self.geometry().loc
     }
 
     pub(super) fn elem_geometry(&self, space_id: usize) -> Rectangle<i32, Logical> {
-        window_rect_with_popups(self, &space_id)
+        let mut geo = window_rect_with_popups(self, &space_id);
+        geo.loc -= self.geometry().loc;
+        geo
     }
 
     pub(super) fn elem_accumulated_damage(


### PR DESCRIPTION
the xdg-shell protocol defines that a window should be placed relative to its geometry. the geometry should only include user visible parts, so non funtional parts like drop shadows should be ignored for placement.

from the [spec](https://wayland.app/protocols/xdg-shell#xdg_surface:request:set_window_geometry):
> When maintaining a position, the compositor should treat the (x, y) coordinate of the window geometry as the top left corner of the window.

this also fixes maximize for a lot of clients where before some parts of the decorations (menu bar) where not visible and the size did not align with the output size.

placing a window at (0,0) works now fine for most clients, but it seems that winit (or at least glutin) based clients do not put their decorations inside the geometry when run on anvil. so for clients like `alacritty` placing a window at `(0,0)` would move the top bar out of the visible bounds of the output. the client toolkit examples seem to work fine as they define a negative geometry to include the decorations.

on gnome the window geometry looks correct for alacritty:
```
[ 346182.829]  -> xdg_surface@31.set_window_geometry(-4, -28, 808, 632)
```

but on anvil the geometry does not include the decorations:
```
[ 368479.083]  -> xdg_surface@16.set_window_geometry(0, 0, 800, 600)
```

not sure what causes this behavior.

(looks like  the geometry is correctly updated after a maximize, only the initial geometry seems to be wrong)