### PR TITLE
0.30 Fix dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ x11rb = { version = "0.9.0", optional = true }
 xkbcommon = "0.4.0"
 scan_fmt = { version = "0.2.3", default-features = false }
 
+[patch.crates-io]
+winit = { git = "https://github.com/rust-windowing/winit", rev = "4c39b3188cee29548761b57f38e4aa046cbe31ea" }
+
 [dev-dependencies]
 slog-term = "2.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,12 @@ slog-stdlog = { version = "4", optional = true }
 tempfile = { version = "3.0", optional = true }
 thiserror = "1.0.25"
 udev = { version = "0.6", optional = true }
-wayland-egl = { version = "=0.30.0-beta.2", optional = true }
-wayland-protocols = { version = "=0.30.0-beta.2", features = ["unstable", "staging", "server"], optional = true }
-wayland-protocols-wlr = { version = "=0.1.0-beta.2", features = ["server"]}
-wayland-server = { version = "=0.30.0-beta.2", optional = true }
-wayland-sys = { version = "=0.30.0-beta.2", optional = true }
-wayland-backend = { version = "=0.1.0-beta.2", optional = true }
+wayland-egl = { version = "=0.30.0-beta.3", optional = true }
+wayland-protocols = { version = "=0.30.0-beta.3", features = ["unstable", "staging", "server"], optional = true }
+wayland-protocols-wlr = { version = "=0.1.0-beta.3", features = ["server"]}
+wayland-server = { version = "=0.30.0-beta.3", optional = true }
+wayland-sys = { version = "=0.30.0-beta.3", optional = true }
+wayland-backend = { version = "=0.1.0-beta.3", optional = true }
 winit = { version = "0.26", optional = true }
 x11rb = { version = "0.9.0", optional = true }
 xkbcommon = "0.4.0"


### PR DESCRIPTION
- Updates wayland-rs to beta.3 to fix egl-acceleration
- Updates winit to a git-dependency temporarily until the next version fixes redrawing on wayland