### PR TITLE
allocator: Fix overflow

### DIFF
--- a/src/backend/x11/surface.rs
+++ b/src/backend/x11/surface.rs
@@ -109,15 +109,17 @@ impl X11Surface {
                 mem::swap(&mut next, current);
             }
 
-            let window = self.window().ok_or(AllocateBuffersError::WindowDestroyed)?;
-            let pixmap = PixmapWrapper::with_dmabuf(
-                &*connection,
-                window.as_ref(),
-                next.userdata().get::<Dmabuf>().unwrap(),
-            )?;
+            {
+                let window = self.window().ok_or(AllocateBuffersError::WindowDestroyed)?;
+                let pixmap = PixmapWrapper::with_dmabuf(
+                    &*connection,
+                    window.as_ref(),
+                    next.userdata().get::<Dmabuf>().unwrap(),
+                )?;
 
-            // Now present the current buffer
-            let _ = pixmap.present(&*connection, window.as_ref())?;
+                // Now present the current buffer
+                let _ = pixmap.present(&*connection, window.as_ref())?;
+            }
             self.swapchain.submitted(&next);
 
             // Flush the connection after presenting to the window to ensure we don't run out of buffer space in the X11 connection.


### PR DESCRIPTION
Fixes a potential overflow inside the `Swapchain`, if the numbers of cycled slots is not consistent.
Currently if an allocated slot does not get used for a long time, it will overflow causing a panic.
Instead we should reset unused slots.

Fixes https://github.com/pop-os/cosmic-comp/issues/10

As far as I know this is not reproducable in anvil, but given cosmic-comp does a little more complex buffer management and I cannot see any obvious misuse of the api, this seems to be the correct fix. And securing the swapchain against an overflow is good practice anyway.

@PolyMeilex and @h1771t please test and confirm this fixes the problem on your systems.