### PR TITLE
Renderer/integer coordinates

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -127,7 +127,7 @@ where
             scale,
             Transform::Normal,
             &[Rectangle::from_loc_and_size(
-                (0.0, 0.0),
+                (0, 0),
                 self.size.to_physical_precise_round(scale),
             )],
             1.0,
@@ -207,7 +207,6 @@ where
                     x.loc -= dst.loc;
                     x
                 })
-                .map(|x| x.to_f64())
                 .collect::<Vec<_>>();
             let src: Rectangle<i32, Buffer> = match digit {
                 9 => Rectangle::from_loc_and_size((0, 0), (22, 35)),
@@ -225,7 +224,7 @@ where
             frame.render_texture_from_to(
                 &self.texture,
                 src.to_f64(),
-                dst.to_f64(),
+                dst,
                 &damage,
                 Transform::Normal,
                 1.0,

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -39,10 +39,7 @@ where
         renderer
             .render(mode.size, transform, |renderer, frame| {
                 let mut damage = window.accumulated_damage((0.0, 0.0), scale, None);
-                frame.clear(
-                    CLEAR_COLOR,
-                    &[Rectangle::from_loc_and_size((0, 0), mode.size).to_f64()],
-                )?;
+                frame.clear(CLEAR_COLOR, &[Rectangle::from_loc_and_size((0, 0), mode.size)])?;
                 draw_window(
                     dh,
                     renderer,

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -931,10 +931,7 @@ fn initial_render(
     renderer
         .render((1, 1).into(), Transform::Normal, |_, frame| {
             frame
-                .clear(
-                    CLEAR_COLOR,
-                    &[Rectangle::from_loc_and_size((0.0, 0.0), (1.0, 1.0))],
-                )
+                .clear(CLEAR_COLOR, &[Rectangle::from_loc_and_size((0, 0), (1, 1))])
                 .map_err(Into::<SwapBuffersError>::into)
         })
         .map_err(Into::<SwapBuffersError>::into)

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -179,7 +179,7 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
         backend
             .renderer()
             .render(size, Transform::Flipped180, |renderer, frame| {
-                frame.clear([0.1, 0.0, 0.0, 1.0], &[damage.to_f64()]).unwrap();
+                frame.clear([0.1, 0.0, 0.0, 1.0], &[damage]).unwrap();
 
                 state.xdg_shell_state.toplevel_surfaces(|surfaces| {
                     for surface in surfaces {

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -2096,13 +2096,6 @@ impl Gles2Frame {
         unsafe {
             self.gl.ActiveTexture(ffi::TEXTURE0);
             self.gl.BindTexture(target, tex.0.texture);
-            self.gl
-                .TexParameteri(target, ffi::TEXTURE_WRAP_S, ffi::CLAMP_TO_BORDER as i32);
-            self.gl
-                .TexParameteri(target, ffi::TEXTURE_WRAP_T, ffi::CLAMP_TO_BORDER as i32);
-            let border_color = [0.0f32, 0.0f32, 0.0f32, 0.0f32];
-            self.gl
-                .TexParameterfv(target, ffi::TEXTURE_BORDER_COLOR, border_color.as_ptr());
             self.gl.TexParameteri(
                 target,
                 ffi::TEXTURE_MIN_FILTER,

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1851,7 +1851,7 @@ impl Frame for Gles2Frame {
     type Error = Gles2Error;
     type TextureId = Gles2Texture;
 
-    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<f64, Physical>]) -> Result<(), Self::Error> {
+    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
         if at.is_empty() {
             return Ok(());
         }
@@ -1976,8 +1976,8 @@ impl Frame for Gles2Frame {
         &mut self,
         texture: &Self::TextureId,
         src: Rectangle<f64, BufferCoord>,
-        dest: Rectangle<f64, Physical>,
-        damage: &[Rectangle<f64, Physical>],
+        dest: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
         transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error> {
@@ -2022,7 +2022,10 @@ impl Frame for Gles2Frame {
         tex_mat = tex_mat * Matrix3::from_translation(Vector2::new(-0.5, -0.5));
         // at last scale back to tex space
         tex_mat = tex_mat
-            * Matrix3::from_nonuniform_scale((1.0f64 / dest.size.w) as f32, (1.0f64 / dest.size.h) as f32);
+            * Matrix3::from_nonuniform_scale(
+                (1.0f64 / dest.size.w as f64) as f32,
+                (1.0f64 / dest.size.h as f64) as f32,
+            );
 
         let instances = damage
             .iter()
@@ -2031,11 +2034,10 @@ impl Frame for Gles2Frame {
 
                 let rect_constrained_loc = rect
                     .loc
-                    .constrain(Rectangle::from_extemities((0f64, 0f64), dest_size.to_point()));
-                let rect_clamped_size = rect.size.clamp(
-                    (0f64, 0f64),
-                    (dest_size.to_point() - rect_constrained_loc).to_size(),
-                );
+                    .constrain(Rectangle::from_extemities((0, 0), dest_size.to_point()));
+                let rect_clamped_size = rect
+                    .size
+                    .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
 
                 let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
                 [

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -139,7 +139,7 @@ pub trait Frame {
     ///
     /// This operation is only valid in between a `begin` and `finish`-call.
     /// If called outside this operation may error-out, do nothing or modify future rendering results in any way.
-    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<f64, Physical>]) -> Result<(), Self::Error>;
+    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error>;
 
     /// Render a texture to the current target as a flat 2d-plane at a given
     /// position and applying the given transformation with the given alpha value.
@@ -148,11 +148,11 @@ pub trait Frame {
     fn render_texture_at(
         &mut self,
         texture: &Self::TextureId,
-        pos: Point<f64, Physical>,
+        pos: Point<i32, Physical>,
         texture_scale: i32,
         output_scale: impl Into<Scale<f64>>,
         src_transform: Transform,
-        damage: &[Rectangle<f64, Physical>],
+        damage: &[Rectangle<i32, Physical>],
         alpha: f32,
     ) -> Result<(), Self::Error> {
         self.render_texture_from_to(
@@ -178,8 +178,8 @@ pub trait Frame {
         &mut self,
         texture: &Self::TextureId,
         src: Rectangle<f64, BufferCoord>,
-        dst: Rectangle<f64, Physical>,
-        damage: &[Rectangle<f64, Physical>],
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
         src_transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error>;

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -441,16 +441,13 @@ where
                     let damage = damage
                         .iter()
                         .cloned()
-                        // first move the damage by the surface offset in logical space
-                        .map(|geo| geo.to_f64())
-                        // then clamp to surface size again in logical space
+                        // clamp to surface size
                         .flat_map(|geo| geo.intersection(dst))
-                        // lastly transform it into physical space
+                        // move relative to surface
                         .map(|mut geo| {
                             geo.loc -= dst.loc;
                             geo
                         })
-                        .map(|geo| geo.to_f64())
                         .collect::<Vec<_>>();
 
                     if damage.is_empty() {
@@ -465,14 +462,9 @@ where
                             .to_logical(buffer_scale, buffer_transform)
                             .to_f64(),
                     );
-                    if let Err(err) = frame.render_texture_from_to(
-                        texture,
-                        src,
-                        dst.to_f64(),
-                        &damage,
-                        buffer_transform,
-                        1.0,
-                    ) {
+                    if let Err(err) =
+                        frame.render_texture_from_to(texture, src, dst, &damage, buffer_transform, 1.0)
+                    {
                         result = Err(err);
                     }
                 }

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -604,8 +604,6 @@ impl Space {
                         .iter()
                         // Map from global space to output space
                         .map(|geo| Rectangle::from_loc_and_size(geo.loc - output_geo.loc, geo.size))
-                        // Map from logical to physical
-                        .map(|geo| geo.to_f64())
                         .collect::<Vec<_>>(),
                 )?;
                 // Then re-draw all windows & layers overlapping with a damage rect.
@@ -994,16 +992,16 @@ macro_rules! custom_elements_internal {
 /// # impl Frame for DummyFrame {
 /// #   type Error = SwapBuffersError;
 /// #   type TextureId = DummyTexture;
-/// #   fn clear(&mut self, color: [f32; 4], at: &[Rectangle<f64, Physical>]) -> Result<(), Self::Error> { Ok(()) }
+/// #   fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> { Ok(()) }
 /// #   #[allow(clippy::too_many_arguments)]
 /// #   fn render_texture_at(
 /// #       &mut self,
 /// #       texture: &Self::TextureId,
-/// #       pos: Point<f64, Physical>,
+/// #       pos: Point<i32, Physical>,
 /// #       texture_scale: i32,
 /// #       output_scale: impl Into<Scale<f64>>,
 /// #       src_transform: Transform,
-/// #       damage: &[Rectangle<f64, Physical>],
+/// #       damage: &[Rectangle<i32, Physical>],
 /// #       alpha: f32,
 /// #   ) -> Result<(), Self::Error> {
 /// #       Ok(())
@@ -1012,8 +1010,8 @@ macro_rules! custom_elements_internal {
 /// #       &mut self,
 /// #       texture: &Self::TextureId,
 /// #       src: Rectangle<f64, Buffer>,
-/// #       dst: Rectangle<f64, Physical>,
-/// #       damage: &[Rectangle<f64, Physical>],
+/// #       dst: Rectangle<i32, Physical>,
+/// #       damage: &[Rectangle<i32, Physical>],
 /// #       src_transform: Transform,
 /// #       alpha: f32,
 /// #   ) -> Result<(), Self::Error> {

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -124,7 +124,7 @@ impl Frame for DummyFrame {
     type Error = SwapBuffersError;
     type TextureId = DummyTexture;
 
-    fn clear(&mut self, _color: [f32; 4], _damage: &[Rectangle<f64, Physical>]) -> Result<(), Self::Error> {
+    fn clear(&mut self, _color: [f32; 4], _damage: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -132,8 +132,8 @@ impl Frame for DummyFrame {
         &mut self,
         _texture: &Self::TextureId,
         _src: Rectangle<f64, Buffer>,
-        _dst: Rectangle<f64, Physical>,
-        _damage: &[Rectangle<f64, Physical>],
+        _dst: Rectangle<i32, Physical>,
+        _damage: &[Rectangle<i32, Physical>],
         _src_transform: Transform,
         _alpha: f32,
     ) -> Result<(), Self::Error> {


### PR DESCRIPTION
This PR brings back integer coordinates to the renderer for all position and sizes.
The src still uses f64 so that the renderer can decide on the precision for cropping.

Additonal it removes the use of `gl_clamp_to_border` which is now unnecessary and
also caused on some platforms that do not support it (gles < 3.2)