### PR TITLE
desktop/layer: Automatically re-arrange on dead surfaces

### DIFF
--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -362,7 +362,10 @@ impl LayerMap {
     /// This function needs to be called periodically (though not necessarily frequently)
     /// to be able cleanup internally used resources.
     pub fn cleanup(&mut self, dh: &DisplayHandle) {
-        self.layers.retain(|layer| layer.alive());
+        if self.layers.iter().any(|l| !l.alive()) {
+            self.layers.retain(|layer| layer.alive());
+            self.arrange(dh);
+        }
         self.surfaces
             .retain(|i| dh.backend_handle().object_info(i.clone()).is_ok());
     }


### PR DESCRIPTION
Compositors might try to avoid calling `LayerMap::arrange` to frequently as the re-calculation of zones is unnecessarily expensive, if the layer-surfaces themselves are not changing.

`LayerMap::cleanup` (which is far less expensive) will correctly get rid of old surfaces in that case, but because there is no `surface_unmapped` event, compositors can't easily figure out, if any surfaces got removed to trigger a re-arrange.

Lets fix this by doing it automatically for the compositor in cases where a layer_surface disconnected.