### PR TITLE
Fix new clippy 1.62 lints

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -682,7 +682,7 @@ impl AnvilState<UdevData> {
             }
             crate::shell::fixup_positions(&self.backend_data.dh, &mut self.space);
 
-            let _device = self.handle.remove(backend_data.registration_token);
+            self.handle.remove(backend_data.registration_token);
             let _device = backend_data.event_dispatcher.into_source_inner();
 
             debug!(self.log, "Dropping device");

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -153,7 +153,7 @@ impl backend::KeyboardKeyEvent<LibinputInputBackend> for event::keyboard::Keyboa
     }
 }
 
-impl<'a> backend::Event<LibinputInputBackend> for event::pointer::PointerAxisEvent {
+impl backend::Event<LibinputInputBackend> for event::pointer::PointerAxisEvent {
     fn time(&self) -> u32 {
         event::pointer::PointerEventTrait::time(self)
     }

--- a/src/backend/x11/extension.rs
+++ b/src/backend/x11/extension.rs
@@ -5,7 +5,7 @@ use super::{MissingExtensionError, X11Error};
 /// This macro generates a struct which checks for the presence of some X11 extensions and stores
 /// the version supplied by the X server.
 ///
-/// ```rust
+/// ```ignore(cannot-test-this-because-non-exported-macro)
 /// extensions! {
 ///     // The extension to check for. This should correspond to the name of the extension inside x11rb's `x11rb::protocol::xproto::<name>` module path.
 ///     xfixes {

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -40,6 +40,7 @@
  */
 use std::{
     env,
+    fmt::Write,
     io::{self, Read},
     os::unix::{
         io::{AsRawFd, RawFd},
@@ -387,7 +388,8 @@ fn spawn_xwayland(
 
     let mut xwayland_args = format!(":{} -rootless -terminate -wm {}", display, wm_socket.as_raw_fd());
     for socket in listen_sockets {
-        xwayland_args.push_str(&format!(" -listenfd {}", socket.as_raw_fd()));
+        // Will only fail to write on OOM, so this panic is fine.
+        write!(xwayland_args, " -listenfd {}", socket.as_raw_fd()).unwrap();
     }
     // This command let sh to:
     // * Set up signal handler for USR1

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -237,7 +237,7 @@ fn handle_event(
                     .surface_under(pointer.current_location(), WindowSurfaceType::ALL)
                     .map(|(window, surface, _)| (window, surface));
                 if let Some((window, _)) = under.as_ref() {
-                    state.space.raise_window(&window, true);
+                    state.space.raise_window(window, true);
                 }
                 state.seat.get_keyboard().unwrap().set_focus(
                     &display.handle(),

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -78,7 +78,7 @@ impl ImportMemWl for DummyRenderer {
         _damage: &[Rectangle<i32, Buffer>],
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error> {
         use smithay::wayland::shm::with_buffer_contents;
-        let ret = with_buffer_contents(&buffer, |slice, data| {
+        let ret = with_buffer_contents(buffer, |slice, data| {
             let offset = data.offset as u32;
             let width = data.width as u32;
             let height = data.height as u32;


### PR DESCRIPTION
Another new Rust release. Another pull request to fix the clippy lints.

Apparently wlcs_anvil wasn't being run with clippy for some reason, so I fixed the clippy issues there.