### PR TITLE
fix: Don't invert z_index order on insert

### DIFF
--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -110,9 +110,9 @@ impl Space {
     fn insert_window(&mut self, window: &Window, activate: bool) {
         self.windows.insert(window.clone());
         self.windows.sort_by(|w1, w2| {
-            window_state(self.id, w2)
+            window_state(self.id, w1)
                 .z_index
-                .cmp(&window_state(self.id, w1).z_index)
+                .cmp(&window_state(self.id, w2).z_index)
         });
 
         if activate {


### PR DESCRIPTION
I made a mistake on #658 swapping the compare order, because I though the order had to be inverse, but `Space::windows` is already returning a reverse iterator. The nearest elements are the last ones, not the first ones...