### PR TITLE
Add support for viewporter

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -3,11 +3,13 @@
 use std::sync::Mutex;
 
 use slog::Logger;
+#[cfg(feature = "debug")]
+use smithay::utils::Buffer;
 use smithay::{
     backend::renderer::{Frame, ImportAll, Renderer, Texture},
     desktop::space::{RenderElement, SpaceOutputTuple, SurfaceTree},
     reexports::wayland_server::protocol::wl_surface,
-    utils::{Logical, Point, Rectangle, Scale, Size, Transform},
+    utils::{Logical, Physical, Point, Rectangle, Scale, Size, Transform},
     wayland::{
         compositor::{get_role, with_states},
         seat::CursorImageAttributes,
@@ -103,12 +105,21 @@ where
         0
     }
 
-    fn geometry(&self) -> Rectangle<i32, Logical> {
-        Rectangle::from_loc_and_size(self.position, self.size)
+    fn location(&self, scale: impl Into<Scale<f64>>) -> Point<f64, Physical> {
+        self.position.to_f64().to_physical(scale)
     }
 
-    fn accumulated_damage(&self, _: Option<SpaceOutputTuple<'_, '_>>) -> Vec<Rectangle<i32, Logical>> {
-        vec![Rectangle::from_loc_and_size((0, 0), self.size)]
+    fn geometry(&self, scale: impl Into<Scale<f64>>) -> Rectangle<i32, Physical> {
+        Rectangle::from_loc_and_size(self.position, self.size).to_physical_precise_round(scale)
+    }
+
+    fn accumulated_damage(
+        &self,
+        scale: impl Into<Scale<f64>>,
+        _: Option<SpaceOutputTuple<'_, '_>>,
+    ) -> Vec<Rectangle<i32, Physical>> {
+        let scale = scale.into();
+        vec![Rectangle::from_loc_and_size(self.position, self.size).to_physical_precise_up(scale)]
     }
 
     fn draw(
@@ -116,21 +127,21 @@ where
         _renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
         scale: impl Into<Scale<f64>>,
-        location: Point<i32, Logical>,
-        damage: &[Rectangle<i32, Logical>],
+        location: Point<f64, Physical>,
+        _damage: &[Rectangle<i32, Physical>],
         _log: &Logger,
     ) -> Result<(), <R as Renderer>::Error> {
         let scale = scale.into();
         frame.render_texture_at(
             &self.texture,
-            location.to_f64().to_physical(scale).to_i32_round(),
+            location.to_i32_round(),
             1,
             scale,
             Transform::Normal,
-            &*damage
-                .iter()
-                .map(|rect| rect.to_f64().to_physical(scale).to_i32_round())
-                .collect::<Vec<_>>(),
+            &[Rectangle::from_loc_and_size(
+                (0.0, 0.0),
+                self.size.to_physical_precise_round(scale),
+            )],
             1.0,
         )?;
         Ok(())
@@ -156,7 +167,11 @@ where
         0
     }
 
-    fn geometry(&self) -> Rectangle<i32, Logical> {
+    fn location(&self, _scale: impl Into<Scale<f64>>) -> Point<f64, Physical> {
+        (0.0, 0.0).into()
+    }
+
+    fn geometry(&self, scale: impl Into<Scale<f64>>) -> Rectangle<i32, Physical> {
         let digits = if self.value < 10 {
             1
         } else if self.value < 100 {
@@ -164,63 +179,69 @@ where
         } else {
             3
         };
-        Rectangle::from_loc_and_size((0, 0), (24 * digits, 35))
+        Rectangle::from_loc_and_size((0, 0), (24 * digits, 35)).to_physical_precise_round(scale)
     }
 
-    fn accumulated_damage(&self, _: Option<SpaceOutputTuple<'_, '_>>) -> Vec<Rectangle<i32, Logical>> {
-        vec![Rectangle::from_loc_and_size((0, 0), (24 * 3, 35))]
+    fn accumulated_damage(
+        &self,
+        scale: impl Into<Scale<f64>>,
+        _: Option<SpaceOutputTuple<'_, '_>>,
+    ) -> Vec<Rectangle<i32, Physical>> {
+        vec![Rectangle::from_loc_and_size((0, 0), (24 * 3, 35)).to_physical_precise_up(scale)]
     }
 
     fn draw(
         &self,
         _renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
-        scale: f64,
-        location: Point<i32, Logical>,
-        damage: &[Rectangle<i32, Logical>],
+        scale: impl Into<Scale<f64>>,
+        location: Point<f64, Physical>,
+        damage: &[Rectangle<i32, Physical>],
         _log: &Logger,
     ) -> Result<(), <R as Renderer>::Error> {
         let value_str = std::cmp::min(self.value, 999).to_string();
-        let location = location.to_f64().to_physical(scale);
-        let mut offset_x = location.x;
+        let scale = scale.into();
+        let mut offset: Point<f64, Physical> = Point::from((0.0, 0.0));
         for digit in value_str.chars().map(|d| d.to_digit(10).unwrap()) {
+            let digit_location = location + offset;
+            let digit_size = Size::<i32, Logical>::from((22, 35)).to_f64().to_physical(scale);
+            let dst = Rectangle::from_loc_and_size(
+                digit_location.to_i32_round(),
+                ((digit_size.to_point() + digit_location).to_i32_round() - digit_location.to_i32_round())
+                    .to_size(),
+            );
             let damage = damage
                 .iter()
-                .flat_map(|x| {
-                    x.intersection(Rectangle::from_loc_and_size(
-                        Point::from(((offset_x / scale) as i32, 0)),
-                        (22, 35),
-                    ))
-                })
+                .cloned()
+                .flat_map(|x| x.intersection(dst))
                 .map(|mut x| {
-                    x.loc = (0, 0).into();
-                    x.to_f64().to_physical(scale)
+                    x.loc -= dst.loc;
+                    x
                 })
+                .map(|x| x.to_f64())
                 .collect::<Vec<_>>();
+            let src: Rectangle<i32, Buffer> = match digit {
+                9 => Rectangle::from_loc_and_size((0, 0), (22, 35)),
+                6 => Rectangle::from_loc_and_size((22, 0), (22, 35)),
+                3 => Rectangle::from_loc_and_size((44, 0), (22, 35)),
+                1 => Rectangle::from_loc_and_size((66, 0), (22, 35)),
+                8 => Rectangle::from_loc_and_size((0, 35), (22, 35)),
+                0 => Rectangle::from_loc_and_size((22, 35), (22, 35)),
+                2 => Rectangle::from_loc_and_size((44, 35), (22, 35)),
+                7 => Rectangle::from_loc_and_size((0, 70), (22, 35)),
+                4 => Rectangle::from_loc_and_size((22, 70), (22, 35)),
+                5 => Rectangle::from_loc_and_size((44, 70), (22, 35)),
+                _ => unreachable!(),
+            };
             frame.render_texture_from_to(
                 &self.texture,
-                match digit {
-                    9 => Rectangle::from_loc_and_size((0, 0), (22, 35)),
-                    6 => Rectangle::from_loc_and_size((22, 0), (22, 35)),
-                    3 => Rectangle::from_loc_and_size((44, 0), (22, 35)),
-                    1 => Rectangle::from_loc_and_size((66, 0), (22, 35)),
-                    8 => Rectangle::from_loc_and_size((0, 35), (22, 35)),
-                    0 => Rectangle::from_loc_and_size((22, 35), (22, 35)),
-                    2 => Rectangle::from_loc_and_size((44, 35), (22, 35)),
-                    7 => Rectangle::from_loc_and_size((0, 70), (22, 35)),
-                    4 => Rectangle::from_loc_and_size((22, 70), (22, 35)),
-                    5 => Rectangle::from_loc_and_size((44, 70), (22, 35)),
-                    _ => unreachable!(),
-                },
-                Rectangle::from_loc_and_size(
-                    Point::from((offset_x, location.y)),
-                    (22.0 * scale, 35.0 * scale),
-                ),
+                src.to_f64(),
+                dst.to_f64(),
                 &damage,
                 Transform::Normal,
                 1.0,
             )?;
-            offset_x += 24.0 * scale;
+            offset += Point::from((24.0, 0.0)).to_physical(scale);
         }
 
         Ok(())

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -7,7 +7,7 @@ use smithay::{
     backend::renderer::{Frame, ImportAll, Renderer, Texture},
     desktop::space::{RenderElement, SpaceOutputTuple, SurfaceTree},
     reexports::wayland_server::protocol::wl_surface,
-    utils::{Logical, Point, Rectangle, Size, Transform},
+    utils::{Logical, Point, Rectangle, Scale, Size, Transform},
     wayland::{
         compositor::{get_role, with_states},
         seat::CursorImageAttributes,
@@ -115,16 +115,17 @@ where
         &self,
         _renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
-        scale: f64,
+        scale: impl Into<Scale<f64>>,
         location: Point<i32, Logical>,
         damage: &[Rectangle<i32, Logical>],
         _log: &Logger,
     ) -> Result<(), <R as Renderer>::Error> {
+        let scale = scale.into();
         frame.render_texture_at(
             &self.texture,
             location.to_f64().to_physical(scale).to_i32_round(),
             1,
-            scale as f64,
+            scale,
             Transform::Normal,
             &*damage
                 .iter()

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -4,7 +4,7 @@ use smithay::{
         draw_window, draw_window_popups,
         space::{RenderElement, RenderError, Space},
     },
-    utils::{Logical, Rectangle},
+    utils::{Physical, Rectangle},
     wayland::output::Output,
 };
 
@@ -17,7 +17,7 @@ pub fn render_output<R, E>(
     age: usize,
     elements: &[E],
     log: &slog::Logger,
-) -> Result<Option<Vec<Rectangle<i32, Logical>>>, RenderError<R>>
+) -> Result<Option<Vec<Rectangle<i32, Physical>>>, RenderError<R>>
 where
     R: Renderer + ImportAll,
     R::TextureId: 'static,
@@ -36,7 +36,7 @@ where
             .unwrap_or_else(|| Rectangle::from_loc_and_size((0, 0), (0, 0)));
         renderer
             .render(mode.size, transform, |renderer, frame| {
-                let mut damage = window.accumulated_damage(None);
+                let mut damage = window.accumulated_damage((0.0, 0.0), scale, None);
                 frame.clear(
                     CLEAR_COLOR,
                     &[Rectangle::from_loc_and_size((0, 0), mode.size).to_f64()],
@@ -46,11 +46,8 @@ where
                     frame,
                     &window,
                     scale,
-                    (0, 0),
-                    &[Rectangle::from_loc_and_size(
-                        (0, 0),
-                        mode.size.to_f64().to_logical(scale).to_i32_round(),
-                    )],
+                    (0.0, 0.0),
+                    &[Rectangle::from_loc_and_size((0, 0), mode.size)],
                     log,
                 )?;
                 draw_window_popups(
@@ -58,29 +55,22 @@ where
                     frame,
                     &window,
                     scale,
-                    (0, 0),
-                    &[Rectangle::from_loc_and_size(
-                        (0, 0),
-                        mode.size.to_f64().to_logical(scale).to_i32_round(),
-                    )],
+                    (0.0, 0.0),
+                    &[Rectangle::from_loc_and_size((0, 0), mode.size)],
                     log,
                 )?;
                 for elem in elements {
-                    let geo = elem.geometry();
-                    let location = geo.loc - output_geo.loc;
-                    let elem_damage = elem.accumulated_damage(None);
+                    let geo = elem.geometry(scale);
+                    let location = elem.location(scale) - output_geo.loc.to_physical_precise_round(scale);
                     elem.draw(
                         renderer,
                         frame,
                         scale,
                         location,
-                        &[Rectangle::from_loc_and_size((0, 0), geo.size)],
+                        &[Rectangle::from_loc_and_size((0, 0), mode.size)],
                         log,
                     )?;
-                    damage.extend(elem_damage.into_iter().map(|mut rect| {
-                        rect.loc += geo.loc;
-                        rect
-                    }))
+                    damage.extend([Rectangle::from_loc_and_size((0, 0), geo.size)]);
                 }
                 Ok(Some(damage))
             })

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -29,7 +29,7 @@ use smithay::{
                 XdgPopupSurfaceRoleAttributes, XdgRequest, XdgToplevelSurfaceRoleAttributes,
             },
         },
-        Serial,
+        viewporter, Serial,
     },
 };
 
@@ -332,6 +332,8 @@ pub fn init_shell<BackendData: Backend + 'static>(
         },
         log.clone(),
     );
+    // Enable viewporter
+    viewporter::viewporter_init(&mut *display.borrow_mut());
 
     let log_ref = log.clone();
     // init the xdg_shell

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -252,8 +252,7 @@ pub fn run_winit(log: Logger) {
 
             match render_res {
                 Ok(Some(damage)) => {
-                    let scale = output.current_scale().fractional_scale();
-                    if let Err(err) = backend.submit(if age == 0 { None } else { Some(&*damage) }, scale) {
+                    if let Err(err) = backend.submit(if age == 0 { None } else { Some(&*damage) }) {
                         warn!(log, "Failed to submit buffer: {}", err);
                     }
                     backend.window().set_cursor_visible(cursor_visible);

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1970,14 +1970,12 @@ impl Frame for Gles2Frame {
     fn render_texture_from_to(
         &mut self,
         texture: &Self::TextureId,
-        src: Rectangle<i32, Buffer>,
+        src: Rectangle<f64, Buffer>,
         dest: Rectangle<f64, Physical>,
         damage: &[Rectangle<f64, Physical>],
         transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error> {
-        let src = src.to_f64();
-
         let mut mat = Matrix3::<f32>::identity();
 
         // dest position and scale

--- a/src/backend/renderer/gles2/shaders.rs
+++ b/src/backend/renderer/gles2/shaders.rs
@@ -86,7 +86,8 @@ mat2 scale(vec2 scale_vec){
 void main() {
     vec2 transform_translation = position.xy;
     vec2 transform_scale = position.zw;
-    gl_Position = vec4(matrix * vec3((vert * scale(transform_scale)) + transform_translation, 1.0), 1.0);
+    vec3 position = vec3(vert * scale(transform_scale) + transform_translation, 1.0);
+    gl_Position = vec4(matrix * position, 1.0);
 }
 "#;
 

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -10,7 +10,7 @@
 use std::collections::HashSet;
 use std::error::Error;
 
-use crate::utils::{Buffer, Physical, Point, Rectangle, Size, Transform};
+use crate::utils::{Buffer, Physical, Point, Rectangle, Scale, Size, Transform};
 
 #[cfg(feature = "wayland_frontend")]
 use crate::wayland::compositor::SurfaceData;
@@ -147,7 +147,7 @@ pub trait Frame {
         texture: &Self::TextureId,
         pos: Point<f64, Physical>,
         texture_scale: i32,
-        output_scale: f64,
+        output_scale: impl Into<Scale<f64>>,
         src_transform: Transform,
         damage: &[Rectangle<f64, Physical>],
         alpha: f32,

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -154,7 +154,7 @@ pub trait Frame {
     ) -> Result<(), Self::Error> {
         self.render_texture_from_to(
             texture,
-            Rectangle::from_loc_and_size(Point::<i32, Buffer>::from((0, 0)), texture.size()),
+            Rectangle::from_loc_and_size(Point::<i32, Buffer>::from((0, 0)), texture.size()).to_f64(),
             Rectangle::from_loc_and_size(
                 pos,
                 texture
@@ -175,7 +175,7 @@ pub trait Frame {
     fn render_texture_from_to(
         &mut self,
         texture: &Self::TextureId,
-        src: Rectangle<i32, Buffer>,
+        src: Rectangle<f64, Buffer>,
         dst: Rectangle<f64, Physical>,
         damage: &[Rectangle<f64, Physical>],
         src_transform: Transform,

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -160,8 +160,7 @@ pub trait Frame {
                 texture
                     .size()
                     .to_logical(texture_scale, src_transform)
-                    .to_f64()
-                    .to_physical(output_scale),
+                    .to_physical_precise_round(output_scale),
             ),
             damage,
             src_transform,

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     backend::renderer::{buffer_dimensions, Frame, ImportAll, Renderer},
-    utils::{Buffer, Logical, Point, Rectangle, Size, Transform},
+    utils::{Buffer, Logical, Point, Rectangle, Scale, Size, Transform},
     wayland::compositor::{
         is_sync_subsurface, with_surface_tree_upward, BufferAssignment, Damage, SubsurfaceCachedState,
         SurfaceAttributes, SurfaceData, TraversalAction,
@@ -259,11 +259,11 @@ where
 /// Note: This element will render nothing, if you are not using
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
-pub fn draw_surface_tree<R>(
+pub fn draw_surface_tree<R, S>(
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     surface: &WlSurface,
-    scale: f64,
+    scale: S,
     location: Point<i32, Logical>,
     damage: &[Rectangle<i32, Logical>],
     log: &slog::Logger,
@@ -271,9 +271,11 @@ pub fn draw_surface_tree<R>(
 where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
+    S: Into<Scale<f64>>,
 {
     let texture_id = (TypeId::of::<<R as Renderer>::TextureId>(), renderer.id());
     let mut result = Ok(());
+    let scale = scale.into();
     let _ = import_surface_tree_and(
         renderer,
         surface,

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -32,7 +32,7 @@ use crate::{
             Bind,
         },
     },
-    utils::{Logical, Physical, Rectangle, Size},
+    utils::{Logical, Physical, Rectangle, Scale, Size},
 };
 use std::{cell::RefCell, rc::Rc, time::Instant};
 use wayland_egl as wegl;
@@ -322,8 +322,9 @@ impl WinitGraphicsBackend {
     pub fn submit(
         &mut self,
         damage: Option<&[Rectangle<i32, Logical>]>,
-        scale: f64,
+        scale: impl Into<Scale<f64>>,
     ) -> Result<(), crate::backend::SwapBuffersError> {
+        let scale = scale.into();
         let mut damage = match damage {
             Some(damage) if self.damage_tracking && !damage.is_empty() => {
                 let size = self

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -32,7 +32,7 @@ use crate::{
             Bind,
         },
     },
-    utils::{Logical, Physical, Rectangle, Scale, Size},
+    utils::{Logical, Physical, Rectangle, Size},
 };
 use std::{cell::RefCell, rc::Rc, time::Instant};
 use wayland_egl as wegl;
@@ -321,19 +321,11 @@ impl WinitGraphicsBackend {
     /// Submits the back buffer to the window by swapping, requires the window to be previously bound (see [`WinitGraphicsBackend::bind`]).
     pub fn submit(
         &mut self,
-        damage: Option<&[Rectangle<i32, Logical>]>,
-        scale: impl Into<Scale<f64>>,
+        damage: Option<&[Rectangle<i32, Physical>]>,
     ) -> Result<(), crate::backend::SwapBuffersError> {
-        let scale = scale.into();
         let mut damage = match damage {
             Some(damage) if self.damage_tracking && !damage.is_empty() => {
-                let size = self
-                    .size
-                    .borrow()
-                    .physical_size
-                    .to_f64()
-                    .to_logical(scale)
-                    .to_i32_round::<i32>();
+                let size = self.size.borrow().physical_size;
                 let damage = damage
                     .iter()
                     .map(|rect| {
@@ -341,9 +333,6 @@ impl WinitGraphicsBackend {
                             (rect.loc.x, size.h - rect.loc.y - rect.size.h),
                             rect.size,
                         )
-                        .to_f64()
-                        .to_physical(scale)
-                        .to_i32_round::<i32>()
                     })
                     .collect::<Vec<_>>();
                 Some(damage)

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
     desktop::{utils::*, PopupManager, Space},
-    utils::{user_data::UserDataMap, Logical, Point, Rectangle, Scale},
+    utils::{user_data::UserDataMap, Logical, Physical, Point, Rectangle, Scale},
     wayland::{
         compositor::{with_states, with_surface_tree_downward, TraversalAction},
         output::{Inner as OutputInner, Output},
@@ -550,6 +550,42 @@ impl LayerSurface {
         bounding_box
     }
 
+    /// Returns the [`Physical`] bounding box over this layer surface, it subsurfaces as well as any popups.
+    ///
+    /// This differs from using [`bbox_with_popups`] and translating the returned [`Rectangle`]
+    /// to [`Physical`] space as it rounds the subsurface and popup offsets.
+    /// See [`physical_bbox_from_surface_tree`] for more information.
+    ///
+    /// Note: You need to use a [`PopupManager`] to track popups, otherwise the bounding box
+    /// will not include the popups.
+    pub fn physical_bbox_with_popups(
+        &self,
+        location: impl Into<Point<f64, Physical>>,
+        scale: impl Into<Scale<f64>>,
+    ) -> Rectangle<i32, Physical> {
+        let location = location.into();
+        let scale = scale.into();
+        let surface = match self.0.surface.get_surface() {
+            Some(surface) => surface,
+            None => return Rectangle::default(),
+        };
+        let mut geo = physical_bbox_from_surface_tree(surface, location, scale);
+        for (popup, p_location) in PopupManager::popups_for_surface(surface)
+            .ok()
+            .into_iter()
+            .flatten()
+        {
+            if let Some(surface) = popup.get_surface() {
+                geo = geo.merge(physical_bbox_from_surface_tree(
+                    surface,
+                    location + p_location.to_f64().to_physical(scale),
+                    scale,
+                ));
+            }
+        }
+        geo
+    }
+
     /// Finds the topmost surface under this point if any and returns it together with the location of this
     /// surface.
     ///
@@ -587,24 +623,28 @@ impl LayerSurface {
     /// Subsequent calls will return an empty vector until the buffer is updated again.
     pub(super) fn accumulated_damage(
         &self,
+        location: impl Into<Point<f64, Physical>>,
+        scale: impl Into<Scale<f64>>,
         for_values: Option<(&Space, &Output)>,
-    ) -> Vec<Rectangle<i32, Logical>> {
+    ) -> Vec<Rectangle<i32, Physical>> {
+        let location = location.into();
+        let scale = scale.into();
         let mut damage = Vec::new();
         if let Some(surface) = self.get_surface() {
-            damage.extend(
-                damage_from_surface_tree(surface, (0, 0), for_values)
-                    .into_iter()
-                    .flat_map(|rect| rect.intersection(self.bbox())),
-            );
-            for (popup, location) in PopupManager::popups_for_surface(surface)
+            damage.extend(damage_from_surface_tree(surface, location, scale, for_values));
+            for (popup, p_location) in PopupManager::popups_for_surface(surface)
                 .ok()
                 .into_iter()
                 .flatten()
             {
                 if let Some(surface) = popup.get_surface() {
-                    let bbox = bbox_from_surface_tree(surface, location);
-                    let popup_damage = damage_from_surface_tree(surface, location, for_values);
-                    damage.extend(popup_damage.into_iter().flat_map(|rect| rect.intersection(bbox)));
+                    let popup_damage = damage_from_surface_tree(
+                        surface,
+                        location + p_location.to_f64().to_physical(scale),
+                        scale,
+                        for_values,
+                    );
+                    damage.extend(popup_damage);
                 }
             }
         }
@@ -649,14 +689,14 @@ pub fn draw_layer_surface<R, P, S>(
     layer: &LayerSurface,
     scale: S,
     location: P,
-    damage: &[Rectangle<i32, Logical>],
+    damage: &[Rectangle<i32, Physical>],
     log: &slog::Logger,
 ) -> Result<(), <R as Renderer>::Error>
 where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
     S: Into<Scale<f64>>,
-    P: Into<Point<i32, Logical>>,
+    P: Into<Point<f64, Physical>>,
 {
     let location = location.into();
     let scale = scale.into();
@@ -681,14 +721,14 @@ pub fn draw_layer_popups<R, S, P>(
     layer: &LayerSurface,
     scale: S,
     location: P,
-    damage: &[Rectangle<i32, Logical>],
+    damage: &[Rectangle<i32, Physical>],
     log: &slog::Logger,
 ) -> Result<(), <R as Renderer>::Error>
 where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
     S: Into<Scale<f64>>,
-    P: Into<Point<i32, Logical>>,
+    P: Into<Point<f64, Physical>>,
 {
     let location = location.into();
     if let Some(surface) = layer.get_surface() {

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
     desktop::{utils::*, PopupManager, Space},
-    utils::{user_data::UserDataMap, Logical, Point, Rectangle},
+    utils::{user_data::UserDataMap, Logical, Point, Rectangle, Scale},
     wayland::{
         compositor::{with_states, with_surface_tree_downward, TraversalAction},
         output::{Inner as OutputInner, Output},
@@ -643,11 +643,11 @@ impl LayerSurface {
 /// Note: This function will render nothing, if you are not using
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
-pub fn draw_layer_surface<R, P>(
+pub fn draw_layer_surface<R, P, S>(
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     layer: &LayerSurface,
-    scale: f64,
+    scale: S,
     location: P,
     damage: &[Rectangle<i32, Logical>],
     log: &slog::Logger,
@@ -655,9 +655,11 @@ pub fn draw_layer_surface<R, P>(
 where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
+    S: Into<Scale<f64>>,
     P: Into<Point<i32, Logical>>,
 {
     let location = location.into();
+    let scale = scale.into();
     if let Some(surface) = layer.get_surface() {
         draw_surface_tree(renderer, frame, surface, scale, location, damage, log)?;
     }
@@ -673,11 +675,11 @@ where
 /// Note: This function will render nothing, if you are not using
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
-pub fn draw_layer_popups<R, P>(
+pub fn draw_layer_popups<R, S, P>(
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     layer: &LayerSurface,
-    scale: f64,
+    scale: S,
     location: P,
     damage: &[Rectangle<i32, Logical>],
     log: &slog::Logger,
@@ -685,6 +687,7 @@ pub fn draw_layer_popups<R, P>(
 where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
+    S: Into<Scale<f64>>,
     P: Into<Point<i32, Logical>>,
 {
     let location = location.into();

--- a/src/desktop/popup/mod.rs
+++ b/src/desktop/popup/mod.rs
@@ -9,7 +9,7 @@ use wayland_server::protocol::wl_surface::WlSurface;
 
 use crate::{
     backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
-    utils::{Logical, Point, Rectangle},
+    utils::{Logical, Point, Rectangle, Scale},
     wayland::{
         compositor::with_states,
         shell::xdg::{PopupSurface, SurfaceCachedState, XdgPopupSurfaceRoleAttributes},
@@ -107,13 +107,13 @@ impl From<PopupSurface> for PopupKind {
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
 #[allow(clippy::too_many_arguments)]
-pub fn draw_popups<R, P1, P2>(
+pub fn draw_popups<R, P1, P2, S>(
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     for_surface: &WlSurface,
     surface_location: P1,
     offset: P2,
-    scale: f64,
+    scale: S,
     damage: &[Rectangle<i32, Logical>],
     log: &slog::Logger,
 ) -> Result<(), <R as Renderer>::Error>
@@ -122,9 +122,11 @@ where
     <R as Renderer>::TextureId: 'static,
     P1: Into<Point<i32, Logical>>,
     P2: Into<Point<i32, Logical>>,
+    S: Into<Scale<f64>>,
 {
     let location = surface_location.into();
     let offset = offset.into();
+    let scale = scale.into();
     for (popup, p_location) in PopupManager::popups_for_surface(for_surface)
         .ok()
         .into_iter()

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -2,7 +2,7 @@ use crate::desktop::space::popup::RenderPopup;
 use crate::{
     backend::renderer::{ImportAll, Renderer, Texture},
     desktop::{space::*, utils::*},
-    utils::{Logical, Point, Rectangle, Scale},
+    utils::{Logical, Physical, Point, Rectangle, Scale},
     wayland::output::Output,
 };
 use std::{
@@ -43,8 +43,10 @@ where
     fn type_of(&self) -> TypeId {
         Any::type_id(self)
     }
+    /// Returns the location of this element
+    fn location(&self, scale: impl Into<Scale<f64>>) -> Point<f64, Physical>;
     /// Returns the bounding box of this element including its position in the space.
-    fn geometry(&self) -> Rectangle<i32, Logical>;
+    fn geometry(&self, scale: impl Into<Scale<f64>>) -> Rectangle<i32, Physical>;
     /// Returns the damage of the element since it's last update.
     /// It should be relative to the elements coordinates.
     ///
@@ -57,8 +59,9 @@ where
     /// correct, but very inefficient.
     fn accumulated_damage(
         &self,
+        scale: impl Into<Scale<f64>>,
         for_values: Option<SpaceOutputTuple<'_, '_>>,
-    ) -> Vec<Rectangle<i32, Logical>>;
+    ) -> Vec<Rectangle<i32, Physical>>;
     /// Draws the element using the provided `Frame` and `Renderer`.
     ///
     /// - `scale` provides the current fractional scale value to render as
@@ -72,8 +75,8 @@ where
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
         scale: impl Into<Scale<f64>>,
-        location: Point<i32, Logical>,
-        damage: &[Rectangle<i32, Logical>],
+        location: Point<f64, Physical>,
+        damage: &[Rectangle<i32, Physical>],
         log: &slog::Logger,
     ) -> Result<(), <R as Renderer>::Error>;
 
@@ -116,29 +119,34 @@ where
             SpaceElement::Custom(custom, _) => custom.type_of(),
         }
     }
-    pub fn location(&self, space_id: usize) -> Point<i32, Logical> {
+    pub fn location(&self, space_id: usize, scale: impl Into<Scale<f64>>) -> Point<f64, Physical> {
         match self {
-            SpaceElement::Layer(layer) => layer.elem_geometry(space_id).loc,
-            SpaceElement::Window(window) => window.elem_location(space_id),
-            SpaceElement::Popup(popup) => popup.elem_geometry(space_id).loc,
-            SpaceElement::Custom(custom, _) => custom.geometry().loc,
+            SpaceElement::Layer(layer) => layer.elem_location(space_id, scale),
+            SpaceElement::Window(window) => window.elem_location(space_id, scale),
+            SpaceElement::Popup(popup) => popup.elem_location(space_id, scale),
+            SpaceElement::Custom(custom, _) => custom.location(scale),
         }
     }
-    pub fn geometry(&self, space_id: usize) -> Rectangle<i32, Logical> {
+    pub fn geometry(&self, space_id: usize, scale: impl Into<Scale<f64>>) -> Rectangle<i32, Physical> {
         match self {
-            SpaceElement::Layer(layer) => layer.elem_geometry(space_id),
-            SpaceElement::Window(window) => window.elem_geometry(space_id),
-            SpaceElement::Popup(popup) => popup.elem_geometry(space_id),
-            SpaceElement::Custom(custom, _) => custom.geometry(),
+            SpaceElement::Layer(layer) => layer.elem_geometry(space_id, scale),
+            SpaceElement::Window(window) => window.elem_geometry(space_id, scale),
+            SpaceElement::Popup(popup) => popup.elem_geometry(space_id, scale),
+            SpaceElement::Custom(custom, _) => custom.geometry(scale),
         }
     }
-    pub fn accumulated_damage(&self, for_values: Option<(&Space, &Output)>) -> Vec<Rectangle<i32, Logical>> {
+    pub fn accumulated_damage(
+        &self,
+        space_id: usize,
+        scale: impl Into<Scale<f64>>,
+        for_values: Option<(&Space, &Output)>,
+    ) -> Vec<Rectangle<i32, Physical>> {
         match self {
-            SpaceElement::Layer(layer) => layer.elem_accumulated_damage(for_values),
-            SpaceElement::Window(window) => window.elem_accumulated_damage(for_values),
-            SpaceElement::Popup(popup) => popup.elem_accumulated_damage(for_values),
+            SpaceElement::Layer(layer) => layer.elem_accumulated_damage(space_id, scale, for_values),
+            SpaceElement::Window(window) => window.elem_accumulated_damage(space_id, scale, for_values),
+            SpaceElement::Popup(popup) => popup.elem_accumulated_damage(space_id, scale, for_values),
             SpaceElement::Custom(custom, _) => {
-                custom.accumulated_damage(for_values.map(|(s, o)| SpaceOutputTuple(s, o)))
+                custom.accumulated_damage(scale, for_values.map(|(s, o)| SpaceOutputTuple(s, o)))
             }
         }
     }
@@ -149,8 +157,8 @@ where
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
         scale: impl Into<Scale<f64>>,
-        location: Point<i32, Logical>,
-        damage: &[Rectangle<i32, Logical>],
+        location: Point<f64, Physical>,
+        damage: &[Rectangle<i32, Physical>],
         log: &slog::Logger,
     ) -> Result<(), R::Error> {
         match self {
@@ -203,17 +211,27 @@ where
         self.surface.as_ref().id() as usize
     }
 
-    fn geometry(&self) -> Rectangle<i32, Logical> {
-        let mut bbox = bbox_from_surface_tree(&self.surface, (0, 0));
-        bbox.loc += self.position;
-        bbox
+    fn location(&self, scale: impl Into<Scale<f64>>) -> Point<f64, Physical> {
+        self.position.to_f64().to_physical(scale)
+    }
+
+    fn geometry(&self, scale: impl Into<Scale<f64>>) -> Rectangle<i32, Physical> {
+        let scale = scale.into();
+        physical_bbox_from_surface_tree(&self.surface, self.position.to_f64().to_physical(scale), scale)
     }
 
     fn accumulated_damage(
         &self,
+        scale: impl Into<Scale<f64>>,
         for_values: Option<SpaceOutputTuple<'_, '_>>,
-    ) -> Vec<Rectangle<i32, Logical>> {
-        damage_from_surface_tree(&self.surface, (0, 0), for_values.map(|x| (x.0, x.1)))
+    ) -> Vec<Rectangle<i32, Physical>> {
+        let scale = scale.into();
+        damage_from_surface_tree(
+            &self.surface,
+            self.position.to_f64().to_physical(scale),
+            scale,
+            for_values.map(|f| (f.0, f.1)),
+        )
     }
 
     fn draw(
@@ -221,8 +239,8 @@ where
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
         scale: impl Into<Scale<f64>>,
-        location: Point<i32, Logical>,
-        damage: &[Rectangle<i32, Logical>],
+        location: Point<f64, Physical>,
+        damage: &[Rectangle<i32, Physical>],
         log: &slog::Logger,
     ) -> Result<(), <R as Renderer>::Error> {
         crate::backend::renderer::utils::draw_surface_tree(

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -2,7 +2,7 @@ use crate::desktop::space::popup::RenderPopup;
 use crate::{
     backend::renderer::{ImportAll, Renderer, Texture},
     desktop::{space::*, utils::*},
-    utils::{Logical, Point, Rectangle},
+    utils::{Logical, Point, Rectangle, Scale},
     wayland::output::Output,
 };
 use std::{
@@ -71,7 +71,7 @@ where
         &self,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
-        scale: f64,
+        scale: impl Into<Scale<f64>>,
         location: Point<i32, Logical>,
         damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,
@@ -148,7 +148,7 @@ where
         space_id: usize,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
-        scale: f64,
+        scale: impl Into<Scale<f64>>,
         location: Point<i32, Logical>,
         damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,
@@ -220,7 +220,7 @@ where
         &self,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
-        scale: f64,
+        scale: impl Into<Scale<f64>>,
         location: Point<i32, Logical>,
         damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,

--- a/src/desktop/space/layer.rs
+++ b/src/desktop/space/layer.rs
@@ -4,7 +4,7 @@ use crate::{
         layer::{layer_state as output_layer_state, *},
         space::Space,
     },
-    utils::{Logical, Point, Rectangle, Scale},
+    utils::{Physical, Point, Rectangle, Scale},
     wayland::{output::Output, shell::wlr_layer::Layer},
 };
 use std::{
@@ -38,18 +38,34 @@ impl LayerSurface {
         TypeId::of::<LayerSurface>()
     }
 
-    pub(super) fn elem_geometry(&self, _space_id: usize) -> Rectangle<i32, Logical> {
-        let mut bbox = self.bbox_with_popups();
+    pub(super) fn elem_location(
+        &self,
+        _space_id: usize,
+        scale: impl Into<Scale<f64>>,
+    ) -> Point<f64, Physical> {
         let state = output_layer_state(self);
-        bbox.loc += state.location;
-        bbox
+        state.location.to_f64().to_physical(scale)
+    }
+
+    pub(super) fn elem_geometry(
+        &self,
+        _space_id: usize,
+        scale: impl Into<Scale<f64>>,
+    ) -> Rectangle<i32, Physical> {
+        let scale = scale.into();
+        let state = output_layer_state(self);
+        self.physical_bbox_with_popups(state.location.to_f64().to_physical(scale), scale)
     }
 
     pub(super) fn elem_accumulated_damage(
         &self,
+        _space_id: usize,
+        scale: impl Into<Scale<f64>>,
         for_values: Option<(&Space, &Output)>,
-    ) -> Vec<Rectangle<i32, Logical>> {
-        self.accumulated_damage(for_values)
+    ) -> Vec<Rectangle<i32, Physical>> {
+        let scale = scale.into();
+        let state = output_layer_state(self);
+        self.accumulated_damage(state.location.to_f64().to_physical(scale), scale, for_values)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -59,8 +75,8 @@ impl LayerSurface {
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
         scale: impl Into<Scale<f64>>,
-        location: Point<i32, Logical>,
-        damage: &[Rectangle<i32, Logical>],
+        location: Point<f64, Physical>,
+        damage: &[Rectangle<i32, Physical>],
         log: &slog::Logger,
     ) -> Result<(), <R as Renderer>::Error>
     where

--- a/src/desktop/space/layer.rs
+++ b/src/desktop/space/layer.rs
@@ -4,7 +4,7 @@ use crate::{
         layer::{layer_state as output_layer_state, *},
         space::Space,
     },
-    utils::{Logical, Point, Rectangle},
+    utils::{Logical, Point, Rectangle, Scale},
     wayland::{output::Output, shell::wlr_layer::Layer},
 };
 use std::{
@@ -58,7 +58,7 @@ impl LayerSurface {
         space_id: usize,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
-        scale: f64,
+        scale: impl Into<Scale<f64>>,
         location: Point<i32, Logical>,
         damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -548,6 +548,13 @@ impl Space {
             let geo = element.geometry(self.id, output_scale);
             let old_geo = state.last_toplevel_state.get(&ToplevelId::from(element)).cloned();
 
+            // add the damage as reported by the element
+            damage.extend(
+                element
+                    .accumulated_damage(self.id, output_scale, Some((self, output)))
+                    .into_iter(),
+            );
+
             // window was moved, resized or just appeared
             if old_geo.map(|old_geo| old_geo != geo).unwrap_or(true) {
                 slog::trace!(self.logger, "Toplevel geometry changed, damaging previous and current geometry. previous geometry: {:?}, current geometry: {:?}", old_geo, geo);
@@ -556,13 +563,6 @@ impl Space {
                     damage.push(old_geo);
                 }
                 damage.push(geo);
-            } else {
-                // window stayed at its place
-                damage.extend(
-                    element
-                        .accumulated_damage(self.id, output_scale, Some((self, output)))
-                        .into_iter(),
-                );
             }
         }
 

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -827,7 +827,7 @@ macro_rules! custom_elements_internal {
             &self,
             renderer: &mut $renderer,
             frame: &mut <$renderer as $crate::backend::renderer::Renderer>::Frame,
-            scale: f64,
+            scale: impl Into<$crate::utils::Scale<f64>>,
             location: $crate::utils::Point<i32, $crate::utils::Logical>,
             damage: &[$crate::utils::Rectangle<i32, $crate::utils::Logical>],
             log: &slog::Logger,
@@ -857,7 +857,7 @@ macro_rules! custom_elements_internal {
             &self,
             renderer: &mut $renderer,
             frame: &mut <$renderer as $crate::backend::renderer::Renderer>::Frame,
-            scale: f64,
+            scale: impl Into<$crate::utils::Scale<f64>>,
             location: $crate::utils::Point<i32, $crate::utils::Logical>,
             damage: &[$crate::utils::Rectangle<i32, $crate::utils::Logical>],
             log: &slog::Logger,
@@ -941,7 +941,7 @@ macro_rules! custom_elements_internal {
 /// use smithay::{
 ///     backend::renderer::{Texture, Renderer, ImportAll},
 ///     desktop::space::{SurfaceTree, Space, SpaceOutputTuple, RenderElement},
-///     utils::{Point, Size, Rectangle, Transform, Logical},
+///     utils::{Point, Size, Rectangle, Transform, Logical, Scale},
 /// };
 /// use slog::Logger;
 ///
@@ -997,7 +997,7 @@ macro_rules! custom_elements_internal {
 /// #       texture: &Self::TextureId,
 /// #       pos: Point<f64, Physical>,
 /// #       texture_scale: i32,
-/// #       output_scale: f64,
+/// #       output_scale: impl Into<Scale<f64>>,
 /// #       src_transform: Transform,
 /// #       damage: &[Rectangle<f64, Physical>],
 /// #       alpha: f32,
@@ -1078,7 +1078,7 @@ macro_rules! custom_elements_internal {
 ///#        &self,
 ///#        _renderer: &mut R,
 ///#        frame: &mut <R as Renderer>::Frame,
-///#        scale: f64,
+///#        scale: impl Into<Scale<f64>>,
 ///#        location: Point<i32, Logical>,
 ///#        damage: &[Rectangle<i32, Logical>],
 ///#        _log: &Logger,

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -1007,7 +1007,7 @@ macro_rules! custom_elements_internal {
 /// #   fn render_texture_from_to(
 /// #       &mut self,
 /// #       texture: &Self::TextureId,
-/// #       src: Rectangle<i32, Buffer>,
+/// #       src: Rectangle<f64, Buffer>,
 /// #       dst: Rectangle<f64, Physical>,
 /// #       damage: &[Rectangle<f64, Physical>],
 /// #       src_transform: Transform,

--- a/src/desktop/space/output.rs
+++ b/src/desktop/space/output.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::renderer::{ImportAll, Renderer},
     desktop::space::{RenderElement, SpaceElement},
-    utils::{Logical, Point, Rectangle},
+    utils::{Logical, Physical, Point, Rectangle},
     wayland::output::Output,
 };
 use indexmap::IndexMap;
@@ -37,9 +37,16 @@ where
 pub struct OutputState {
     pub location: Point<i32, Logical>,
 
-    // damage and last_state are in space coordinate space
-    pub old_damage: VecDeque<Vec<Rectangle<i32, Logical>>>,
-    pub last_state: IndexMap<ToplevelId, Rectangle<i32, Logical>>,
+    // damage and last_toplevel_state are in space coordinate space
+    // old_damage represents the damage from the last n render iterations
+    // used to track the damage for different buffer ages
+    pub old_damage: VecDeque<Vec<Rectangle<i32, Physical>>>,
+    // physical geometry of the toplevels from the last render iteration
+    pub last_toplevel_state: IndexMap<ToplevelId, Rectangle<i32, Physical>>,
+    // output geometry from the last render iteration
+    // used to react on output geometry changes, like damaging
+    // the whole output
+    pub last_output_geo: Option<Rectangle<i32, Physical>>,
 
     // surfaces for tracking enter and leave events
     pub surfaces: Vec<WlSurface>,

--- a/src/desktop/space/output.rs
+++ b/src/desktop/space/output.rs
@@ -41,8 +41,8 @@ pub struct OutputState {
     // old_damage represents the damage from the last n render iterations
     // used to track the damage for different buffer ages
     pub old_damage: VecDeque<Vec<Rectangle<i32, Physical>>>,
-    // physical geometry of the toplevels from the last render iteration
-    pub last_toplevel_state: IndexMap<ToplevelId, Rectangle<i32, Physical>>,
+    // z_index and physical geometry of the toplevels from the last render iteration
+    pub last_toplevel_state: IndexMap<ToplevelId, (usize, Rectangle<i32, Physical>)>,
     // output geometry from the last render iteration
     // used to react on output geometry changes, like damaging
     // the whole output

--- a/src/desktop/space/popup.rs
+++ b/src/desktop/space/popup.rs
@@ -7,7 +7,7 @@ use crate::{
         utils::{bbox_from_surface_tree, damage_from_surface_tree},
         window::Window,
     },
-    utils::{Logical, Point, Rectangle},
+    utils::{Logical, Point, Rectangle, Scale},
     wayland::{output::Output, shell::wlr_layer::Layer},
 };
 use std::any::TypeId;
@@ -111,12 +111,12 @@ impl RenderPopup {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(super) fn elem_draw<R>(
+    pub(super) fn elem_draw<R, S>(
         &self,
         _space_id: usize,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
-        scale: f64,
+        scale: S,
         location: Point<i32, Logical>,
         damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,
@@ -124,6 +124,7 @@ impl RenderPopup {
     where
         R: Renderer + ImportAll,
         <R as Renderer>::TextureId: 'static,
+        S: Into<Scale<f64>>,
     {
         if let Some(surface) = self.popup.get_surface() {
             draw_surface_tree(renderer, frame, surface, scale, location, damage, log)?;

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -4,7 +4,7 @@ use crate::{
         space::Space,
         window::{draw_window, Window},
     },
-    utils::{Logical, Point, Rectangle, Scale},
+    utils::{Logical, Physical, Point, Rectangle, Scale},
     wayland::output::Output,
 };
 use std::{
@@ -37,11 +37,15 @@ pub fn window_rect(window: &Window, space_id: &usize) -> Rectangle<i32, Logical>
     wgeo
 }
 
-pub fn window_rect_with_popups(window: &Window, space_id: &usize) -> Rectangle<i32, Logical> {
-    let loc = window_loc(window, space_id);
-    let mut wgeo = window.bbox_with_popups();
-    wgeo.loc += loc;
-    wgeo
+pub fn window_physical_geometry(
+    window: &Window,
+    space_id: &usize,
+    scale: impl Into<Scale<f64>>,
+) -> Rectangle<i32, Physical> {
+    let scale = scale.into();
+    let loc = window_loc(window, space_id) - window.geometry().loc;
+    let loc = loc.to_f64().to_physical(scale);
+    window.physical_bbox_with_popups(loc, scale)
 }
 
 pub fn window_loc(window: &Window, space_id: &usize) -> Point<i32, Logical> {
@@ -64,21 +68,32 @@ impl Window {
         TypeId::of::<Window>()
     }
 
-    pub(super) fn elem_location(&self, space_id: usize) -> Point<i32, Logical> {
-        window_loc(self, &space_id) - self.geometry().loc
+    pub(super) fn elem_location(
+        &self,
+        space_id: usize,
+        scale: impl Into<Scale<f64>>,
+    ) -> Point<f64, Physical> {
+        let loc = window_loc(self, &space_id) - self.geometry().loc;
+        loc.to_f64().to_physical(scale)
     }
 
-    pub(super) fn elem_geometry(&self, space_id: usize) -> Rectangle<i32, Logical> {
-        let mut geo = window_rect_with_popups(self, &space_id);
-        geo.loc -= self.geometry().loc;
-        geo
+    pub(super) fn elem_geometry(
+        &self,
+        space_id: usize,
+        scale: impl Into<Scale<f64>>,
+    ) -> Rectangle<i32, Physical> {
+        window_physical_geometry(self, &space_id, scale)
     }
 
     pub(super) fn elem_accumulated_damage(
         &self,
+        space_id: usize,
+        scale: impl Into<Scale<f64>>,
         for_values: Option<(&Space, &Output)>,
-    ) -> Vec<Rectangle<i32, Logical>> {
-        self.accumulated_damage(for_values)
+    ) -> Vec<Rectangle<i32, Physical>> {
+        let scale = scale.into();
+        let loc = window_loc(self, &space_id) - self.geometry().loc;
+        self.accumulated_damage(loc.to_f64().to_physical(scale), scale, for_values)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -88,8 +103,8 @@ impl Window {
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
         scale: S,
-        location: Point<i32, Logical>,
-        damage: &[Rectangle<i32, Logical>],
+        location: Point<f64, Physical>,
+        damage: &[Rectangle<i32, Physical>],
         log: &slog::Logger,
     ) -> Result<(), <R as Renderer>::Error>
     where

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -4,7 +4,7 @@ use crate::{
         space::Space,
         window::{draw_window, Window},
     },
-    utils::{Logical, Point, Rectangle},
+    utils::{Logical, Point, Rectangle, Scale},
     wayland::output::Output,
 };
 use std::{
@@ -82,12 +82,12 @@ impl Window {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(super) fn elem_draw<R>(
+    pub(super) fn elem_draw<R, S>(
         &self,
         space_id: usize,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
-        scale: f64,
+        scale: S,
         location: Point<i32, Logical>,
         damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,
@@ -95,6 +95,7 @@ impl Window {
     where
         R: Renderer + ImportAll,
         <R as Renderer>::TextureId: 'static,
+        S: Into<Scale<f64>>,
     {
         let res = draw_window(renderer, frame, self, scale, location, damage, log);
         if res.is_ok() {

--- a/src/desktop/utils.rs
+++ b/src/desktop/utils.rs
@@ -145,11 +145,14 @@ where
                         });
 
                     damage.extend(new_damage.into_iter().map(|rect| {
-                        let mut rect = rect.to_logical(
-                            data.buffer_scale,
-                            data.buffer_transform,
-                            &data.buffer_dimensions.unwrap(),
-                        );
+                        let mut rect = rect
+                            .to_f64()
+                            .to_logical(
+                                data.buffer_scale as f64,
+                                data.buffer_transform,
+                                &data.buffer_dimensions.unwrap().to_f64(),
+                            )
+                            .to_i32_up();
                         rect.loc += location;
                         rect
                     }));

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
     desktop::{utils::*, PopupManager, Space},
-    utils::{Logical, Point, Rectangle},
+    utils::{Logical, Point, Rectangle, Scale},
     wayland::{
         compositor::with_states,
         output::Output,
@@ -324,11 +324,11 @@ impl Window {
 /// Note: This function will render nothing, if you are not using
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
-pub fn draw_window<R, P>(
+pub fn draw_window<R, P, S>(
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     window: &Window,
-    scale: f64,
+    scale: S,
     location: P,
     damage: &[Rectangle<i32, Logical>],
     log: &slog::Logger,
@@ -336,9 +336,11 @@ pub fn draw_window<R, P>(
 where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
+    S: Into<Scale<f64>>,
     P: Into<Point<i32, Logical>>,
 {
     let location = location.into();
+    let scale = scale.into();
     if let Some(surface) = window.toplevel().get_surface() {
         draw_surface_tree(renderer, frame, surface, scale, location, damage, log)?;
     }
@@ -354,11 +356,11 @@ where
 /// Note: This function will render nothing, if you are not using
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
-pub fn draw_window_popups<R, P>(
+pub fn draw_window_popups<R, S, P>(
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     window: &Window,
-    scale: f64,
+    scale: S,
     location: P,
     damage: &[Rectangle<i32, Logical>],
     log: &slog::Logger,
@@ -366,6 +368,7 @@ pub fn draw_window_popups<R, P>(
 where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
+    S: Into<Scale<f64>>,
     P: Into<Point<i32, Logical>>,
 {
     let location = location.into();

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::protocol::wl_output::Transform as WlTransform;
@@ -253,6 +253,52 @@ floating_point_coordinate_impl! {
 }
 
 /*
+ * Scale
+ */
+
+/// A two-dimensional scale that can be
+/// used to scale [`Point`]s, [`Size`]s and
+/// [`Rectangle`]s
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Scale<N: Coordinate> {
+    /// The scale on the x axis
+    pub x: N,
+    /// The scale on the y axis
+    pub y: N,
+}
+
+impl<N: Coordinate> From<N> for Scale<N> {
+    fn from(scale: N) -> Self {
+        Scale { x: scale, y: scale }
+    }
+}
+
+impl<N: Coordinate> From<(N, N)> for Scale<N> {
+    fn from((scale_x, scale_y): (N, N)) -> Self {
+        Scale {
+            x: scale_x,
+            y: scale_y,
+        }
+    }
+}
+
+impl<N, T> Mul<T> for Scale<N>
+where
+    N: Coordinate,
+    T: Into<Scale<N>>,
+{
+    type Output = Scale<N>;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        let rhs = rhs.into();
+        Scale {
+            x: self.x.upscale(rhs.x),
+            y: self.y.upscale(rhs.y),
+        }
+    }
+}
+
+/*
  * Point
  */
 
@@ -294,6 +340,28 @@ impl<N: Coordinate, Kind> Point<N, Kind> {
         Size {
             w: self.x.abs(),
             h: self.y.abs(),
+            _kind: std::marker::PhantomData,
+        }
+    }
+
+    /// Upscale this [`Point`] by a specified [`Scale`]
+    #[inline]
+    pub fn upscale(self, scale: impl Into<Scale<N>>) -> Point<N, Kind> {
+        let scale = scale.into();
+        Point {
+            x: self.x.upscale(scale.x),
+            y: self.y.upscale(scale.y),
+            _kind: std::marker::PhantomData,
+        }
+    }
+
+    /// Downscale this [`Point`] by a specified [`Scale`]
+    #[inline]
+    pub fn downscale(self, scale: impl Into<Scale<N>>) -> Point<N, Kind> {
+        let scale = scale.into();
+        Point {
+            x: self.x.downscale(scale.x),
+            y: self.y.downscale(scale.y),
             _kind: std::marker::PhantomData,
         }
     }
@@ -399,21 +467,28 @@ impl<N: fmt::Debug> fmt::Debug for Point<N, Buffer> {
 impl<N: Coordinate> Point<N, Logical> {
     #[inline]
     /// Convert this logical point to physical coordinate space according to given scale factor
-    pub fn to_physical(self, scale: N) -> Point<N, Physical> {
+    pub fn to_physical(self, scale: impl Into<Scale<N>>) -> Point<N, Physical> {
+        let scale = scale.into();
         Point {
-            x: self.x.upscale(scale),
-            y: self.y.upscale(scale),
+            x: self.x.upscale(scale.x),
+            y: self.y.upscale(scale.y),
             _kind: std::marker::PhantomData,
         }
     }
 
     #[inline]
     /// Convert this logical point to buffer coordinate space according to given scale factor
-    pub fn to_buffer(self, scale: N, transformation: Transform, area: &Size<N, Logical>) -> Point<N, Buffer> {
+    pub fn to_buffer(
+        self,
+        scale: impl Into<Scale<N>>,
+        transformation: Transform,
+        area: &Size<N, Logical>,
+    ) -> Point<N, Buffer> {
         let point = transformation.transform_point_in(self, area);
+        let scale = scale.into();
         Point {
-            x: point.x.upscale(scale),
-            y: point.y.upscale(scale),
+            x: point.x.upscale(scale.x),
+            y: point.y.upscale(scale.y),
             _kind: std::marker::PhantomData,
         }
     }
@@ -422,10 +497,11 @@ impl<N: Coordinate> Point<N, Logical> {
 impl<N: Coordinate> Point<N, Physical> {
     #[inline]
     /// Convert this physical point to logical coordinate space according to given scale factor
-    pub fn to_logical(self, scale: N) -> Point<N, Logical> {
+    pub fn to_logical(self, scale: impl Into<Scale<N>>) -> Point<N, Logical> {
+        let scale = scale.into();
         Point {
-            x: self.x.downscale(scale),
-            y: self.y.downscale(scale),
+            x: self.x.downscale(scale.x),
+            y: self.y.downscale(scale.y),
             _kind: std::marker::PhantomData,
         }
     }
@@ -434,11 +510,17 @@ impl<N: Coordinate> Point<N, Physical> {
 impl<N: Coordinate> Point<N, Buffer> {
     #[inline]
     /// Convert this physical point to logical coordinate space according to given scale factor
-    pub fn to_logical(self, scale: N, transform: Transform, area: &Size<N, Buffer>) -> Point<N, Logical> {
+    pub fn to_logical(
+        self,
+        scale: impl Into<Scale<N>>,
+        transform: Transform,
+        area: &Size<N, Buffer>,
+    ) -> Point<N, Logical> {
         let point = transform.invert().transform_point_in(self, area);
+        let scale = scale.into();
         Point {
-            x: point.x.downscale(scale),
-            y: point.y.downscale(scale),
+            x: point.x.downscale(scale.x),
+            y: point.y.downscale(scale.y),
             _kind: std::marker::PhantomData,
         }
     }
@@ -591,6 +673,38 @@ impl<N: Coordinate, Kind> Size<N, Kind> {
     }
 }
 
+impl<N: Coordinate, Kind> Size<N, Kind> {
+    /// Upscale this [`Size`] by a specified [`Scale`]
+    #[inline]
+    pub fn upscale(self, scale: impl Into<Scale<N>>) -> Size<N, Kind> {
+        let scale = scale.into();
+        Size {
+            w: self.w.upscale(scale.x),
+            h: self.h.upscale(scale.y),
+            _kind: std::marker::PhantomData,
+        }
+    }
+
+    /// Downscale this [`Size`] by a specified [`Scale`]
+    #[inline]
+    pub fn downscale(self, scale: impl Into<Scale<N>>) -> Size<N, Kind> {
+        let scale = scale.into();
+        Size {
+            w: self.w.downscale(scale.x),
+            h: self.h.downscale(scale.y),
+            _kind: std::marker::PhantomData,
+        }
+    }
+
+    /// Check if this [`Size`] is empty
+    ///
+    /// Returns true if either the width or the height is zero
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.w == N::default() || self.h == N::default()
+    }
+}
+
 impl<Kind> Size<f64, Kind> {
     /// Convert to i32 for integer-space manipulations by rounding float values
     #[inline]
@@ -662,20 +776,22 @@ impl<N: fmt::Debug> fmt::Debug for Size<N, Buffer> {
 impl<N: Coordinate> Size<N, Logical> {
     #[inline]
     /// Convert this logical size to physical coordinate space according to given scale factor
-    pub fn to_physical(self, scale: N) -> Size<N, Physical> {
+    pub fn to_physical(self, scale: impl Into<Scale<N>>) -> Size<N, Physical> {
+        let scale = scale.into();
         Size {
-            w: self.w.upscale(scale),
-            h: self.h.upscale(scale),
+            w: self.w.upscale(scale.x),
+            h: self.h.upscale(scale.y),
             _kind: std::marker::PhantomData,
         }
     }
 
     #[inline]
     /// Convert this logical size to buffer coordinate space according to given scale factor
-    pub fn to_buffer(self, scale: N, transformation: Transform) -> Size<N, Buffer> {
+    pub fn to_buffer(self, scale: impl Into<Scale<N>>, transformation: Transform) -> Size<N, Buffer> {
+        let scale = scale.into();
         transformation.transform_size(Size {
-            w: self.w.upscale(scale),
-            h: self.h.upscale(scale),
+            w: self.w.upscale(scale.x),
+            h: self.h.upscale(scale.y),
             _kind: std::marker::PhantomData,
         })
     }
@@ -684,10 +800,11 @@ impl<N: Coordinate> Size<N, Logical> {
 impl<N: Coordinate> Size<N, Physical> {
     #[inline]
     /// Convert this physical point to logical coordinate space according to given scale factor
-    pub fn to_logical(self, scale: N) -> Size<N, Logical> {
+    pub fn to_logical(self, scale: impl Into<Scale<N>>) -> Size<N, Logical> {
+        let scale = scale.into();
         Size {
-            w: self.w.downscale(scale),
-            h: self.h.downscale(scale),
+            w: self.w.downscale(scale.x),
+            h: self.h.downscale(scale.y),
             _kind: std::marker::PhantomData,
         }
     }
@@ -696,10 +813,11 @@ impl<N: Coordinate> Size<N, Physical> {
 impl<N: Coordinate> Size<N, Buffer> {
     #[inline]
     /// Convert this physical point to logical coordinate space according to given scale factor
-    pub fn to_logical(self, scale: N, transformation: Transform) -> Size<N, Logical> {
+    pub fn to_logical(self, scale: impl Into<Scale<N>>, transformation: Transform) -> Size<N, Logical> {
+        let scale = scale.into();
         transformation.invert().transform_size(Size {
-            w: self.w.downscale(scale),
-            h: self.h.downscale(scale),
+            w: self.w.downscale(scale.x),
+            h: self.h.downscale(scale.y),
             _kind: std::marker::PhantomData,
         })
     }
@@ -763,6 +881,29 @@ impl<N: Coordinate, Kind> SubAssign for Size<N, Kind> {
     }
 }
 
+impl<N: Coordinate, Kind> PartialOrd<Size<N, Kind>> for Size<N, Kind> {
+    #[inline]
+    fn partial_cmp(&self, other: &Size<N, Kind>) -> Option<std::cmp::Ordering> {
+        match self.w.partial_cmp(&other.w) {
+            Some(core::cmp::Ordering::Equal) => {}
+            ord => return ord,
+        }
+        self.h.partial_cmp(&other.h)
+    }
+}
+
+impl<N: Coordinate + Div<Output = N>, Kind> Div<Size<N, Kind>> for Size<N, Kind> {
+    type Output = Scale<N>;
+
+    #[inline]
+    fn div(self, rhs: Size<N, Kind>) -> Self::Output {
+        Scale {
+            x: self.w / rhs.w,
+            y: self.h / rhs.h,
+        }
+    }
+}
+
 impl<N: Clone, Kind> Clone for Size<N, Kind> {
     #[inline]
     fn clone(&self) -> Self {
@@ -820,7 +961,7 @@ impl<N: Coordinate, Kind> Sub<Size<N, Kind>> for Point<N, Kind> {
 
 /// A rectangle defined by its top-left corner and dimensions
 ///
-/// Operations on retangles are saturating.
+/// Operations on rectangles are saturating.
 #[repr(C)]
 pub struct Rectangle<N, Kind> {
     /// Location of the top-left corner of the rectangle
@@ -836,6 +977,34 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
             loc: self.loc.to_f64(),
             size: self.size.to_f64(),
         }
+    }
+}
+
+impl<N: Coordinate, Kind> Rectangle<N, Kind> {
+    /// Upscale this [`Rectangle`] by the supplied [`Scale`]
+    pub fn upscale(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Kind> {
+        let scale = scale.into();
+        Rectangle {
+            loc: self.loc.upscale(scale),
+            size: self.size.upscale(scale),
+        }
+    }
+
+    /// Upscale this [`Rectangle`] by the supplied [`Scale`]
+    pub fn downscale(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Kind> {
+        let scale = scale.into();
+        Rectangle {
+            loc: self.loc.downscale(scale),
+            size: self.size.downscale(scale),
+        }
+    }
+
+    /// Check if this [`Rectangle`] is empty
+    ///
+    /// Returns true if either the width or the height
+    /// of the [`Size`] is zero
+    pub fn is_empty(&self) -> bool {
+        self.size.is_empty()
     }
 }
 
@@ -973,7 +1142,8 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
 impl<N: Coordinate> Rectangle<N, Logical> {
     /// Convert this logical rectangle to physical coordinate space according to given scale factor
     #[inline]
-    pub fn to_physical(self, scale: N) -> Rectangle<N, Physical> {
+    pub fn to_physical(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Physical> {
+        let scale = scale.into();
         Rectangle {
             loc: self.loc.to_physical(scale),
             size: self.size.to_physical(scale),
@@ -984,20 +1154,21 @@ impl<N: Coordinate> Rectangle<N, Logical> {
     #[inline]
     pub fn to_buffer(
         self,
-        scale: N,
+        scale: impl Into<Scale<N>>,
         transformation: Transform,
         area: &Size<N, Logical>,
     ) -> Rectangle<N, Buffer> {
         let rect = transformation.transform_rect_in(self, area);
+        let scale = scale.into();
         Rectangle {
             loc: Point {
-                x: rect.loc.x.upscale(scale),
-                y: rect.loc.y.upscale(scale),
+                x: rect.loc.x.upscale(scale.x),
+                y: rect.loc.y.upscale(scale.y),
                 _kind: std::marker::PhantomData,
             },
             size: Size {
-                w: rect.size.w.upscale(scale),
-                h: rect.size.h.upscale(scale),
+                w: rect.size.w.upscale(scale.x),
+                h: rect.size.h.upscale(scale.y),
                 _kind: std::marker::PhantomData,
             },
         }
@@ -1007,7 +1178,8 @@ impl<N: Coordinate> Rectangle<N, Logical> {
 impl<N: Coordinate> Rectangle<N, Physical> {
     /// Convert this physical rectangle to logical coordinate space according to given scale factor
     #[inline]
-    pub fn to_logical(self, scale: N) -> Rectangle<N, Logical> {
+    pub fn to_logical(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Logical> {
+        let scale = scale.into();
         Rectangle {
             loc: self.loc.to_logical(scale),
             size: self.size.to_logical(scale),
@@ -1020,20 +1192,21 @@ impl<N: Coordinate> Rectangle<N, Buffer> {
     #[inline]
     pub fn to_logical(
         self,
-        scale: N,
+        scale: impl Into<Scale<N>>,
         transformation: Transform,
         area: &Size<N, Buffer>,
     ) -> Rectangle<N, Logical> {
         let rect = transformation.invert().transform_rect_in(self, area);
+        let scale = scale.into();
         Rectangle {
             loc: Point {
-                x: rect.loc.x.downscale(scale),
-                y: rect.loc.y.downscale(scale),
+                x: rect.loc.x.downscale(scale.x),
+                y: rect.loc.y.downscale(scale.y),
                 _kind: std::marker::PhantomData,
             },
             size: Size {
-                w: rect.size.w.downscale(scale),
-                h: rect.size.h.downscale(scale),
+                w: rect.size.w.downscale(scale.x),
+                h: rect.size.h.downscale(scale.y),
                 _kind: std::marker::PhantomData,
             },
         }

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -1155,18 +1155,11 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
     #[inline]
     pub fn overlaps(self, other: impl Into<Rectangle<N, Kind>>) -> bool {
         let other = other.into();
-        // if the rectangle is not outside of the other
-        // they must overlap
-        !(
-            // self is left of other
-            self.loc.x.saturating_add(self.size.w) < other.loc.x
-            // self is right of other
-            ||  self.loc.x > other.loc.x.saturating_add(other.size.w)
-            // self is above of other
-            ||  self.loc.y.saturating_add(self.size.h) < other.loc.y
-            // self is below of other
-            ||  self.loc.y > other.loc.y.saturating_add(other.size.h)
-        )
+
+        self.loc.x <= other.loc.x.saturating_add(other.size.w)
+            && other.loc.x <= self.loc.x.saturating_add(self.size.w)
+            && self.loc.y <= other.loc.y.saturating_add(other.size.h)
+            && other.loc.y <= self.loc.y.saturating_add(self.size.h)
     }
 
     /// Clamp rectangle to min and max corners resulting in the overlapping area of two rectangles

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -267,6 +267,17 @@ pub struct Scale<N: Coordinate> {
     pub y: N,
 }
 
+impl<N: Coordinate> Scale<N> {
+    /// Convert the underlying numerical type to f64 for floating point manipulations
+    #[inline]
+    pub fn to_f64(self) -> Scale<f64> {
+        Scale {
+            x: self.x.to_f64(),
+            y: self.y.to_f64(),
+        }
+    }
+}
+
 impl<N: Coordinate> From<N> for Scale<N> {
     fn from(scale: N) -> Self {
         Scale { x: scale, y: scale }
@@ -474,6 +485,36 @@ impl<N: Coordinate> Point<N, Logical> {
             y: self.y.upscale(scale.y),
             _kind: std::marker::PhantomData,
         }
+    }
+
+    /// Convert this logical point to physical coordinate space according to given scale factor
+    /// and round the result
+    #[inline]
+    pub fn to_physical_precise_round<S: Coordinate, R: Coordinate>(
+        self,
+        scale: impl Into<Scale<S>>,
+    ) -> Point<R, Physical> {
+        self.to_f64().to_physical(scale.into().to_f64()).to_i32_round()
+    }
+
+    /// Convert this logical point to physical coordinate space according to given scale factor
+    /// and ceil the result
+    #[inline]
+    pub fn to_physical_precise_ceil<S: Coordinate, R: Coordinate>(
+        &self,
+        scale: impl Into<Scale<S>>,
+    ) -> Point<R, Physical> {
+        self.to_f64().to_physical(scale.into().to_f64()).to_i32_ceil()
+    }
+
+    /// Convert this logical point to physical coordinate space according to given scale factor
+    /// and floor the result
+    #[inline]
+    pub fn to_physical_precise_floor<S: Coordinate, R: Coordinate>(
+        &self,
+        scale: impl Into<Scale<S>>,
+    ) -> Point<R, Physical> {
+        self.to_f64().to_physical(scale.into().to_f64()).to_i32_floor()
     }
 
     #[inline]
@@ -783,6 +824,36 @@ impl<N: Coordinate> Size<N, Logical> {
             h: self.h.upscale(scale.y),
             _kind: std::marker::PhantomData,
         }
+    }
+
+    /// Convert this logical size to physical coordinate space according to given scale factor
+    /// and round the result
+    #[inline]
+    pub fn to_physical_precise_round<S: Coordinate, R: Coordinate>(
+        self,
+        scale: impl Into<Scale<S>>,
+    ) -> Size<R, Physical> {
+        self.to_f64().to_physical(scale.into().to_f64()).to_i32_round()
+    }
+
+    /// Convert this logical size to physical coordinate space according to given scale factor
+    /// and ceil the result
+    #[inline]
+    pub fn to_physical_precise_ceil<S: Coordinate, R: Coordinate>(
+        &self,
+        scale: impl Into<Scale<S>>,
+    ) -> Size<R, Physical> {
+        self.to_f64().to_physical(scale.into().to_f64()).to_i32_ceil()
+    }
+
+    /// Convert this logical size to physical coordinate space according to given scale factor
+    /// and floor the result
+    #[inline]
+    pub fn to_physical_precise_floor<S: Coordinate, R: Coordinate>(
+        &self,
+        scale: impl Into<Scale<S>>,
+    ) -> Size<R, Physical> {
+        self.to_f64().to_physical(scale.into().to_f64()).to_i32_floor()
     }
 
     #[inline]
@@ -1148,6 +1219,40 @@ impl<N: Coordinate> Rectangle<N, Logical> {
             loc: self.loc.to_physical(scale),
             size: self.size.to_physical(scale),
         }
+    }
+
+    /// Convert this logical rectangle to physical coordinate space according to given scale factor
+    /// and round the result
+    #[inline]
+    pub fn to_physical_precise_round<S: Coordinate, R: Coordinate>(
+        self,
+        scale: impl Into<Scale<S>>,
+    ) -> Rectangle<R, Physical> {
+        self.to_f64().to_physical(scale.into().to_f64()).to_i32_round()
+    }
+
+    /// Convert this logical rectangle to physical coordinate space according to given scale factor,
+    /// returning the largest N-space rectangle fitting into the N-based rectangle
+    ///
+    /// This will ceil the location and floor the size after applying the scale
+    #[inline]
+    pub fn to_physical_precise_down<S: Coordinate, R: Coordinate>(
+        &self,
+        scale: impl Into<Scale<S>>,
+    ) -> Rectangle<R, Physical> {
+        self.to_f64().to_physical(scale.into().to_f64()).to_i32_down()
+    }
+
+    /// Convert this logical rectangle to physical coordinate space according to given scale factor,
+    /// returning the smallest N-space rectangle encapsulating the N-based rectangle
+    ///
+    /// This will floor the location and ceil the size after applying the scale
+    #[inline]
+    pub fn to_physical_precise_up<S: Coordinate, R: Coordinate>(
+        &self,
+        scale: impl Into<Scale<S>>,
+    ) -> Rectangle<R, Physical> {
+        self.to_f64().to_physical(scale.into().to_f64()).to_i32_up()
     }
 
     /// Convert this logical rectangle to buffer coordinate space according to given scale factor

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,7 +10,9 @@ pub mod x11rb;
 pub(crate) mod ids;
 pub mod user_data;
 
-pub use self::geometry::{Buffer, Coordinate, Logical, Physical, Point, Raw, Rectangle, Size, Transform};
+pub use self::geometry::{
+    Buffer, Coordinate, Logical, Physical, Point, Raw, Rectangle, Scale, Size, Transform,
+};
 
 /// This resource is not managed by Smithay
 #[derive(Debug)]

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -63,6 +63,7 @@ pub mod seat;
 pub mod shell;
 pub mod shm;
 pub mod tablet_manager;
+pub mod viewporter;
 pub mod xdg_activation;
 pub mod xdg_foreign;
 

--- a/src/wayland/viewporter/mod.rs
+++ b/src/wayland/viewporter/mod.rs
@@ -1,0 +1,288 @@
+//! Utilities for handling the `wp_viewporter` protocol
+//!
+//! ## How to use it
+//!
+//! ### Initialization
+//!
+//! To initialize this implementation, use the [`viewporter_init`]
+//! method provided by this module.
+//!
+//! ```
+//! use smithay::wayland::viewporter::viewporter_init;
+//!
+//! # let mut display = wayland_server::Display::new();
+//! // Call the init function:
+//! viewporter_init(&mut display);
+//!
+//! // You're now ready to go!
+//! ```
+//!
+//! ### Use the viewport state
+//!
+//! The [`viewport state`](ViewportCachedState) is double-buffered and
+//! can be accessed by using the [`with_states`] function
+//!
+//! ```no_compile
+//! let viewport = with_states(surface, |states| {
+//!     states.cached_state.current::<ViewportCachedState>();
+//! });
+//! ```
+//!
+//! Before accessing the state you should call [`ensure_viewport_valid`]
+//! to ensure the viewport is valid.
+//!
+//! Note: If you already hand over buffer management to smithay by using
+//! [`on_commit_buffer_handler`](crate::backend::renderer::utils::on_commit_buffer_handler)
+//! the implementation will already call [`ensure_viewport_valid`] for you.
+
+use std::{cell::RefCell, ops::Deref as _};
+
+use wayland_protocols::viewporter::server::{wp_viewport, wp_viewporter};
+use wayland_server::{protocol::wl_surface, Display, Filter, Global, Main};
+
+use crate::utils::{Logical, Rectangle, Size};
+
+use super::compositor::{self, with_states, Cacheable, SurfaceData};
+
+/// Create new [`wp_viewporter`](wayland_protocols::viewporter::server::wp_viewporter) global.
+///
+/// It returns the global handle, in case you wish to remove these global from
+/// the event loop in the future.
+pub fn viewporter_init(display: &mut Display) -> Global<wp_viewporter::WpViewporter> {
+    display.create_global(
+        1,
+        Filter::new(move |(new_viewporter, _), _, _| {
+            implement_viewporter(new_viewporter);
+        }),
+    )
+}
+
+fn implement_viewporter(viewporter: Main<wp_viewporter::WpViewporter>) -> wp_viewporter::WpViewporter {
+    viewporter.quick_assign(move |_, request, _| match request {
+        wp_viewporter::Request::GetViewport { id, surface } => {
+            implement_viewport(id, surface);
+        }
+        wp_viewporter::Request::Destroy => {
+            // All is already handled by our destructor
+        }
+        _ => unreachable!(),
+    });
+    viewporter.deref().clone()
+}
+
+#[derive(Default)]
+struct Viewport(Option<Main<wp_viewport::WpViewport>>);
+
+impl std::ops::Deref for Viewport {
+    type Target = Option<Main<wp_viewport::WpViewport>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Viewport {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+fn implement_viewport(viewport: Main<wp_viewport::WpViewport>, surface: wl_surface::WlSurface) {
+    let already_has_viewport = with_states(&surface, |states| {
+        states
+            .data_map
+            .insert_if_missing(|| RefCell::new(Viewport::default()));
+        states
+            .data_map
+            .get::<RefCell<Viewport>>()
+            .unwrap()
+            .borrow()
+            .is_some()
+    })
+    .unwrap_or_default();
+
+    if already_has_viewport {
+        surface.as_ref().post_error(
+            wp_viewporter::Error::ViewportExists as u32,
+            "the surface already has a viewport object associated".to_string(),
+        );
+        return;
+    }
+
+    compositor::add_commit_hook(&surface, viewport_commit_hook);
+
+    viewport.quick_assign(move |viewport, request, _| match request {
+        wp_viewport::Request::Destroy => {
+            let _ = with_states(&surface, |states| {
+                states
+                    .data_map
+                    .get::<RefCell<Viewport>>()
+                    .unwrap()
+                    .borrow_mut()
+                    .take();
+                *states.cached_state.pending::<ViewportCachedState>() = ViewportCachedState::default();
+            });
+        }
+        wp_viewport::Request::SetSource { x, y, width, height } => {
+            // If all of x, y, width and height are -1.0, the source rectangle is unset instead.
+            // Any other set of values where width or height are zero or negative,
+            // or x or y are negative, raise the bad_value protocol error.
+            let is_unset = x == -1.0 && y == -1.0 && width == -1.0 && height == -1.0;
+            let is_valid_src = x >= 0.0 && y >= 0.0 && width > 0.0 && height > 0.0;
+
+            if !is_unset && !is_valid_src {
+                viewport.as_ref().post_error(
+                    wp_viewport::Error::BadValue as u32,
+                    "negative or zero values in width or height or negative values in x or y".to_string(),
+                );
+                return;
+            }
+
+            let res = with_states(&surface, |states| {
+                let mut viewport_state = states.cached_state.pending::<ViewportCachedState>();
+                let src = if is_unset {
+                    None
+                } else {
+                    Some(Rectangle::from_loc_and_size((x, y), (width, height)))
+                };
+                viewport_state.src = src;
+            });
+
+            // If the wl_surface associated with the wp_viewport is destroyed,
+            // all wp_viewport requests except 'destroy' raise the protocol error no_surface.
+            if res.is_err() {
+                viewport.as_ref().post_error(
+                    wp_viewport::Error::NoSurface as u32,
+                    "the wl_surface was destroyed".to_string(),
+                );
+            }
+        }
+        wp_viewport::Request::SetDestination { width, height } => {
+            // If width is -1 and height is -1, the destination size is unset instead.
+            // Any other pair of values for width and height that contains zero or
+            // negative values raises the bad_value protocol error.
+            let is_unset = width == -1 && height == -1;
+            let is_valid_size = width > 0 && height > 0;
+
+            if !is_unset && !is_valid_size {
+                viewport.as_ref().post_error(
+                    wp_viewport::Error::BadValue as u32,
+                    "negative or zero values in width or height".to_string(),
+                );
+                return;
+            }
+
+            let res = with_states(&surface, |states| {
+                let mut viewport_state = states.cached_state.pending::<ViewportCachedState>();
+                let size = if is_unset {
+                    None
+                } else {
+                    Some(Size::from((width, height)))
+                };
+                viewport_state.dst = size;
+            });
+
+            // If the wl_surface associated with the wp_viewport is destroyed,
+            // all wp_viewport requests except 'destroy' raise the protocol error no_surface.
+            if res.is_err() {
+                viewport.as_ref().post_error(
+                    wp_viewport::Error::NoSurface as u32,
+                    "the wl_surface was destroyed".to_string(),
+                );
+            }
+        }
+        _ => unreachable!(),
+    });
+}
+
+fn viewport_commit_hook(surface: &wl_surface::WlSurface) {
+    let _ = with_states(surface, |states| {
+        states
+            .data_map
+            .insert_if_missing(|| RefCell::new(Viewport::default()));
+        let viewport = states.data_map.get::<RefCell<Viewport>>().unwrap().borrow();
+        if let Some(viewport) = &**viewport {
+            let viewport_state = states.cached_state.pending::<ViewportCachedState>();
+
+            // If src_width or src_height are not integers and destination size is not set,
+            // the bad_size protocol error is raised when the surface state is applied.
+            let src_size = viewport_state.src.map(|src| src.size);
+            if viewport_state.dst.is_none()
+                && src_size != src_size.map(|s| Size::from((s.w as i32, s.h as i32)).to_f64())
+            {
+                viewport.as_ref().post_error(
+                    wp_viewport::Error::BadSize as u32,
+                    "destination size is not integer".to_string(),
+                );
+            }
+        }
+    });
+}
+
+/// Ensures that the viewport, if any, is valid accordingly to the protocol specification.
+///
+/// If the viewport violates any protocol checks a protocol error will be raised and `false`
+/// is returned.
+pub fn ensure_viewport_valid(states: &SurfaceData, buffer_size: Size<i32, Logical>) -> bool {
+    states
+        .data_map
+        .insert_if_missing(|| RefCell::new(Viewport::default()));
+    let viewport = states.data_map.get::<RefCell<Viewport>>().unwrap().borrow();
+
+    if let Some(viewport) = &**viewport {
+        let state = states.cached_state.pending::<ViewportCachedState>();
+
+        let buffer_rect = Rectangle::from_loc_and_size((0.0, 0.0), buffer_size.to_f64());
+        let src = state.src.unwrap_or(buffer_rect);
+        let valid = buffer_rect.contains_rect(src);
+        if !valid {
+            viewport.as_ref().post_error(
+                wp_viewport::Error::OutOfBuffer as u32,
+                "source rectangle extends outside of the content area".to_string(),
+            );
+        }
+        valid
+    } else {
+        true
+    }
+}
+
+/// Represents the double-buffered viewport
+/// state of a [`WlSurface`](wl_surface::WlSurface)
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ViewportCachedState {
+    /// Defines the source [`Rectangle`] of the [`WlSurface`](wl_surface::WlSurface) in [`Logical`]
+    /// coordinates used for cropping.
+    pub src: Option<Rectangle<f64, Logical>>,
+    /// Defines the destination [`Size`] of the [`WlSurface`](wl_surface::WlSurface) in [`Logical`]
+    /// coordinates used for scaling.
+    pub dst: Option<Size<i32, Logical>>,
+}
+
+impl ViewportCachedState {
+    /// Gets the actual size the [`WlSurface`](wl_surface::WlSurface) should have on screen in
+    /// [`Logical`] coordinates.
+    ///
+    /// This will return the destination size if set or the size of the source rectangle.
+    /// If both are unset `None` is returned.
+    pub fn size(&self) -> Option<Size<i32, Logical>> {
+        self.dst.or_else(|| {
+            self.src
+                .map(|src| Size::from((src.size.w as i32, src.size.h as i32)))
+        })
+    }
+}
+
+impl Cacheable for ViewportCachedState {
+    fn commit(&mut self) -> Self {
+        ViewportCachedState {
+            src: self.src,
+            dst: self.dst,
+        }
+    }
+
+    fn merge_into(self, into: &mut Self) {
+        into.src = self.src;
+        into.dst = self.dst;
+    }
+}

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -131,7 +131,7 @@ impl Frame for DummyFrame {
     fn render_texture_from_to(
         &mut self,
         _texture: &Self::TextureId,
-        _src: Rectangle<i32, Buffer>,
+        _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<f64, Physical>,
         _damage: &[Rectangle<f64, Physical>],
         _src_transform: Transform,


### PR DESCRIPTION
## Changes
- Add a two-dimensions `Scale`
  Allows for different scales on x and y axis, which could be used for some special use-cases for outputs.
  Preparation for compositor driven crop & scale
- Support for `wp_viewporter`
- Rounding physical coordinates to align with the physical pixel grid
  ~~(also implements the rounding described in [wp-fractional-scale-v1](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/143)~~
  Rounding is done as the final step, `wp-fractional-scale-v1` will be integrated in a seperate PR
- Fixes for damage artifacts on some fractional scales

## Open Questions
- [X] ~~Leave the `location` in `draw_surface_tree` (and probably other) in `Logical` space?
  This could reduce the places where we round the physical coordinates~~
  No, using physical reduces the places where we need to round and allows the `RenderElements` to
  multipliy the scale with some factor without affecting the location

## TODO
- [X] `viewporter` docs
- [X] `Space::render_output`: check/fix output geo rounding
- [X] test `multigpu` for regressions
- [X] test `udev` for regressions 
- [ ] Update changelog

## (Unrelated) Issues
- [X] z-index change does not damage output
- [X] window activation does not damage output
