### PR TITLE
The Vulkan allocator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
         - backend_session
         - backend_session_logind
         - backend_session_libseat
+        - backend_vulkan
         - backend_x11
         - desktop
         - renderer_gl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
 
 [dependencies]
 appendlist = "1.4"
+# Intentionally pick a commit from "0.37-stable" branch since additions for 0.37.1 are used
+ash = { git = "https://github.com/ash-rs/ash", rev = "62960ad680207e8496ae19ebd11f7c7ae8422e27", optional = true }
 bitflags = "1"
 calloop = "0.10.1"
 cgmath = "0.18.0"
@@ -42,6 +44,7 @@ libloading = { version="0.7.0", optional = true }
 nix = "0.22"
 once_cell = "1.8.0"
 rand = "0.8.4"
+scopeguard = { version = "1.1.0", optional = true }
 slog = "2"
 slog-stdlog = { version = "4", optional = true }
 tempfile = { version = "3.0", optional = true }
@@ -69,7 +72,7 @@ gl_generator = { version = "0.14", optional = true }
 pkg-config = { version = "0.3.17", optional = true }
 
 [features]
-default = ["backend_drm", "backend_gbm", "backend_libinput", "backend_udev", "backend_session_logind", "backend_x11", "backend_winit", "desktop", "renderer_gl", "renderer_multi", "xwayland", "wayland_frontend", "slog-stdlog"]
+default = ["backend_drm", "backend_gbm", "backend_libinput", "backend_udev", "backend_session_logind", "backend_x11", "backend_winit", "desktop", "renderer_gl", "renderer_multi", "xwayland", "wayland_frontend", "slog-stdlog", "backend_vulkan"]
 backend_winit = ["winit", "backend_egl", "wayland-egl", "renderer_gl"]
 backend_x11 = ["x11rb", "x11rb/dri3", "x11rb/xfixes", "x11rb/present", "x11rb_event_source", "backend_gbm", "backend_drm", "backend_egl"]
 backend_drm = ["drm", "drm-ffi"]
@@ -78,6 +81,7 @@ backend_egl = ["gl_generator", "libloading"]
 backend_libinput = ["input"]
 backend_session = []
 backend_udev = ["udev", "input/udev"]
+backend_vulkan = ["ash", "scopeguard"]
 backend_session_logind = ["dbus", "backend_session", "pkg-config"]
 backend_session_elogind = ["backend_session_logind"]
 backend_session_libseat = ["backend_session", "libseat"]
@@ -105,3 +109,7 @@ required-features = ["wayland_frontend"]
 [[example]]
 name = "compositor"
 required-features = ["wayland_frontend"]
+
+[[example]]
+name = "vulkan"
+required-features = ["backend_vulkan"]

--- a/examples/vulkan.rs
+++ b/examples/vulkan.rs
@@ -1,12 +1,19 @@
 use std::sync::Mutex;
 
+use drm_fourcc::{DrmFourcc, DrmModifier};
 use slog::{o, Drain};
-use smithay::backend::vulkan::{Instance, PhysicalDevice};
+use smithay::backend::{
+    allocator::{
+        dmabuf::AsDmabuf,
+        vulkan::{ImageUsageFlags, VulkanAllocator},
+        Allocator, Buffer,
+    },
+    vulkan::{version::Version, Instance, PhysicalDevice},
+};
 
 fn main() {
     let logger = slog::Logger::root(Mutex::new(slog_term::term_full().fuse()).fuse(), o!());
 
-    println!("Version: {}", Instance::max_instance_version().unwrap());
     println!(
         "Available instance extensions: {:?}",
         Instance::enumerate_extensions().unwrap().collect::<Vec<_>>()
@@ -24,4 +31,30 @@ fn main() {
             phy.driver()
         );
     }
+
+    let physical_device = PhysicalDevice::enumerate(&instance)
+        .unwrap()
+        .next()
+        .expect("No physical devices");
+
+    // We don't actually use any buffers created by the allocator in this example.
+    let mut allocator = VulkanAllocator::new(&physical_device, ImageUsageFlags::empty()).unwrap();
+
+    let image = allocator
+        .create_buffer(100, 200, DrmFourcc::Argb8888, &[DrmModifier::Linear])
+        .expect("create");
+
+    assert_eq!(image.width(), 100);
+    assert_eq!(image.height(), 200);
+
+    let image_dmabuf = image.export().expect("Export dmabuf");
+
+    drop(image);
+
+    let _image2 = allocator
+        .create_buffer(200, 200, DrmFourcc::Argb8888, &[DrmModifier::Linear])
+        .expect("create");
+
+    drop(allocator);
+    drop(image_dmabuf);
 }

--- a/examples/vulkan.rs
+++ b/examples/vulkan.rs
@@ -1,0 +1,27 @@
+use std::sync::Mutex;
+
+use slog::{o, Drain};
+use smithay::backend::vulkan::{Instance, PhysicalDevice};
+
+fn main() {
+    let logger = slog::Logger::root(Mutex::new(slog_term::term_full().fuse()).fuse(), o!());
+
+    println!("Version: {}", Instance::max_instance_version().unwrap());
+    println!(
+        "Available instance extensions: {:?}",
+        Instance::enumerate_extensions().unwrap().collect::<Vec<_>>()
+    );
+    println!();
+
+    let instance = Instance::new(Version::VERSION_1_3, None, logger).unwrap();
+
+    for (idx, phy) in PhysicalDevice::enumerate(&instance).unwrap().enumerate() {
+        println!(
+            "Device #{}: {} v{}, {:?}",
+            idx,
+            phy.name(),
+            phy.api_version(),
+            phy.driver()
+        );
+    }
+}

--- a/src/backend/allocator/mod.rs
+++ b/src/backend/allocator/mod.rs
@@ -21,6 +21,8 @@ pub mod dumb;
 pub mod format;
 #[cfg(feature = "backend_gbm")]
 pub mod gbm;
+#[cfg(feature = "backend_vulkan")]
+pub mod vulkan;
 
 mod swapchain;
 use std::{

--- a/src/backend/allocator/vulkan/format.rs
+++ b/src/backend/allocator/vulkan/format.rs
@@ -1,0 +1,73 @@
+//! Format conversions between Vulkan and DRM formats.
+
+/// Macro to generate format conversions between Vulkan and FourCC format codes.
+///
+/// Any entry in this table may have attributes associated with a conversion. This is needed for `PACK` Vulkan
+/// formats which may only have an alternative given a specific host endian.
+///
+/// See the module documentation for usage details.
+macro_rules! vk_format_table {
+    (
+        $(
+            // This meta specifier is used for format conversions for PACK formats.
+            $(#[$conv_meta:meta])*
+            $fourcc: ident => $vk: ident
+        ),* $(,)?
+    ) => {
+        /// Converts a FourCC format code to a Vulkan format code.
+        ///
+        /// This will return [`None`] if the format is not known.
+        ///
+        /// These format conversions will return all known FourCC and Vulkan format conversions. However a
+        /// Vulkan implementation may not support some Vulkan format. One notable example of this are the
+        /// formats introduced in `VK_EXT_4444_formats`. The corresponding FourCC codes will return the
+        /// formats from `VK_EXT_4444_formats`, but the caller is responsible for testing that a Vulkan device
+        /// supports these formats.
+        pub const fn get_vk_format(fourcc: $crate::backend::allocator::Fourcc) -> Option<ash::vk::Format> {
+            // FIXME: Use reexport for ash::vk::Format
+            match fourcc {
+                $(
+                    $(#[$conv_meta])*
+                    $crate::backend::allocator::Fourcc::$fourcc => Some(ash::vk::Format::$vk),
+                )*
+
+                _ => None,
+            }
+        }
+
+        /// Returns all the known format conversions.
+        ///
+        /// The list contains FourCC format codes that may be converted using [`get_vk_format`].
+        pub const fn known_formats() -> &'static [$crate::backend::allocator::Fourcc] {
+            &[
+                $(
+                    $crate::backend::allocator::Fourcc::$fourcc
+                ),*
+            ]
+        }
+    };
+}
+
+// FIXME: SRGB format is not always correct.
+//
+// Vulkan classifies formats by both channel sizes and colorspace. FourCC format codes do not classify formats
+// based on colorspace.
+//
+// To implement this correctly, it is likely that parsing vulkan.xml and classifying families of colorspaces
+// would be needed since there are a lot of formats.
+//
+// Many of these conversions come from wsi_common_wayland.c in Mesa
+vk_format_table! {
+    Argb8888 => B8G8R8A8_SRGB,
+    Xrgb8888 => B8G8R8A8_SRGB,
+
+    Abgr8888 => R8G8B8A8_SRGB,
+    Xbgr8888 => R8G8B8A8_SRGB,
+
+    // PACK32 formats are equivalent to u32 instead of [u8; 4] and thus depend their layout depends the host
+    // endian.
+    #[cfg(target_endian = "little")]
+    Rgba8888 => A8B8G8R8_SRGB_PACK32,
+    #[cfg(target_endian = "little")]
+    Rgbx8888 => A8B8G8R8_SRGB_PACK32
+}

--- a/src/backend/allocator/vulkan/mod.rs
+++ b/src/backend/allocator/vulkan/mod.rs
@@ -1,0 +1,787 @@
+//! Module for Buffers created using Vulkan.
+//!
+//! The [`VulkanAllocator`] type implements the [`Allocator`] trait and [`VulkanImage`] implements [`Buffer`].
+//! A [`VulkanImage`] may be exported as a [dmabuf](super::dmabuf).
+//!
+//! The Vulkan allocator supports up to Vulkan 1.3.
+//!
+//! The Vulkan allocator requires the following device extensions (and their dependencies):
+//! - `VK_EXT_image_drm_format_modifier`
+//! - `VK_EXT_external_memory_dmabuf`
+//! - `VK_KHR_external_memory_fd`
+//!
+//! Additionally the Vulkan allocator may enable the following extensions if available:
+//! - `VK_EXT_4444_formats`
+//!
+//! To get the required extensions a device must support to use the Vulkan allocator, use
+//! [`VulkanAllocator::required_extensions`].
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
+pub mod format;
+
+use std::{
+    ffi::CStr,
+    fmt,
+    sync::{mpsc, Arc, Weak},
+};
+
+use ash::{
+    extensions::{ext, khr},
+    vk,
+};
+use bitflags::bitflags;
+use drm_fourcc::{DrmFormat, DrmFourcc, DrmModifier};
+
+use crate::{
+    backend::{
+        allocator::dmabuf::DmabufFlags,
+        vulkan::{version::Version, PhysicalDevice},
+    },
+    utils::{Buffer as BufferCoord, Size},
+};
+
+use super::{
+    dmabuf::{AsDmabuf, Dmabuf, MAX_PLANES},
+    Allocator, Buffer,
+};
+
+bitflags! {
+    /// Flags to indicate the intended usage for a buffer.
+    ///
+    /// The usage flags may influence whether a buffer with a specific format and modifier combination may
+    /// successfully be imported by a graphics api when it is exported as a [`Dmabuf`].
+    ///
+    /// For example, if a [`Buffer`] is used for scan-out, it is only necessary to specify the color
+    /// attachment usage. However, if the exported buffer is used by a client and intended to be rendered to,
+    /// then it is possible that the import will fail because the buffer was not allocated with right usage
+    /// for the format and modifier combination.
+    ///
+    /// The default usage set when creating a [`VulkanAllocator`] guarantees that an exported buffer may be
+    /// imported successfully with the same usage.
+    ///
+    /// If you need to allocate buffers with different usages dynamically, then you may use
+    /// [`VulkanAllocator::create_buffer_with_usage`].
+    ///
+    /// [`VulkanAllocator::is_format_supported`] can check if the combination of format, modifier and usage
+    /// flags are supported.
+    pub struct ImageUsageFlags: vk::Flags {
+        /// The image may be the source of a transfer command.
+        ///
+        /// This allows the content of the exported buffer to be downloaded from the GPU.
+        const TRANSFER_SRC = vk::ImageUsageFlags::TRANSFER_SRC.as_raw();
+
+        /// The image may be the destination of a transfer command.
+        ///
+        /// This allows the content of the exported buffer to be modified by a memory upload to the GPU.
+        const TRANSFER_DST = vk::ImageUsageFlags::TRANSFER_DST.as_raw();
+
+        /// Image may be sampled in a shader.
+        ///
+        /// This should be used if the exported buffer will be used as a texture.
+        const SAMPLED = vk::ImageUsageFlags::SAMPLED.as_raw();
+
+        /// The image may be used in a color attachment.
+        ///
+        /// This should be used if the exported buffer will be rendered to.
+        const COLOR_ATTACHMENT = vk::ImageUsageFlags::COLOR_ATTACHMENT.as_raw();
+    }
+}
+
+/// Error type for [`VulkanAllocator`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The allocator could not be created.
+    ///
+    /// This can occur for a few reasons:
+    /// - No suitable queue family was found.
+    #[error("could not create allocator")]
+    Setup,
+
+    /// The size specified to create the buffer was too small.
+    ///
+    /// The size must be greater than `0 x 0` pixels.
+    #[error("invalid buffer size")]
+    InvalidSize,
+
+    /// The specified format is not supported.
+    ///
+    /// This error may occur for a few reasons:
+    /// 1. There is no equivalent Vulkan format for the specified format code.
+    /// 2. The driver does not support any of the specified modifiers for the format code.
+    /// 3. The driver does support some of the format, but the size of the buffer requested is too large.
+    #[error("format is not supported")]
+    UnsupportedFormat,
+
+    /// Some error from the Vulkan driver.
+    #[error(transparent)]
+    Vk(#[from] vk::Result),
+}
+
+/// An allocator which uses Vulkan to create buffers.
+pub struct VulkanAllocator {
+    formats: Vec<FormatEntry>,
+    images: Vec<ImageInner>,
+    default_usage: ImageUsageFlags,
+    remaining_allocations: u32,
+    extension_fns: ExtensionFns,
+    dropped_recv: mpsc::Receiver<ImageInner>,
+    dropped_sender: mpsc::Sender<ImageInner>,
+    phd: PhysicalDevice,
+    device: Arc<ash::Device>,
+}
+
+impl fmt::Debug for VulkanAllocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VulkanAllocator")
+            .field("formats", &self.formats)
+            .field("images", &self.images)
+            .field("remaining_allocations", &self.remaining_allocations)
+            .field("dropped_recv", &self.dropped_recv)
+            .field("dropped_sender", &self.dropped_sender)
+            .field("phd", &self.phd)
+            .finish()
+    }
+}
+
+impl VulkanAllocator {
+    /// Maximum supported version instance version that may be used with the allocator.
+    pub const MAX_INSTANCE_VERSION: Version = Version::VERSION_1_3;
+
+    /// Returns the list of device extensions required by the Vulkan allocator.
+    ///
+    /// This function may return a different list for each [`PhysicalDevice`], meaning each device should be
+    /// filtered using it's own call to this function.
+    pub fn required_extensions(phd: &PhysicalDevice) -> Vec<&'static CStr> {
+        // Always required extensions
+        let mut extensions = vec![
+            vk::ExtImageDrmFormatModifierFn::name(),
+            vk::ExtExternalMemoryDmaBufFn::name(),
+            vk::KhrExternalMemoryFdFn::name(),
+        ];
+
+        if phd.api_version() < Version::VERSION_1_2 {
+            // VK_EXT_image_drm_format_modifier requires VK_KHR_image_format_list.
+            // VK_KHR_image_format_list is part of the core API in Vulkan 1.2
+            extensions.push(vk::KhrImageFormatListFn::name());
+        }
+
+        // Optional extensions:
+
+        // VK_EXT_4444_formats is part of the core API in Vulkan 1.3. Although not always supported
+        // (see the 1.3 features to enable)
+        if phd.api_version() < Version::VERSION_1_3 {
+            // In 1.2 and below, the device must support the extension to use it.
+            if phd.has_device_extension(vk::Ext4444FormatsFn::name()) {
+                extensions.push(vk::Ext4444FormatsFn::name());
+            }
+        }
+
+        extensions
+    }
+
+    /// Creates a [`VulkanAllocator`].
+    ///
+    /// # Panics
+    ///
+    /// If the version of instance which created the [`PhysicalDevice`] is higher than [`VulkanAllocator::MAX_INSTANCE_VERSION`].
+    pub fn new(phd: &PhysicalDevice, default_usage: ImageUsageFlags) -> Result<VulkanAllocator, Error> {
+        // Panic if the instance version is too high
+        if phd.instance().api_version() > Self::MAX_INSTANCE_VERSION {
+            panic!("Exceeded maximum instance api version for VulkanAllocator (1.3 max)")
+        }
+
+        // Get required extensions
+        let extensions = Self::required_extensions(phd);
+        let extension_pointers = extensions.iter().copied().map(CStr::as_ptr).collect::<Vec<_>>();
+
+        // We don't actually submit any commands to the queue, but Vulkan requires that we create devices with
+        // at least one queue (VUID-VkDeviceCreateInfo-queueCreateInfoCount-arraylength).
+        let queue_families = unsafe {
+            phd.instance()
+                .handle()
+                .get_physical_device_queue_family_properties(phd.handle())
+        };
+
+        let queue_family_index = queue_families
+            .iter()
+            // Find a queue with transfer
+            .position(|properties| properties.queue_flags.contains(vk::QueueFlags::TRANSFER))
+            // If there is no transfer queue family, then try graphics (which must support transfer)
+            .or_else(|| {
+                queue_families
+                    .iter()
+                    .position(|properties| properties.queue_flags.contains(vk::QueueFlags::GRAPHICS))
+            })
+            .ok_or(Error::Setup)?;
+
+        // TODO: Enable 4444 formats features
+        let queue_create_info = [vk::DeviceQueueCreateInfo::builder()
+            .queue_family_index(queue_family_index as u32)
+            .queue_priorities(&[0.0])
+            .build()];
+        let create_info = vk::DeviceCreateInfo::builder()
+            .enabled_extension_names(&extension_pointers)
+            .queue_create_infos(&queue_create_info);
+
+        let instance = phd.instance().handle();
+        let device = unsafe { instance.create_device(phd.handle(), &create_info, None) }?;
+
+        // Load extension functions
+        let extension_fns = ExtensionFns {
+            ext_image_format_modifier: ext::ImageDrmFormatModifier::new(instance, &device),
+            khr_external_memory_fd: khr::ExternalMemoryFd::new(instance, &device),
+        };
+
+        let (dropped_sender, dropped_recv) = mpsc::channel();
+
+        let mut allocator = VulkanAllocator {
+            formats: Vec::new(),
+            images: Vec::new(),
+            default_usage,
+            remaining_allocations: phd.limits().max_memory_allocation_count,
+            extension_fns,
+            dropped_recv,
+            dropped_sender,
+            phd: phd.clone(),
+            device: Arc::new(device),
+        };
+
+        allocator.init_formats();
+
+        Ok(allocator)
+    }
+
+    /// Returns whether this allocator supports the specified format with the usage flags.
+    pub fn is_format_supported(&self, format: DrmFormat, usage: ImageUsageFlags) -> bool {
+        // TODO: Check if the extents are also valid?
+        // Vulkan states a maximum extent size for images.
+        // This may also be useful as a function on Allocator.
+        unsafe { self.get_format_info(format, vk::ImageUsageFlags::from_raw(usage.bits())) }
+            .ok()
+            .is_some()
+    }
+
+    /// Try to create a buffer with the given dimensions, pixel format and usage flags.
+    pub fn create_buffer_with_usage(
+        &mut self,
+        width: u32,
+        height: u32,
+        fourcc: DrmFourcc,
+        modifiers: &[DrmModifier],
+        usage: ImageUsageFlags,
+    ) -> Result<VulkanImage, Error> {
+        self.cleanup();
+
+        let vk_format = format::get_vk_format(fourcc).ok_or(Error::UnsupportedFormat)?;
+        let vk_usage = vk::ImageUsageFlags::from_raw(usage.bits());
+
+        // VUID-VkImageCreateInfo-extent-00944, VUID-VkImageCreateInfo-extent-00945
+        if width == 0 || height == 0 {
+            return Err(Error::InvalidSize);
+        }
+
+        // Filter out any format + modifier combinations that are not supported
+        let modifiers = self.filter_modifiers(width, height, vk_usage, fourcc, modifiers);
+
+        // VUID-VkImageDrmFormatModifierListCreateInfoEXT-drmFormatModifierCount-arraylength
+        if modifiers.is_empty() {
+            return Err(Error::UnsupportedFormat);
+        }
+
+        Ok(unsafe { self.create_image(width, height, vk_format, vk_usage, fourcc, &modifiers[..]) }?)
+    }
+
+    /// Returns the [`PhysicalDevice`] this allocator was created with.
+    pub fn physical_device(&self) -> &PhysicalDevice {
+        &self.phd
+    }
+}
+
+impl Allocator<VulkanImage> for VulkanAllocator {
+    type Error = Error;
+
+    fn create_buffer(
+        &mut self,
+        width: u32,
+        height: u32,
+        fourcc: DrmFourcc,
+        modifiers: &[DrmModifier],
+    ) -> Result<VulkanImage, Self::Error> {
+        self.create_buffer_with_usage(width, height, fourcc, modifiers, self.default_usage)
+    }
+}
+
+impl Drop for VulkanAllocator {
+    fn drop(&mut self) {
+        unsafe {
+            for image in &self.images {
+                self.device.destroy_image(image.image, None);
+                self.device.free_memory(image.memory, None);
+            }
+
+            self.device.destroy_device(None);
+        }
+    }
+}
+
+/// Vulkan image object.
+///
+/// This type implements [`Buffer`] and the underlying image may be exported as a dmabuf.
+pub struct VulkanImage {
+    inner: ImageInner,
+    width: u32,
+    height: u32,
+    format: DrmFormat,
+    /// The number of planes the image has for dmabuf export.
+    format_plane_count: u32,
+    khr_external_memory_fd: khr::ExternalMemoryFd,
+    dropped_sender: mpsc::Sender<ImageInner>,
+    device: Weak<ash::Device>,
+}
+
+impl fmt::Debug for VulkanImage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VulkanImage")
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("format", &self.format)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl Buffer for VulkanImage {
+    fn width(&self) -> u32 {
+        self.width
+    }
+
+    fn height(&self) -> u32 {
+        self.height
+    }
+
+    fn size(&self) -> Size<i32, BufferCoord> {
+        (self.width as i32, self.height as i32).into()
+    }
+
+    fn format(&self) -> DrmFormat {
+        self.format
+    }
+}
+
+impl AsDmabuf for VulkanImage {
+    type Error = ExportError;
+
+    fn export(&self) -> Result<Dmabuf, Self::Error> {
+        let device = self.device.upgrade().ok_or(ExportError::AllocatorDestroyed)?;
+
+        // Implementation may be broken if the plane count is wrong.
+        if self.format_plane_count == 0 {
+            return Err(ExportError::Failed);
+        }
+
+        assert!(
+            self.format_plane_count as usize <= MAX_PLANES,
+            "Vulkan implementation reported too many planes"
+        );
+
+        let create_info = vk::MemoryGetFdInfoKHR::builder()
+            .handle_type(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT)
+            // VUID-VkMemoryGetFdInfoKHR-handleType-00671: Memory was allocated with DMA_BUF_EXT
+            .memory(self.inner.memory);
+
+        let fd = unsafe { self.khr_external_memory_fd.get_memory_fd(&create_info) }?;
+        let mut builder = Dmabuf::builder(self.size(), self.format().code, DmabufFlags::empty());
+
+        for idx in 0..self.format_plane_count {
+            // get_image_subresource_layout only gets the layout of one memory plane. This mask specifies
+            // which plane should the layout be obtained for.
+            let aspect_mask = match idx {
+                0 => vk::ImageAspectFlags::MEMORY_PLANE_0_EXT,
+                1 => vk::ImageAspectFlags::MEMORY_PLANE_1_EXT,
+                2 => vk::ImageAspectFlags::MEMORY_PLANE_2_EXT,
+                3 => vk::ImageAspectFlags::MEMORY_PLANE_3_EXT,
+                _ => unreachable!(),
+            };
+
+            // VUID-vkGetImageSubresourceLayout-image-02270: All allocate images are created with drm tiling
+            let subresource = vk::ImageSubresource::builder().aspect_mask(aspect_mask).build();
+            let layout = unsafe { device.get_image_subresource_layout(self.inner.image, subresource) };
+            builder.add_plane(
+                fd,
+                idx,
+                layout.offset as u32,
+                layout.row_pitch as u32,
+                self.format().modifier,
+            );
+        }
+
+        Ok(builder.build().unwrap())
+    }
+}
+
+impl Drop for VulkanImage {
+    fn drop(&mut self) {
+        let _ = self.dropped_sender.send(self.inner);
+    }
+}
+
+/// The error type for exporting a [`VulkanImage`] as a [`Dmabuf`].
+#[derive(Debug, thiserror::Error)]
+pub enum ExportError {
+    /// The image could not export a dmabuf since the allocator has been destroyed.
+    #[error("allocator has been destroyed")]
+    AllocatorDestroyed,
+
+    /// The allocator could not export a dmabuf for an implementation dependent reason.
+    #[error("could not export a dmabuf")]
+    Failed,
+
+    /// Vulkan API error.
+    #[error(transparent)]
+    Vk(#[from] vk::Result),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ImageInner {
+    // TODO: image usage?
+    image: vk::Image,
+    /// The first entry will always have a non-null device memory handle.
+    ///
+    /// The other three entries may be a null handle or valid device memory (the latter with disjoint dmabufs).
+    memory: vk::DeviceMemory,
+}
+
+#[derive(Debug)]
+struct FormatEntry {
+    format: DrmFormat,
+    modifier_properties: vk::DrmFormatModifierPropertiesEXT,
+}
+
+struct ExtensionFns {
+    /// Functions to get DRM format information.
+    ///
+    /// These are required, and therefore you may assume this functionality is available.
+    ext_image_format_modifier: ext::ImageDrmFormatModifier,
+    /// Functions used for dmabuf import and export.
+    ///
+    /// If this is [`Some`], then the allocator will support dmabuf import and export operations.
+    khr_external_memory_fd: khr::ExternalMemoryFd,
+}
+
+impl VulkanAllocator {
+    fn init_formats(&mut self) {
+        for &fourcc in format::known_formats() {
+            let vk_format = format::get_vk_format(fourcc).unwrap();
+            let format_properties = vk::FormatProperties::default();
+            let modifier_properties =
+                unsafe { self.get_drm_format_properties_list(vk_format, format_properties) };
+
+            for modifier_properties in modifier_properties {
+                self.formats.push(FormatEntry {
+                    format: DrmFormat {
+                        code: fourcc,
+                        modifier: DrmModifier::from(modifier_properties.drm_format_modifier),
+                    },
+                    modifier_properties,
+                });
+            }
+        }
+    }
+
+    /// # Safety
+    ///
+    /// See valid usage requirements for https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDrmFormatModifierPropertiesListEXT.html
+    unsafe fn get_drm_format_properties_list(
+        &self,
+        format: vk::Format,
+        format_properties: vk::FormatProperties,
+    ) -> Vec<vk::DrmFormatModifierPropertiesEXT> {
+        let mut list = vk::DrmFormatModifierPropertiesListEXT::default();
+
+        // Get the number of entries
+        unsafe {
+            let mut format_properties2 = vk::FormatProperties2::builder()
+                .format_properties(format_properties)
+                .push_next(&mut list);
+
+            self.phd
+                .instance()
+                .handle()
+                .get_physical_device_format_properties2(self.phd.handle(), format, &mut format_properties2)
+        };
+
+        let mut data = Vec::with_capacity(list.drm_format_modifier_count as usize);
+        list.p_drm_format_modifier_properties = data.as_mut_ptr();
+
+        // Read the properties into the vector
+        unsafe {
+            let mut format_properties2 = vk::FormatProperties2::builder()
+                .format_properties(format_properties)
+                .push_next(&mut list);
+
+            self.phd
+                .instance()
+                .handle()
+                .get_physical_device_format_properties2(self.phd.handle(), format, &mut format_properties2);
+
+            // SAFETY: Vulkan just initialized the elements of the vector.
+            data.set_len(list.drm_format_modifier_count as usize);
+        }
+
+        data
+    }
+
+    /// Returns whether the format + modifier combination and the usage flags are supported.
+    unsafe fn get_format_info(
+        &self,
+        format: DrmFormat,
+        usage: vk::ImageUsageFlags,
+    ) -> Result<Option<vk::ImageFormatProperties>, vk::Result> {
+        let vk_format = format::get_vk_format(format.code);
+
+        match vk_format {
+            Some(vk_format) => {
+                let mut image_drm_format_info = vk::PhysicalDeviceImageDrmFormatModifierInfoEXT::builder()
+                    .drm_format_modifier(format.modifier.into())
+                    .sharing_mode(vk::SharingMode::EXCLUSIVE);
+                let format_info = vk::PhysicalDeviceImageFormatInfo2::builder()
+                    .format(vk_format)
+                    .ty(vk::ImageType::TYPE_2D)
+                    .tiling(vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT)
+                    .usage(usage)
+                    .flags(vk::ImageCreateFlags::empty())
+                    // VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249
+                    .push_next(&mut image_drm_format_info);
+                let mut image_format_properties = vk::ImageFormatProperties2::default();
+
+                // VUID-vkGetPhysicalDeviceImageFormatProperties-tiling-02248: Must use vkGetPhysicalDeviceImageFormatProperties2
+                let result = unsafe {
+                    self.phd
+                        .instance()
+                        .handle()
+                        .get_physical_device_image_format_properties2(
+                            self.phd.handle(),
+                            &format_info,
+                            &mut image_format_properties,
+                        )
+                };
+
+                result
+                    .map(|_| Some(image_format_properties.image_format_properties))
+                    .or_else(|result| {
+                        // Unsupported format + usage combination
+                        if result == vk::Result::ERROR_FORMAT_NOT_SUPPORTED {
+                            Ok(None)
+                        } else {
+                            Err(result)
+                        }
+                    })
+            }
+
+            None => Ok(None),
+        }
+    }
+
+    fn filter_modifiers(
+        &self,
+        width: u32,
+        height: u32,
+        vk_usage: vk::ImageUsageFlags,
+        fourcc: DrmFourcc,
+        modifiers: &[DrmModifier],
+    ) -> Vec<u64> {
+        modifiers
+            .iter()
+            .copied()
+            .filter_map(move |modifier| {
+                let info = unsafe {
+                    self.get_format_info(
+                        DrmFormat {
+                            code: fourcc,
+                            modifier,
+                        },
+                        vk_usage,
+                    )
+                }
+                .ok()
+                .flatten()?;
+
+                Some((modifier, info))
+            })
+            // Filter modifiers where the required image creation limits are not met
+            .filter(move |(_, properties)| {
+                let max_extent = properties.max_extent;
+
+                // VUID-VkImageCreateInfo-extent-02252
+                max_extent.width >= width
+                // VUID-VkImageCreateInfo-extent-02253
+                && max_extent.height >= height
+                // VUID-VkImageCreateInfo-extent-02254
+                // VUID-VkImageCreateInfo-extent-00946
+                // VUID-VkImageCreateInfo-imageType-00957
+                && max_extent.depth >= 1
+                // VUID-VkImageCreateInfo-samples-02258
+                && properties.sample_counts.contains(vk::SampleCountFlags::TYPE_1)
+            })
+            .map(|(modifier, _)| modifier)
+            .map(Into::<u64>::into)
+            // TODO: Could use a smallvec or tinyvec to reduce number allocations
+            .collect::<Vec<_>>()
+    }
+
+    /// # Safety
+    ///
+    /// * The list of modifiers must be supported for the given format and image usage flags.
+    /// * The extent of the image must be within the maximum extents Vulkan tells.
+    unsafe fn create_image(
+        &mut self,
+        width: u32,
+        height: u32,
+        vk_format: vk::Format,
+        vk_usage: vk::ImageUsageFlags,
+        fourcc: DrmFourcc,
+        modifiers: &[u64],
+    ) -> Result<VulkanImage, vk::Result> {
+        assert!(width > 0);
+        assert!(height > 0);
+
+        // Ensure maximum allocations are not exceeded.
+        if self.remaining_allocations == 0 {
+            todo!()
+        }
+
+        // Now that the list of valid modifiers is known, create an image using one of the modifiers.
+        let mut modifier_list =
+            vk::ImageDrmFormatModifierListCreateInfoEXT::builder().drm_format_modifiers(modifiers);
+        let mut external_memory_image_create_info = vk::ExternalMemoryImageCreateInfo::builder()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
+
+        let image_create_info = vk::ImageCreateInfo::builder()
+            .image_type(vk::ImageType::TYPE_2D)
+            .format(vk_format)
+            .extent(vk::Extent3D {
+                width,
+                height,
+                // VUID-VkImageCreateInfo-extent-00946
+                // VUID-VkImageCreateInfo-imageType-00957
+                depth: 1,
+            })
+            // VUID-VkImageCreateInfo-samples-parameter
+            .samples(vk::SampleCountFlags::TYPE_1)
+            // VUID-VkImageCreateInfo-mipLevels-00947
+            .mip_levels(1)
+            // VUID-VkImageCreateInfo-arrayLayers-00948
+            .array_layers(1)
+            // VUID-VkImageCreateInfo-pNext-02262
+            .tiling(vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT)
+            // VUID-VkImageCreateInfo-usage-requiredbitmask
+            // FIXME: We don't assert any usage flags are set
+            .usage(vk_usage)
+            // VUID-VkImageCreateInfo-initialLayout-00993
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            // VUID-VkImageCreateInfo-tiling-02261
+            .push_next(&mut modifier_list)
+            // TODO: VUID-VkImageCreateInfo-pNext-00990
+            .push_next(&mut external_memory_image_create_info);
+
+        // The image is placed in a scope guard to safely handle future allocation failures.
+        let mut guard = scopeguard::guard(
+            ImageInner {
+                // This is the only spot where ? may be used to detect and error since no previous handles have been created.
+                image: unsafe { self.device.create_image(&image_create_info, None) }?,
+                memory: vk::DeviceMemory::null(),
+            },
+            |inner| unsafe { self.device.destroy_image(inner.image, None) },
+        );
+
+        // Get the modifier Vulkan created the image using.
+        let format = {
+            let mut image_modifier_properties = vk::ImageDrmFormatModifierPropertiesEXT::default();
+
+            unsafe {
+                self.extension_fns
+                    .ext_image_format_modifier
+                    .get_image_drm_format_modifier_properties(guard.image, &mut image_modifier_properties)
+            }?;
+
+            DrmFormat {
+                code: fourcc,
+                modifier: DrmModifier::from(image_modifier_properties.drm_format_modifier),
+            }
+        };
+
+        // Now that we know the plane count, get the number of planes for the format + modifier
+        let format_plane_count = self
+            .formats
+            .iter()
+            .find(|entry| entry.format == format)
+            .unwrap()
+            .modifier_properties
+            .drm_format_modifier_plane_count;
+
+        // Allocate image memory
+        let memory_reqs = unsafe { self.device.get_image_memory_requirements(guard.image) };
+        // TODO: Memory type index
+        let mut export_memory_allocate_info = vk::ExportMemoryAllocateInfo::builder()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
+        let alloc_create_info = vk::MemoryAllocateInfo::builder()
+            .allocation_size(memory_reqs.size)
+            .push_next(&mut export_memory_allocate_info);
+
+        unsafe {
+            // Allocate memory for the image.
+            guard.memory = self.device.allocate_memory(&alloc_create_info, None)?;
+            // Finally bind the memory to the image
+            self.device.bind_image_memory(guard.image, guard.memory, 0)?;
+        }
+
+        // Initialization is complete, prevent the scope guard from running it's dropfn.
+        let inner = scopeguard::ScopeGuard::into_inner(guard);
+
+        // Track the image for destruction.
+        self.images.push(inner);
+
+        self.remaining_allocations -= 1;
+
+        Ok(VulkanImage {
+            inner,
+            width,
+            height,
+            format,
+            format_plane_count,
+            khr_external_memory_fd: self.extension_fns.khr_external_memory_fd.clone(),
+            dropped_sender: self.dropped_sender.clone(),
+            device: Arc::downgrade(&self.device),
+        })
+    }
+
+    fn cleanup(&mut self) {
+        let dropped = self.dropped_recv.try_iter().collect::<Vec<_>>();
+
+        self.images.retain(|image| {
+            // Only drop if the
+            let drop = dropped.contains(image);
+
+            if drop {
+                // Destroy the underlying image resource
+                unsafe {
+                    self.device.destroy_image(image.image, None);
+                    self.device.free_memory(image.memory, None);
+                }
+
+                self.remaining_allocations = self
+                    .remaining_allocations
+                    .checked_add(1)
+                    .expect("Remaining allocations overflowed");
+                debug_assert!(
+                    self.phd.limits().max_memory_allocation_count >= self.remaining_allocations,
+                    "Too many allocations released",
+                );
+            }
+
+            // If the image was dropped, return false
+            !drop
+        })
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -91,6 +91,9 @@ pub mod session;
 #[cfg(feature = "backend_udev")]
 pub mod udev;
 
+#[cfg(feature = "backend_vulkan")]
+pub mod vulkan;
+
 #[cfg(feature = "backend_winit")]
 pub mod winit;
 

--- a/src/backend/vulkan/inner.rs
+++ b/src/backend/vulkan/inner.rs
@@ -1,0 +1,74 @@
+use std::{
+    ffi::{CStr, CString},
+    fmt,
+};
+
+use ash::{extensions::ext::DebugUtils, vk};
+use slog::Logger;
+
+use super::{version::Version, LoadError, LIBRARY};
+
+pub struct InstanceInner {
+    pub instance: ash::Instance,
+    pub version: Version,
+    pub debug_state: Option<DebugState>,
+
+    /// Enabled instance extensions.
+    pub enabled_extensions: Vec<&'static CStr>,
+}
+
+pub struct DebugState {
+    pub debug_utils: DebugUtils,
+    pub debug_messenger: vk::DebugUtilsMessengerEXT,
+    pub logger_ptr: *mut Logger,
+}
+
+impl fmt::Debug for InstanceInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InstanceInner")
+            .field("instance", &self.instance.handle())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for InstanceInner {
+    fn drop(&mut self) {
+        let logger = if let Some(debug) = &self.debug_state {
+            unsafe {
+                debug
+                    .debug_utils
+                    .destroy_debug_utils_messenger(debug.debug_messenger, None);
+            }
+
+            Some(unsafe { Box::from_raw(debug.logger_ptr as *mut slog::Logger) })
+        } else {
+            None
+        };
+
+        // Users of `Instance` are responsible for compliance with `VUID-vkDestroyInstance-instance-00629`.
+
+        // SAFETY (Host Synchronization): InstanceInner is always stored in an Arc, therefore destruction is
+        // synchronized (since the inner value of an Arc is always dropped on a single thread).
+        unsafe { self.instance.destroy_instance(None) };
+
+        // Now that the instance has been destroyed, we can destroy the logger.
+        drop(logger);
+    }
+}
+
+impl super::Instance {
+    pub(super) fn enumerate_layers() -> Result<impl Iterator<Item = CString>, LoadError> {
+        let library = LIBRARY.as_ref().or(Err(LoadError))?;
+
+        let layers = library
+            .enumerate_instance_layer_properties()
+            .or(Err(LoadError))?
+            .into_iter()
+            .map(|properties| {
+                // SAFETY: Vulkan guarantees the string is null terminated.
+                unsafe { CStr::from_ptr(&properties.layer_name as *const _) }.to_owned()
+            });
+
+        Ok(layers)
+    }
+}

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -1,0 +1,742 @@
+//! Types to initialize and use Vulkan.
+//!
+//! This module provides some thin abstractions over [`ash`](https://crates.io/crates/ash) for initializing
+//! Vulkan.
+//!
+//! This module does not provide abstractions for logical devices, rendering or memory allocation. These
+//! should instead be provided in higher level abstractions.
+//!
+//! Smithay requires at least Vulkan 1.1[^version].
+//!
+//! # [`Instance`]
+//!
+//! To use Vulkan, you would first instantiate an [`Instance`]. An instance is effectively the Vulkan library
+//! and provides some information about the environment. This includes the list of supported
+//! [instance extensions](Instance::enumerate_extensions) and the list of available physical devices.
+//!
+//! An instance is constructed using an [`Instance::new`] or [`Instance::with_extensions`].
+//!
+//! ## Layers
+//!
+//! The validation layers will be enabled if debug assertions are enabled and the validation layers are
+//! available on your system.
+//!
+//! ## Instance extensions
+//!
+//! Instances may be created with some enabled extensions. Note that any features gated by an extension are
+//! only available if the extension (and it's dependencies) are enabled (you will get a validation error if
+//! you ignore that).
+//!
+//! Some features such as window system integration are only available if their features are enabled.
+//! Available instance extensions may be obtained using [`Instance::enumerate_extensions`].
+//!
+//! # [`PhysicalDevice`]
+//!
+//! Once you have an instance, you may want to find a suitable device to use. A [`PhysicalDevice`] describes a
+//! Vulkan implementation that may correspond to a real or virtual device.
+//!
+//! To get all the available devices, use [`PhysicalDevice::enumerate`].
+//!
+//! Physical devices are also describe the logical devices that can be created. A physical device can describe
+//! a variety of properties that may be used for device selection, including but not limited to:
+//! - [Device name](PhysicalDevice::name)
+//! - [Supported Vulkan API version](PhysicalDevice::api_version)
+//! - [Type](PhysicalDevice::ty) of the device
+//! - [Driver information](PhysicalDevice::driver)
+//! - [Extensions](PhysicalDevice::device_extensions)
+//! - [Features](PhysicalDevice::features) and [limits](PhysicalDevice::limits)
+//!
+//! Physical devices implement [`Eq`][^device_eq], meaning two physical devices can be tested for equality.
+//!
+//! ## Device extensions
+//!
+//! Depending on the device extension (see the Vulkan specification), a device extension may indicate some
+//! physical device data is available or indicate some device feature is supported. Any features that are
+//! added using a device extension must be enabled in order to be used.
+//!
+//! [^version]: Internally Vulkan 1.1 is required because several extensions that were made part of core are
+//! used quite extensively in some of the extensions our abstractions use. The vast majority of systems using
+//! Vulkan also support at least Vulkan 1.1. If you need Vulkan 1.0 support, please open an issue and we can
+//! discuss Vulkan 1.0 support.
+//!
+//! [^device_eq]: Two physical devices are only equal if both physical devices are created from the same
+//! instance and have the same physical device handle.
+
+#![warn(missing_debug_implementations)]
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::{
+    env::{self, VarError},
+    ffi::{CStr, CString},
+    sync::Arc,
+};
+
+use ash::{
+    extensions::ext::DebugUtils,
+    prelude::VkResult,
+    vk::{self, PhysicalDeviceDrmPropertiesEXT},
+    Entry,
+};
+use libc::c_void;
+use once_cell::sync::Lazy;
+use scopeguard::ScopeGuard;
+
+use crate::backend::vulkan::inner::DebugState;
+
+use self::{inner::InstanceInner, version::Version};
+
+#[cfg(feature = "backend_drm")]
+use super::drm::DrmNode;
+#[cfg(feature = "backend_drm")]
+use nix::sys::stat;
+
+mod inner;
+mod phd;
+
+pub mod version;
+
+static LIBRARY: Lazy<Result<Entry, LoadError>> =
+    Lazy::new(|| unsafe { Entry::load().map_err(|_| LoadError) });
+
+/// Error loading the Vulkan library
+#[derive(Debug, thiserror::Error)]
+#[error("Failed to load the Vulkan library")]
+pub struct LoadError;
+
+/// An error that may occur when creating an [`Instance`].
+#[derive(Debug, thiserror::Error)]
+pub enum InstanceError {
+    /// The instance was created using Vulkan 1.0.
+    #[error("Smithay requires at least Vulkan 1.1")]
+    UnsupportedVersion,
+
+    /// Failed to load the Vulkan library.
+    #[error(transparent)]
+    Load(#[from] LoadError),
+
+    /// Vulkan API error.
+    #[error(transparent)]
+    Vk(#[from] vk::Result),
+}
+
+/// App info to be passed to the Vulkan implementation.
+#[derive(Debug)]
+pub struct AppInfo {
+    /// Name of the app.
+    pub name: String,
+    /// Version of the app.
+    pub version: Version,
+}
+
+/// A Vulkan instance.
+///
+/// An instance is the object which tracks an application's Vulkan state. An instance allows an application to
+/// get a list of physical devices.
+///
+/// In the Vulkan it is common to have objects which may not outlive the parent instance. A great way to
+/// ensure compliance when using child objects is to [`Clone`] the instance and keep a handle with the child
+/// object. This will ensure the child object does not outlive the instance.
+///
+/// An instance is [`Send`] and [`Sync`] which allows meaning multiple threads to access the Vulkan state.
+/// Note that this **does not** mean the entire Vulkan API is thread safe, you will need to read the
+/// specification to determine what parts of the Vulkan API require external synchronization.
+///
+/// # Instance extensions
+///
+/// In order to use features exposed through instance extensions (such as window system integration), you must
+/// enable the extensions corresponding to the feature.
+///
+/// By default, [`Instance`] will automatically try to enable the following instance extensions if available:
+/// * `VK_EXT_debug_utils`
+///
+/// No users should assume the instance extensions that are automatically enabled are available.
+#[derive(Debug, Clone)]
+pub struct Instance(Arc<InstanceInner>);
+
+impl Instance {
+    /// Creates a new [`Instance`].
+    pub fn new<L>(
+        max_version: Version,
+        app_info: Option<AppInfo>,
+        logger: L,
+    ) -> Result<Instance, InstanceError>
+    where
+        L: Into<Option<slog::Logger>>,
+    {
+        unsafe { Self::with_extensions(max_version, app_info, logger, &[]) }
+    }
+
+    /// Creates a new [`Instance`] with some additionally specified extensions.
+    ///
+    /// # Safety
+    ///
+    /// * All valid usage requirements specified by [`vkCreateInstance`](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateInstance.html)
+    ///   must be satisfied.
+    /// * Any enabled extensions must also have the dependency extensions enabled
+    ///   (see `VUID-vkCreateInstance-ppEnabledExtensionNames-01388`).
+    pub unsafe fn with_extensions<L>(
+        max_version: Version,
+        app_info: Option<AppInfo>,
+        logger: L,
+        extensions: &[&'static CStr],
+    ) -> Result<Instance, InstanceError>
+    where
+        L: Into<Option<slog::Logger>>,
+    {
+        let logger =
+            crate::slog_or_fallback(logger.into()).new(slog::o!("smithay_module" => "backend_vulkan"));
+
+        assert!(
+            max_version >= Version::VERSION_1_1,
+            "Smithay requires at least Vulkan 1.1"
+        );
+        let requested_max_version = get_env_or_max_version(max_version, &logger);
+
+        // Determine the maximum instance version that is possible.
+        let max_version = {
+            LIBRARY
+                .as_ref()
+                .or(Err(LoadError))?
+                .try_enumerate_instance_version()
+                // Any allocation errors must be the result of the loader or layers
+                .or(Err(LoadError))?
+                .map(Version::from_raw)
+                // Vulkan 1.0 does not have `vkEnumerateInstanceVersion`.
+                .unwrap_or(Version::VERSION_1_0)
+        };
+
+        if max_version == Version::VERSION_1_0 {
+            slog::error!(logger, "Vulkan does not support version 1.1");
+            return Err(InstanceError::UnsupportedVersion);
+        }
+
+        // Pick the lower of the requested max version and max possible version
+        let api_version = Version::from_raw(u32::min(max_version.to_raw(), requested_max_version.to_raw()));
+
+        let available_layers = Self::enumerate_layers()?.collect::<Vec<_>>();
+        let available_extensions = Self::enumerate_extensions()?.collect::<Vec<_>>();
+
+        let mut layers = Vec::new();
+
+        // Enable debug layers if present and debug assertions are enabled.
+        if cfg!(debug_assertions) {
+            const VALIDATION: &CStr =
+                unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_LAYER_KHRONOS_validation\0") };
+
+            if available_layers
+                .iter()
+                .any(|layer| layer.as_c_str() == VALIDATION)
+            {
+                layers.push(VALIDATION);
+            } else {
+                slog::warn!(
+                    logger,
+                    "Validation layers not available. These can be installed through your package manager",
+                );
+            }
+        }
+
+        let mut enabled_extensions = Vec::<&'static CStr>::new();
+        enabled_extensions.extend(extensions);
+
+        // Enable debug utils if available.
+        let has_debug_utils = available_extensions
+            .iter()
+            .any(|name| name.as_c_str() == vk::ExtDebugUtilsFn::name());
+
+        if has_debug_utils {
+            enabled_extensions.push(vk::ExtDebugUtilsFn::name());
+        }
+
+        // Both of these are safe because both vecs contain static CStrs.
+        let extension_pointers = enabled_extensions
+            .iter()
+            .map(|name| name.as_ptr())
+            .collect::<Vec<_>>();
+        let layer_pointers = layers.iter().map(|name| name.as_ptr()).collect::<Vec<_>>();
+
+        let app_version = app_info.as_ref().map(|info| info.version.to_raw());
+        let app_name =
+            app_info.map(|info| CString::new(info.name).expect("app name contains null terminator"));
+        let mut app_info = vk::ApplicationInfo::builder()
+            .api_version(api_version.to_raw())
+            // SAFETY: null terminated with no interior null bytes.
+            .engine_name(unsafe { CStr::from_bytes_with_nul_unchecked(b"Smithay\0") })
+            .engine_version(Version::SMITHAY.to_raw());
+
+        if let Some(app_version) = app_version {
+            app_info = app_info.application_version(app_version);
+        }
+
+        if let Some(app_name) = &app_name {
+            app_info = app_info.application_name(app_name);
+        }
+
+        let library = LIBRARY.as_ref().map_err(|_| LoadError)?;
+        let create_info = vk::InstanceCreateInfo::builder()
+            .application_info(&app_info)
+            .enabled_layer_names(&layer_pointers)
+            .enabled_extension_names(&extension_pointers);
+
+        // Place the instance in a scopeguard in case creating the debug messenger fails.
+        let instance = scopeguard::guard(
+            unsafe { library.create_instance(&create_info, None) }?,
+            |instance| unsafe {
+                instance.destroy_instance(None);
+            },
+        );
+
+        // Setup the debug utils
+        let debug_state = if has_debug_utils {
+            let messenger_logger = logger.new(slog::o!("vulkan" => "debug_messenger"));
+            let debug_utils = DebugUtils::new(library, &instance);
+
+            // Place the pointer to the logger in a scopeguard to prevent a memory leak in case creating the
+            // debug messenger fails.
+            let logger_ptr = scopeguard::guard(Box::into_raw(Box::new(messenger_logger)), |ptr| unsafe {
+                let _ = Box::from_raw(ptr);
+            });
+
+            let create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+                .message_severity(
+                    vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
+                        | vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE
+                        | vk::DebugUtilsMessageSeverityFlagsEXT::INFO
+                        | vk::DebugUtilsMessageSeverityFlagsEXT::ERROR,
+                )
+                .message_type(
+                    vk::DebugUtilsMessageTypeFlagsEXT::GENERAL
+                        | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
+                        | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
+                )
+                .pfn_user_callback(Some(vulkan_debug_utils_callback))
+                .user_data(*logger_ptr as *mut _);
+
+            let debug_messenger = unsafe { debug_utils.create_debug_utils_messenger(&create_info, None) }?;
+
+            // Disarm the destructor for the logger pointer since the instance is now responsible for
+            // destroying the logger.
+            let logger_ptr = ScopeGuard::into_inner(logger_ptr);
+
+            Some(DebugState {
+                debug_utils,
+                debug_messenger,
+                logger_ptr,
+            })
+        } else {
+            None
+        };
+
+        // Creating the debug messenger was successful, disarm the scopeguard and let InstanceInner manage
+        // destroying the instance.
+        let instance = ScopeGuard::into_inner(instance);
+        let inner = InstanceInner {
+            instance,
+            version: api_version,
+            debug_state,
+            enabled_extensions,
+        };
+
+        slog::info!(logger, "Created new instance" ; slog::o!("version" => format!("{}", api_version)));
+        slog::info!(
+            logger,
+            "Enabled instance extensions: {:?}",
+            inner.enabled_extensions
+        );
+
+        Ok(Instance(Arc::new(inner)))
+    }
+
+    /// Returns an iterator which contains the available instance extensions on the system.
+    pub fn enumerate_extensions() -> Result<impl Iterator<Item = CString>, LoadError> {
+        let library = LIBRARY.as_ref().or(Err(LoadError))?;
+
+        let extensions = library
+            .enumerate_instance_extension_properties(None)
+            .or(Err(LoadError))?
+            .into_iter()
+            .map(|properties| {
+                // SAFETY: Vulkan guarantees the string is null terminated.
+                unsafe { CStr::from_ptr(&properties.extension_name as *const _) }.to_owned()
+            })
+            .collect::<Vec<_>>()
+            .into_iter();
+
+        Ok(extensions)
+    }
+
+    /// Returns the enabled instance extensions.
+    pub fn enabled_extensions(&self) -> impl Iterator<Item = &CStr> {
+        self.0.enabled_extensions.iter().copied()
+    }
+
+    /// Returns true if the specified instance extension is enabled.
+    ///
+    /// This function may be used to ensure safe access to features provided by instance extensions.
+    pub fn is_extension_enabled(&self, extension: &CStr) -> bool {
+        self.enabled_extensions().any(|name| name == extension)
+    }
+
+    /// Returns the version of Vulkan supported by this instance.
+    ///
+    /// This corresponds to the version specified when building the instance.
+    pub fn api_version(&self) -> Version {
+        self.0.version
+    }
+
+    /// Returns a reference to the underlying [`ash::Instance`].
+    ///
+    /// Any objects created using the handle must be destroyed before the final instance is dropped per the
+    /// valid usage requirements (`VUID-vkDestroyInstance-instance-00629`).
+    pub fn handle(&self) -> &ash::Instance {
+        &self.0.instance
+    }
+}
+
+// SAFETY: Destruction is externally synchronized (using an internal Arc).
+unsafe impl Send for Instance {}
+unsafe impl Sync for Instance {}
+
+/// A Vulkan physical device.
+///
+/// A physical device refers to a Vulkan implementation. A physical device has no associated resources and may
+/// be used to create a logical device.
+#[derive(Debug, Clone)]
+pub struct PhysicalDevice {
+    phd: vk::PhysicalDevice,
+    info: PhdInfo,
+    extensions: Vec<CString>,
+    instance: Instance,
+}
+
+impl PhysicalDevice {
+    /// Enumerates over all physical devices available on the system, returning an iterator of [`PhysicalDevice`]
+    pub fn enumerate(instance: &Instance) -> VkResult<impl Iterator<Item = PhysicalDevice>> {
+        // Must clone instance or else the returned iterator has a lifetime over `&Instance`
+        let instance = instance.clone();
+        let devices = unsafe { instance.handle().enumerate_physical_devices() }?;
+        let devices = devices
+            .into_iter()
+            // TODO: Warn if any physical devices have an error when getting device properties.
+            .flat_map(move |phd| unsafe { PhysicalDevice::from_phd(&instance, phd) })
+            .flatten();
+
+        Ok(devices)
+    }
+
+    /// Returns the name of the device.
+    pub fn name(&self) -> &str {
+        &self.info.name
+    }
+
+    /// Returns the version of Vulkan supported by this device.
+    ///
+    /// Unlike the `api_version` property, which is the version reported by the device directly, this function
+    /// returns the version the device can actually support, based on the instance’s, `api_version`.
+    ///
+    /// The Vulkan specification provides more information about the version requirements: <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-validusage-versions>
+    pub fn api_version(&self) -> Version {
+        self.info.api_version
+    }
+
+    /// Returns the device type.
+    ///
+    /// This may be used during device selection to choose a higher performance GPU.
+    pub fn ty(&self) -> vk::PhysicalDeviceType {
+        self.info.properties.device_type
+    }
+
+    /// Returns the Vulkan 1.0 physical device features.
+    pub fn features(&self) -> vk::PhysicalDeviceFeatures {
+        self.info.features
+    }
+
+    /// Returns the Vulkan 1.1 physical device features.
+    ///
+    /// Confusingly, this is only available if the device supports at least Version 1.2 (since this type was
+    /// added in Vulkan 1.2).
+    pub fn features_1_1(&self) -> Option<vk::PhysicalDeviceVulkan11Features> {
+        self.info.features_1_1
+    }
+
+    /// Returns the Vulkan 1.2 physical device features.
+    ///
+    /// This will return [`None`] if the physical device does not support at least Vulkan 1.2.
+    pub fn features_1_2(&self) -> Option<vk::PhysicalDeviceVulkan12Features> {
+        self.info.features_1_2
+    }
+
+    /// Returns the Vulkan 1.3 physical device features.
+    ///
+    /// This will return [`None`] if the physical device does not support at least Vulkan 1.3.
+    pub fn features_1_3(&self) -> Option<vk::PhysicalDeviceVulkan13Features> {
+        self.info.features_1_3
+    }
+
+    /// Returns the physical device properties.
+    ///
+    /// Some properties such as the device name can be obtained using other functions defined on
+    /// [`PhysicalDevice`].
+    pub fn properties(&self) -> vk::PhysicalDeviceProperties {
+        self.info.properties
+    }
+
+    /// Returns the Vulkan 1.1 physical device properties.
+    ///
+    /// Confusingly, this is only available if the device supports at least Version 1.2 (since this type was
+    /// added in Vulkan 1.2).
+    pub fn properties_1_1(&self) -> Option<vk::PhysicalDeviceVulkan11Properties> {
+        self.info.properties_1_1
+    }
+
+    /// Returns the Vulkan 1.2 physical device properties.
+    ///
+    /// This will return [`None`] if the physical device does not support at least Vulkan 1.2.
+    pub fn properties_1_2(&self) -> Option<vk::PhysicalDeviceVulkan12Properties> {
+        self.info.properties_1_2
+    }
+
+    /// Returns the Vulkan 1.3 physical device properties.
+    ///
+    /// This will return [`None`] if the physical device does not support at least Vulkan 1.3.
+    pub fn properties_1_3(&self) -> Option<vk::PhysicalDeviceVulkan13Properties> {
+        self.info.properties_1_3
+    }
+
+    /// Returns the device's descriptor set properties.
+    ///
+    /// This also describes the maximum memory allocation size.
+    pub fn properties_maintenance_3(&self) -> vk::PhysicalDeviceMaintenance3Properties {
+        self.info.maintenance_3
+    }
+
+    /// Returns the physical device limits.
+    pub fn limits(&self) -> vk::PhysicalDeviceLimits {
+        self.info.properties.limits
+    }
+
+    /// Information about the Vulkan driver.
+    ///
+    /// This may return [`None`] for a few reasons:
+    /// * The Vulkan implementation is not at least 1.2
+    /// * If the Vulkan implementation is not at least Vulkan 1.2, the `VK_KHR_driver_properties` device
+    ///   extension is not available.
+    pub fn driver(&self) -> Option<&DriverInfo> {
+        self.info.driver.as_ref()
+    }
+
+    /// Returns the major and minor numbers of the primary node which corresponds to this physical device's DRM
+    /// device.
+    #[cfg(feature = "backend_drm")]
+    pub fn primary_node(&self) -> Option<DrmNode> {
+        self.info
+            .properties_drm
+            .filter(|props| props.has_primary == vk::TRUE)
+            .and_then(|props| {
+                DrmNode::from_dev_id(stat::makedev(props.primary_major as _, props.primary_minor as _)).ok()
+            })
+    }
+
+    /// Returns the major and minor numbers of the render node which corresponds to this physical device's DRM
+    /// device.
+    ///
+    /// Note that not every device has a render node. If there is no render node (this function returns [`None`])
+    /// then try to use the primary node.
+    #[cfg(feature = "backend_drm")]
+    pub fn render_node(&self) -> Option<DrmNode> {
+        self.info
+            .properties_drm
+            .filter(|props| props.has_render == vk::TRUE)
+            .and_then(|props| {
+                DrmNode::from_dev_id(stat::makedev(props.render_major as _, props.render_minor as _)).ok()
+            })
+    }
+
+    /// Gets some physical device properties.
+    ///
+    /// This function is used to get some physical device data associated with an extension and is
+    /// equivalent to calling [`vkGetPhysicalDeviceProperties2`].
+    ///
+    /// # Safety
+    ///
+    /// - All valid usage requirements for [`vkGetPhysicalDeviceProperties2`] apply. Read the specification
+    ///   for more information.
+    ///
+    /// [`vkGetPhysicalDeviceProperties2`]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceProperties2.html
+    pub unsafe fn get_properties(&self, props: &mut vk::PhysicalDeviceProperties2) {
+        let instance = self.instance().handle();
+        // SAFETY: The caller has garunteed all valid usage requirements for vkGetPhysicalDeviceProperties2
+        // are satisfied.
+        unsafe { instance.get_physical_device_properties2(self.handle(), props) }
+    }
+
+    /// Returns the device extensions supported by the physical device.
+    pub fn device_extensions(&self) -> impl Iterator<Item = &CStr> {
+        self.extensions.iter().map(CString::as_c_str)
+    }
+
+    /// Returns `true` if this device supports the specified device extension.
+    pub fn has_device_extension(&self, extension: &CStr) -> bool {
+        self.device_extensions().any(|name| name == extension)
+    }
+
+    /// Returns a handle to the underlying [`vk::PhysicalDevice`].
+    ///
+    /// The handle refers to a specific physical device advertised by the instance. This handle is only valid
+    /// for the lifetime of the instance.
+    pub fn handle(&self) -> vk::PhysicalDevice {
+        self.phd
+    }
+
+    /// The instance which provided this physical device.
+    pub fn instance(&self) -> &Instance {
+        &self.instance
+    }
+}
+
+impl PartialEq for PhysicalDevice {
+    fn eq(&self, other: &Self) -> bool {
+        // Both the physical device handle and instance handle must be the same
+        self.phd == other.phd && self.instance().handle().handle() == other.instance().handle().handle()
+    }
+}
+
+// SAFETY: The internal pointers in the PhysicalDevice*Properties are always null and only copies of the
+// PhysicalDevice*Properties types are returned.
+unsafe impl Send for PhysicalDevice {}
+unsafe impl Sync for PhysicalDevice {}
+
+/// Information about the driver providing a [`PhysicalDevice`].
+#[derive(Debug, Clone)]
+pub struct DriverInfo {
+    /// ID which identifies the driver.
+    pub id: vk::DriverId,
+
+    /// The name of the driver.
+    pub name: String,
+
+    /// Information describing the driver.
+    ///
+    /// This may include information such as the driver version.
+    pub info: String,
+
+    /// The Vulkan conformance test this driver is conformant against.
+    pub conformance: vk::ConformanceVersion,
+}
+
+#[derive(Debug, Clone)]
+struct PhdInfo {
+    api_version: Version,
+    name: String,
+    properties: vk::PhysicalDeviceProperties,
+    features: vk::PhysicalDeviceFeatures,
+    maintenance_3: vk::PhysicalDeviceMaintenance3Properties,
+    properties_1_1: Option<vk::PhysicalDeviceVulkan11Properties>,
+    features_1_1: Option<vk::PhysicalDeviceVulkan11Features>,
+    properties_1_2: Option<vk::PhysicalDeviceVulkan12Properties>,
+    features_1_2: Option<vk::PhysicalDeviceVulkan12Features>,
+    properties_1_3: Option<vk::PhysicalDeviceVulkan13Properties>,
+    features_1_3: Option<vk::PhysicalDeviceVulkan13Features>,
+    /// Information about the DRM device which corresponds to this physical device.
+    #[cfg_attr(not(feature = "backend_drm"), allow(dead_code))]
+    properties_drm: Option<PhysicalDeviceDrmPropertiesEXT>,
+    driver: Option<DriverInfo>,
+}
+
+fn get_env_or_max_version(max_version: Version, logger: &slog::Logger) -> Version {
+    // Consider max version overrides from env
+    match env::var("SMITHAY_VK_VERSION") {
+        Ok(version) => {
+            let overriden_version = match &version[..] {
+                "1.0" => {
+                    slog::warn!(
+                        logger,
+                        "Smithay does not support Vulkan 1.0, ignoring SMITHAY_VK_VERSION"
+                    );
+                    return max_version;
+                }
+                "1.1" => Some(Version::VERSION_1_1),
+                "1.2" => Some(Version::VERSION_1_2),
+                "1.3" => Some(Version::VERSION_1_3),
+                _ => None,
+            };
+
+            // The env var can only lower the maximum version, not raise it.
+            if let Some(overridden_version) = overriden_version {
+                if overridden_version > max_version {
+                    slog::warn!(
+                        logger,
+                        "Ignoring SMITHAY_VK_VERSION since the requested max version is higher than the maximum of {}.{}",
+                        max_version.major,
+                        max_version.minor
+                    );
+                    max_version
+                } else {
+                    overridden_version
+                }
+            } else {
+                slog::warn!(logger, "SMITHAY_VK_VERSION was set to an unknown Vulkan version");
+                max_version
+            }
+        }
+
+        Err(VarError::NotUnicode(_)) => {
+            slog::warn!(
+                logger,
+                "Value of SMITHAY_VK_VERSION is not valid Unicode, ignoring."
+            );
+
+            max_version
+        }
+
+        Err(VarError::NotPresent) => max_version,
+    }
+}
+
+unsafe extern "system" fn vulkan_debug_utils_callback(
+    message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
+    message_type: vk::DebugUtilsMessageTypeFlagsEXT,
+    p_callback_data: *const vk::DebugUtilsMessengerCallbackDataEXT,
+    logger: *mut c_void,
+) -> vk::Bool32 {
+    let _ = std::panic::catch_unwind(|| {
+        // Get the logger from the user data pointer we gave to Vulkan.
+        //
+        // The logger is allocated on the heap using a box, but we do not want to drop the logger, so read from
+        // the pointer.
+        let logger: &slog::Logger = unsafe { (logger as *mut slog::Logger).as_ref() }.unwrap();
+
+        // VUID-VkDebugUtilsMessengerCallbackDataEXT-pMessage-parameter: Message must be valid UTF-8 with a null
+        // terminator.
+        let message = unsafe { CStr::from_ptr((*p_callback_data).p_message) }.to_string_lossy();
+        // Message type is in full uppercase since we print the bitflag debug representation.
+        let ty = format!("{:?}", message_type).to_lowercase();
+
+        match message_severity {
+            vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE => {
+                slog::trace!(logger, "{}", message ; "ty" => ty)
+            }
+            vk::DebugUtilsMessageSeverityFlagsEXT::INFO => slog::info!(logger, "{}", message ; "ty" => ty),
+            vk::DebugUtilsMessageSeverityFlagsEXT::WARNING => slog::warn!(logger, "{}", message ; "ty" => ty),
+            vk::DebugUtilsMessageSeverityFlagsEXT::ERROR => slog::error!(logger, "{}", message ; "ty" => ty),
+            _ => (),
+        }
+    });
+
+    // Must always return false.
+    vk::FALSE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Instance, PhysicalDevice};
+
+    fn is_send_sync<T: Send + Sync>() {}
+
+    /// Test that both [`Instance`] and [`PhysicalDevice`] are Send and Sync.
+    #[test]
+    fn send_sync() {
+        is_send_sync::<Instance>();
+        is_send_sync::<PhysicalDevice>();
+    }
+}

--- a/src/backend/vulkan/phd.rs
+++ b/src/backend/vulkan/phd.rs
@@ -1,0 +1,234 @@
+//! Functions to get physical device information
+
+use std::ffi::{CStr, CString};
+
+use ash::{prelude::VkResult, vk};
+
+use super::{version::Version, DriverInfo, PhdInfo};
+
+impl super::PhysicalDevice {
+    /// # Safety:
+    ///
+    /// The physical device must belong to the specified instance.
+    pub(super) unsafe fn from_phd(
+        instance: &super::Instance,
+        phd: vk::PhysicalDevice,
+    ) -> VkResult<Option<super::PhysicalDevice>> {
+        let instance = instance.clone();
+
+        let extensions = unsafe { instance.handle().enumerate_device_extension_properties(phd) }?;
+        let extensions = extensions
+            .iter()
+            .map(|extension| {
+                // SAFETY: Vulkan guarantees the device name is valid UTF-8 with a null terminator.
+                unsafe { CStr::from_ptr(&extension.extension_name as *const _) }.to_owned()
+            })
+            .collect::<Vec<_>>();
+
+        if let Some(info) =
+            unsafe { PhdInfo::from_phd(instance.handle(), instance.api_version(), phd, &extensions) }
+        {
+            Ok(Some(Self {
+                phd,
+                info,
+                extensions,
+                instance,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl super::PhdInfo {
+    /// Returns [`None`] if the physical device does not support Vulkan 1.1
+    ///
+    /// # Panics
+    ///
+    /// - If the instance version is not at least Vulkan 1.1
+    ///
+    /// # Safety
+    ///
+    /// - The instance version must be the same version the instance was created with.
+    /// - The physical device must belong to the specified instance.
+    unsafe fn from_phd(
+        instance: &ash::Instance,
+        instance_version: Version,
+        phd: vk::PhysicalDevice,
+        supported_extensions: &[CString],
+    ) -> Option<Self> {
+        assert!(instance_version >= Version::VERSION_1_1);
+
+        let properties = unsafe { instance.get_physical_device_properties(phd) };
+        let features = unsafe { instance.get_physical_device_features(phd) };
+
+        // Pick the lower of the instance version and device version to get the actual version of Vulkan that
+        // can be used with the device.
+        let api_version = Version::from_raw(u32::min(properties.api_version, instance_version.to_raw()));
+
+        if api_version < Version::VERSION_1_1 {
+            // Device does not support Vulkan 1.1, so ignore it.
+            return None;
+        }
+
+        // SAFETY: Vulkan guarantees the device name is valid UTF-8 with a null terminator.
+        let name = unsafe { CStr::from_ptr(&properties.device_name as *const _) }
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Maintenance3
+        //
+        // SAFETY: Maintenance3 extension is supported since Vulkan 1.1
+        let maintenance_3 = unsafe {
+            let mut maintenance_3 = vk::PhysicalDeviceMaintenance3Properties::default();
+            let mut props = vk::PhysicalDeviceProperties2::builder().push_next(&mut maintenance_3);
+            instance.get_physical_device_properties2(phd, &mut props);
+            maintenance_3
+        };
+
+        // Vulkan 1.1 features
+        //
+        // Confusingly these types were not added until Vulkan 1.2
+        let (properties_1_1, features_1_1) = {
+            if api_version >= Version::VERSION_1_2 {
+                unsafe {
+                    let mut properties_1_1 = vk::PhysicalDeviceVulkan11Properties::default();
+                    let mut props = vk::PhysicalDeviceProperties2::builder().push_next(&mut properties_1_1);
+                    instance.get_physical_device_properties2(phd, &mut props);
+
+                    let mut features_1_1 = vk::PhysicalDeviceVulkan11Features::default();
+                    let mut features = vk::PhysicalDeviceFeatures2::builder().push_next(&mut features_1_1);
+                    instance.get_physical_device_features2(phd, &mut features);
+
+                    (Some(properties_1_1), Some(features_1_1))
+                }
+            } else {
+                (None, None)
+            }
+        };
+
+        // Vulkan 1.2
+        let (properties_1_2, features_1_2) = {
+            if api_version >= Version::VERSION_1_2 {
+                // SAFETY: The physical device supports Vulkan 1.2
+                unsafe {
+                    let mut properties_1_2 = vk::PhysicalDeviceVulkan12Properties::default();
+                    let mut props = vk::PhysicalDeviceProperties2::builder().push_next(&mut properties_1_2);
+                    instance.get_physical_device_properties2(phd, &mut props);
+
+                    let mut features_1_2 = vk::PhysicalDeviceVulkan12Features::default();
+                    let mut features = vk::PhysicalDeviceFeatures2::builder().push_next(&mut features_1_2);
+                    instance.get_physical_device_features2(phd, &mut features);
+
+                    (Some(properties_1_2), Some(features_1_2))
+                }
+            } else {
+                (None, None)
+            }
+        };
+
+        // Vulkan 1.3
+        let (properties_1_3, features_1_3) = {
+            if api_version >= Version::VERSION_1_3 {
+                // SAFETY: The physical device supports Vulkan 1.3
+                unsafe {
+                    let mut properties_1_2 = vk::PhysicalDeviceVulkan13Properties::default();
+                    let mut props = vk::PhysicalDeviceProperties2::builder().push_next(&mut properties_1_2);
+                    instance.get_physical_device_properties2(phd, &mut props);
+
+                    let mut features_1_2 = vk::PhysicalDeviceVulkan13Features::default();
+                    let mut features = vk::PhysicalDeviceFeatures2::builder().push_next(&mut features_1_2);
+                    instance.get_physical_device_features2(phd, &mut features);
+
+                    (Some(properties_1_2), Some(features_1_2))
+                }
+            } else {
+                (None, None)
+            }
+        };
+
+        // VK_EXT_physical_device_drm
+        let properties_drm = if supported_extensions
+            .iter()
+            .any(|name| name.as_c_str() == vk::ExtPhysicalDeviceDrmFn::name())
+        {
+            // SAFETY: The caller has garunteed the physical device supports VK_EXT_physical_device_drm
+            unsafe {
+                let mut properties_drm = vk::PhysicalDeviceDrmPropertiesEXT::default();
+                let mut props = vk::PhysicalDeviceProperties2::builder().push_next(&mut properties_drm);
+                instance.get_physical_device_properties2(phd, &mut props);
+                Some(properties_drm)
+            }
+        } else {
+            None
+        };
+
+        // VK_KHR_driver_properties or Vulkan 1.2
+        let driver = if api_version >= Version::VERSION_1_2 {
+            // Copy the data from the Vulkan 1.2 properties into the extension struct for data creation.
+            let properties = vk::PhysicalDeviceDriverProperties {
+                driver_id: properties_1_2.unwrap().driver_id,
+                driver_name: properties_1_2.unwrap().driver_name,
+                driver_info: properties_1_2.unwrap().driver_info,
+                conformance_version: properties_1_2.unwrap().conformance_version,
+                ..Default::default()
+            };
+
+            Some(unsafe { DriverInfo::from_driver_properties(properties) })
+        } else if supported_extensions
+            .iter()
+            .any(|name| name.as_c_str() == vk::KhrDriverPropertiesFn::name())
+        {
+            // SAFETY: VK_KHR_driver_properties is supported
+            unsafe {
+                let mut driver_props = vk::PhysicalDeviceDriverProperties::default();
+                let mut props = vk::PhysicalDeviceProperties2::builder().push_next(&mut driver_props);
+                instance.get_physical_device_properties2(phd, &mut props);
+
+                Some(DriverInfo::from_driver_properties(driver_props))
+            }
+        } else {
+            None
+        };
+
+        Some(Self {
+            api_version,
+            name,
+            properties,
+            features,
+            maintenance_3,
+            properties_1_1,
+            features_1_1,
+            properties_1_2,
+            features_1_2,
+            properties_1_3,
+            features_1_3,
+            properties_drm,
+            driver,
+        })
+    }
+}
+
+impl super::DriverInfo {
+    unsafe fn from_driver_properties(properties: vk::PhysicalDeviceDriverProperties) -> DriverInfo {
+        // SAFETY: Vulkan guarantees the driver name is valid UTF-8 with a null terminator.
+        let name = unsafe { CStr::from_ptr(&properties.driver_name as *const _) }
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // SAFETY: Vulkan guarantees the driver info is valid UTF-8 with a null terminator.
+        let info = unsafe { CStr::from_ptr(&properties.driver_info as *const _) }
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        DriverInfo {
+            id: properties.driver_id,
+            name,
+            info,
+            conformance: properties.conformance_version,
+        }
+    }
+}

--- a/src/backend/vulkan/version.rs
+++ b/src/backend/vulkan/version.rs
@@ -1,0 +1,104 @@
+//! The [`Version`] type.
+
+use std::{
+    cmp::Ordering,
+    fmt::{self, Formatter},
+};
+
+use ash::vk;
+
+/// A Vulkan API version.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct Version {
+    /// The variant of the Vulkan API.
+    ///
+    /// Generally this value will be `0` because the Vulkan specification uses variant `0`.
+    pub variant: u32,
+
+    /// The major version of the Vulkan API.
+    pub major: u32,
+
+    /// The minor version of the Vulkan API.
+    pub minor: u32,
+
+    /// The patch version of the Vulkan API.
+    ///
+    /// Most Vulkan API calls which take a version typically ignore the patch value. Consumers of the Vulkan API may
+    /// typically ignore the patch value.
+    pub patch: u32,
+}
+
+impl Version {
+    /// Version 1.0 of the Vulkan API.
+    pub const VERSION_1_0: Version = Version::from_raw(vk::API_VERSION_1_0);
+
+    /// Version 1.1 of the Vulkan API.
+    pub const VERSION_1_1: Version = Version::from_raw(vk::API_VERSION_1_1);
+
+    /// Version 1.2 of the Vulkan API.
+    pub const VERSION_1_2: Version = Version::from_raw(vk::API_VERSION_1_2);
+
+    /// Version 1.3 of the Vulkan API.
+    pub const VERSION_1_3: Version = Version::from_raw(vk::API_VERSION_1_3);
+
+    /// The version of Smithay.
+    pub const SMITHAY: Version = Version {
+        // TODO: May be useful to place the version information in a single spot that isn't just Vulkan
+        variant: 0,
+        major: 0,
+        minor: 3,
+        patch: 0,
+    };
+
+    /// Converts a packed version into a version struct.
+    pub const fn from_raw(raw: u32) -> Version {
+        Version {
+            variant: vk::api_version_variant(raw),
+            major: vk::api_version_major(raw),
+            minor: vk::api_version_minor(raw),
+            patch: vk::api_version_patch(raw),
+        }
+    }
+
+    /// Converts a version struct into a packed version.
+    pub const fn to_raw(self) -> u32 {
+        vk::make_api_version(self.variant, self.major, self.minor, self.patch)
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}.{}.{} variant {}",
+            self.major, self.minor, self.patch, self.variant
+        )
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.variant.cmp(&other.variant) {
+            Ordering::Equal => {}
+            ord => return ord,
+        }
+
+        match self.major.cmp(&other.major) {
+            Ordering::Equal => {}
+            ord => return ord,
+        }
+
+        match self.minor.cmp(&other.minor) {
+            Ordering::Equal => {}
+            ord => return ord,
+        }
+
+        self.patch.cmp(&other.patch)
+    }
+}

--- a/src/reexports.rs
+++ b/src/reexports.rs
@@ -1,5 +1,7 @@
 //! Reexports of crates, that are part of the public api, for convenience
 
+#[cfg(feature = "backend_vulkan")]
+pub use ash;
 pub use calloop;
 #[cfg(feature = "dbus")]
 pub use dbus;


### PR DESCRIPTION
## Scope

First is a thin lightweight wrapper around ash to get an Instance and PhysicalDevices. This helper is kept intentionally lightweight to prevent essentially replicating a crate like vulkano. Creation of a logical `Device` is intentionally not covered since extensions to `DeviceCreateInfo` and queue creation are hard to model in a public API. The Vulkan allocator and a future renderer are expected to initialize their own logical device(s) and queues.

The Vulkan allocator is modeled around the `Allocator` trait. Implementing memory import/export and dmabuf import could be done, but it involves much more complex lifetimes (since memory import/export requires copy commands, which means command execution and needing to delay destruction of images until command execution finishes). In the future we could expand the allocator api to handle this as an alternative to gbm's memory import/export functions. This may be harder to do but will allow custom Vulkan renderers to be build more easily (since all the external memory logical will be in one type you can just pull in).

There are a few things we do need to do before merging:
- [x] ~~A new ash release (https://github.com/ash-rs/ash/pull/632). 0.37.1 will not eliminate the builders, so if we do not want to wait for 0.38.0 then we will need to readd the builders.~~ Will use 0.37.1 pre-release with a set revision for now.
- [x] Double check we do not have validation errors.