### PR TITLE
session/libseat: process immediate events after creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 [dependencies]
 appendlist = "1.4"
 bitflags = "1"
-calloop = "0.10.0"
+calloop = "0.10.1"
 cgmath = "0.18.0"
 dbus = { version = "0.9.4", optional = true }
 downcast-rs = "1.2.0"

--- a/src/backend/session/libseat.rs
+++ b/src/backend/session/libseat.rs
@@ -95,10 +95,11 @@ impl LibSeatSession {
             // In some cases enable_seat event is avalible right after startup
             // so, we can dispatch it
             seat.dispatch(0).unwrap();
+            let active = matches!(rx.try_recv(), Ok(SeatEvent::Enable));
 
             let internal = Rc::new(LibSeatSessionImpl {
                 seat: RefCell::new(seat),
-                active: Arc::new(AtomicBool::new(false)),
+                active: Arc::new(AtomicBool::new(active)),
                 devices: RefCell::new(HashMap::new()),
                 logger,
             });


### PR DESCRIPTION
Depends on https://github.com/Smithay/calloop/pull/102

This makes the libseat session match the behaviour of the other sessions more closely by directly reflecting the active-state after creation instead of after it's first dispatch.