### PR TITLE
output: Track fractional scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - `wayland::output::Output` now has a `current_scale` method to quickly retrieve its set scale.
 - `wayland::shell::wlr_layer::KeyboardInteractivity` now implements `PartialEq` and `Eq`.
 - Added `TouchHandle` for Wayland client touch support (see `Seat::get_touch`)
+- `wayland::output::Scale` was introduced to handle fractional scale values better
 
 #### Backends
 

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -15,6 +15,7 @@ use smithay::{
     utils::{Logical, Point},
     wayland::{
         compositor::with_states,
+        output::Scale,
         seat::{keysyms as xkb, AxisFrame, FilterResult, Keysym, ModifiersState},
         shell::wlr_layer::{KeyboardInteractivity, Layer as WlrLayer, LayerSurfaceCachedState},
         Serial, SERIAL_COUNTER as SCOUNTER,
@@ -322,11 +323,9 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
                     let mut space = self.space.borrow_mut();
                     let output = space.outputs().find(|o| o.name() == output_name).unwrap().clone();
 
-                    let geometry = space.output_geometry(&output).unwrap();
-                    let current_scale = space.output_scale(&output).unwrap();
+                    let current_scale = output.current_scale().fractional_scale();
                     let new_scale = current_scale + 0.25;
-                    output.change_current_state(None, None, Some(new_scale.ceil() as i32), None);
-                    space.map_output(&output, new_scale, geometry.loc);
+                    output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
 
                     crate::shell::fixup_positions(&mut *space);
                     self.backend_data.reset_buffers(&output);
@@ -336,11 +335,9 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
                     let mut space = self.space.borrow_mut();
                     let output = space.outputs().find(|o| o.name() == output_name).unwrap().clone();
 
-                    let geometry = space.output_geometry(&output).unwrap();
-                    let current_scale = space.output_scale(&output).unwrap();
+                    let current_scale = output.current_scale().fractional_scale();
                     let new_scale = f64::max(1.0, current_scale - 0.25);
-                    output.change_current_state(None, None, Some(new_scale.ceil() as i32), None);
-                    space.map_output(&output, new_scale, geometry.loc);
+                    output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
 
                     crate::shell::fixup_positions(&mut *space);
                     self.backend_data.reset_buffers(&output);
@@ -427,11 +424,10 @@ impl AnvilState<UdevData> {
                     if let Some(output) = output {
                         let (output_location, scale) = (
                             space.output_geometry(&output).unwrap().loc,
-                            space.output_scale(&output).unwrap(),
+                            output.current_scale().fractional_scale(),
                         );
                         let new_scale = scale + 0.25;
-                        output.change_current_state(None, None, Some(new_scale.ceil() as i32), None);
-                        space.map_output(&output, new_scale, output_location);
+                        output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
 
                         let rescale = scale as f64 / new_scale as f64;
                         let output_location = output_location.to_f64();
@@ -460,11 +456,10 @@ impl AnvilState<UdevData> {
                     if let Some(output) = output {
                         let (output_location, scale) = (
                             space.output_geometry(&output).unwrap().loc,
-                            space.output_scale(&output).unwrap(),
+                            output.current_scale().fractional_scale(),
                         );
                         let new_scale = f64::max(1.0, scale - 0.25);
-                        output.change_current_state(None, None, Some(new_scale.ceil() as i32), None);
-                        space.map_output(&output, new_scale, output_location);
+                        output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
 
                         let rescale = scale as f64 / new_scale as f64;
                         let output_location = output_location.to_f64();

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -30,7 +30,7 @@ where
     {
         let transform = output.current_transform().into();
         let mode = output.current_mode().unwrap();
-        let scale = space.output_scale(output).unwrap();
+        let scale = output.current_scale().fractional_scale();
         let output_geo = space
             .output_geometry(output)
             .unwrap_or_else(|| Rectangle::from_loc_and_size((0, 0), (0, 0)));

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -987,8 +987,7 @@ pub fn fixup_positions(space: &mut Space) {
             .output_geometry(&output)
             .map(|geo| geo.size)
             .unwrap_or_else(|| Size::from((0, 0)));
-        let scale = space.output_scale(&output).unwrap_or(1.0);
-        space.map_output(&output, scale, offset);
+        space.map_output(&output, offset);
         layer_map_for_output(&output).arrange();
         offset.x += size.w;
     }

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -479,7 +479,7 @@ fn scan_connectors(
                 .into();
             output.change_current_state(Some(mode), None, None, Some(position));
             output.set_preferred(mode);
-            space.map_output(&output, 1.0, position);
+            space.map_output(&output, position);
 
             output
                 .user_data()

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -148,7 +148,7 @@ pub fn run_winit(log: Logger) {
         Some((0, 0).into()),
     );
     output.set_preferred(mode);
-    state.space.borrow_mut().map_output(&output, 1.0, (0, 0));
+    state.space.borrow_mut().map_output(&output, (0, 0));
 
     let start_time = std::time::Instant::now();
 
@@ -164,8 +164,7 @@ pub fn run_winit(log: Logger) {
                     let mut space = state.space.borrow_mut();
                     // We only have one output
                     let output = space.outputs().next().unwrap().clone();
-                    let current_scale = space.output_scale(&output).unwrap();
-                    space.map_output(&output, current_scale, (0, 0));
+                    space.map_output(&output, (0, 0));
                     let mode = Mode {
                         size,
                         refresh: 60_000,
@@ -253,7 +252,7 @@ pub fn run_winit(log: Logger) {
 
             match render_res {
                 Ok(Some(damage)) => {
-                    let scale = state.space.borrow().output_scale(&output).unwrap_or(1.0);
+                    let scale = output.current_scale().fractional_scale();
                     if let Err(err) = backend.submit(if age == 0 { None } else { Some(&*damage) }, scale) {
                         warn!(log, "Failed to submit buffer: {}", err);
                     }

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -165,7 +165,7 @@ pub fn run_x11(log: Logger) {
     let _global = output.create_global(&mut *display.borrow_mut());
     output.change_current_state(Some(mode), None, None, Some((0, 0).into()));
     output.set_preferred(mode);
-    state.space.borrow_mut().map_output(&output, 1.0, (0, 0));
+    state.space.borrow_mut().map_output(&output, (0, 0));
 
     let output_clone = output.clone();
     event_loop

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -55,7 +55,12 @@ pub fn layer_map_for_output(o: &Output) -> RefMut<'_, LayerMap> {
             zone: Rectangle::from_loc_and_size(
                 (0, 0),
                 o.current_mode()
-                    .map(|mode| mode.size.to_logical(o.current_scale()))
+                    .map(|mode| {
+                        mode.size
+                            .to_f64()
+                            .to_logical(o.current_scale().fractional_scale())
+                            .to_i32_round()
+                    })
                     .unwrap_or_else(|| (0, 0).into()),
             ),
             surfaces: Vec::new(),
@@ -193,7 +198,12 @@ impl LayerMap {
                 (0, 0),
                 output
                     .current_mode()
-                    .map(|mode| mode.size.to_logical(output.current_scale()))
+                    .map(|mode| {
+                        mode.size
+                            .to_f64()
+                            .to_logical(output.current_scale().fractional_scale())
+                            .to_i32_round()
+                    })
                     .unwrap_or_else(|| (0, 0).into()),
             );
             let mut zone = output_rect;

--- a/src/desktop/space/output.rs
+++ b/src/desktop/space/output.rs
@@ -36,7 +36,6 @@ where
 #[derive(Clone, Default)]
 pub struct OutputState {
     pub location: Point<i32, Logical>,
-    pub render_scale: f64,
 
     // damage and last_state are in space coordinate space
     pub old_damage: VecDeque<Vec<Rectangle<i32, Logical>>>,

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -132,7 +132,8 @@ pub enum Scale {
 }
 
 impl Scale {
-    fn integer_scale(&self) -> i32 {
+    /// Returns the integer scale as advertised for this `Scale` variant
+    pub fn integer_scale(&self) -> i32 {
         match self {
             Scale::Integer(scale) => *scale,
             Scale::Fractional(scale) => scale.ceil() as i32,
@@ -142,7 +143,8 @@ impl Scale {
         }
     }
 
-    fn fractional_scale(&self) -> f64 {
+    /// Returns the fractional scale (calculated if necessary)
+    pub fn fractional_scale(&self) -> f64 {
         match self {
             Scale::Integer(scale) => *scale as f64,
             Scale::Fractional(scale) => *scale,
@@ -394,7 +396,6 @@ impl Output {
         new_mode: Option<Mode>,
         new_transform: Option<Transform>,
         new_scale: Option<Scale>,
-        new_fractional_scale: Option<Option<f64>>,
         new_location: Option<Point<i32, Logical>>,
     ) {
         let mut inner = self.inner.0.lock().unwrap();

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -93,7 +93,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
     let _global = output.create_global(&mut *display.borrow_mut());
     output.change_current_state(Some(mode), None, None, Some((0, 0).into()));
     output.set_preferred(mode);
-    state.space.borrow_mut().map_output(&output, 1.0, (0, 0));
+    state.space.borrow_mut().map_output(&output, (0, 0));
 
     while state.running.load(Ordering::SeqCst) {
         // pretend to draw something


### PR DESCRIPTION
based on #557

- The first commit introduces a new `Scale` type to represent different integer/fractional scaling combinations + xdg_output using it to calculate it's `logical_size`
- The second commit removes the `OutputState::render_scale` and replaces it with the new fractional_scale values from the Output's `Scale`.
