### PR TITLE
manage globals using DisplayHandle

### DIFF
--- a/examples/compositor.rs
+++ b/examples/compositor.rs
@@ -25,8 +25,9 @@ impl CompositorHandler for App {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut display: Display<App> = Display::new()?;
+    let dh = display.handle();
 
-    let compositor_state = CompositorState::new(&mut display, None);
+    let compositor_state = CompositorState::new::<App, _>(&dh, None);
 
     let mut state = App { compositor_state };
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -117,17 +117,18 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
     let log = log();
 
     let mut display: Display<App> = Display::new()?;
+    let dh = display.handle();
 
     let seat_state = SeatState::new();
-    let seat = Seat::new(&mut display, "winit", None);
+    let seat = Seat::<App>::new(&dh, "winit", None);
 
     let mut state = {
         App {
-            compositor_state: CompositorState::new(&mut display, None),
-            xdg_shell_state: XdgShellState::new(&mut display, None).0,
-            shm_state: ShmState::new(&mut display, vec![], None),
+            compositor_state: CompositorState::new::<App, _>(&dh, None),
+            xdg_shell_state: XdgShellState::new::<App, _>(&dh, None).0,
+            shm_state: ShmState::new::<App, _>(&dh, vec![], None),
             seat_state,
-            data_device_state: DataDeviceState::new(&mut display, None),
+            data_device_state: DataDeviceState::new::<App, _>(&dh, None),
             seat,
         }
     };

--- a/examples/seat.rs
+++ b/examples/seat.rs
@@ -22,9 +22,10 @@ impl SeatHandler for App {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut display: Display<App> = Display::new()?;
+    let dh = display.handle();
 
     let seat_state = SeatState::new();
-    let seat = Seat::new(&mut display, "Example", None);
+    let seat = Seat::<App>::new(&dh, "Example", None);
 
     let mut state = App { seat_state, seat };
 

--- a/smallvil/src/state.rs
+++ b/smallvil/src/state.rs
@@ -50,16 +50,18 @@ impl Smallvil {
     pub fn new(event_loop: &mut EventLoop<CalloopData>, display: &mut Display<Self>, log: Logger) -> Self {
         let start_time = std::time::Instant::now();
 
-        let compositor_state = CompositorState::new(display, log.clone());
-        let xdg_shell_state = XdgShellState::new(display, log.clone()).0;
-        let shm_state = ShmState::new(display, vec![], log.clone());
-        let output_manager_state = OutputManagerState::new_with_xdg_output(display);
+        let dh = display.handle();
+
+        let compositor_state = CompositorState::new::<Self, _>(&dh, log.clone());
+        let xdg_shell_state = XdgShellState::new::<Self, _>(&dh, log.clone()).0;
+        let shm_state = ShmState::new::<Self, _>(&dh, vec![], log.clone());
+        let output_manager_state = OutputManagerState::new_with_xdg_output::<Self>(&dh);
         let seat_state = SeatState::new();
-        let data_device_state = DataDeviceState::new(display, log.clone());
+        let data_device_state = DataDeviceState::new::<Self, _>(&dh, log.clone());
 
         // A seat is a group of keyboards, pointer and touch devices.
         // A seat typically has a pointer and maintains a keyboard focus and a pointer focus.
-        let mut seat: Seat<Self> = Seat::new(display, "winit", log.clone());
+        let mut seat: Seat<Self> = Seat::new(&dh, "winit", log.clone());
 
         // Notify clients that we have a keyboard, for the sake of the example we assume that keyboard is always present.
         // You may want to track keyboard hot-plug in real compositor.

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -16,7 +16,7 @@ use smithay::{
 
 use slog::Logger;
 
-use crate::CalloopData;
+use crate::{CalloopData, Smallvil};
 
 pub fn init_winit(
     event_loop: &mut EventLoop<CalloopData>,
@@ -33,8 +33,8 @@ pub fn init_winit(
         refresh: 60_000,
     };
 
-    let (output, _global) = Output::new(
-        display,
+    let (output, _global) = Output::new::<Smallvil, _>(
+        &display.handle(),
         "winit".to_string(),
         PhysicalProperties {
             size: (0, 0).into(),

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -96,7 +96,7 @@ use wayland_server::backend::GlobalId;
 use wayland_server::protocol::wl_compositor::WlCompositor;
 use wayland_server::protocol::wl_subcompositor::WlSubcompositor;
 use wayland_server::protocol::{wl_buffer, wl_callback, wl_output, wl_region, wl_surface::WlSurface};
-use wayland_server::{Display, DisplayHandle, GlobalDispatch, Resource};
+use wayland_server::{DisplayHandle, GlobalDispatch, Resource};
 
 /// Description of a part of a surface that
 /// should be considered damaged and needs to be redrawn
@@ -418,15 +418,15 @@ impl CompositorState {
     ///
     /// It returns the two global handles, in case you wish to remove these globals from
     /// the event loop in the future.
-    pub fn new<D, L>(display: &mut Display<D>, logger: L) -> Self
+    pub fn new<D, L>(display: &DisplayHandle, logger: L) -> Self
     where
         L: Into<Option<::slog::Logger>>,
         D: GlobalDispatch<WlCompositor, ()> + GlobalDispatch<WlSubcompositor, ()> + 'static,
     {
         let log = crate::slog_or_fallback(logger).new(slog::o!("smithay_module" => "compositor_handler"));
 
-        let compositor = display.handle().create_global::<D, WlCompositor, ()>(4, ());
-        let subcompositor = display.handle().create_global::<D, WlSubcompositor, ()>(1, ());
+        let compositor = display.create_global::<D, WlCompositor, ()>(4, ());
+        let subcompositor = display.create_global::<D, WlSubcompositor, ()>(1, ());
 
         CompositorState {
             log,

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -37,7 +37,7 @@ use wayland_server::{
         wl_data_source::WlDataSource,
         wl_surface::WlSurface,
     },
-    Client, Display, DisplayHandle, GlobalDispatch,
+    Client, DisplayHandle, GlobalDispatch,
 };
 
 use super::{
@@ -140,7 +140,7 @@ pub struct DataDeviceState {
 
 impl DataDeviceState {
     /// Regiseter new [WlDataDeviceManager] global
-    pub fn new<D, L>(display: &mut Display<D>, logger: L) -> Self
+    pub fn new<D, L>(display: &DisplayHandle, logger: L) -> Self
     where
         L: Into<Option<::slog::Logger>>,
         D: GlobalDispatch<WlDataDeviceManager, ()> + 'static,
@@ -148,7 +148,7 @@ impl DataDeviceState {
     {
         let log = crate::slog_or_fallback(logger).new(slog::o!("smithay_module" => "data_device_mgr"));
 
-        let manager_global_id = display.handle().create_global::<D, WlDataDeviceManager, _>(3, ());
+        let manager_global_id = display.create_global::<D, WlDataDeviceManager, _>(3, ());
 
         Self {
             log,

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -12,9 +12,10 @@
 //! use smithay::wayland::seat::Seat;
 //!
 //! # let mut display = wayland_server::Display::new().unwrap();
+//! # let display_handle = display.handle();
 //! // insert the seat:
 //! let seat = Seat::new(
-//!     &mut display,             // the display
+//!     &display_handle,          // the display
 //!     "seat-0".into(),          // the name of the seat, will be advertized to clients
 //!     None                      // insert a logger here
 //! );
@@ -69,8 +70,8 @@ use wayland_server::{
         wl_surface,
         wl_touch::WlTouch,
     },
-    DataInit, DelegateDispatch, DelegateGlobalDispatch, Dispatch, Display, DisplayHandle, GlobalDispatch,
-    New, Resource,
+    DataInit, DelegateDispatch, DelegateGlobalDispatch, Dispatch, DisplayHandle, GlobalDispatch, New,
+    Resource,
 };
 
 #[derive(Debug)]
@@ -158,7 +159,7 @@ impl<D: 'static> Seat<D> {
     /// You are provided with the state token to retrieve it (allowing
     /// you to add or remove capabilities from it), and the global handle,
     /// in case you want to remove it.
-    pub fn new<N, L>(display: &mut Display<D>, name: N, logger: L) -> Self
+    pub fn new<N, L>(display: &DisplayHandle, name: N, logger: L) -> Self
     where
         D: GlobalDispatch<WlSeat, SeatGlobalData<D>> + 'static,
         N: Into<String>,
@@ -183,9 +184,7 @@ impl<D: 'static> Seat<D> {
             log,
         });
 
-        let global_id = display
-            .handle()
-            .create_global::<D, _, _>(5, SeatGlobalData { arc: arc.clone() });
+        let global_id = display.create_global::<D, _, _>(5, SeatGlobalData { arc: arc.clone() });
         arc.inner.lock().unwrap().global_id = Some(global_id);
 
         Self { arc }
@@ -237,8 +236,9 @@ impl<D> Seat<D> {
     /// # use smithay::wayland::seat::Seat;
     /// #
     /// # let mut display = wayland_server::Display::new().unwrap();
+    /// # let display_handle = display.handle();
     /// # let mut seat = Seat::new(
-    /// #     &mut display,
+    /// #     &display_handle,
     /// #     "seat-0".into(),
     /// #     None
     /// # );
@@ -383,8 +383,9 @@ impl<D> Seat<D> {
     /// # use smithay::wayland::seat::Seat;
     /// #
     /// # let mut display = wayland_server::Display::new().unwrap();
+    /// # let display_handle = display.handle();
     /// # let (mut seat, seat_global) = Seat::new(
-    /// #     &mut display,
+    /// #     &display_handle,
     /// #     "seat-0".into(),
     /// #     None
     /// # );

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -34,7 +34,7 @@ use wayland_protocols_wlr::layer_shell::v1::server::{
 use wayland_server::{
     backend::GlobalId,
     protocol::{wl_output::WlOutput, wl_surface},
-    Display, DisplayHandle, GlobalDispatch, Resource,
+    DisplayHandle, GlobalDispatch, Resource,
 };
 
 use crate::{
@@ -161,7 +161,7 @@ pub struct WlrLayerShellState {
 
 impl WlrLayerShellState {
     /// Create a new `wlr_layer_shell` globals
-    pub fn new<L, D>(display: &mut Display<D>, logger: L) -> WlrLayerShellState
+    pub fn new<L, D>(display: &DisplayHandle, logger: L) -> WlrLayerShellState
     where
         L: Into<Option<::slog::Logger>>,
         D: GlobalDispatch<ZwlrLayerShellV1, ()>,
@@ -169,7 +169,7 @@ impl WlrLayerShellState {
     {
         let log = crate::slog_or_fallback(logger);
 
-        let shell_global = display.handle().create_global::<D, ZwlrLayerShellV1, _>(4, ());
+        let shell_global = display.create_global::<D, ZwlrLayerShellV1, _>(4, ());
 
         WlrLayerShellState {
             known_layers: Default::default(),

--- a/src/wayland/shell/xdg/decoration.rs
+++ b/src/wayland/shell/xdg/decoration.rs
@@ -40,8 +40,8 @@ use wayland_protocols::xdg::decoration::zv1::server::{
     zxdg_toplevel_decoration_v1::{self, Mode},
 };
 use wayland_server::{
-    backend::GlobalId, Client, DataInit, DelegateDispatch, DelegateGlobalDispatch, Dispatch, Display,
-    DisplayHandle, GlobalDispatch, New, Resource, WEnum,
+    backend::GlobalId, Client, DataInit, DelegateDispatch, DelegateGlobalDispatch, Dispatch, DisplayHandle,
+    GlobalDispatch, New, Resource, WEnum,
 };
 
 use super::{ToplevelSurface, XdgShellHandler};
@@ -57,7 +57,7 @@ impl XdgDecorationManager {
     /// Creates a new delegate type for handling xdg decoration events.
     ///
     /// A global id is also returned to allow destroying the global in the future.
-    pub fn new<D, L>(display: &mut Display<D>, logger: L) -> (XdgDecorationManager, GlobalId)
+    pub fn new<D, L>(display: &DisplayHandle, logger: L) -> (XdgDecorationManager, GlobalId)
     where
         D: GlobalDispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, ()>
             + Dispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, ()>
@@ -65,9 +65,8 @@ impl XdgDecorationManager {
         L: Into<Option<::slog::Logger>>,
     {
         let _logger = crate::slog_or_fallback(logger);
-        let global = display
-            .handle()
-            .create_global::<D, zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, _>(1, ());
+        let global =
+            display.create_global::<D, zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, _>(1, ());
 
         (XdgDecorationManager { _logger }, global)
     }

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -77,7 +77,7 @@ use wayland_protocols::xdg::shell::server::{xdg_popup, xdg_positioner, xdg_tople
 use wayland_server::backend::GlobalId;
 use wayland_server::{
     protocol::{wl_output, wl_seat, wl_surface},
-    Display, DisplayHandle, GlobalDispatch, Resource,
+    DisplayHandle, GlobalDispatch, Resource,
 };
 
 use super::PingError;
@@ -742,7 +742,7 @@ pub struct XdgShellState {
 
 impl XdgShellState {
     /// Create a new `xdg_shell` global
-    pub fn new<D, L>(display: &mut Display<D>, logger: L) -> (XdgShellState, GlobalId)
+    pub fn new<D, L>(display: &DisplayHandle, logger: L) -> (XdgShellState, GlobalId)
     where
         L: Into<Option<::slog::Logger>>,
         D: GlobalDispatch<XdgWmBase, ()> + 'static,
@@ -757,7 +757,7 @@ impl XdgShellState {
             _log: log.new(slog::o!("smithay_module" => "xdg_shell_handler")),
         };
 
-        let xdg_shell_global = display.handle().create_global::<D, XdgWmBase, _>(3, ());
+        let xdg_shell_global = display.create_global::<D, XdgWmBase, _>(3, ());
 
         (shell_state, xdg_shell_global)
     }

--- a/src/wayland/shm/mod.rs
+++ b/src/wayland/shm/mod.rs
@@ -81,7 +81,7 @@ use wayland_server::{
         wl_shm::{self, WlShm},
         wl_shm_pool::WlShmPool,
     },
-    Dispatch, Display, GlobalDispatch,
+    Dispatch, DisplayHandle, GlobalDispatch,
 };
 
 mod handlers;
@@ -110,7 +110,7 @@ impl ShmState {
     /// The global is directly created on the provided [`Display`](wayland_server::Display),
     /// and this function returns the a delegate type. The id provided by [`ShmState::global`] may be used to
     /// remove this global in the future.
-    pub fn new<L, D>(display: &mut Display<D>, mut formats: Vec<wl_shm::Format>, logger: L) -> ShmState
+    pub fn new<D, L>(display: &DisplayHandle, mut formats: Vec<wl_shm::Format>, logger: L) -> ShmState
     where
         D: GlobalDispatch<WlShm, ()>
             + Dispatch<WlShm, ()>
@@ -126,7 +126,7 @@ impl ShmState {
         formats.push(wl_shm::Format::Argb8888);
         formats.push(wl_shm::Format::Xrgb8888);
 
-        let shm = display.handle().create_global::<D, WlShm, _>(1, ());
+        let shm = display.create_global::<D, WlShm, _>(1, ());
 
         ShmState {
             formats,


### PR DESCRIPTION
This does now require turbofish syntax for global creation. This makes global registration much more flexible.