### PR TITLE
desktop: Split of popup rendering

### DIFF
--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -55,7 +55,7 @@ pub mod space;
 pub mod utils;
 mod window;
 
-pub use self::layer::{draw_layer_surface, layer_map_for_output, LayerMap, LayerSurface};
+pub use self::layer::{draw_layer_popups, draw_layer_surface, layer_map_for_output, LayerMap, LayerSurface};
 pub use self::popup::*;
 pub use self::space::Space;
 pub use self::window::*;

--- a/src/desktop/popup/mod.rs
+++ b/src/desktop/popup/mod.rs
@@ -8,6 +8,7 @@ pub use manager::*;
 use wayland_server::protocol::wl_surface::WlSurface;
 
 use crate::{
+    backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
     utils::{Logical, Point, Rectangle},
     wayland::{
         compositor::with_states,
@@ -93,4 +94,54 @@ impl From<PopupSurface> for PopupKind {
     fn from(p: PopupSurface) -> PopupKind {
         PopupKind::Xdg(p)
     }
+}
+
+/// Renders popups of a given [`WlSurface`] using a provided renderer and frame.
+///
+/// - `surface_location` os the location the surface would been draw at
+/// - `offset` will further offset the popups location (e.g. window popups should be offset by the windows geometry)
+/// - `scale` needs to be equivalent to the fractional scale the rendered result should have.
+/// - `damage` is the set of regions of the layer surface that should be drawn.
+///
+/// Note: This function will render nothing, if you are not using
+/// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
+/// to let smithay handle buffer management.
+#[allow(clippy::too_many_arguments)]
+pub fn draw_popups<R, P1, P2>(
+    renderer: &mut R,
+    frame: &mut <R as Renderer>::Frame,
+    for_surface: &WlSurface,
+    surface_location: P1,
+    offset: P2,
+    scale: f64,
+    damage: &[Rectangle<i32, Logical>],
+    log: &slog::Logger,
+) -> Result<(), <R as Renderer>::Error>
+where
+    R: Renderer + ImportAll,
+    <R as Renderer>::TextureId: 'static,
+    P1: Into<Point<i32, Logical>>,
+    P2: Into<Point<i32, Logical>>,
+{
+    let location = surface_location.into();
+    let offset = offset.into();
+    for (popup, p_location) in PopupManager::popups_for_surface(for_surface)
+        .ok()
+        .into_iter()
+        .flatten()
+    {
+        if let Some(surface) = popup.get_surface() {
+            let offset = offset + p_location - popup.geometry().loc;
+            let damage = damage
+                .iter()
+                .cloned()
+                .map(|mut geo| {
+                    geo.loc -= offset;
+                    geo
+                })
+                .collect::<Vec<_>>();
+            draw_surface_tree(renderer, frame, surface, scale, location + offset, &damage, log)?;
+        }
+    }
+    Ok(())
 }

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -341,24 +341,45 @@ where
     let location = location.into();
     if let Some(surface) = window.toplevel().get_surface() {
         draw_surface_tree(renderer, frame, surface, scale, location, damage, log)?;
-        for (popup, p_location) in PopupManager::popups_for_surface(surface)
-            .ok()
-            .into_iter()
-            .flatten()
-        {
-            if let Some(surface) = popup.get_surface() {
-                let offset = window.geometry().loc + p_location - popup.geometry().loc;
-                let damage = damage
-                    .iter()
-                    .cloned()
-                    .map(|mut geo| {
-                        geo.loc -= offset;
-                        geo
-                    })
-                    .collect::<Vec<_>>();
-                draw_surface_tree(renderer, frame, surface, scale, location + offset, &damage, log)?;
-            }
-        }
+    }
+    Ok(())
+}
+
+/// Renders popups of a given [`Window`] using a provided renderer and frame
+///
+/// - `scale` needs to be equivalent to the fractional scale the rendered result should have.
+/// - `location` is the position the window would be drawn at (popups will be drawn relative to that coordiante).
+/// - `damage` is the set of regions of the layer surface that should be drawn.
+///
+/// Note: This function will render nothing, if you are not using
+/// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
+/// to let smithay handle buffer management.
+pub fn draw_window_popups<R, P>(
+    renderer: &mut R,
+    frame: &mut <R as Renderer>::Frame,
+    window: &Window,
+    scale: f64,
+    location: P,
+    damage: &[Rectangle<i32, Logical>],
+    log: &slog::Logger,
+) -> Result<(), <R as Renderer>::Error>
+where
+    R: Renderer + ImportAll,
+    <R as Renderer>::TextureId: 'static,
+    P: Into<Point<i32, Logical>>,
+{
+    let location = location.into();
+    if let Some(surface) = window.toplevel().get_surface() {
+        super::popup::draw_popups(
+            renderer,
+            frame,
+            surface,
+            location,
+            window.geometry().loc,
+            scale,
+            damage,
+            log,
+        )?;
     }
     Ok(())
 }


### PR DESCRIPTION
So while we have defined `RenderZIndex::Popups` and `RenderZIndex::PopupsOverlay`, we effectively don't use them, because the popups's RenderElements are not *rendered*. Instead they are only used for damage tracking, but popups are rendered with their parent.

Turns out this is not really helpful (e.g. [xdg-shell-wrapper](https://github.com/pop-os/xdg-shell-wrapper) cannot use `Window`, because `draw_window` draws the popups, which xdg-shell-wrapper instead handles by creating popups themselves).

So this PR introduces new popup-rendering helpers (which can be used to replace the old usecase)
and finally splits rendering of popups between it's parents and the actual popup RenderElement. This fixes the z-index we draw popups at!