### PR TITLE
layer_shell: Add new_popup callback

### DIFF
--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -268,6 +268,13 @@ where
                         .unwrap()
                         .parent = Some(parent_surface);
                 });
+
+                WlrLayerShellHandler::new_popup(
+                    state,
+                    dh,
+                    make_surface_handle(layer_surface),
+                    crate::wayland::shell::xdg::handlers::make_popup_handle(&popup),
+                );
             }
             zwlr_layer_surface_v1::Request::AckConfigure { serial } => {
                 let serial = Serial::from(serial);
@@ -324,4 +331,14 @@ where
     compositor::with_states(&data.wl_surface, |states| {
         f(&mut *states.cached_state.pending::<LayerSurfaceCachedState>())
     })
+}
+
+pub fn make_surface_handle(
+    resource: &zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
+) -> crate::wayland::shell::wlr_layer::LayerSurface {
+    let data = resource.data::<WlrLayerSurfaceUserData>().unwrap();
+    crate::wayland::shell::wlr_layer::LayerSurface {
+        wl_surface: data.wl_surface.clone(),
+        shell_surface: resource.clone(),
+    }
 }

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -63,6 +63,7 @@ use crate::{
     utils::{alive_tracker::IsAlive, Logical, Size},
     wayland::{
         compositor::{self, Cacheable},
+        shell::xdg,
         Serial, SERIAL_COUNTER,
     },
 };
@@ -229,6 +230,9 @@ pub trait WlrLayerShellHandler {
         layer: Layer,
         namespace: String,
     );
+
+    /// A new popup was assigned a layer surface as it's parent
+    fn new_popup(&mut self, dh: &DisplayHandle, parent: LayerSurface, popup: xdg::PopupSurface) {}
 
     /// A surface has acknowledged a configure serial.
     fn ack_configure(

--- a/src/wayland/shell/xdg/handlers.rs
+++ b/src/wayland/shell/xdg/handlers.rs
@@ -11,5 +11,6 @@ mod positioner;
 pub use positioner::XdgPositionerUserData;
 
 mod surface;
+pub(in crate::wayland::shell) use surface::make_popup_handle;
 pub(super) use surface::{get_parent, send_popup_configure, send_toplevel_configure, set_parent};
 pub use surface::{XdgShellSurfaceUserData, XdgSurfaceUserData};

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -31,8 +31,7 @@ use toplevel::make_toplevel_handle;
 pub use toplevel::{get_parent, send_toplevel_configure, set_parent};
 
 mod popup;
-use popup::make_popup_handle;
-pub use popup::send_popup_configure;
+pub use popup::{make_popup_handle, send_popup_configure};
 
 /// User data of XdgSurface
 #[derive(Debug)]


### PR DESCRIPTION
Currently there is no event generated by the [zwlr_layer_surface_v1::get_popup](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:request:get_popup) request.

This is an issue when trying to implement positioning logic for popup with layershell surfaces as parent.
On the [xdg_surface::get_popup](https://wayland.app/protocols/xdg-shell#xdg_surface:request:get_popup) call they don't have yet a parent, making it impossible to know, which location they should be positioned relative to.

On the first commit, it is already too late, given the xdg-shell protocol mandates that configure-events are only send at very specific times:
> For version 2 or older, the configure event for an xdg_popup is only ever sent once for the initial configuration. Starting with version 3, it may be sent again if the popup is setup with an xdg_positioner with set_reactive requested, or in response to xdg_popup.reposition requests.

Thus every non-xdg-shell, that supports popups, like layer-shell, needs it's own `new_popup`-callback for downstream to be able to implement positioning logic. This PR adds such a callback to the `WlrLayerShellHandler`.