### PR TITLE
egl: Fix buffers

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -8,7 +8,7 @@ use smithay::utils::Buffer;
 use smithay::{
     backend::renderer::{Frame, ImportAll, Renderer, Texture},
     desktop::space::{RenderElement, SpaceOutputTuple, SurfaceTree},
-    reexports::wayland_server::{protocol::wl_surface, DisplayHandle},
+    reexports::wayland_server::protocol::wl_surface,
     utils::{Logical, Physical, Point, Rectangle, Scale, Size, Transform},
     wayland::{
         compositor::{get_role, with_states},
@@ -111,7 +111,6 @@ where
 
     fn draw(
         &self,
-        _dh: &DisplayHandle,
         _renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
         scale: impl Into<Scale<f64>>,
@@ -180,7 +179,6 @@ where
 
     fn draw(
         &self,
-        _dh: &DisplayHandle,
         _renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
         scale: impl Into<Scale<f64>>,

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -4,7 +4,6 @@ use smithay::{
         draw_window, draw_window_popups,
         space::{RenderElement, RenderError, Space},
     },
-    reexports::wayland_server::DisplayHandle,
     utils::{Physical, Rectangle},
     wayland::output::Output,
 };
@@ -12,7 +11,6 @@ use smithay::{
 use crate::{drawing::*, shell::FullscreenSurface};
 
 pub fn render_output<R, E>(
-    dh: &DisplayHandle,
     output: &Output,
     space: &mut Space,
     renderer: &mut R,
@@ -41,7 +39,6 @@ where
                 let mut damage = window.accumulated_damage((0.0, 0.0), scale, None);
                 frame.clear(CLEAR_COLOR, &[Rectangle::from_loc_and_size((0, 0), mode.size)])?;
                 draw_window(
-                    dh,
                     renderer,
                     frame,
                     &window,
@@ -51,7 +48,6 @@ where
                     log,
                 )?;
                 draw_window_popups(
-                    dh,
                     renderer,
                     frame,
                     &window,
@@ -64,7 +60,6 @@ where
                     let geo = elem.geometry(scale);
                     let location = elem.location(scale) - output_geo.loc.to_physical_precise_round(scale);
                     elem.draw(
-                        dh,
                         renderer,
                         frame,
                         scale,
@@ -79,6 +74,6 @@ where
             .and_then(std::convert::identity)
             .map_err(RenderError::<R>::Rendering)
     } else {
-        space.render_output(dh, &mut *renderer, output, age as usize, CLEAR_COLOR, &*elements)
+        space.render_output(&mut *renderer, output, age as usize, CLEAR_COLOR, &*elements)
     }
 }

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -339,7 +339,7 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
         &mut self.compositor_state
     }
     fn commit(&mut self, dh: &DisplayHandle, surface: &WlSurface) {
-        on_commit_buffer_handler(dh, surface);
+        on_commit_buffer_handler(surface);
         self.backend_data.early_import(surface);
 
         #[cfg(feature = "xwayland")]

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -153,7 +153,7 @@ impl Backend for UdevData {
     fn early_import(&mut self, surface: &wl_surface::WlSurface) {
         if let Err(err) = self
             .gpus
-            .early_import(&self.dh, Some(self.primary_gpu), self.primary_gpu, surface)
+            .early_import(Some(self.primary_gpu), self.primary_gpu, surface)
         {
             warn!(self.logger, "Early buffer import failed: {}", err);
         }
@@ -867,16 +867,8 @@ fn render_surface(
 
     // and draw to our buffer
     // TODO we can pass the damage rectangles inside a AtomicCommitRequest
-    let render_res = crate::render::render_output(
-        &surface.dh,
-        &output,
-        space,
-        renderer,
-        age.into(),
-        &*elements,
-        logger,
-    )
-    .map(|x| x.is_some());
+    let render_res = crate::render::render_output(&output, space, renderer, age.into(), &*elements, logger)
+        .map(|x| x.is_some());
 
     match render_res.map_err(|err| match err {
         RenderError::Rendering(err) => err.into(),

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -253,18 +253,11 @@ pub fn run_winit(log: Logger) {
             let space = &mut state.space;
             let render_res = backend.bind().and_then(|_| {
                 let renderer = backend.renderer();
-                crate::render::render_output(
-                    &display.handle(),
-                    &output,
-                    space,
-                    renderer,
-                    age,
-                    &*elements,
-                    &log,
-                )
-                .map_err(|err| match err {
-                    RenderError::Rendering(err) => err.into(),
-                    _ => unreachable!(),
+                crate::render::render_output(&output, space, renderer, age, &*elements, &log).map_err(|err| {
+                    match err {
+                        RenderError::Rendering(err) => err.into(),
+                        _ => unreachable!(),
+                    }
                 })
             });
 

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -287,7 +287,6 @@ pub fn run_x11(log: Logger) {
             }
 
             let render_res = crate::render::render_output(
-                &display.handle(),
                 &output,
                 &mut state.space,
                 &mut backend_data.renderer,

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -75,8 +75,8 @@ impl CompositorHandler for App {
         &mut self.compositor_state
     }
 
-    fn commit(&mut self, dh: &DisplayHandle, surface: &WlSurface) {
-        on_commit_buffer_handler(dh, surface);
+    fn commit(&mut self, _dh: &DisplayHandle, surface: &WlSurface) {
+        on_commit_buffer_handler(surface);
     }
 }
 
@@ -183,19 +183,9 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
 
                 state.xdg_shell_state.toplevel_surfaces(|surfaces| {
                     for surface in surfaces {
-                        let dh = &mut display.handle();
                         let surface = surface.wl_surface();
-                        draw_surface_tree(
-                            dh,
-                            renderer,
-                            frame,
-                            surface,
-                            1.0,
-                            (0.0, 0.0).into(),
-                            &[damage],
-                            &log,
-                        )
-                        .unwrap();
+                        draw_surface_tree(renderer, frame, surface, 1.0, (0.0, 0.0).into(), &[damage], &log)
+                            .unwrap();
 
                         send_frames_surface_tree(surface, start_time.elapsed().as_millis() as u32);
                     }

--- a/smallvil/src/handlers/compositor.rs
+++ b/smallvil/src/handlers/compositor.rs
@@ -18,8 +18,8 @@ impl CompositorHandler for Smallvil {
         &mut self.compositor_state
     }
 
-    fn commit(&mut self, dh: &DisplayHandle, surface: &WlSurface) {
-        on_commit_buffer_handler(dh, surface);
+    fn commit(&mut self, _dh: &DisplayHandle, surface: &WlSurface) {
+        on_commit_buffer_handler(surface);
         self.space.commit(surface);
 
         resize_grab::handle_commit(&mut self.space, surface);

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -114,7 +114,6 @@ pub fn winit_dispatch(
         state
             .space
             .render_output::<Gles2Renderer, SurfaceTree>(
-                &display.handle(),
                 backend.renderer(),
                 output,
                 0,

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -801,7 +801,6 @@ impl EGLBufferReader {
     /// a [`BufferAccessError::NotManaged`](crate::backend::egl::BufferAccessError::NotManaged) is returned.
     pub fn egl_buffer_contents(
         &self,
-        _dh: &DisplayHandle,
         buffer: &WlBuffer,
     ) -> ::std::result::Result<EGLBuffer, BufferAccessError> {
         let mut format: i32 = 0;
@@ -918,7 +917,6 @@ impl EGLBufferReader {
     /// context has been lost, `None` is returned.
     pub fn egl_buffer_dimensions(
         &self,
-        dh: &DisplayHandle,
         buffer: &WlBuffer,
     ) -> Option<crate::utils::Size<i32, crate::utils::Buffer>> {
         let mut width: i32 = 0;

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -756,6 +756,7 @@ fn get_dmabuf_formats(
 pub struct EGLBufferReader {
     display: Arc<EGLDisplayHandle>,
     wayland: Option<Arc<*mut wl_display>>,
+    #[allow(dead_code)]
     logger: ::slog::Logger,
 }
 
@@ -800,14 +801,9 @@ impl EGLBufferReader {
     /// a [`BufferAccessError::NotManaged`](crate::backend::egl::BufferAccessError::NotManaged) is returned.
     pub fn egl_buffer_contents(
         &self,
-        dh: &DisplayHandle,
+        _dh: &DisplayHandle,
         buffer: &WlBuffer,
     ) -> ::std::result::Result<EGLBuffer, BufferAccessError> {
-        if dh.get_object_data(buffer.id()).is_err() {
-            debug!(self.logger, "Suplied buffer is no longer alive");
-            return Err(BufferAccessError::NotManaged(EGLError::BadParameter));
-        }
-
         let mut format: i32 = 0;
         let query = wrap_egl_call(|| unsafe {
             ffi::egl::QueryWaylandBufferWL(
@@ -925,11 +921,6 @@ impl EGLBufferReader {
         dh: &DisplayHandle,
         buffer: &WlBuffer,
     ) -> Option<crate::utils::Size<i32, crate::utils::Buffer>> {
-        if dh.get_object_data(buffer.id()).is_err() {
-            debug!(self.logger, "Supplied buffer is no longer alive");
-            return None;
-        }
-
         let mut width: i32 = 0;
         if unsafe {
             ffi::egl::QueryWaylandBufferWL(

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -16,12 +16,6 @@ use std::{
         mpsc::{channel, Receiver, Sender},
     },
 };
-#[cfg(all(
-    feature = "wayland_frontend",
-    feature = "backend_egl",
-    feature = "use_system_lib"
-))]
-use wayland_server::DisplayHandle;
 
 #[cfg(feature = "wayland_frontend")]
 use std::{cell::RefCell, collections::HashMap};
@@ -1026,7 +1020,6 @@ impl ImportEgl for Gles2Renderer {
 
     fn import_egl_buffer(
         &mut self,
-        dh: &DisplayHandle,
         buffer: &wl_buffer::WlBuffer,
         _surface: Option<&crate::wayland::compositor::SurfaceData>,
         _damage: &[Rectangle<i32, BufferCoord>],
@@ -1052,7 +1045,7 @@ impl ImportEgl for Gles2Renderer {
             .egl_reader
             .as_ref()
             .unwrap()
-            .egl_buffer_contents(dh, buffer)
+            .egl_buffer_contents(buffer)
             .map_err(Gles2Error::EGLBufferAccessError)?;
 
         let tex = self.import_egl_image(egl.image(0).unwrap(), egl.format == EGLFormat::External, None)?;

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -338,7 +338,6 @@ impl<A: GraphicsApi> GpuManager<A> {
     #[cfg(feature = "wayland_frontend")]
     pub fn early_import(
         &mut self,
-        dh: &DisplayHandle,
         source: Option<DrmNode>,
         target: DrmNode,
         surface: &WlSurface,
@@ -398,7 +397,7 @@ impl<A: GraphicsApi> GpuManager<A> {
                             });
 
                         if let Err(err) =
-                            self.early_import_buffer(dh, source, target, buffer, states, &*buffer_damage)
+                            self.early_import_buffer(source, target, buffer, states, &*buffer_damage)
                         {
                             result = Err(err);
                         }
@@ -424,7 +423,6 @@ impl<A: GraphicsApi> GpuManager<A> {
     #[cfg(feature = "wayland_frontend")]
     fn early_import_buffer(
         &mut self,
-        dh: &DisplayHandle,
         source: Option<DrmNode>,
         target: DrmNode,
         buffer: &wl_buffer::WlBuffer,
@@ -436,7 +434,7 @@ impl<A: GraphicsApi> GpuManager<A> {
         <A::Device as ApiDevice>::Renderer: ImportMemWl + ImportDmaWl + ExportMem,
         <<A::Device as ApiDevice>::Renderer as ExportMem>::TextureMapping: 'static,
     {
-        match buffer_type(dh, buffer) {
+        match buffer_type(buffer) {
             Some(BufferType::Dma) => {
                 let (mut target_device, others) = self
                     .devices

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -19,10 +19,7 @@ use std::{
     cell::RefCell,
     collections::{hash_map::Entry, HashMap},
 };
-use wayland_server::{
-    protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface},
-    DisplayHandle,
-};
+use wayland_server::protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface};
 
 /// Type stored in WlSurface states data_map
 ///
@@ -55,7 +52,7 @@ pub struct RendererSurfaceState {
 const MAX_DAMAGE: usize = 4;
 
 impl RendererSurfaceState {
-    pub(crate) fn update_buffer(&mut self, dh: &DisplayHandle, states: &SurfaceData) {
+    pub(crate) fn update_buffer(&mut self, states: &SurfaceData) {
         let mut attrs = states.cached_state.current::<SurfaceAttributes>();
         self.buffer_delta = attrs.buffer_delta.take();
 
@@ -66,9 +63,10 @@ impl RendererSurfaceState {
         match attrs.buffer.take() {
             Some(BufferAssignment::NewBuffer(buffer)) => {
                 // new contents
-                self.buffer_dimensions = buffer_dimensions(dh, &buffer);
+                self.buffer_dimensions = buffer_dimensions(&buffer);
                 if self.buffer_dimensions.is_none() {
-                    // egl sometimes behaves like this, just ignore the buffer for now
+                    // This results in us rendering nothing (can happen e.g. for failed egl-buffer-calls),
+                    // but it is better than crashing the compositor for a bad buffer
                     return;
                 }
 
@@ -194,7 +192,7 @@ impl RendererSurfaceState {
 /// not be accessible anymore, but [`draw_surface_tree`] and other
 /// `draw_*` helpers of the [desktop module](`crate::desktop`) will
 /// become usable for surfaces handled this way.
-pub fn on_commit_buffer_handler(dh: &DisplayHandle, surface: &WlSurface) {
+pub fn on_commit_buffer_handler(surface: &WlSurface) {
     if !is_sync_subsurface(surface) {
         let mut new_surfaces = Vec::new();
         with_surface_tree_upward(
@@ -213,7 +211,7 @@ pub fn on_commit_buffer_handler(dh: &DisplayHandle, surface: &WlSurface) {
                     .get::<RendererSurfaceStateUserData>()
                     .unwrap()
                     .borrow_mut();
-                data.update_buffer(dh, states);
+                data.update_buffer(states);
             },
             |_, _, _| true,
         );
@@ -302,7 +300,6 @@ where
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
 pub fn import_surface_tree<R>(
-    dh: &DisplayHandle,
     renderer: &mut R,
     surface: &WlSurface,
     log: &slog::Logger,
@@ -311,11 +308,10 @@ where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
 {
-    import_surface_tree_and(dh, renderer, surface, 1.0, log, (0.0, 0.0).into(), |_, _, _| {})
+    import_surface_tree_and(renderer, surface, 1.0, log, (0.0, 0.0).into(), |_, _, _| {})
 }
 
 fn import_surface_tree_and<F, R, S>(
-    dh: &DisplayHandle,
     renderer: &mut R,
     surface: &WlSurface,
     scale: S,
@@ -345,7 +341,7 @@ where
                 let buffer_damage = data.damage_since(last_commit.copied());
                 if let Entry::Vacant(e) = data.textures.entry(texture_id) {
                     if let Some(buffer) = data.buffer.as_ref() {
-                        match renderer.import_buffer(dh, buffer, Some(states), &buffer_damage) {
+                        match renderer.import_buffer(buffer, Some(states), &buffer_damage) {
                             Some(Ok(m)) => {
                                 e.insert(Box::new(m));
                                 data.renderer_seen.insert(texture_id, data.commit_count);
@@ -392,7 +388,6 @@ where
 /// to let smithay handle buffer management.
 #[allow(clippy::too_many_arguments)]
 pub fn draw_surface_tree<R, S>(
-    dh: &DisplayHandle,
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     surface: &WlSurface,
@@ -410,7 +405,6 @@ where
     let mut result = Ok(());
     let scale = scale.into();
     let _ = import_surface_tree_and(
-        dh,
         renderer,
         surface,
         scale,

--- a/src/backend/renderer/utils.rs
+++ b/src/backend/renderer/utils.rs
@@ -67,6 +67,10 @@ impl RendererSurfaceState {
             Some(BufferAssignment::NewBuffer(buffer)) => {
                 // new contents
                 self.buffer_dimensions = buffer_dimensions(dh, &buffer);
+                if self.buffer_dimensions.is_none() {
+                    // egl sometimes behaves like this, just ignore the buffer for now
+                    return;
+                }
 
                 #[cfg(feature = "desktop")]
                 if self.buffer_scale != attrs.buffer_scale

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -605,7 +605,6 @@ impl LayerSurface {
 /// to let smithay handle buffer management.
 #[allow(clippy::too_many_arguments)]
 pub fn draw_layer_surface<R, P, S>(
-    dh: &DisplayHandle,
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     layer: &LayerSurface,
@@ -622,7 +621,7 @@ where
 {
     let location = location.into();
     let surface = layer.wl_surface();
-    draw_surface_tree(dh, renderer, frame, surface, scale.into(), location, damage, log)
+    draw_surface_tree(renderer, frame, surface, scale.into(), location, damage, log)
 }
 
 /// Renders popups of a given [`LayerSurface`] using a provided renderer and frame
@@ -636,7 +635,6 @@ where
 /// to let smithay handle buffer management.
 #[allow(clippy::too_many_arguments)]
 pub fn draw_layer_popups<R, S, P>(
-    dh: &DisplayHandle,
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     layer: &LayerSurface,
@@ -653,5 +651,5 @@ where
 {
     let location = location.into();
     let surface = layer.wl_surface();
-    super::popup::draw_popups(dh, renderer, frame, surface, location, (0, 0), scale, damage, log)
+    super::popup::draw_popups(renderer, frame, surface, location, (0, 0), scale, damage, log)
 }

--- a/src/desktop/popup/mod.rs
+++ b/src/desktop/popup/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 
 pub use grab::*;
 pub use manager::*;
-use wayland_server::{protocol::wl_surface::WlSurface, DisplayHandle};
+use wayland_server::protocol::wl_surface::WlSurface;
 
 use crate::{
     backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
@@ -99,7 +99,6 @@ impl From<PopupSurface> for PopupKind {
 /// to let smithay handle buffer management.
 #[allow(clippy::too_many_arguments)]
 pub fn draw_popups<R, P1, P2, S>(
-    dh: &DisplayHandle,
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     for_surface: &WlSurface,
@@ -124,16 +123,7 @@ where
         let offset = (offset + p_location - popup.geometry().loc)
             .to_f64()
             .to_physical(scale);
-        draw_surface_tree(
-            dh,
-            renderer,
-            frame,
-            surface,
-            scale,
-            location + offset,
-            damage,
-            log,
-        )?;
+        draw_surface_tree(renderer, frame, surface, scale, location + offset, damage, log)?;
     }
     Ok(())
 }

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -10,7 +10,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 use wayland_server::protocol::wl_surface::WlSurface;
-use wayland_server::{DisplayHandle, Resource};
+use wayland_server::Resource;
 
 /// Indicates default values for some zindexs inside smithay
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -74,7 +74,6 @@ where
     #[allow(clippy::too_many_arguments)]
     fn draw(
         &self,
-        dh: &DisplayHandle,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
         scale: impl Into<Scale<f64>>,
@@ -156,7 +155,6 @@ where
     #[allow(clippy::too_many_arguments)]
     pub fn draw(
         &self,
-        dh: &DisplayHandle,
         space_id: usize,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
@@ -167,15 +165,15 @@ where
     ) -> Result<(), R::Error> {
         match self {
             SpaceElement::Layer(layer) => {
-                layer.elem_draw(dh, space_id, renderer, frame, scale, location, damage, log)
+                layer.elem_draw(space_id, renderer, frame, scale, location, damage, log)
             }
             SpaceElement::Window(window) => {
-                window.elem_draw(dh, space_id, renderer, frame, scale, location, damage, log)
+                window.elem_draw(space_id, renderer, frame, scale, location, damage, log)
             }
             SpaceElement::Popup(popup) => {
-                popup.elem_draw(dh, space_id, renderer, frame, scale, location, damage, log)
+                popup.elem_draw(space_id, renderer, frame, scale, location, damage, log)
             }
-            SpaceElement::Custom(custom, _) => custom.draw(dh, renderer, frame, scale, location, damage, log),
+            SpaceElement::Custom(custom, _) => custom.draw(renderer, frame, scale, location, damage, log),
         }
     }
     pub fn z_index(&self) -> u8 {
@@ -240,7 +238,6 @@ where
 
     fn draw(
         &self,
-        dh: &DisplayHandle,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
         scale: impl Into<Scale<f64>>,
@@ -249,7 +246,6 @@ where
         log: &slog::Logger,
     ) -> Result<(), <R as Renderer>::Error> {
         crate::backend::renderer::utils::draw_surface_tree(
-            dh,
             renderer,
             frame,
             &self.surface,

--- a/src/desktop/space/layer.rs
+++ b/src/desktop/space/layer.rs
@@ -1,5 +1,3 @@
-use wayland_server::DisplayHandle;
-
 use crate::{
     backend::renderer::{ImportAll, Renderer},
     desktop::{
@@ -73,7 +71,6 @@ impl LayerSurface {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn elem_draw<R>(
         &self,
-        dh: &DisplayHandle,
         space_id: usize,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
@@ -86,7 +83,7 @@ impl LayerSurface {
         R: Renderer + ImportAll,
         <R as Renderer>::TextureId: 'static,
     {
-        let res = draw_layer_surface(dh, renderer, frame, self, scale, location, damage, log);
+        let res = draw_layer_surface(renderer, frame, self, scale, location, damage, log);
         if res.is_ok() {
             layer_state(space_id, self).drawn = true;
         }

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -448,7 +448,6 @@ impl Space {
     /// (or `None` if that list would be empty) in case of success.
     pub fn render_output<R, E>(
         &mut self,
-        dh: &DisplayHandle,
         renderer: &mut R,
         output: &Output,
         age: usize,
@@ -618,7 +617,6 @@ impl Space {
                             damage
                         );
                         element.draw(
-                            dh,
                             self.id,
                             renderer,
                             frame,
@@ -823,7 +821,6 @@ macro_rules! custom_elements_internal {
     (@draw <$renderer:ty>; $($(#[$meta:meta])* $body:ident=$field:ty $(as <$other_renderer:ty>)?),* $(,)?) => {
         fn draw(
             &self,
-            dh: &$crate::reexports::wayland_server::DisplayHandle,
             renderer: &mut $renderer,
             frame: &mut <$renderer as $crate::backend::renderer::Renderer>::Frame,
             scale: impl Into<$crate::utils::Scale<f64>>,
@@ -845,7 +842,7 @@ macro_rules! custom_elements_internal {
                     $(
                         #[$meta]
                     )*
-                    Self::$body(x) => $crate::custom_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, dh, renderer, frame, scale, location, damage, log)
+                    Self::$body(x) => $crate::custom_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, renderer, frame, scale, location, damage, log)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -854,7 +851,6 @@ macro_rules! custom_elements_internal {
     (@draw $renderer:ty; $($(#[$meta:meta])* $body:ident=$field:ty $(as <$other_renderer:ty>)?),* $(,)?) => {
         fn draw(
             &self,
-            dh: &$crate::reexports::wayland_server::DisplayHandle,
             renderer: &mut $renderer,
             frame: &mut <$renderer as $crate::backend::renderer::Renderer>::Frame,
             scale: impl Into<$crate::utils::Scale<f64>>,
@@ -868,7 +864,7 @@ macro_rules! custom_elements_internal {
                     $(
                         #[$meta]
                     )*
-                    Self::$body(x) => $crate::custom_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, dh, renderer, frame, scale, location, damage, log)
+                    Self::$body(x) => $crate::custom_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, renderer, frame, scale, location, damage, log)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -979,7 +975,6 @@ macro_rules! custom_elements_internal {
 /// # impl ImportAll for DummyRenderer {
 /// #    fn import_buffer(
 /// #        &mut self,
-/// #        dh: &DisplayHandle,
 /// #        buffer: &wl_buffer::WlBuffer,
 /// #        surface: Option<&SurfaceData>,
 /// #        damage: &[Rectangle<i32, Buffer>],
@@ -1082,7 +1077,6 @@ macro_rules! custom_elements_internal {
 ///#
 ///#    fn draw(
 ///#        &self,
-///#        dh: &DisplayHandle,
 ///#        _renderer: &mut R,
 ///#        frame: &mut <R as Renderer>::Frame,
 ///#        scale: impl Into<Scale<f64>>,
@@ -1104,7 +1098,7 @@ macro_rules! custom_elements_internal {
 ///# let dh = display.handle();
 ///
 /// let elements = [CustomElem::from(surface_tree)];
-/// space.render_output(&dh, &mut renderer, &output, age, [0.0, 0.0, 0.0, 1.0], &elements);
+/// space.render_output(&mut renderer, &output, age, [0.0, 0.0, 0.0, 1.0], &elements);
 /// ```
 #[macro_export]
 macro_rules! custom_elements {

--- a/src/desktop/space/popup.rs
+++ b/src/desktop/space/popup.rs
@@ -1,4 +1,4 @@
-use wayland_server::{DisplayHandle, Resource};
+use wayland_server::Resource;
 
 use crate::{
     backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
@@ -106,7 +106,6 @@ impl RenderPopup {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn elem_draw<R, S>(
         &self,
-        dh: &DisplayHandle,
         _space_id: usize,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
@@ -121,7 +120,7 @@ impl RenderPopup {
         S: Into<Scale<f64>>,
     {
         let surface = self.popup.wl_surface();
-        draw_surface_tree(dh, renderer, frame, surface, scale, location, damage, log)
+        draw_surface_tree(renderer, frame, surface, scale, location, damage, log)
     }
 
     pub(super) fn elem_z_index(&self) -> u8 {

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -1,5 +1,3 @@
-use wayland_server::DisplayHandle;
-
 use crate::{
     backend::renderer::{ImportAll, Renderer},
     desktop::{
@@ -101,7 +99,6 @@ impl Window {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn elem_draw<R, S>(
         &self,
-        dh: &DisplayHandle,
         space_id: usize,
         renderer: &mut R,
         frame: &mut <R as Renderer>::Frame,
@@ -115,7 +112,7 @@ impl Window {
         <R as Renderer>::TextureId: 'static,
         S: Into<Scale<f64>>,
     {
-        let res = draw_window(dh, renderer, frame, self, scale, location, damage, log);
+        let res = draw_window(renderer, frame, self, scale, location, damage, log);
         if res.is_ok() {
             window_state(space_id, self).drawn = true;
         }

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -13,7 +13,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use wayland_protocols::xdg::shell::server::xdg_toplevel;
-use wayland_server::{protocol::wl_surface, DisplayHandle};
+use wayland_server::protocol::wl_surface;
 
 crate::utils::ids::id_gen!(next_window_id, WINDOW_ID, WINDOW_IDS);
 
@@ -324,7 +324,6 @@ impl Window {
 /// to let smithay handle buffer management.
 #[allow(clippy::too_many_arguments)]
 pub fn draw_window<R, P, S>(
-    dh: &DisplayHandle,
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     window: &Window,
@@ -341,7 +340,7 @@ where
 {
     let location = location.into();
     let surface = window.toplevel().wl_surface();
-    draw_surface_tree(dh, renderer, frame, surface, scale.into(), location, damage, log)
+    draw_surface_tree(renderer, frame, surface, scale.into(), location, damage, log)
 }
 
 /// Renders popups of a given [`Window`] using a provided renderer and frame
@@ -355,7 +354,6 @@ where
 /// to let smithay handle buffer management.
 #[allow(clippy::too_many_arguments)]
 pub fn draw_window_popups<R, S, P>(
-    dh: &DisplayHandle,
     renderer: &mut R,
     frame: &mut <R as Renderer>::Frame,
     window: &Window,
@@ -373,7 +371,6 @@ where
     let location = location.into();
     let surface = window.toplevel().wl_surface();
     super::popup::draw_popups(
-        dh,
         renderer,
         frame,
         surface,

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -133,15 +133,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
                 ));
             }
 
-            let _ = render_output(
-                &dh,
-                &output,
-                &mut state.space,
-                &mut renderer,
-                0,
-                &*elements,
-                &logger,
-            );
+            let _ = render_output(&output, &mut state.space, &mut renderer, 0, &*elements, &logger);
         }
 
         // Send frame events so that client start drawing their next frame


### PR DESCRIPTION
- Checks for 0x0-buffers, so we don't crash on invalid buffers
- Remove a broken egl-buffer check (confirmed doesn't crash when trying with an invalid buffer)
- As a consequence DisplayHandle is not needed for most of renderer-apis anymore (just like before 0.30), so lets remove it again.