### PR TITLE
Compositor driven window crop and scale

### DIFF
--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -359,6 +359,7 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
         // of a xdg_surface has to be sent during the commit if
         // the surface is not already configured
         let window = Window::new(SurfaceKind::Xdg(surface));
+        window.set_constrain_size(Some(Size::from((800, 600))));
         place_new_window(&mut self.space, &window, true);
     }
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -184,8 +184,17 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
                 state.xdg_shell_state.toplevel_surfaces(|surfaces| {
                     for surface in surfaces {
                         let surface = surface.wl_surface();
-                        draw_surface_tree(renderer, frame, surface, 1.0, (0.0, 0.0).into(), &[damage], &log)
-                            .unwrap();
+                        draw_surface_tree(
+                            renderer,
+                            frame,
+                            surface,
+                            1.0,
+                            (0.0, 0.0).into(),
+                            &[damage],
+                            None,
+                            &log,
+                        )
+                        .unwrap();
 
                         send_frames_surface_tree(surface, start_time.elapsed().as_millis() as u32);
                     }

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -617,7 +617,16 @@ where
 {
     let location = location.into();
     let surface = layer.wl_surface();
-    draw_surface_tree(renderer, frame, surface, scale.into(), location, damage, log)
+    draw_surface_tree(
+        renderer,
+        frame,
+        surface,
+        scale.into(),
+        location,
+        damage,
+        None,
+        log,
+    )
 }
 
 /// Renders popups of a given [`LayerSurface`] using a provided renderer and frame

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -483,7 +483,7 @@ impl LayerSurface {
 
     /// Returns the bounding box over this layer surface and its subsurfaces.
     pub fn bbox(&self) -> Rectangle<i32, Logical> {
-        bbox_from_surface_tree(self.0.surface.wl_surface(), (0, 0))
+        bbox_from_surface_tree(self.0.surface.wl_surface(), (0, 0), 1.0, None)
     }
 
     /// Returns the bounding box over this layer surface, it subsurfaces as well as any popups.
@@ -494,7 +494,8 @@ impl LayerSurface {
         let mut bounding_box = self.bbox();
         let surface = self.0.surface.wl_surface();
         for (popup, location) in PopupManager::popups_for_surface(surface) {
-            bounding_box = bounding_box.merge(bbox_from_surface_tree(popup.wl_surface(), location));
+            bounding_box =
+                bounding_box.merge(bbox_from_surface_tree(popup.wl_surface(), location, 1.0, None));
         }
 
         bounding_box
@@ -516,12 +517,13 @@ impl LayerSurface {
         let location = location.into();
         let scale = scale.into();
         let surface = self.0.surface.wl_surface();
-        let mut geo = physical_bbox_from_surface_tree(surface, location, scale);
+        let mut geo = physical_bbox_from_surface_tree(surface, location, scale, None);
         for (popup, p_location) in PopupManager::popups_for_surface(surface) {
             geo = geo.merge(physical_bbox_from_surface_tree(
                 popup.wl_surface(),
                 location + p_location.to_f64().to_physical(scale),
                 scale,
+                None,
             ));
         }
         geo
@@ -540,12 +542,12 @@ impl LayerSurface {
         let surface = self.wl_surface();
         for (popup, location) in PopupManager::popups_for_surface(surface) {
             let surface = popup.wl_surface();
-            if let Some(result) = under_from_surface_tree(surface, point, location, surface_type) {
+            if let Some(result) = under_from_surface_tree(surface, point, location, 1.0, None, surface_type) {
                 return Some(result);
             }
         }
 
-        under_from_surface_tree(surface, point, (0, 0), surface_type)
+        under_from_surface_tree(surface, point, (0, 0), 1.0, None, surface_type)
     }
 
     /// Returns the damage of all the surfaces of this layer surface.
@@ -560,7 +562,7 @@ impl LayerSurface {
         for_values: Option<(&Space, &Output)>,
     ) -> Vec<Rectangle<i32, Physical>> {
         let surface = self.wl_surface();
-        damage_from_surface_tree(surface, location, scale, for_values)
+        damage_from_surface_tree(surface, location, scale, None, for_values)
     }
 
     /// Returns the opaque regions of all the surfaces of this layer surface.
@@ -570,7 +572,7 @@ impl LayerSurface {
         scale: impl Into<Scale<f64>>,
     ) -> Option<Vec<Rectangle<i32, Physical>>> {
         let surface = self.wl_surface();
-        opaque_regions_from_surface_tree(surface, location, scale)
+        opaque_regions_from_surface_tree(surface, location, scale, None)
     }
 
     /// Sends the frame callback to all the subsurfaces in this

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -658,5 +658,15 @@ where
 {
     let location = location.into();
     let surface = layer.wl_surface();
-    super::popup::draw_popups(renderer, frame, surface, location, (0, 0), scale, damage, log)
+    super::popup::draw_popups(
+        renderer,
+        frame,
+        surface,
+        location,
+        (0, 0),
+        scale,
+        damage,
+        None,
+        log,
+    )
 }

--- a/src/desktop/popup/mod.rs
+++ b/src/desktop/popup/mod.rs
@@ -106,6 +106,7 @@ pub fn draw_popups<R, P1, P2, S>(
     offset: P2,
     scale: S,
     damage: &[Rectangle<i32, Physical>],
+    src: Option<Rectangle<i32, Logical>>,
     log: &slog::Logger,
 ) -> Result<(), <R as Renderer>::Error>
 where
@@ -130,7 +131,7 @@ where
             scale,
             location + offset,
             damage,
-            None,
+            src,
             log,
         )?;
     }

--- a/src/desktop/popup/mod.rs
+++ b/src/desktop/popup/mod.rs
@@ -123,7 +123,16 @@ where
         let offset = (offset + p_location - popup.geometry().loc)
             .to_f64()
             .to_physical(scale);
-        draw_surface_tree(renderer, frame, surface, scale, location + offset, damage, log)?;
+        draw_surface_tree(
+            renderer,
+            frame,
+            surface,
+            scale,
+            location + offset,
+            damage,
+            None,
+            log,
+        )?;
     }
     Ok(())
 }

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -286,6 +286,7 @@ where
             scale,
             location,
             damage,
+            None,
             log,
         )
     }

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -248,7 +248,12 @@ where
 
     fn geometry(&self, scale: impl Into<Scale<f64>>) -> Rectangle<i32, Physical> {
         let scale = scale.into();
-        physical_bbox_from_surface_tree(&self.surface, self.position.to_f64().to_physical(scale), scale)
+        physical_bbox_from_surface_tree(
+            &self.surface,
+            self.position.to_f64().to_physical(scale),
+            scale,
+            None,
+        )
     }
 
     fn accumulated_damage(
@@ -261,13 +266,19 @@ where
             &self.surface,
             self.position.to_f64().to_physical(scale),
             scale,
+            None,
             for_values.map(|f| (f.0, f.1)),
         )
     }
 
     fn opaque_regions(&self, scale: impl Into<Scale<f64>>) -> Option<Vec<Rectangle<i32, Physical>>> {
         let scale = scale.into();
-        opaque_regions_from_surface_tree(&self.surface, self.position.to_f64().to_physical(scale), scale)
+        opaque_regions_from_surface_tree(
+            &self.surface,
+            self.position.to_f64().to_physical(scale),
+            scale,
+            None,
+        )
     }
 
     fn draw(

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -408,6 +408,8 @@ impl Space {
                     &mut output_state.surfaces,
                     surface,
                     window_loc(window, &self.id),
+                    1.0,
+                    None,
                     &self.logger,
                 );
 
@@ -422,6 +424,8 @@ impl Space {
                         &mut output_state.surfaces,
                         surface,
                         location,
+                        1.0,
+                        None,
                         &self.logger,
                     );
                 }

--- a/src/desktop/space/popup.rs
+++ b/src/desktop/space/popup.rs
@@ -135,7 +135,7 @@ impl RenderPopup {
         S: Into<Scale<f64>>,
     {
         let surface = self.popup.wl_surface();
-        draw_surface_tree(renderer, frame, surface, scale, location, damage, log)
+        draw_surface_tree(renderer, frame, surface, scale, location, damage, None, log)
     }
 
     pub(super) fn elem_z_index(&self) -> u8 {

--- a/src/desktop/space/popup.rs
+++ b/src/desktop/space/popup.rs
@@ -87,6 +87,7 @@ impl RenderPopup {
             self.popup.wl_surface(),
             self.location.to_f64().to_physical(scale),
             scale,
+            None,
         )
     }
 
@@ -101,6 +102,7 @@ impl RenderPopup {
             self.popup.wl_surface(),
             self.location.to_f64().to_physical(scale),
             scale,
+            None,
             for_values,
         )
     }
@@ -115,6 +117,7 @@ impl RenderPopup {
             self.popup.wl_surface(),
             self.location.to_f64().to_physical(scale),
             scale,
+            None,
         )
     }
 

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -334,7 +334,16 @@ where
 {
     let location = location.into();
     let surface = window.toplevel().wl_surface();
-    draw_surface_tree(renderer, frame, surface, scale.into(), location, damage, log)
+    draw_surface_tree(
+        renderer,
+        frame,
+        surface,
+        scale.into(),
+        location,
+        damage,
+        None,
+        log,
+    )
 }
 
 /// Renders popups of a given [`Window`] using a provided renderer and frame


### PR DESCRIPTION
This PR adds compositor driven window crop and scale.

---
Todo:
- [ ] popup position has issues
- [X] ~~popup input is not transformed (where can the `InputTransformed` be assigned?)~~
      For now `Window::refresh` also updates the popup transforms and `PopupManager::commit`
      will re-extract the transform and set it to not miss a transform
- [ ] more testing