### PR TITLE
space: Replace window-local z_index with space-local

### DIFF
--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -61,7 +61,7 @@ impl<BackendData> PointerGrab<AnvilState<BackendData>> for MoveSurfaceGrab {
         let new_location = self.initial_window_location.to_f64() + delta;
 
         data.space
-            .map_window(&self.window, new_location.to_i32_round(), true);
+            .map_window(&self.window, new_location.to_i32_round(), None, true);
     }
 
     fn button(
@@ -248,7 +248,7 @@ impl<BackendData> PointerGrab<AnvilState<BackendData>> for ResizeSurfaceGrab {
                             self.initial_window_location.y + (self.initial_window_size.h - geometry.size.h);
                     }
 
-                    data.space.map_window(&self.window, location, true);
+                    data.space.map_window(&self.window, location, None, true);
                 }
 
                 with_states(self.window.toplevel().wl_surface(), |states| {
@@ -666,7 +666,7 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
         let output = &self.space.outputs_for_window(&window)[0];
         let geometry = self.space.output_geometry(output).unwrap();
 
-        self.space.map_window(&window, geometry.loc, true);
+        self.space.map_window(&window, geometry.loc, None, true);
         surface.with_pending_state(|state| {
             state.states.set(xdg_toplevel::State::Maximized);
             state.size = Some(geometry.size);
@@ -896,7 +896,7 @@ fn place_new_window(space: &mut Space, window: &Window, activate: bool) {
     let x = x_range.sample(&mut rng);
     let y = y_range.sample(&mut rng);
 
-    space.map_window(window, (x, y), activate);
+    space.map_window(window, (x, y), None, activate);
 }
 
 pub fn fixup_positions(dh: &DisplayHandle, space: &mut Space) {

--- a/anvil/src/xwayland/mod.rs
+++ b/anvil/src/xwayland/mod.rs
@@ -226,7 +226,7 @@ impl X11State {
         }
 
         let x11surface = X11Surface { surface };
-        space.map_window(&Window::new(Kind::X11(x11surface)), location, true);
+        space.map_window(&Window::new(Kind::X11(x11surface)), location, None, true);
     }
 }
 

--- a/smallvil/src/grabs/move_grab.rs
+++ b/smallvil/src/grabs/move_grab.rs
@@ -25,7 +25,7 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
         let delta = event.location - self.start_data.location;
         let new_location = self.initial_window_location.to_f64() + delta;
         data.space
-            .map_window(&self.window, new_location.to_i32_round(), true);
+            .map_window(&self.window, new_location.to_i32_round(), None, true);
     }
 
     fn button(

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -268,7 +268,7 @@ pub fn handle_commit(space: &mut Space, surface: &WlSurface) -> Option<()> {
 
     if new_loc.x.is_some() || new_loc.y.is_some() {
         // If TOP or LEFT side of the window got resized, we have to move it
-        space.map_window(&window, window_loc, false);
+        space.map_window(&window, window_loc, None, false);
     }
 
     Some(())

--- a/smallvil/src/handlers/xdg_shell.rs
+++ b/smallvil/src/handlers/xdg_shell.rs
@@ -28,7 +28,7 @@ impl XdgShellHandler for Smallvil {
 
     fn new_toplevel(&mut self, _dh: &DisplayHandle, surface: ToplevelSurface) {
         let window = Window::new(Kind::Xdg(surface.clone()));
-        self.space.map_window(&window, (0, 0), false);
+        self.space.map_window(&window, (0, 0), None, false);
 
         surface.send_configure();
     }

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -32,6 +32,18 @@ pub enum RenderZindex {
     PopupsOverlay = 70,
 }
 
+impl From<RenderZindex> for u8 {
+    fn from(idx: RenderZindex) -> u8 {
+        idx as u8
+    }
+}
+
+impl From<RenderZindex> for Option<u8> {
+    fn from(idx: RenderZindex) -> Option<u8> {
+        Some(idx as u8)
+    }
+}
+
 /// Trait for custom elements to be rendered during [`Space::render_output`].
 pub trait RenderElement<R>
 where
@@ -176,10 +188,10 @@ where
             SpaceElement::Custom(custom, _) => custom.draw(renderer, frame, scale, location, damage, log),
         }
     }
-    pub fn z_index(&self) -> u8 {
+    pub fn z_index(&self, space_id: usize) -> u8 {
         match self {
             SpaceElement::Layer(layer) => layer.elem_z_index(),
-            SpaceElement::Window(window) => window.elem_z_index(),
+            SpaceElement::Window(window) => window.elem_z_index(space_id),
             SpaceElement::Popup(popup) => popup.elem_z_index(),
             SpaceElement::Custom(custom, _) => custom.z_index(),
         }

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -13,12 +13,11 @@ use std::{
     collections::HashMap,
 };
 
-use super::RenderZindex;
-
 #[derive(Default)]
 pub struct WindowState {
     pub location: Point<i32, Logical>,
     pub drawn: bool,
+    pub z_index: u8,
 }
 
 pub type WindowUserdata = RefCell<HashMap<usize, WindowState>>;
@@ -119,11 +118,7 @@ impl Window {
         res
     }
 
-    pub(super) fn elem_z_index(&self) -> u8 {
-        self.0
-            .z_index
-            .lock()
-            .unwrap()
-            .unwrap_or(RenderZindex::Shell as u8)
+    pub(super) fn elem_z_index(&self, space_id: usize) -> u8 {
+        window_state(space_id, self).z_index
     }
 }

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -83,7 +83,6 @@ pub(super) struct WindowInner {
     pub(super) id: usize,
     toplevel: Kind,
     bbox: Mutex<Rectangle<i32, Logical>>,
-    pub(super) z_index: Mutex<Option<u8>>,
     user_data: UserDataMap,
 }
 
@@ -142,7 +141,6 @@ impl Window {
             toplevel,
             bbox: Mutex::new(Rectangle::from_loc_and_size((0, 0), (0, 0))),
             user_data: UserDataMap::new(),
-            z_index: Mutex::new(None),
         }))
     }
 
@@ -298,18 +296,6 @@ impl Window {
     /// Returns a [`UserDataMap`] to allow associating arbitrary data with this window.
     pub fn user_data(&self) -> &UserDataMap {
         &self.0.user_data
-    }
-
-    /// Overrides the default z-index of this window.
-    /// (Default is [`RenderZindex::Shell`](crate::desktop::space::RenderZindex))
-    pub fn override_z_index(&self, index: u8) {
-        *self.0.z_index.lock().unwrap() = Some(index);
-    }
-
-    /// Resets a previously overriden z-index to the default of
-    /// [`RenderZindex::Shell`](crate::desktop::space::RenderZindex).
-    pub fn clear_z_index(&self) {
-        self.0.z_index.lock().unwrap().take();
     }
 }
 

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -183,7 +183,7 @@ fn handle_event(
             });
             if let Some(toplevel) = toplevel.cloned() {
                 // set its location
-                state.space.map_window(&toplevel, location, false);
+                state.space.map_window(&toplevel, location, None, false);
             }
         }
         // pointer inputs


### PR DESCRIPTION
Previously a window's z_index could be overridden by [`Window::override_z_index`], which worked fine for rendering, but broke input helpers such as [`Space::surface_under`], because windows could essentially re-order their relative position to other windows without updating the stack-order inside the spaces they were mapped to.

Instead this PR now makes a window's z_index a space-local variable (attached to the `WindowState`), that can be set when inserting a window.
After adding a window, the index-set will be sorted by the z-index to correctly reflect the positions. [`IndexSet::sort`] is guaranteed to be stable, so the implicit insertion order should not be influenced by this.