### PR TITLE
0.30: various consitency fixes

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -35,7 +35,7 @@ use smithay::{
                 ToplevelSurface, XdgShellState,
             },
         },
-        shm::ShmState,
+        shm::{ShmHandler, ShmState},
         socket::ListeningSocketSource,
         tablet_manager::TabletSeatTrait,
         viewporter::ViewporterState,
@@ -130,8 +130,8 @@ impl<BackendData> ServerDndGrabHandler for AnvilState<BackendData> {
 delegate_data_device!(@<BackendData: 'static> AnvilState<BackendData>);
 delegate_output!(@<BackendData: 'static> AnvilState<BackendData>);
 
-impl<BackendData> AsRef<ShmState> for AnvilState<BackendData> {
-    fn as_ref(&self) -> &ShmState {
+impl<BackendData> ShmHandler for AnvilState<BackendData> {
+    fn shm_state(&self) -> &ShmState {
         &self.shm_state
     }
 }

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -31,7 +31,7 @@ use smithay::{
         shell::{
             wlr_layer::WlrLayerShellState,
             xdg::{
-                decoration::{XdgDecorationHandler, XdgDecorationManager},
+                decoration::{XdgDecorationHandler, XdgDecorationState},
                 ToplevelSurface, XdgShellState,
             },
         },
@@ -84,7 +84,7 @@ pub struct AnvilState<BackendData: 'static> {
     pub shm_state: ShmState,
     pub viewporter_state: ViewporterState,
     pub xdg_activation_state: XdgActivationState,
-    pub xdg_decoration_state: XdgDecorationManager,
+    pub xdg_decoration_state: XdgDecorationState,
     pub xdg_shell_state: XdgShellState,
 
     pub dnd_icon: Option<WlSurface>,
@@ -251,7 +251,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
         let shm_state = ShmState::new::<Self, _>(&dh, vec![], log.clone());
         let viewporter_state = ViewporterState::new::<Self, _>(&dh, log.clone());
         let xdg_activation_state = XdgActivationState::new::<Self, _>(&dh, log.clone());
-        let xdg_decoration_state = XdgDecorationManager::new::<Self, _>(&dh, log.clone()).0;
+        let xdg_decoration_state = XdgDecorationState::new::<Self, _>(&dh, log.clone()).0;
         let xdg_shell_state = XdgShellState::new::<Self, _>(&dh, log.clone()).0;
 
         // init input

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -21,7 +21,7 @@ use smithay::{
         data_device::{ClientDndGrabHandler, DataDeviceHandler, DataDeviceState, ServerDndGrabHandler},
         seat::{FilterResult, Seat, SeatHandler, SeatState},
         shell::xdg::{PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler, XdgShellState},
-        shm::ShmState,
+        shm::{ShmHandler, ShmState},
         Serial,
     },
 };
@@ -80,8 +80,8 @@ impl CompositorHandler for App {
     }
 }
 
-impl AsRef<ShmState> for App {
-    fn as_ref(&self) -> &ShmState {
+impl ShmHandler for App {
+    fn shm_state(&self) -> &ShmState {
         &self.shm_state
     }
 }

--- a/smallvil/src/handlers/compositor.rs
+++ b/smallvil/src/handlers/compositor.rs
@@ -9,7 +9,7 @@ use smithay::{
     wayland::{
         buffer::BufferHandler,
         compositor::{CompositorHandler, CompositorState},
-        shm::ShmState,
+        shm::{ShmHandler, ShmState},
     },
 };
 
@@ -30,8 +30,8 @@ impl BufferHandler for Smallvil {
     fn buffer_destroyed(&mut self, _buffer: &wl_buffer::WlBuffer) {}
 }
 
-impl AsRef<ShmState> for Smallvil {
-    fn as_ref(&self) -> &ShmState {
+impl ShmHandler for Smallvil {
+    fn shm_state(&self) -> &ShmState {
         &self.shm_state
     }
 }

--- a/src/wayland/shm/mod.rs
+++ b/src/wayland/shm/mod.rs
@@ -20,7 +20,7 @@
 //! extern crate smithay;
 //!
 //! use smithay::wayland::buffer::BufferHandler;
-//! use smithay::wayland::shm::ShmState;
+//! use smithay::wayland::shm::{ShmState, ShmHandler};
 //! use smithay::delegate_shm;
 //! use wayland_server::protocol::wl_shm::Format;
 //!
@@ -45,8 +45,8 @@
 //!         // Some parts of window management may also use this function.
 //!     }
 //! }
-//! impl AsRef<ShmState> for State {
-//!     fn as_ref(&self) -> &ShmState {
+//! impl ShmHandler for State {
+//!     fn shm_state(&self) -> &ShmState {
 //!         &self.shm_state
 //!     }
 //! }
@@ -136,7 +136,7 @@ impl ShmState {
             + Dispatch<WlShm, ()>
             + Dispatch<WlShmPool, ShmPoolUserData>
             + BufferHandler
-            + AsRef<ShmState>
+            + ShmHandler
             + 'static,
         L: Into<Option<::slog::Logger>>,
     {
@@ -159,6 +159,12 @@ impl ShmState {
     pub fn global(&self) -> GlobalId {
         self.shm.clone()
     }
+}
+
+/// Shm global handler
+pub trait ShmHandler {
+    /// Return the Shm global state
+    fn shm_state(&self) -> &ShmState;
 }
 
 /// Error that can occur when accessing an SHM buffer


### PR DESCRIPTION
Some fixes to the consistency of using the 0.30 branch.

Each commit stands for itself and can be dropped if controversial:
- ShmState is the only one using `AsRef` for referring to its state -> replaced by `ShmHandler`
- The `XdgDecorationManager` is the only state object not named `State` but after its protocol object -> replaced with `XdgDecorationState`