### PR TITLE
data_device: Send `cancelled()` to old source in `set_selection`

### DIFF
--- a/src/wayland/data_device/seat_data.rs
+++ b/src/wayland/data_device/seat_data.rs
@@ -62,6 +62,14 @@ impl SeatData {
         D: DataDeviceHandler,
         D: 'static,
     {
+        if let Selection::Client(data_source) = &self.selection {
+            match &new_selection {
+                Selection::Client(new_data_source) if new_data_source == data_source => {}
+                _ => {
+                    data_source.cancelled();
+                }
+            }
+        }
         self.selection = new_selection;
         self.send_selection::<D>(dh);
     }


### PR DESCRIPTION
Previously, copy-paste into Firefox was broken if text had previously been copied within Firefox, since it seemed to assume its source was still current given it had not been cancelled. This fixes that.

There are still other issues with copy and paste in Firefox.