### PR TITLE
fix: send device leave event after button released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@
 - `xdg_shell` had an issue where it was possible that configured state gets overwritten before it was acked/committed.
 - `wl_keyboard` rewind the `keymap` file before passing it to the client
 - `wl_shm` properly validates parameters when creating a `wl_buffer`.
+- `ServerDnDGrab` and `DnDGrab` now correctly send data device `leave` event on button release
+
 
 #### Backends
 

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -191,8 +191,6 @@ impl PointerGrab for DnDGrab {
                         if device.as_ref().same_client_as(surface.as_ref()) {
                             if validated {
                                 device.drop();
-                            } else {
-                                device.leave();
                             }
                         }
                     }

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -188,10 +188,8 @@ impl PointerGrab for DnDGrab {
             if let Some(ref surface) = self.current_focus {
                 if self.data_source.is_some() || self.origin.as_ref().same_client_as(surface.as_ref()) {
                     for device in &seat_data.known_devices {
-                        if device.as_ref().same_client_as(surface.as_ref()) {
-                            if validated {
-                                device.drop();
-                            }
+                        if device.as_ref().same_client_as(surface.as_ref()) && validated {
+                            device.drop();
                         }
                     }
                 }

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -218,6 +218,13 @@ impl PointerGrab for DnDGrab {
             self.icon = None;
             // in all cases abandon the drop
             // no more buttons are pressed, release the grab
+            if let Some(ref surface) = self.current_focus {
+                for device in &seat_data.known_devices {
+                    if device.as_ref().same_client_as(surface.as_ref()) {
+                        device.leave();
+                    }
+                }
+            }
             handle.unset_grab(serial, time);
         }
     }

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -192,8 +192,6 @@ where
                     if device.as_ref().same_client_as(surface.as_ref()) {
                         if validated {
                             device.drop();
-                        } else {
-                            device.leave();
                         }
                     }
                 }
@@ -213,6 +211,13 @@ where
             }
             // in all cases abandon the drop
             // no more buttons are pressed, release the grab
+            if let Some(ref surface) = self.current_focus {
+                for device in &seat_data.known_devices {
+                    if device.as_ref().same_client_as(surface.as_ref()) {
+                        device.leave();
+                    }
+                }
+            }
             handle.unset_grab(serial, time);
         }
     }

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -189,10 +189,8 @@ where
             };
             if let Some(ref surface) = self.current_focus {
                 for device in &seat_data.known_devices {
-                    if device.as_ref().same_client_as(surface.as_ref()) {
-                        if validated {
-                            device.drop();
-                        }
+                    if device.as_ref().same_client_as(surface.as_ref()) && validated {
+                        device.drop();
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes DnD behavior. It always sends a data_device leave event before releasing the dnd grab when the button is released.