### PR TITLE
use multiple dispatch implementations for buffers

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -13,7 +13,7 @@ use smithay::{
     reexports::wayland_server::Display,
     utils::{Rectangle, Transform},
     wayland::{
-        buffer::{Buffer, BufferHandler},
+        buffer::BufferHandler,
         compositor::{
             with_surface_tree_downward, CompositorHandler, CompositorState, SurfaceAttributes,
             TraversalAction,
@@ -27,13 +27,16 @@ use smithay::{
 use wayland_protocols::xdg::shell::server::xdg_toplevel;
 use wayland_server::{
     backend::{ClientData, ClientId, DisconnectReason},
-    protocol::wl_surface::{self, WlSurface},
+    protocol::{
+        wl_buffer,
+        wl_surface::{self, WlSurface},
+    },
     socket::ListeningSocket,
     DisplayHandle,
 };
 
 impl BufferHandler for App {
-    fn buffer_destroyed(&mut self, _buffer: &Buffer) {}
+    fn buffer_destroyed(&mut self, _buffer: &wl_buffer::WlBuffer) {}
 }
 
 impl XdgShellHandler for App {

--- a/smallvil/src/handlers/compositor.rs
+++ b/smallvil/src/handlers/compositor.rs
@@ -1,7 +1,10 @@
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
     delegate_compositor, delegate_shm,
-    reexports::wayland_server::{protocol::wl_surface::WlSurface, DisplayHandle},
+    reexports::wayland_server::{
+        protocol::{wl_buffer, wl_surface::WlSurface},
+        DisplayHandle,
+    },
     wayland::{
         buffer::BufferHandler,
         compositor::{CompositorHandler, CompositorState},
@@ -23,7 +26,7 @@ impl CompositorHandler for Smallvil {
 }
 
 impl BufferHandler for Smallvil {
-    fn buffer_destroyed(&mut self, _buffer: &smithay::wayland::buffer::Buffer) {}
+    fn buffer_destroyed(&mut self, _buffer: &wl_buffer::WlBuffer) {}
 }
 
 impl AsRef<ShmState> for Smallvil {

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -11,15 +11,12 @@ use std::sync::{Mutex, Weak};
 use libc::c_void;
 use nix::libc::c_int;
 #[cfg(all(feature = "use_system_lib", feature = "wayland_frontend"))]
-use wayland_server::{protocol::wl_buffer::WlBuffer, DisplayHandle};
+use wayland_server::{protocol::wl_buffer::WlBuffer, DisplayHandle, Resource};
 #[cfg(feature = "use_system_lib")]
 use wayland_sys::server::wl_display;
 
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
-use crate::{
-    backend::egl::{BufferAccessError, EGLBuffer, Format},
-    wayland::buffer::Buffer,
-};
+use crate::backend::egl::{BufferAccessError, EGLBuffer, Format};
 use crate::{
     backend::{
         allocator::{dmabuf::Dmabuf, Buffer as _, Format as DrmFormat, Fourcc, Modifier},
@@ -806,7 +803,6 @@ impl EGLBufferReader {
         dh: &DisplayHandle,
         buffer: &WlBuffer,
     ) -> ::std::result::Result<EGLBuffer, BufferAccessError> {
-        use wayland_server::Resource;
         if dh.get_object_data(buffer.id()).is_err() {
             debug!(self.logger, "Suplied buffer is no longer alive");
             return Err(BufferAccessError::NotManaged(EGLError::BadParameter));
@@ -927,7 +923,7 @@ impl EGLBufferReader {
     pub fn egl_buffer_dimensions(
         &self,
         dh: &DisplayHandle,
-        buffer: &Buffer,
+        buffer: &WlBuffer,
     ) -> Option<crate::utils::Size<i32, crate::utils::Buffer>> {
         if dh.get_object_data(buffer.id()).is_err() {
             debug!(self.logger, "Supplied buffer is no longer alive");

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -14,9 +14,12 @@ use crate::utils::{Buffer as BufferCoord, Physical, Point, Rectangle, Size, Tran
 use cgmath::Matrix3;
 
 #[cfg(feature = "wayland_frontend")]
-use crate::wayland::{buffer::Buffer, compositor::SurfaceData};
+use crate::wayland::compositor::SurfaceData;
 #[cfg(feature = "wayland_frontend")]
-use wayland_server::{protocol::wl_shm, DisplayHandle};
+use wayland_server::{
+    protocol::{wl_buffer, wl_shm},
+    DisplayHandle,
+};
 
 #[cfg(feature = "renderer_gl")]
 pub mod gles2;
@@ -253,7 +256,7 @@ pub trait ImportMemWl: ImportMem {
     /// with an empty list `&[]`, the renderer is allowed to not update the texture at all.
     fn import_shm_buffer(
         &mut self,
-        buffer: &Buffer,
+        buffer: &wl_buffer::WlBuffer,
         surface: Option<&crate::wayland::compositor::SurfaceData>,
         damage: &[Rectangle<i32, BufferCoord>],
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>;
@@ -362,7 +365,7 @@ pub trait ImportEgl: Renderer {
     fn import_egl_buffer(
         &mut self,
         dh: &DisplayHandle,
-        buffer: &Buffer,
+        buffer: &wl_buffer::WlBuffer,
         surface: Option<&crate::wayland::compositor::SurfaceData>,
         damage: &[Rectangle<i32, BufferCoord>],
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>;
@@ -384,7 +387,7 @@ pub trait ImportDmaWl: ImportDma {
     /// to avoid relying on implementation details, keep the buffer alive, until you destroyed this texture again.
     fn import_dma_buffer(
         &mut self,
-        buffer: &Buffer,
+        buffer: &wl_buffer::WlBuffer,
         _surface: Option<&crate::wayland::compositor::SurfaceData>,
         damage: &[Rectangle<i32, BufferCoord>],
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error> {
@@ -446,7 +449,7 @@ pub trait ImportAll: Renderer {
     fn import_buffer(
         &mut self,
         dh: &DisplayHandle,
-        buffer: &Buffer,
+        buffer: &wl_buffer::WlBuffer,
         surface: Option<&crate::wayland::compositor::SurfaceData>,
         damage: &[Rectangle<i32, BufferCoord>],
     ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>>;
@@ -462,7 +465,7 @@ impl<R: Renderer + ImportMemWl + ImportEgl + ImportDmaWl> ImportAll for R {
     fn import_buffer(
         &mut self,
         dh: &DisplayHandle,
-        buffer: &Buffer,
+        buffer: &wl_buffer::WlBuffer,
         surface: Option<&SurfaceData>,
         damage: &[Rectangle<i32, BufferCoord>],
     ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>> {
@@ -483,7 +486,7 @@ impl<R: Renderer + ImportMemWl + ImportDmaWl> ImportAll for R {
     fn import_buffer(
         &mut self,
         dh: &DisplayHandle,
-        buffer: &Buffer,
+        buffer: &wl_buffer::WlBuffer,
         surface: Option<&SurfaceData>,
         damage: &[Rectangle<i32, BufferCoord>],
     ) -> Option<Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error>> {
@@ -582,11 +585,10 @@ pub enum BufferType {
 /// Returns `None` if the type is not known to smithay
 /// or otherwise not supported (e.g. not initialized using one of smithays [`crate::wayland`]-handlers).
 #[cfg(feature = "wayland_frontend")]
-pub fn buffer_type(_dh: &DisplayHandle, buffer: &Buffer) -> Option<BufferType> {
-    // TODO: Dma
-    // if buffer.data::<Dmabuf>().is_some() {
-    //     return Some(BufferType::Dma);
-    // }
+pub fn buffer_type(_dh: &DisplayHandle, buffer: &wl_buffer::WlBuffer) -> Option<BufferType> {
+    if crate::wayland::dmabuf::get_dmabuf(buffer).is_ok() {
+        return Some(BufferType::Dma);
+    }
 
     if crate::wayland::shm::with_buffer_contents(buffer, |_, _| ()).is_ok() {
         return Some(BufferType::Shm);
@@ -612,14 +614,15 @@ pub fn buffer_type(_dh: &DisplayHandle, buffer: &Buffer) -> Option<BufferType> {
 ///
 /// *Note*: This will only return dimensions for buffer types known to smithay (see [`buffer_type`])
 #[cfg(feature = "wayland_frontend")]
-pub fn buffer_dimensions(_dh: &DisplayHandle, buffer: &Buffer) -> Option<Size<i32, BufferCoord>> {
-    #[allow(unused_imports)] // TODO: Dma
+pub fn buffer_dimensions(
+    _dh: &DisplayHandle,
+    buffer: &wl_buffer::WlBuffer,
+) -> Option<Size<i32, BufferCoord>> {
     use crate::{backend::allocator::Buffer, wayland::shm};
 
-    // TODO: Dma
-    // if let Some(buf) = buffer.data::<Dmabuf>() {
-    //     return Some((buf.width() as i32, buf.height() as i32).into());
-    // }
+    if let Ok(buf) = crate::wayland::dmabuf::get_dmabuf(buffer) {
+        return Some((buf.width() as i32, buf.height() as i32).into());
+    }
 
     match shm::with_buffer_contents(buffer, |_, data| (data.width, data.height).into()) {
         Ok(data) => Some(data),

--- a/src/backend/renderer/multigpu/egl.rs
+++ b/src/backend/renderer/multigpu/egl.rs
@@ -25,7 +25,6 @@ use crate::{
         },
     },
     utils::{Buffer as BufferCoords, Rectangle},
-    wayland::buffer::Buffer,
 };
 
 /// Errors raised by the [`EglGlesBackend`]
@@ -157,16 +156,10 @@ where
     fn import_egl_buffer(
         &mut self,
         dh: &DisplayHandle,
-        buffer: &Buffer,
+        buffer: &wl_buffer::WlBuffer,
         surface: Option<&crate::wayland::compositor::SurfaceData>,
         damage: &[Rectangle<i32, BufferCoords>],
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error> {
-        let buffer = buffer.buffer(dh).map_err(|_| {
-            Gles2Error::EGLBufferAccessError(crate::backend::egl::BufferAccessError::NotManaged(
-                crate::backend::egl::EGLError::BadParameter,
-            ))
-        })?;
-
         if let Some(ref mut renderer) = self.target.as_mut() {
             if let Ok(dmabuf) = Self::try_import_egl(dh, renderer.renderer_mut(), &buffer) {
                 let node = *renderer.node();

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -3,12 +3,9 @@
 use crate::{
     backend::renderer::{buffer_dimensions, Frame, ImportAll, Renderer},
     utils::{Buffer as BufferCoord, Logical, Point, Rectangle, Size, Transform},
-    wayland::{
-        buffer::Buffer,
-        compositor::{
-            add_destruction_hook, is_sync_subsurface, with_surface_tree_upward, BufferAssignment, Damage,
-            SubsurfaceCachedState, SurfaceAttributes, SurfaceData, TraversalAction,
-        },
+    wayland::compositor::{
+        add_destruction_hook, is_sync_subsurface, with_surface_tree_upward, BufferAssignment, Damage,
+        SubsurfaceCachedState, SurfaceAttributes, SurfaceData, TraversalAction,
     },
 };
 use std::collections::VecDeque;
@@ -43,11 +40,7 @@ impl SurfaceState {
         match attrs.buffer.take() {
             Some(BufferAssignment::NewBuffer { buffer, .. }) => {
                 // new contents
-                self.buffer_dimensions = {
-                    let buffer = Buffer::from_wl(&buffer, dh);
-
-                    buffer_dimensions(dh, &buffer)
-                };
+                self.buffer_dimensions = buffer_dimensions(dh, &buffer);
 
                 #[cfg(feature = "desktop")]
                 if self.buffer_scale != attrs.buffer_scale
@@ -238,9 +231,7 @@ where
                 let buffer_damage = data.damage_since(last_commit.copied());
                 if let Entry::Vacant(e) = data.textures.entry(texture_id) {
                     if let Some(buffer) = data.buffer.as_ref() {
-                        let buffer = Buffer::from_wl(buffer, dh);
-
-                        match renderer.import_buffer(dh, &buffer, Some(states), &buffer_damage) {
+                        match renderer.import_buffer(dh, buffer, Some(states), &buffer_damage) {
                             Some(Ok(m)) => {
                                 e.insert(Box::new(m));
                                 data.renderer_seen.insert(texture_id, data.commit_count);

--- a/src/wayland/buffer/mod.rs
+++ b/src/wayland/buffer/mod.rs
@@ -1,20 +1,9 @@
-//! Buffer management utilities.
+//! Buffer management traits.
 //!
-//! This module provides the [`Buffer`] type to represent a [`WlBuffer`] managed by Smithay and data
-//! associated with said buffer. This module has a dual purpose. This module provides a way for the compositor
-//! to be told when a client has destroyed a buffer. The other purpose is to provide a way for specific types
-//! of [`WlBuffer`] to abstractly associate some data with the protocol object without conflicting
-//! [`Dispatch`](crate::reexports::wayland_server::Dispatch) implementations.
+//! This module provides the [`BufferHandler`] trait to notify compositors that a [`WlBuffer`] managed by
+//! Smithay has been destroyed.
 
-use std::{any::Any, sync::Arc};
-
-use wayland_server::{
-    backend::{protocol::Message, ClientId, Handle, InvalidId, ObjectData, ObjectId},
-    protocol::wl_buffer::WlBuffer,
-    Client, DataInit, DisplayHandle, New, Resource,
-};
-
-use crate::utils::UnmanagedResource;
+use wayland_server::protocol::wl_buffer;
 
 /// Handler trait for associating data with a [`WlBuffer`].
 ///
@@ -22,194 +11,12 @@ use crate::utils::UnmanagedResource;
 ///
 /// # For buffer abstractions
 ///
-/// Buffer abstractions (such as [`shm`](crate::wayland::shm)) should require this trait to allow notification
-/// when a buffer is destroyed.
+/// Buffer abstractions (such as [`shm`](crate::wayland::shm)) should require this trait in their
+/// [`DelegateDispatch`](wayland_server::DelegateDispatch) implementations to notify the compositor when a
+/// buffer is destroyed.
 pub trait BufferHandler {
     /// Called when the client has destroyed the buffer.
     ///
     /// At this point the buffer is no longer usable by Smithay.
-    fn buffer_destroyed(&mut self, buffer: &Buffer);
-}
-
-/// A wrapper around a [`WlBuffer`] managed by Smithay.
-#[derive(Debug, Clone, PartialEq)]
-pub struct Buffer(BufferInner);
-
-impl Buffer {
-    /// Initializes a buffer, associating some user data with the buffer. This function causes the buffer to
-    /// managed by Smithay.
-    ///
-    /// The data associated with the buffer may obtained using [`Buffer::buffer_data`].
-    pub fn init_buffer<D, T>(init: &mut DataInit<'_, D>, buffer: New<WlBuffer>, data: T) -> Buffer
-    where
-        D: BufferHandler + 'static,
-        T: Send + Sync + 'static,
-    {
-        let data = Arc::new(BufferData { data: Box::new(data) });
-        let buffer = init.custom_init(buffer, data.clone());
-
-        Buffer(BufferInner::Managed {
-            buffer: buffer.id(),
-            data,
-        })
-    }
-
-    /// Creates a [`WlBuffer`] protocol object and associates some data with the buffer. This buffer object
-    /// is immediately managed by Smithay.
-    ///
-    /// The data associated with the buffer may obtained using [`Buffer::buffer_data`].
-    ///
-    /// # Usage
-    ///
-    /// You must send the created protocol object to the client immediately or else protocol errors will occur.
-    #[must_use = "You must send the WlBuffer to the client or else protocol errors will occur"]
-    pub fn create_buffer<D, T>(
-        dh: &DisplayHandle,
-        client: &Client,
-        data: T,
-    ) -> Result<(WlBuffer, Buffer), InvalidId>
-    where
-        D: BufferHandler + 'static,
-        T: Send + Sync + 'static,
-    {
-        let backend = dh.backend_handle();
-        let data = Arc::new(BufferData { data: Box::new(data) });
-        let buffer_id = backend.create_object::<D>(client.id(), WlBuffer::interface(), 1, data.clone())?;
-        let wl_buffer = WlBuffer::from_id(dh, buffer_id.clone())?;
-
-        Ok((
-            wl_buffer,
-            Buffer(BufferInner::Managed {
-                buffer: buffer_id,
-                data,
-            }),
-        ))
-    }
-
-    /// Creates a [`Buffer`] from a [`WlBuffer`].
-    pub fn from_wl(buffer: &WlBuffer, dh: &DisplayHandle) -> Buffer {
-        match dh.get_object_data(buffer.id()) {
-            Ok(data) => {
-                match data.downcast::<BufferData>() {
-                    Ok(data) => Buffer(BufferInner::Managed {
-                        buffer: buffer.id(),
-                        data,
-                    }),
-
-                    // The buffer has some user data but is not managed by Smithay.
-                    Err(_) => Buffer(BufferInner::Unmanaged(buffer.clone())),
-                }
-            }
-
-            // A completely unmanaged buffer (generally EGL)
-            Err(_) => Buffer(BufferInner::Unmanaged(buffer.clone())),
-        }
-    }
-
-    /// Returns the object id of the underlying [`WlBuffer`].
-    pub fn id(&self) -> ObjectId {
-        match &self.0 {
-            BufferInner::Managed { buffer, .. } => buffer.clone(),
-            BufferInner::Unmanaged(buffer) => buffer.id(),
-        }
-    }
-
-    /// Returns a reference to the underlying [`WlBuffer`].
-    pub fn buffer(&self, dh: &DisplayHandle) -> Result<WlBuffer, InvalidId> {
-        match &self.0 {
-            BufferInner::Managed { buffer, .. } => WlBuffer::from_id(dh, buffer.clone()),
-            BufferInner::Unmanaged(buffer) => Ok(buffer.clone()),
-        }
-    }
-
-    /// Sends a `release` event, indicating the buffer is no longer in use by the compositor, meaning the
-    /// client is free to reuse or destroy the buffer.
-    pub fn release(&self, dh: &DisplayHandle) -> Result<(), InvalidId> {
-        self.buffer(dh)?.release();
-        Ok(())
-    }
-
-    /// Returns the data associated with the buffer.
-    ///
-    /// This function is intended for abstractions to obtain the buffer data they store. Users should use the
-    /// functions provided by the buffer abstractions to obtain the data. For example, data associated with an
-    /// shm buffer should be obtained using [`with_buffer_contents`](crate::wayland::shm::with_buffer_contents)
-    /// instead of specifying the type of the data in the `T` generic for this function.
-    pub fn buffer_data<T>(&self) -> Result<Option<&T>, UnmanagedResource>
-    where
-        T: Send + Sync + 'static,
-    {
-        match self.0 {
-            BufferInner::Managed { ref data, .. } => Ok(<dyn Any>::downcast_ref::<T>(&*data.data)),
-            BufferInner::Unmanaged(_) => Err(UnmanagedResource),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-enum BufferInner {
-    /// The buffer is managed by Smithay.
-    Managed {
-        /// Object id of the [`WlBuffer`].
-        ///
-        /// This cannot be a [`WlBuffer`] or else there will be an Arc cycle.
-        buffer: ObjectId,
-
-        /// Data associated with the managed buffer.
-        data: Arc<BufferData>,
-    },
-
-    /// Buffer not managed by Smithay.
-    ///
-    /// There is no user data that may be taken from the buffer.
-    Unmanaged(WlBuffer),
-}
-
-impl PartialEq for BufferInner {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                Self::Managed {
-                    buffer: self_buffer, ..
-                },
-                Self::Managed {
-                    buffer: other_buffer, ..
-                },
-            ) => self_buffer == other_buffer,
-
-            (Self::Unmanaged(self_buffer), Self::Unmanaged(other_buffer)) => self_buffer == other_buffer,
-
-            _ => false,
-        }
-    }
-}
-
-#[derive(Debug)]
-struct BufferData {
-    data: Box<(dyn Any + Send + Sync + 'static)>,
-}
-
-impl<D> ObjectData<D> for BufferData
-where
-    D: BufferHandler + 'static,
-{
-    fn request(
-        self: Arc<Self>,
-        _: &Handle,
-        data: &mut D,
-        _: ClientId,
-        msg: Message<ObjectId>,
-    ) -> Option<Arc<dyn ObjectData<D>>> {
-        // WlBuffer has a single request which is a destructor.
-        debug_assert_eq!(msg.opcode, 0);
-
-        data.buffer_destroyed(&Buffer(BufferInner::Managed {
-            buffer: msg.sender_id,
-            data: self,
-        }));
-
-        None
-    }
-
-    fn destroyed(&self, _: &mut D, _: ClientId, _: ObjectId) {}
+    fn buffer_destroyed(&mut self, buffer: &wl_buffer::WlBuffer);
 }


### PR DESCRIPTION
This simplifies the codebase and removes the need for a Buffer wrapper type that would need conversion all around compositor implementations.