### PR TITLE
add missing display handle params in trait functions

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -64,7 +64,7 @@ impl DataDeviceHandler for App {
         &self.data_device_state
     }
 
-    fn send_selection(&mut self, _mime_type: String, _fd: RawFd) {}
+    fn send_selection(&mut self, _dh: &DisplayHandle, _mime_type: String, _fd: RawFd) {}
 }
 
 impl ClientDndGrabHandler for App {}

--- a/src/wayland/data_device/device.rs
+++ b/src/wayland/data_device/device.rs
@@ -88,7 +88,7 @@ where
                         if keyboard.client_of_object_has_focus(&resource.id()) {
                             let seat_data = seat.user_data().get::<RefCell<SeatData>>().unwrap();
 
-                            handler.new_selection(source.clone());
+                            handler.new_selection(dh, source.clone());
                             // The client has kbd focus, it can set the selection
                             seat_data.borrow_mut().set_selection::<D>(
                                 dh,

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -371,7 +371,7 @@ fn handle_dnd<D>(
             let source_actions =
                 with_source_metadata(source, |meta| meta.dnd_action).unwrap_or_else(|_| DndAction::empty());
             let possible_actions = source_actions & dnd_actions;
-            data.chosen_action = handler.action_choice(possible_actions, preferred_action);
+            data.chosen_action = handler.action_choice(dh, possible_actions, preferred_action);
             // check that the user provided callback respects that one precise action should be chosen
             debug_assert!(
                 [DndAction::None, DndAction::Move, DndAction::Copy, DndAction::Ask]

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -62,20 +62,21 @@ pub trait DataDeviceHandler: Sized + ClientDndGrabHandler + ServerDndGrabHandler
     fn data_device_state(&self) -> &DataDeviceState;
 
     /// Action chooser for DnD negociation
-    fn action_choice(&mut self, available: DndAction, preferred: DndAction) -> DndAction {
+    #[allow(unused_variables)]
+    fn action_choice(&mut self, dh: &DisplayHandle, available: DndAction, preferred: DndAction) -> DndAction {
         default_action_chooser(available, preferred)
     }
 
     /// A client has set the selection
     #[allow(unused_variables)]
-    fn new_selection(&mut self, source: Option<WlDataSource>) {}
+    fn new_selection(&mut self, dh: &DisplayHandle, source: Option<WlDataSource>) {}
 
     /// A client requested to read the server-set selection
     ///
     /// * `mime_type` - the requested mime type
     /// * `fd` - the fd to write into
     #[allow(unused_variables)]
-    fn send_selection(&mut self, mime_type: String, fd: RawFd) {}
+    fn send_selection(&mut self, dh: &DisplayHandle, mime_type: String, fd: RawFd) {}
 }
 
 /// Events that are generated during client initiated drag'n'drop

--- a/src/wayland/data_device/seat_data.rs
+++ b/src/wayland/data_device/seat_data.rs
@@ -240,7 +240,7 @@ where
     ) -> Option<Arc<dyn ObjectData<D>>> {
         let dh = DisplayHandle::from(dh.clone());
         if let Ok((_resource, request)) = WlDataOffer::parse_request(&dh, msg) {
-            handle_server_selection(handler, request, &self.offer_meta);
+            handle_server_selection(handler, &dh, request, &self.offer_meta);
         }
 
         None
@@ -251,6 +251,7 @@ where
 
 pub fn handle_server_selection<D>(
     handler: &mut D,
+    dh: &DisplayHandle,
     request: wl_data_offer::Request,
     offer_meta: &SourceMetadata,
 ) where
@@ -269,7 +270,7 @@ pub fn handle_server_selection<D>(
             );
             let _ = ::nix::unistd::close(fd);
         } else {
-            handler.send_selection(mime_type, fd);
+            handler.send_selection(dh, mime_type, fd);
         }
     }
 }

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -331,7 +331,7 @@ fn handle_server_dnd<D>(
                 return;
             }
             let possible_actions = metadata.dnd_action & dnd_actions;
-            data.chosen_action = handler.action_choice(possible_actions, preferred_action);
+            data.chosen_action = handler.action_choice(dh, possible_actions, preferred_action);
             // check that the user provided callback respects that one precise action should be chosen
             debug_assert!(
                 [DndAction::None, DndAction::Move, DndAction::Copy, DndAction::Ask]

--- a/src/wayland/dmabuf/dispatch.rs
+++ b/src/wayland/dmabuf/dispatch.rs
@@ -173,7 +173,7 @@ where
                 // create_dmabuf performs an implicit ensure_unused function call.
                 if let Some(dmabuf) = data.create_dmabuf(dh, params, width, height, format, flags) {
                     if state.dmabuf_state().globals.get(&data.id).is_some() {
-                        match state.dmabuf_imported(&DmabufGlobal { id: data.id }, dmabuf.clone()) {
+                        match state.dmabuf_imported(dh, &DmabufGlobal { id: data.id }, dmabuf.clone()) {
                             Ok(_) => {
                                 match Buffer::create_buffer::<D, _>(dh, client, dmabuf) {
                                     Ok((wl_buffer, _)) => {
@@ -221,7 +221,7 @@ where
                 // create_dmabuf performs an implicit ensure_unused function call.
                 if let Some(dmabuf) = data.create_dmabuf(dh, params, width, height, format, flags) {
                     if state.dmabuf_state().globals.get(&data.id).is_some() {
-                        match state.dmabuf_imported(&DmabufGlobal { id: data.id }, dmabuf.clone()) {
+                        match state.dmabuf_imported(dh, &DmabufGlobal { id: data.id }, dmabuf.clone()) {
                             Ok(_) => {
                                 // Import was successful, initialize the dmabuf data
                                 Buffer::init_buffer(data_init, buffer_id, dmabuf);

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -267,7 +267,12 @@ pub trait DmabufHandler: BufferHandler {
     ///
     /// If the import fails due to an implementation specific reason, then [`ImportError::Failed`] should be
     /// returned.
-    fn dmabuf_imported(&mut self, global: &DmabufGlobal, dmabuf: Dmabuf) -> Result<(), ImportError>;
+    fn dmabuf_imported(
+        &mut self,
+        dh: &DisplayHandle,
+        global: &DmabufGlobal,
+        dmabuf: Dmabuf,
+    ) -> Result<(), ImportError>;
 }
 
 /// Error that may occur when importing a [`Dmabuf`].

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -154,6 +154,7 @@ where
 
                 WlrLayerShellHandler::request(
                     state,
+                    dh,
                     LayerShellRequest::NewLayerSurface {
                         surface: handle,
                         output,
@@ -312,6 +313,7 @@ where
 
                 WlrLayerShellHandler::request(
                     state,
+                    dh,
                     LayerShellRequest::AckConfigure {
                         surface: data.wl_surface.clone(),
                         configure,

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -194,8 +194,9 @@ impl WlrLayerShellState {
 pub trait WlrLayerShellHandler {
     /// [WlrLayerShellState] getter
     fn shell_state(&mut self) -> &mut WlrLayerShellState;
+
     /// Layer shell request
-    fn request(&mut self, request: LayerShellRequest);
+    fn request(&mut self, dh: &DisplayHandle, request: LayerShellRequest);
 }
 
 /// A handle to a layer surface

--- a/src/wayland/xdg_activation/dispatch.rs
+++ b/src/wayland/xdg_activation/dispatch.rs
@@ -27,7 +27,7 @@ where
         _: &xdg_activation_v1::XdgActivationV1,
         request: xdg_activation_v1::Request,
         _: &(),
-        _: &DisplayHandle,
+        dh: &DisplayHandle,
         data_init: &mut DataInit<'_, D>,
     ) {
         match request {
@@ -57,7 +57,7 @@ where
                     activation_state
                         .activation_requests
                         .insert(token.clone(), (token_data.clone(), surface.clone()));
-                    state.request_activation(token, token_data, surface);
+                    state.request_activation(dh, token, token_data, surface);
                 }
             }
 

--- a/src/wayland/xdg_activation/mod.rs
+++ b/src/wayland/xdg_activation/mod.rs
@@ -66,7 +66,7 @@ use wayland_protocols::xdg::activation::v1::server::xdg_activation_v1;
 use wayland_server::{
     backend::GlobalId,
     protocol::{wl_seat::WlSeat, wl_surface::WlSurface},
-    Dispatch, Display, GlobalDispatch,
+    Dispatch, Display, DisplayHandle, GlobalDispatch,
 };
 
 use rand::distributions::{Alphanumeric, DistString};
@@ -240,6 +240,7 @@ pub trait XdgActivationHandler {
     /// ignore any future requests.
     fn request_activation(
         &mut self,
+        dh: &DisplayHandle,
         token: XdgActivationToken,
         token_data: XdgActivationTokenData,
         surface: WlSurface,


### PR DESCRIPTION
These are available when dispatching requests, may as well provide the display handle for convince.