### PR TITLE
gles2: Don't blend on clear

### DIFF
--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1867,6 +1867,7 @@ impl Frame for Gles2Frame {
             .collect::<Vec<ffi::types::GLfloat>>();
 
         unsafe {
+            self.gl.Disable(ffi::BLEND);
             self.gl.UseProgram(self.solid_program.program);
             self.gl.Uniform4f(
                 self.solid_program.uniform_color,
@@ -1959,6 +1960,8 @@ impl Frame for Gles2Frame {
                 .DisableVertexAttribArray(self.solid_program.attrib_vert as u32);
             self.gl
                 .DisableVertexAttribArray(self.solid_program.attrib_position as u32);
+            self.gl.Enable(ffi::BLEND);
+            self.gl.BlendFunc(ffi::ONE, ffi::ONE_MINUS_SRC_ALPHA);
         }
 
         Ok(())


### PR DESCRIPTION
We don't want `Renderer::clear` to merge with existing buffer contents, but the `Gles2Renderer` does just that.
We fail to notice it in most cases, because most compositors clear with an alpha value of 1. However clearing with any other alpha value will not yield the expected result, when blending is enabled. So instead we should disable blending, so that the framebuffer's color is replaced with the new clear_color.