### PR TITLE
space: Use cached output surface list for outputs_for_window

### DIFF
--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -343,29 +343,11 @@ impl Space {
         if !self.windows.contains(w) {
             return Vec::new();
         }
-
-        let w_geo = window_rect(w, &self.id);
-        let mut outputs = self
-            .outputs
-            .iter()
-            .cloned()
-            .filter(|o| {
-                let o_geo = self.output_geometry(o).unwrap();
-                w_geo.overlaps(o_geo)
-            })
-            .collect::<Vec<Output>>();
-        outputs.sort_by(|o1, o2| {
-            let overlap = |rect1: Rectangle<i32, Logical>, rect2: Rectangle<i32, Logical>| -> i32 {
-                // x overlap
-                std::cmp::max(0, std::cmp::min(rect1.loc.x + rect1.size.w, rect2.loc.x + rect2.size.w) - std::cmp::max(rect1.loc.x, rect2.loc.x))
-                // y overlap
-                * std::cmp::max(0, std::cmp::min(rect1.loc.y + rect1.size.h, rect2.loc.y + rect2.size.h) - std::cmp::max(rect1.loc.y, rect2.loc.y))
-            };
-            let o1_area = overlap(self.output_geometry(o1).unwrap(), w_geo);
-            let o2_area = overlap(self.output_geometry(o2).unwrap(), w_geo);
-            o1_area.cmp(&o2_area)
-        });
-        outputs
+        
+        self.outputs.iter().filter(|o| {
+            let output_state = output_state(self.id, o);
+            output_state.surfaces.contains(w.toplevel().wl_surface())
+        }).cloned().collect()
     }
 
     /// Refresh some internal values and update client state,

--- a/src/desktop/space/output.rs
+++ b/src/desktop/space/output.rs
@@ -5,12 +5,12 @@ use crate::{
     wayland::output::Output,
 };
 use indexmap::IndexMap;
-use wayland_server::protocol::wl_surface::WlSurface;
+use wayland_server::backend::ObjectId;
 
 use std::{
     any::TypeId,
     cell::{RefCell, RefMut},
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
 };
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -49,7 +49,7 @@ pub struct OutputState {
     pub last_output_geo: Option<Rectangle<i32, Physical>>,
 
     // surfaces for tracking enter and leave events
-    pub surfaces: Vec<WlSurface>,
+    pub surfaces: HashSet<ObjectId>,
 }
 
 pub type OutputUserdata = RefCell<HashMap<usize, OutputState>>;


### PR DESCRIPTION
The idea of this commit is to make the `Space::outputs_for_window` function substantially cheaper. This solution has some trade-offs.

1. This uses the existing surface-list inside the `OutputState`, that gets updated on every `Space::refresh` anyway to track `output_enter` and `output_leave` events. This means the result of this function would now not be accurate any more, if no refresh happened between changes to the shell-state and this call. I would argue this is insignificant for most compositors as refreshes should happen frequently anyway.

2. Sorting the outputs was never guaranteed in the methods docs and was wrong to begin with, because it sorted by the smallest overlapping area first than the intended largest.
anvil makes use of this behaviour to select the output with the most (or erroneously least) overlap for maximizing and fullscreening. Given that we never noticed this problem, it is likely a rare edge case. If interesting to compositors they can easily compute this themselves. Additionally I don't think this is a very good metric, rather the output currently focused by the seat triggering that request should be used.

3. The last commit improves further on this by storing the surfaces (or rather their `ObjectId`s) inside a `HashSet`, which is possible due to wayland-rs 0.30.0-beta.6 `Hash` implementation for ids. This makes the lookup take constant time instead of scaling with the amount of surfaces on an output.

This is useful for example for implementing the proposed `ext_toplevel_info` or `wlr_toplevel_management` protocols, which need information about which outputs a toplevel reside on. Given there is no way to watch any output changes with smithays current abstraction, they need to frequently call `outputs_for_windows`. This issue should likely be addressed separately, but in the meantime this improves the situation significantly.