### PR TITLE
space: Allow to retrieve window/layer from subsurface

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use smithay::{
-    desktop::{PopupManager, Space},
+    desktop::{PopupManager, Space, WindowSurfaceType},
     reexports::{
         calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
         wayland_protocols::unstable::xdg_decoration,
@@ -107,7 +107,9 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                         if token_data.timestamp.elapsed().as_secs() < 10 {
                             // Just grant the wish
                             let mut space = anvil_state.space.borrow_mut();
-                            let w = space.window_for_surface(&surface).cloned();
+                            let w = space
+                                .window_for_surface(&surface, WindowSurfaceType::TOPLEVEL)
+                                .cloned();
                             if let Some(window) = w {
                                 space.raise_window(&window, true);
                             }

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -179,14 +179,62 @@ impl LayerMap {
     }
 
     /// Returns the [`LayerSurface`] matching a given [`WlSurface`], if any.
-    pub fn layer_for_surface(&self, surface: &WlSurface) -> Option<&LayerSurface> {
+    ///
+    /// `surface_type` can be used to limit the types of surfaces queried for equality.
+    pub fn layer_for_surface(
+        &self,
+        surface: &WlSurface,
+        surface_type: WindowSurfaceType,
+    ) -> Option<&LayerSurface> {
         if !surface.as_ref().is_alive() {
             return None;
         }
 
-        self.layers
-            .iter()
-            .find(|w| w.get_surface().map(|x| x == surface).unwrap_or(false))
+        if surface_type.contains(WindowSurfaceType::TOPLEVEL) {
+            if let Some(layer) = self
+                .layers
+                .iter()
+                .find(|l| l.get_surface().map(|x| x == surface).unwrap_or(false))
+            {
+                return Some(layer);
+            }
+        }
+
+        if surface_type.contains(WindowSurfaceType::SUBSURFACE) {
+            use std::sync::atomic::{AtomicBool, Ordering};
+
+            if let Some(layer) = self.layers.iter().find(|l| {
+                let toplevel = l.get_surface().unwrap();
+                let found = AtomicBool::new(false);
+                with_surface_tree_downward(
+                    toplevel,
+                    surface,
+                    |_, _, search| TraversalAction::DoChildren(search),
+                    |s, _, search| {
+                        found.fetch_or(s == *search, Ordering::SeqCst);
+                    },
+                    |_, _, _| !found.load(Ordering::SeqCst),
+                );
+                found.load(Ordering::SeqCst)
+            }) {
+                return Some(layer);
+            }
+        }
+
+        if surface_type.contains(WindowSurfaceType::POPUP) {
+            if let Some(layer) = self.layers.iter().find(|l| {
+                PopupManager::popups_for_surface(l.get_surface().unwrap())
+                    .ok()
+                    .map(|mut popups| {
+                        popups.any(|(p, _)| p.get_surface().map(|s| s == surface).unwrap_or(false))
+                    })
+                    .unwrap_or(false)
+            }) {
+                return Some(layer);
+            }
+        }
+
+        None
     }
 
     /// Force re-arranging the layer surfaces, e.g. when the output size changes.


### PR DESCRIPTION
Currently the `_from_surface` methods of the various desktop-helpers only match for toplevel-surfaces.
However it can be useful (although not used by anvil in any way) to retrieve a matching window/layer/etc from a subsurface as well. E.g. to figure out on which outputs a surface resides.

Currently there is no way to do that. This PR aims to solve that, by allowing `_from_surface` to work with sub-surfaces. Because this requires walking surface-trees and thus might be unnecessary overhead for a lot of simple operations, this utilizes the `WindowSurfaceType` as a new attribute to filter, which surfaces should be matched.