### PR TITLE
Fix grab motion events

### DIFF
--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -52,9 +52,12 @@ impl<BackendData> PointerGrab<AnvilState<BackendData>> for MoveSurfaceGrab {
         &mut self,
         data: &mut AnvilState<BackendData>,
         _dh: &DisplayHandle,
-        _handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
         event: &MotionEvent,
     ) {
+        // While the grab is active, no client has pointer focus
+        handle.motion(event.location, None, event.serial, event.time);
+
         let delta = event.location - self.start_data.location;
         let new_location = self.initial_window_location.to_f64() + delta;
 
@@ -138,6 +141,9 @@ impl<BackendData> PointerGrab<AnvilState<BackendData>> for ResizeSurfaceGrab {
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
         event: &MotionEvent,
     ) {
+        // While the grab is active, no client has pointer focus
+        handle.motion(event.location, None, event.serial, event.time);
+
         // It is impossible to get `min_size` and `max_size` of dead toplevel, so we return early.
         if !self.window.toplevel().alive() {
             handle.unset_grab(event.serial, event.time);

--- a/smallvil/src/grabs/move_grab.rs
+++ b/smallvil/src/grabs/move_grab.rs
@@ -19,9 +19,12 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
         &mut self,
         data: &mut Smallvil,
         _dh: &DisplayHandle,
-        _handle: &mut PointerInnerHandle<'_, Smallvil>,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
         event: &MotionEvent,
     ) {
+        // While the grab is active, no client has pointer focus
+        handle.motion(event.location, None, event.serial, event.time);
+
         let delta = event.location - self.start_data.location;
         let new_location = self.initial_window_location.to_f64() + delta;
         data.space

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -77,6 +77,7 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
         handle: &mut PointerInnerHandle<'_, Smallvil>,
         event: &MotionEvent,
     ) {
+        // While the grab is active, no client has pointer focus
         handle.motion(event.location, None, event.serial, event.time);
 
         let mut delta = event.location - self.start_data.location;

--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -41,14 +41,15 @@ impl Smallvil {
                 let output_geo = self.space.output_geometry(output).unwrap();
 
                 let pos = event.position_transformed(output_geo.size) + output_geo.loc.to_f64();
-                self.pointer_location = pos;
 
                 let serial = SERIAL_COUNTER.next_serial();
 
-                let under = self.surface_under_pointer();
+                let pointer = self.seat.get_pointer().unwrap();
+
+                let under = self.surface_under_pointer(&pointer);
 
                 let dh = &mut display.handle();
-                self.seat.get_pointer().unwrap().motion(
+                pointer.motion(
                     self,
                     dh,
                     &MotionEvent {
@@ -71,7 +72,7 @@ impl Smallvil {
                 let button_state = wl_pointer::ButtonState::from(event.state());
 
                 if wl_pointer::ButtonState::Pressed == button_state && !pointer.is_grabbed() {
-                    if let Some(window) = self.space.window_under(self.pointer_location).cloned() {
+                    if let Some(window) = self.space.window_under(pointer.current_location()).cloned() {
                         self.space.raise_window(&window, true);
                         keyboard.set_focus(dh, Some(window.toplevel().wl_surface()), serial);
                         window.set_activated(true);

--- a/smallvil/src/state.rs
+++ b/smallvil/src/state.rs
@@ -16,7 +16,7 @@ use smithay::{
         compositor::CompositorState,
         data_device::DataDeviceState,
         output::OutputManagerState,
-        seat::{Seat, SeatState},
+        seat::{PointerHandle, Seat, SeatState},
         shell::xdg::XdgShellState,
         shm::ShmState,
         socket::ListeningSocketSource,
@@ -26,8 +26,6 @@ use smithay::{
 use crate::CalloopData;
 
 pub struct Smallvil {
-    pub pointer_location: Point<f64, Logical>,
-
     pub start_time: std::time::Instant,
     pub socket_name: OsString,
 
@@ -84,8 +82,6 @@ impl Smallvil {
         let loop_signal = event_loop.get_signal();
 
         Self {
-            pointer_location: Default::default(),
-
             start_time,
 
             space,
@@ -145,8 +141,11 @@ impl Smallvil {
         socket_name
     }
 
-    pub fn surface_under_pointer(&self) -> Option<(WlSurface, Point<i32, Logical>)> {
-        let pos = self.pointer_location;
+    pub fn surface_under_pointer(
+        &self,
+        pointer: &PointerHandle<Self>,
+    ) -> Option<(WlSurface, Point<i32, Logical>)> {
+        let pos = pointer.current_location();
         self.space
             .surface_under(pos, WindowSurfaceType::all())
             .map(|(_, surface, location)| (surface, location))

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -64,9 +64,12 @@ where
         &mut self,
         _data: &mut D,
         dh: &DisplayHandle,
-        _handle: &mut PointerInnerHandle<'_, D>,
+        handle: &mut PointerInnerHandle<'_, D>,
         event: &MotionEvent,
     ) {
+        // While the grab is active, no client has pointer focus
+        handle.motion(event.location, None, event.serial, event.time);
+
         let seat_data = self
             .seat
             .user_data()

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -54,13 +54,16 @@ where
         &mut self,
         _data: &mut D,
         dh: &DisplayHandle,
-        _handle: &mut PointerInnerHandle<'_, D>,
+        handle: &mut PointerInnerHandle<'_, D>,
         event: &MotionEvent,
     ) {
         let focus = event.focus.clone();
         let location = event.location;
         let serial = event.serial;
         let time = event.time;
+
+        // While the grab is active, no client has pointer focus
+        handle.motion(location, None, serial, time);
 
         let seat_data = self
             .seat


### PR DESCRIPTION
This is basically https://github.com/Smithay/smithay/pull/490/ for 0.30...

It reintroduces `pointer.motion` calls previously missing from the grabs and also makes sure to take focus away, where appropriate.

The second commit removes `state.pointer_location` from smallvil so we catch this problem more easily in the future.
I would have given anvil the same treatment, but the cursor state and location is here much more intertwined with the rendering code and tablet code. The latter probably requires some more changes to tablet_tool at first to make it internally track its location as well.