### PR TITLE
Allow `xdg_activation_token_v1::destroy` after token is constructed

### DIFF
--- a/src/wayland/xdg_activation/handlers.rs
+++ b/src/wayland/xdg_activation/handlers.rs
@@ -54,7 +54,7 @@ fn get_activation_token(
         let mut token_constructed = false;
 
         move |id, req, _| {
-            if !token_constructed {
+            if !token_constructed || matches!(req, xdg_activation_token_v1::Request::Destroy) {
                 match req {
                     xdg_activation_token_v1::Request::SetSerial { serial, seat } => {
                         token_serial = Some((serial.into(), seat));


### PR DESCRIPTION
Fixes protocol error starting `gtk4-demo`. I'm not sure if this could be handled better or if `destroy` should actually be doing anything.