### PR TITLE
libinput: Don't query unset axis

### DIFF
--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -165,11 +165,21 @@ impl backend::Event<LibinputInputBackend> for event::pointer::PointerAxisEvent {
 
 impl backend::PointerAxisEvent<LibinputInputBackend> for event::pointer::PointerAxisEvent {
     fn amount(&self, axis: Axis) -> Option<f64> {
-        Some(self.axis_value(axis.into()))
+        let axis = axis.into();
+        if self.has_axis(axis) {
+            Some(self.axis_value(axis))
+        } else {
+            None
+        }
     }
 
     fn amount_discrete(&self, axis: Axis) -> Option<f64> {
-        self.axis_value_discrete(axis.into())
+        let axis = axis.into();
+        if self.has_axis(axis) {
+            self.axis_value_discrete(axis)
+        } else {
+            None
+        }
     }
 
     fn source(&self) -> backend::AxisSource {


### PR DESCRIPTION
libinput is currently spamming logs for every axis even, because smithay's libinput backend queries every axis. I am not sure, why libinput would call out this as a bug (0.0 as a return value is semantically equivalent to no scrolling, is it?), but we can mitigate this annoying log message by don't doing that...