### PR TITLE
input: Allow focus to be grabbed by generic `*Handler`-trait objects instead of `WlSurface`s.

### DIFF
--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -300,7 +300,7 @@ pub fn set_data_device_focus(seat: &Seat, client: Option<Client>) {
     // before initializing its data device, which would already init the user_data.
     seat.user_data().insert_if_missing(|| {
         RefCell::new(SeatData::new(
-            seat.arc.log.new(o!("smithay_module" => "data_device_mgr")),
+            seat.rc.log.new(o!("smithay_module" => "data_device_mgr")),
         ))
     });
     let seat_data = seat.user_data().get::<RefCell<SeatData>>().unwrap();
@@ -317,7 +317,7 @@ pub fn set_data_device_selection(seat: &Seat, mime_types: Vec<String>) {
     // TODO: same question as in set_data_device_focus
     seat.user_data().insert_if_missing(|| {
         RefCell::new(SeatData::new(
-            seat.arc.log.new(o!("smithay_module" => "data_device_mgr")),
+            seat.rc.log.new(o!("smithay_module" => "data_device_mgr")),
         ))
     });
     let seat_data = seat.user_data().get::<RefCell<SeatData>>().unwrap();
@@ -346,7 +346,7 @@ pub fn start_dnd<C>(
     // TODO: same question as in set_data_device_focus
     seat.user_data().insert_if_missing(|| {
         RefCell::new(SeatData::new(
-            seat.arc.log.new(o!("smithay_module" => "data_device_mgr")),
+            seat.rc.log.new(o!("smithay_module" => "data_device_mgr")),
         ))
     });
     if let Some(pointer) = seat.get_pointer() {
@@ -450,7 +450,7 @@ where
                         icon: icon.clone(),
                         seat: seat.clone(),
                     });
-                    let start_data = pointer.grab_start_data().unwrap();
+                    let start_data = pointer.take_grab_start_data().unwrap();
                     pointer.set_grab(
                         dnd_grab::DnDGrab::new(
                             start_data,

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -3,12 +3,17 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::rc::Rc;
 
-use wayland_server::protocol::wl_touch::WlTouch;
-use wayland_server::{Filter, Main};
+#[cfg(feature = "wayland_frontend")]
+use wayland_server::{
+    protocol::{
+        wl_touch::WlTouch,
+        wl_surface::WlSurface,
+    },
+    Filter, Main,
+};
 
 use crate::backend::input::TouchSlot;
 use crate::utils::{Logical, Point};
-use crate::wayland::seat::wl_surface::WlSurface;
 use crate::wayland::Serial;
 
 /// An handle to a touch handler.
@@ -27,13 +32,6 @@ impl TouchHandle {
         Self {
             inner: Default::default(),
         }
-    }
-
-    /// Register a new touch handle to this handler
-    ///
-    /// This should be done first, before anything else is done with this touch handle.
-    pub(crate) fn new_touch(&self, touch: WlTouch) {
-        self.inner.borrow_mut().known_handles.push(touch);
     }
 
     /// Notify clients about new touch points.
@@ -84,12 +82,10 @@ impl TouchHandle {
 #[derive(Default, Debug)]
 struct TouchFocus {
     surface_offset: Point<f64, Logical>,
-    handles: Vec<WlTouch>,
 }
 
 #[derive(Default, Debug)]
 struct TouchInternal {
-    known_handles: Vec<WlTouch>,
     focus: HashMap<TouchSlot, TouchFocus>,
 }
 


### PR DESCRIPTION
This is a first attempt at decoupling a large portion of the `wayland/seat` module from `WlSurface` as the only object to receive any input events.

## Motivation

Currently all custom input-handling code has to be build from ground-up in downstream compositors. smithay either provides raw input events or converts those (almost automatically, except for focus handling) into appropriate wayland-events.

There is no middle ground, where some pre-processing can take place other components could benefit from. Especially implementing window-decorations on the server-side is tedious currently. Custom shells are a giant pain.

The plan with this is to allow custom *elements* to be attached to a `Window` or even a `Space`, that can handle input events or trigger grabs like any wayland client inside smithay.

## Drawbacks

The current implementation is quite rough around some edges, that need discussion:

- The new `Pointer/KeyboardHandler`-traits don't require `Clone`. A lot of the old code assumed, that the focus object is clonable, given `WlSurface`s do have this property.
  - Grabs are sometimes initialized from existing grab's start data. Because the `GrabStartData` contains the focus it is also not clonable anymore. Instead a new `take_grab_start_data` method was introduced.
    - Additionally `grab_start_data` now returns a `Ref<StartData>`, which exposes the underlying `RefCell`. This makes double-borrows and thus runtime errors a little too easy.
  - The `ClickGrab` requires the focus to be clonable. As a result only `WlSurface`s will exhibit the click-grab semantics now. Other focused object will not receive events outside of their surface. (Specialization could help with this...)
  - The `PointerHandler` has no **implicit** `pending_focus` anymore, because this cannot be done without cloning. Working around this using `Rc<RefCell<_>>` and the like proved to be not working, because it breaks down-casting, which is required for some `WlSurface` specific-code (e.g. PopupGrabs).
    - Instead grabs can now call `PointerInnerHandle::set_pending_focus` **explicitly** to pass through a focus object to be restored after a grab ends. This puts more responsibility into grab-implementations..
    - Given the focus is still passed into the handler on every `motion`-call, the code calling into the `PointerHandler` arguably needs a way to clone or create new handles for recieving focus anyway. Maybe requiring `Clone` would actually be more desirable?
- Calling `motion` with `None` as focus requires a type-parameter now. Internally pointer/keyboard do have a `DummyHandler` for this. While we could expose it to the user, I opted to provide a `motion_no_focus` function instead. It feels more ergonomic, but I am not sure it is better. Maybe we should split `motion` and `set_focus`, which would also remove the effective requirement for downstream to be able to provide the focus object for every pointer movement.

## TODOs / Open Questions

- [ ] #569 needs to be ported to this in some form
- [ ] Changing keyboard repeat infos currently does not propagate to wl_keyboards (where would we put this code?)
- [ ] Decide where to put this
  - Right now it resides (like `Output`) inside `src/wayland`, although the module could be used without `wayland_frontend`.
  - Maybe introduce a new toplevel module?
- [ ] Decide what types to use. Currently things like `ButtonState` or `KeyState` are either:
  - Taken from `backend::input` (which also has no feature gate, so maybe this is the easiest solution?)
  - Or defined locally in the module + conversation implementations via `Into`/`From`
  - (or wayland-definitions could be used directly, but I have already removed the code in an attempt to make this usable without)
- [ ] What to do with `src/wayland/seat/touch`? It is missing a lot of the functionality of `pointer`/`keyboard` like grabs. Right now a similar implementation would not make a lot of sense imo.

## Alternatives

- Status Quo - maybe downstream *should* implement its own dispatching? (I disagree.)