### PR TITLE
egl: expose pub(crate) fields as public functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - `ImportShm` was renamed to `ImportMem`
 - `ImportMem` and `ImportDma` were split and do now have accompanying traits `ImportMemWl` and `ImportDmaWl` to import wayland buffers.
 - Added `EGLSurface::get_size`
+- `EGLDisplay::get_extensions` was renamed to `extensions` and now returns a `&[String]`.
 
 ### Additions
 
@@ -91,6 +92,8 @@
 - Added `ExportMem` trait to copy framebuffers and textures into memory
 - Added `multigpu`-module to the renderer, which makes handling multi-gpu setups easier!
 - Added `backend::renderer::utils::import_surface_tree` to be able to import buffers before rendering
+- Added `EGLContext::display` to allow getting the underlying display of some context.
+- Make `EGLContext::dmabuf_render_formats` and `EGLContext::dmabuf_texture_formats` also accessible from `EGLDisplay`.
 
 #### Desktop
 

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -23,7 +23,7 @@ use slog::{info, o, trace};
 #[derive(Debug)]
 pub struct EGLContext {
     context: ffi::egl::types::EGLContext,
-    pub(crate) display: EGLDisplay,
+    display: EGLDisplay,
     config_id: ffi::egl::types::EGLConfig,
     pixel_format: Option<PixelFormat>,
     user_data: Arc<UserDataMap>,
@@ -98,15 +98,15 @@ impl EGLContext {
             }
             None => {
                 if !display
-                    .extensions
+                    .extensions()
                     .iter()
                     .any(|x| x == "EGL_KHR_no_config_context")
                     && !display
-                        .extensions
+                        .extensions()
                         .iter()
                         .any(|x| x == "EGL_MESA_configless_context")
                     && !display
-                        .extensions
+                        .extensions()
                         .iter()
                         .any(|x| x == "EGL_KHR_surfaceless_context")
                 {
@@ -125,8 +125,8 @@ impl EGLContext {
         if let Some((attributes, _)) = config {
             let version = attributes.version;
 
-            if display.egl_version >= (1, 5)
-                || display.extensions.iter().any(|s| s == "EGL_KHR_create_context")
+            if display.get_egl_version() >= (1, 5)
+                || display.extensions().iter().any(|s| s == "EGL_KHR_create_context")
             {
                 trace!(log, "Setting CONTEXT_MAJOR_VERSION to {}", version.0);
                 context_attributes.push(ffi::egl::CONTEXT_MAJOR_VERSION as i32);
@@ -135,7 +135,7 @@ impl EGLContext {
                 context_attributes.push(ffi::egl::CONTEXT_MINOR_VERSION as i32);
                 context_attributes.push(version.1 as i32);
 
-                if attributes.debug && display.egl_version >= (1, 5) {
+                if attributes.debug && display.get_egl_version() >= (1, 5) {
                     trace!(log, "Setting CONTEXT_OPENGL_DEBUG to TRUE");
                     context_attributes.push(ffi::egl::CONTEXT_OPENGL_DEBUG as i32);
                     context_attributes.push(ffi::egl::TRUE as i32);
@@ -143,7 +143,7 @@ impl EGLContext {
 
                 context_attributes.push(ffi::egl::CONTEXT_FLAGS_KHR as i32);
                 context_attributes.push(0);
-            } else if display.egl_version >= (1, 3) {
+            } else if display.get_egl_version() >= (1, 3) {
                 trace!(log, "Setting CONTEXT_CLIENT_VERSION to {}", version.0);
                 context_attributes.push(ffi::egl::CONTEXT_CLIENT_VERSION as i32);
                 context_attributes.push(version.0 as i32);
@@ -159,7 +159,7 @@ impl EGLContext {
         trace!(log, "Creating EGL context...");
         let context = wrap_egl_call(|| unsafe {
             ffi::egl::CreateContext(
-                **display.display,
+                **display.get_display_handle(),
                 config_id,
                 shared
                     .map(|context| context.context)
@@ -194,7 +194,12 @@ impl EGLContext {
     pub unsafe fn make_current_with_surface(&self, surface: &EGLSurface) -> Result<(), MakeCurrentError> {
         let surface_ptr = surface.surface.load(Ordering::SeqCst);
         wrap_egl_call(|| {
-            ffi::egl::MakeCurrent(**self.display.display, surface_ptr, surface_ptr, self.context)
+            ffi::egl::MakeCurrent(
+                **self.display.get_display_handle(),
+                surface_ptr,
+                surface_ptr,
+                self.context,
+            )
         })
         .map(|_| ())
         .map_err(Into::into)
@@ -209,7 +214,7 @@ impl EGLContext {
     pub unsafe fn make_current(&self) -> Result<(), MakeCurrentError> {
         wrap_egl_call(|| {
             ffi::egl::MakeCurrent(
-                **self.display.display,
+                **self.display.get_display_handle(),
                 ffi::egl::NO_SURFACE,
                 ffi::egl::NO_SURFACE,
                 self.context,
@@ -241,7 +246,7 @@ impl EGLContext {
         if self.is_current() {
             wrap_egl_call(|| unsafe {
                 ffi::egl::MakeCurrent(
-                    **self.display.display,
+                    **self.display.get_display_handle(),
                     ffi::egl::NO_SURFACE,
                     ffi::egl::NO_SURFACE,
                     ffi::egl::NO_CONTEXT,
@@ -251,14 +256,19 @@ impl EGLContext {
         Ok(())
     }
 
+    /// Returns the display which created this context.
+    pub fn display(&self) -> &EGLDisplay {
+        &self.display
+    }
+
     /// Returns a list of formats for dmabufs that can be rendered to.
     pub fn dmabuf_render_formats(&self) -> &HashSet<DrmFormat> {
-        &self.display.dmabuf_render_formats
+        self.display.dmabuf_render_formats()
     }
 
     /// Returns a list of formats for dmabufs that can be used as textures.
     pub fn dmabuf_texture_formats(&self) -> &HashSet<DrmFormat> {
-        &self.display.dmabuf_import_formats
+        self.display.dmabuf_texture_formats()
     }
 
     /// Retrieve user_data associated with this context
@@ -283,7 +293,7 @@ impl Drop for EGLContext {
             // We need to ensure the context is unbound, otherwise it egl stalls the destroy call
             // ignore failures at this point
             let _ = self.unbind();
-            ffi::egl::DestroyContext(**self.display.display, self.context);
+            ffi::egl::DestroyContext(**self.display.get_display_handle(), self.context);
         }
     }
 }

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -69,11 +69,11 @@ impl Drop for EGLDisplayHandle {
 /// [`EGLDisplay`] represents an initialised EGL environment
 #[derive(Debug, Clone)]
 pub struct EGLDisplay {
-    pub(crate) display: Arc<EGLDisplayHandle>,
-    pub(crate) egl_version: (i32, i32),
-    pub(crate) extensions: Vec<String>,
-    pub(crate) dmabuf_import_formats: HashSet<DrmFormat>,
-    pub(crate) dmabuf_render_formats: HashSet<DrmFormat>,
+    display: Arc<EGLDisplayHandle>,
+    egl_version: (i32, i32),
+    extensions: Vec<String>,
+    dmabuf_import_formats: HashSet<DrmFormat>,
+    dmabuf_render_formats: HashSet<DrmFormat>,
     surface_type: ffi::EGLint,
     logger: slog::Logger,
 }
@@ -405,8 +405,18 @@ impl EGLDisplay {
     }
 
     /// Returns the supported extensions of this display
-    pub fn get_extensions(&self) -> Vec<String> {
-        self.extensions.clone()
+    pub fn extensions(&self) -> &[String] {
+        &self.extensions[..]
+    }
+
+    /// Returns a list of formats for dmabufs that can be rendered to.
+    pub fn dmabuf_render_formats(&self) -> &HashSet<DrmFormat> {
+        &self.dmabuf_render_formats
+    }
+
+    /// Returns a list of formats for dmabufs that can be used as textures.
+    pub fn dmabuf_texture_formats(&self) -> &HashSet<DrmFormat> {
+        &self.dmabuf_import_formats
     }
 
     /// Exports an [`EGLImage`] as a [`Dmabuf`]

--- a/src/backend/egl/surface.rs
+++ b/src/backend/egl/surface.rs
@@ -65,13 +65,13 @@ impl EGLSurface {
     {
         let log = crate::slog_or_fallback(log.into()).new(o!("smithay_module" => "renderer_egl"));
 
-        let surface = native.create(&display.display, config)?;
+        let surface = native.create(&display.get_display_handle(), config)?;
         if surface == ffi::egl::NO_SURFACE {
             return Err(EGLError::BadSurface);
         }
 
         Ok(EGLSurface {
-            display: display.display.clone(),
+            display: display.get_display_handle(),
             native: Box::new(native),
             surface: AtomicPtr::new(surface as *mut _),
             config_id: config,

--- a/src/backend/renderer/multigpu/egl.rs
+++ b/src/backend/renderer/multigpu/egl.rs
@@ -222,7 +222,7 @@ impl<'a, 'b, Target> MultiRenderer<'a, 'b, EglGlesBackend, EglGlesBackend, Targe
             .map_err(MultigpuError::Render)?;
         renderer
             .egl_context()
-            .display
+            .display()
             .create_dmabuf_from_image(egl.image(0).unwrap(), egl.size, egl.y_inverted)
             .map_err(Gles2Error::BindBufferEGLError)
             .map_err(MultigpuError::Render)

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -229,8 +229,8 @@ where
     let egl = Rc::new(surface);
     let renderer = unsafe { Gles2Renderer::new(context, log.clone())? };
     let resize_notification = Rc::new(Cell::new(None));
-    let damage_tracking = display.extensions.iter().any(|ext| ext == "EGL_EXT_buffer_age")
-        && display.extensions.iter().any(|ext| {
+    let damage_tracking = display.extensions().iter().any(|ext| ext == "EGL_EXT_buffer_age")
+        && display.extensions().iter().any(|ext| {
             ext == "EGL_KHR_swap_buffers_with_damage" || ext == "EGL_EXT_swap_buffers_with_damage"
         });
 


### PR DESCRIPTION
This makes some aspects of the EGL backend accessible from outside Smithay that may useful. Some small changes are also made like renaming `get_extensions` to `extensions`