### PR TITLE
Update WlSeat to version 7

### DIFF
--- a/src/wayland/seat/keyboard/keymap_file.rs
+++ b/src/wayland/seat/keyboard/keymap_file.rs
@@ -32,11 +32,11 @@ impl KeymapFile {
         }
     }
 
-    pub fn with_fd<F>(&self, supports_seeled: bool, cb: F) -> Result<(), std::io::Error>
+    pub fn with_fd<F>(&self, supports_sealed: bool, cb: F) -> Result<(), std::io::Error>
     where
         F: FnOnce(RawFd, usize),
     {
-        if let Some(file) = supports_seeled.then(|| self.sealed.as_ref()).flatten() {
+        if let Some(file) = supports_sealed.then(|| self.sealed.as_ref()).flatten() {
             cb(file.as_raw_fd(), file.size);
             Ok(())
         } else {

--- a/src/wayland/seat/keyboard/keymap_file.rs
+++ b/src/wayland/seat/keyboard/keymap_file.rs
@@ -1,0 +1,101 @@
+use std::{
+    ffi::{CStr, CString},
+    fs::File,
+    io::{Seek, Write},
+    os::unix::prelude::{AsRawFd, FromRawFd, RawFd},
+    path::PathBuf,
+};
+
+use nix::{
+    fcntl::{FcntlArg, SealFlag},
+    sys::memfd::MemFdCreateFlag,
+};
+use slog::error;
+
+#[derive(Debug)]
+pub struct KeymapFile {
+    sealed: Option<SealedFile>,
+    keymap: CString,
+}
+
+impl KeymapFile {
+    pub fn new(keymap: CString, log: slog::Logger) -> Self {
+        let sealed = SealedFile::new(&keymap);
+
+        if let Err(err) = sealed.as_ref() {
+            error!(log, "Error when creating sealed keymap file: {}", err);
+        }
+
+        Self {
+            sealed: sealed.ok(),
+            keymap,
+        }
+    }
+
+    pub fn with_fd<F>(&self, supports_seeled: bool, cb: F) -> Result<(), std::io::Error>
+    where
+        F: FnOnce(RawFd, usize),
+    {
+        if let Some(file) = supports_seeled.then(|| self.sealed.as_ref()).flatten() {
+            cb(file.as_raw_fd(), file.size);
+            Ok(())
+        } else {
+            let dir = std::env::var_os("XDG_RUNTIME_DIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(std::env::temp_dir);
+
+            let keymap = self.keymap.as_bytes_with_nul();
+            let mut file = tempfile::tempfile_in(dir)?;
+            file.write_all(keymap)?;
+            file.flush()?;
+
+            cb(file.as_raw_fd(), keymap.len());
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SealedFile {
+    file: File,
+    size: usize,
+}
+
+impl SealedFile {
+    fn new(keymap: &CStr) -> Result<Self, std::io::Error> {
+        let name = CString::new("smithay-keymap").expect("File name should not contain interior nul byte");
+        let keymap = keymap.to_bytes_with_nul();
+
+        let fd = nix::sys::memfd::memfd_create(
+            &name,
+            MemFdCreateFlag::MFD_CLOEXEC | MemFdCreateFlag::MFD_ALLOW_SEALING,
+        )?;
+
+        let mut file = unsafe { File::from_raw_fd(fd) };
+        file.write_all(keymap)?;
+        file.flush()?;
+
+        file.seek(std::io::SeekFrom::Start(0))?;
+
+        nix::fcntl::fcntl(
+            file.as_raw_fd(),
+            FcntlArg::F_ADD_SEALS(
+                SealFlag::F_SEAL_SEAL
+                    | SealFlag::F_SEAL_SHRINK
+                    | SealFlag::F_SEAL_GROW
+                    | SealFlag::F_SEAL_WRITE,
+            ),
+        )?;
+
+        Ok(Self {
+            file,
+            size: keymap.len(),
+        })
+    }
+}
+
+impl AsRawFd for SealedFile {
+    fn as_raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
+}

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -184,7 +184,7 @@ impl<D: 'static> Seat<D> {
             log,
         });
 
-        let global_id = display.create_global::<D, _, _>(5, SeatGlobalData { arc: arc.clone() });
+        let global_id = display.create_global::<D, _, _>(7, SeatGlobalData { arc: arc.clone() });
         arc.inner.lock().unwrap().global_id = Some(global_id);
 
         Self { arc }

--- a/src/wayland/seat/pointer/mod.rs
+++ b/src/wayland/seat/pointer/mod.rs
@@ -403,6 +403,17 @@ impl<'a, D> PointerInnerHandle<'a, D> {
             if pointer.version() >= 5 {
                 // axis source
                 if let Some(source) = details.source {
+                    // WheelTilt was not supported before version 6
+                    // The best we can do is replace it with Wheel
+                    let source = if pointer.version() < 6 {
+                        match source {
+                            wl_pointer::AxisSource::WheelTilt => wl_pointer::AxisSource::Wheel,
+                            other => other,
+                        }
+                    } else {
+                        source
+                    };
+
                     pointer.axis_source(source);
                 }
                 // axis discrete


### PR DESCRIPTION
Ver 6 was about touch events that we already have: https://github.com/wayland-project/wayland/commit/6a18a87727c64719c68168568b9ab1e4d7c2d9c1
Ver 7 is about sealing the keymap files:  https://github.com/wayland-project/wayland/commit/905c0a341ddf0a885811d19e2b79c65a3f1d210c

The Sealing could allow for some optimizations, but I'm not sure which OSes support that, so I just left the inefficient version where we create a file per client.