### PR TITLE
drm/atomic: Re-evaluate properties for newly added connectors

### DIFF
--- a/src/backend/drm/device/atomic.rs
+++ b/src/backend/drm/device/atomic.rs
@@ -26,7 +26,6 @@ type OldState = (
 pub type Mapping = (
     HashMap<connector::Handle, HashMap<String, property::Handle>>,
     HashMap<crtc::Handle, HashMap<String, property::Handle>>,
-    HashMap<framebuffer::Handle, HashMap<String, property::Handle>>,
     HashMap<plane::Handle, HashMap<String, property::Handle>>,
 );
 #[derive(Debug)]
@@ -49,7 +48,7 @@ impl<A: AsRawFd + 'static> AtomicDrmDevice<A> {
             fd,
             active,
             old_state: (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
-            prop_mapping: (HashMap::new(), HashMap::new(), HashMap::new(), HashMap::new()),
+            prop_mapping: (HashMap::new(), HashMap::new(), HashMap::new()),
             logger: logger.new(o!("smithay_module" => "backend_drm_atomic", "drm_module" => "device")),
         };
 
@@ -82,8 +81,7 @@ impl<A: AsRawFd + 'static> AtomicDrmDevice<A> {
         // And we do this a fair bit, so lets cache that mapping.
         dev.map_props(res_handles.connectors(), &mut mapping.0)?;
         dev.map_props(res_handles.crtcs(), &mut mapping.1)?;
-        dev.map_props(res_handles.framebuffers(), &mut mapping.2)?;
-        dev.map_props(planes, &mut mapping.3)?;
+        dev.map_props(planes, &mut mapping.2)?;
 
         dev.old_state = old_state;
         dev.prop_mapping = mapping;
@@ -205,7 +203,7 @@ impl<A: AsRawFd + 'static> AtomicDrmDevice<A> {
         for plane in plane_handles.planes() {
             let prop = self
                 .prop_mapping
-                .3
+                .2
                 .get(plane)
                 .expect("Unknown handle")
                 .get("CRTC_ID")
@@ -214,7 +212,7 @@ impl<A: AsRawFd + 'static> AtomicDrmDevice<A> {
 
             let prop = self
                 .prop_mapping
-                .3
+                .2
                 .get(plane)
                 .expect("Unknown handle")
                 .get("FB_ID")

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -14,7 +14,7 @@ use std::sync::{
 use crate::backend::{
     allocator::format::{get_bpp, get_depth},
     drm::{
-        device::atomic::Mapping,
+        device::atomic::{map_props, Mapping},
         device::{DevPath, DrmDeviceInternal},
         error::Error,
         plane_type,
@@ -34,7 +34,7 @@ impl State {
     fn current_state<A: AsRawFd + ControlDevice>(
         fd: &A,
         crtc: crtc::Handle,
-        prop_mapping: &Mapping,
+        prop_mapping: &mut Mapping,
     ) -> Result<Self, Error> {
         let crtc_info = fd.get_crtc(crtc).map_err(|source| Error::Access {
             errmsg: "Error loading crtc info",
@@ -67,6 +67,8 @@ impl State {
         //
         // If they don't match, `commit_pending` will return true and they will be changed on the next `commit`.
         let mut current_connectors = HashSet::new();
+        // make sure the mapping is up to date
+        map_props(fd, res_handles.connectors(), &mut prop_mapping.0)?;
         for conn in res_handles.connectors() {
             let crtc_prop = prop_mapping
                 .0
@@ -113,12 +115,12 @@ pub struct PlaneInfo {
 
 #[derive(Debug)]
 pub struct AtomicDrmSurface<A: AsRawFd + 'static> {
-    pub(super) fd: Arc<DrmDeviceInternal<A>>,
+    pub(in crate::backend::drm) fd: Arc<DrmDeviceInternal<A>>,
     pub(super) active: Arc<AtomicBool>,
     crtc: crtc::Handle,
     plane: plane::Handle,
     additional_planes: Mutex<Vec<PlaneInfo>>,
-    prop_mapping: Mapping,
+    prop_mapping: RwLock<Mapping>,
     state: RwLock<State>,
     pending: RwLock<State>,
     test_buffer: Mutex<Option<(DumbBuffer, framebuffer::Handle)>>,
@@ -132,7 +134,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         active: Arc<AtomicBool>,
         crtc: crtc::Handle,
         plane: plane::Handle,
-        prop_mapping: Mapping,
+        mut prop_mapping: Mapping,
         mode: Mode,
         connectors: &[connector::Handle],
         logger: ::slog::Logger,
@@ -147,7 +149,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
             connectors
         );
 
-        let state = State::current_state(&*fd, crtc, &prop_mapping)?;
+        let state = State::current_state(&*fd, crtc, &mut prop_mapping)?;
         let blob = fd.create_property_blob(&mode).map_err(|source| Error::Access {
             errmsg: "Failed to create Property Blob for mode",
             dev: fd.dev_path(),
@@ -165,7 +167,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
             crtc,
             plane,
             additional_planes: Mutex::new(Vec::new()),
-            prop_mapping,
+            prop_mapping: RwLock::new(prop_mapping),
             state: RwLock::new(state),
             pending: RwLock::new(pending),
             test_buffer: Mutex::new(None),
@@ -237,11 +239,34 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         self.pending.read().unwrap().mode
     }
 
+    fn ensure_props_known(&self, conns: &[connector::Handle]) -> Result<(), Error> {
+        let mapping_exists = {
+            let prop_mapping = self.prop_mapping.read().unwrap();
+            conns.iter().all(|conn| prop_mapping.0.get(conn).is_some())
+        };
+        if !mapping_exists {
+            map_props(
+                &*self.fd,
+                self.fd
+                    .resource_handles()
+                    .map_err(|source| Error::Access {
+                        errmsg: "Error loading connector info",
+                        dev: self.fd.dev_path(),
+                        source,
+                    })?
+                    .connectors(),
+                &mut self.prop_mapping.write().unwrap().0,
+            )?;
+        }
+        Ok(())
+    }
+
     pub fn add_connector(&self, conn: connector::Handle) -> Result<(), Error> {
         if !self.active.load(Ordering::SeqCst) {
             return Err(Error::DeviceInactive);
         }
 
+        self.ensure_props_known(&[conn])?;
         let info = self.fd.get_connector(conn).map_err(|source| Error::Access {
             errmsg: "Error loading connector info",
             dev: self.fd.dev_path(),
@@ -338,6 +363,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         let current = self.state.write().unwrap();
         let mut pending = self.pending.write().unwrap();
 
+        self.ensure_props_known(connectors)?;
         let conns = connectors.iter().cloned().collect::<HashSet<_>>();
         let mut added = conns.difference(&current.connectors);
         let mut removed = current.connectors.difference(&conns);
@@ -716,57 +742,6 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         Ok(result)
     }
 
-    pub(crate) fn conn_prop_handle(
-        &self,
-        handle: connector::Handle,
-        name: &'static str,
-    ) -> Result<property::Handle, Error> {
-        self.prop_mapping
-            .0
-            .get(&handle)
-            .expect("Unknown handle")
-            .get(name)
-            .ok_or_else(|| Error::UnknownProperty {
-                handle: handle.into(),
-                name,
-            })
-            .map(|x| *x)
-    }
-
-    pub(crate) fn crtc_prop_handle(
-        &self,
-        handle: crtc::Handle,
-        name: &'static str,
-    ) -> Result<property::Handle, Error> {
-        self.prop_mapping
-            .1
-            .get(&handle)
-            .expect("Unknown handle")
-            .get(name)
-            .ok_or_else(|| Error::UnknownProperty {
-                handle: handle.into(),
-                name,
-            })
-            .map(|x| *x)
-    }
-
-    pub(crate) fn plane_prop_handle(
-        &self,
-        handle: plane::Handle,
-        name: &'static str,
-    ) -> Result<property::Handle, Error> {
-        self.prop_mapping
-            .2
-            .get(&handle)
-            .expect("Unknown handle")
-            .get(name)
-            .ok_or_else(|| Error::UnknownProperty {
-                handle: handle.into(),
-                name,
-            })
-            .map(|x| *x)
-    }
-
     // If a mode is set a matching blob needs to be set (the inverse is not true)
     #[allow(clippy::too_many_arguments)]
     pub fn build_request<'a>(
@@ -779,6 +754,8 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         mode: Option<Mode>,
         blob: Option<property::Value<'static>>,
     ) -> Result<AtomicModeReq, Error> {
+        let prop_mapping = self.prop_mapping.read().unwrap();
+
         // okay, here we build the actual requests used by the surface.
         let mut req = AtomicModeReq::new();
 
@@ -789,7 +766,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         for conn in new_connectors {
             req.add_property(
                 *conn,
-                self.conn_prop_handle(*conn, "CRTC_ID")?,
+                conn_prop_handle(&*prop_mapping, *conn, "CRTC_ID")?,
                 property::Value::CRTC(Some(self.crtc)),
             );
         }
@@ -801,20 +778,24 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         for conn in removed_connectors {
             req.add_property(
                 *conn,
-                self.conn_prop_handle(*conn, "CRTC_ID")?,
+                conn_prop_handle(&*prop_mapping, *conn, "CRTC_ID")?,
                 property::Value::CRTC(None),
             );
         }
 
         // we need to set the new mode, if there is one
         if let Some(blob) = blob {
-            req.add_property(self.crtc, self.crtc_prop_handle(self.crtc, "MODE_ID")?, blob);
+            req.add_property(
+                self.crtc,
+                crtc_prop_handle(&*prop_mapping, self.crtc, "MODE_ID")?,
+                blob,
+            );
         }
 
         // we also need to set this crtc active
         req.add_property(
             self.crtc,
-            self.crtc_prop_handle(self.crtc, "ACTIVE")?,
+            crtc_prop_handle(&*prop_mapping, self.crtc, "ACTIVE")?,
             property::Value::Boolean(true),
         );
 
@@ -823,7 +804,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
             for (fb, plane) in fbs {
                 req.add_property(
                     *plane,
-                    self.plane_prop_handle(*plane, "FB_ID")?,
+                    plane_prop_handle(&*prop_mapping, *plane, "FB_ID")?,
                     property::Value::Framebuffer(Some(*fb)),
                 );
             }
@@ -832,7 +813,7 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         // we also need to connect the primary plane
         req.add_property(
             primary,
-            self.plane_prop_handle(primary, "CRTC_ID")?,
+            plane_prop_handle(&*prop_mapping, primary, "CRTC_ID")?,
             property::Value::CRTC(Some(self.crtc)),
         );
 
@@ -840,47 +821,47 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         if let Some(mode) = mode {
             req.add_property(
                 primary,
-                self.plane_prop_handle(primary, "SRC_X")?,
+                plane_prop_handle(&*prop_mapping, primary, "SRC_X")?,
                 property::Value::UnsignedRange(0),
             );
             req.add_property(
                 primary,
-                self.plane_prop_handle(primary, "SRC_Y")?,
+                plane_prop_handle(&*prop_mapping, primary, "SRC_Y")?,
                 property::Value::UnsignedRange(0),
             );
             req.add_property(
                 primary,
-                self.plane_prop_handle(primary, "SRC_W")?,
+                plane_prop_handle(&*prop_mapping, primary, "SRC_W")?,
                 // these are 16.16. fixed point
                 property::Value::UnsignedRange((mode.size().0 as u64) << 16),
             );
             req.add_property(
                 primary,
-                self.plane_prop_handle(primary, "SRC_H")?,
+                plane_prop_handle(&*prop_mapping, primary, "SRC_H")?,
                 property::Value::UnsignedRange((mode.size().1 as u64) << 16),
             );
             // we can map parts of the plane onto different coordinated on the crtc, but we just use a 1:1 mapping.
             req.add_property(
                 primary,
-                self.plane_prop_handle(primary, "CRTC_X")?,
+                plane_prop_handle(&*prop_mapping, primary, "CRTC_X")?,
                 property::Value::SignedRange(0),
             );
             req.add_property(
                 primary,
-                self.plane_prop_handle(primary, "CRTC_Y")?,
+                plane_prop_handle(&*prop_mapping, primary, "CRTC_Y")?,
                 property::Value::SignedRange(0),
             );
             req.add_property(
                 primary,
-                self.plane_prop_handle(primary, "CRTC_W")?,
+                plane_prop_handle(&*prop_mapping, primary, "CRTC_W")?,
                 property::Value::UnsignedRange(mode.size().0 as u64),
             );
             req.add_property(
                 primary,
-                self.plane_prop_handle(primary, "CRTC_H")?,
+                plane_prop_handle(&*prop_mapping, primary, "CRTC_H")?,
                 property::Value::UnsignedRange(mode.size().1 as u64),
             );
-            if let Ok(prop) = self.plane_prop_handle(primary, "rotation") {
+            if let Ok(prop) = plane_prop_handle(&*prop_mapping, primary, "rotation") {
                 req.add_property(primary, prop, property::Value::Bitmask(1u64));
             }
         }
@@ -889,47 +870,47 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         for plane_info in planes {
             req.add_property(
                 plane_info.handle,
-                self.plane_prop_handle(plane_info.handle, "SRC_X")?,
+                plane_prop_handle(&*prop_mapping, plane_info.handle, "SRC_X")?,
                 property::Value::UnsignedRange(0),
             );
             req.add_property(
                 plane_info.handle,
-                self.plane_prop_handle(plane_info.handle, "SRC_Y")?,
+                plane_prop_handle(&*prop_mapping, plane_info.handle, "SRC_Y")?,
                 property::Value::UnsignedRange(0),
             );
             req.add_property(
                 plane_info.handle,
-                self.plane_prop_handle(plane_info.handle, "SRC_W")?,
+                plane_prop_handle(&*prop_mapping, plane_info.handle, "SRC_W")?,
                 // these are 16.16. fixed point
                 property::Value::UnsignedRange((plane_info.w as u64) << 16),
             );
             req.add_property(
                 plane_info.handle,
-                self.plane_prop_handle(plane_info.handle, "SRC_H")?,
+                plane_prop_handle(&*prop_mapping, plane_info.handle, "SRC_H")?,
                 property::Value::UnsignedRange((plane_info.h as u64) << 16),
             );
             // we can map parts of the plane onto different coordinated on the crtc, but we just use a 1:1 mapping.
             req.add_property(
                 plane_info.handle,
-                self.plane_prop_handle(plane_info.handle, "CRTC_X")?,
+                plane_prop_handle(&*prop_mapping, plane_info.handle, "CRTC_X")?,
                 property::Value::SignedRange(plane_info.x as i64),
             );
             req.add_property(
                 plane_info.handle,
-                self.plane_prop_handle(plane_info.handle, "CRTC_Y")?,
+                plane_prop_handle(&*prop_mapping, plane_info.handle, "CRTC_Y")?,
                 property::Value::SignedRange(plane_info.y as i64),
             );
             req.add_property(
                 plane_info.handle,
-                self.plane_prop_handle(plane_info.handle, "CRTC_W")?,
+                plane_prop_handle(&*prop_mapping, plane_info.handle, "CRTC_W")?,
                 property::Value::UnsignedRange(plane_info.w as u64),
             );
             req.add_property(
                 plane_info.handle,
-                self.plane_prop_handle(plane_info.handle, "CRTC_H")?,
+                plane_prop_handle(&*prop_mapping, plane_info.handle, "CRTC_H")?,
                 property::Value::UnsignedRange(plane_info.h as u64),
             );
-            if let Ok(prop) = self.plane_prop_handle(plane_info.handle, "rotation") {
+            if let Ok(prop) = plane_prop_handle(&*prop_mapping, plane_info.handle, "rotation") {
                 req.add_property(plane_info.handle, prop, property::Value::Bitmask(1u64));
             }
         }
@@ -942,17 +923,18 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
     // as other compositors might not make use of other planes,
     // leaving our e.g. cursor or overlays as a relict of a better time on the screen.
     pub fn clear_plane(&self, plane: plane::Handle) -> Result<(), Error> {
+        let prop_mapping = self.prop_mapping.read().unwrap();
         let mut req = AtomicModeReq::new();
 
         req.add_property(
             self.plane,
-            self.plane_prop_handle(self.plane, "CRTC_ID")?,
+            plane_prop_handle(&*prop_mapping, self.plane, "CRTC_ID")?,
             property::Value::CRTC(None),
         );
 
         req.add_property(
             self.plane,
-            self.plane_prop_handle(self.plane, "FB_ID")?,
+            plane_prop_handle(&*prop_mapping, self.plane, "FB_ID")?,
             property::Value::Framebuffer(None),
         );
 
@@ -980,9 +962,9 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
         fd: Option<&B>,
     ) -> Result<(), Error> {
         *self.state.write().unwrap() = if let Some(fd) = fd {
-            State::current_state(fd, self.crtc, &self.prop_mapping)?
+            State::current_state(fd, self.crtc, &mut *self.prop_mapping.write().unwrap())?
         } else {
-            State::current_state(&*self.fd, self.crtc, &self.prop_mapping)?
+            State::current_state(&*self.fd, self.crtc, &mut *self.prop_mapping.write().unwrap())?
         };
         Ok(())
     }
@@ -1023,9 +1005,9 @@ impl<A: AsRawFd + 'static> Drop for AtomicDrmSurface<A> {
         // disable connectors again
         let current = self.state.read().unwrap();
         let mut req = AtomicModeReq::new();
+        let prop_mapping = self.prop_mapping.read().unwrap();
         for conn in current.connectors.iter() {
-            let prop = self
-                .prop_mapping
+            let prop = prop_mapping
                 .0
                 .get(conn)
                 .expect("Unknown Handle")
@@ -1033,15 +1015,13 @@ impl<A: AsRawFd + 'static> Drop for AtomicDrmSurface<A> {
                 .expect("Unknown property CRTC_ID");
             req.add_property(*conn, *prop, property::Value::CRTC(None));
         }
-        let active_prop = self
-            .prop_mapping
+        let active_prop = prop_mapping
             .1
             .get(&self.crtc)
             .expect("Unknown Handle")
             .get("ACTIVE")
             .expect("Unknown property ACTIVE");
-        let mode_prop = self
-            .prop_mapping
+        let mode_prop = prop_mapping
             .1
             .get(&self.crtc)
             .expect("Unknown Handle")
@@ -1056,6 +1036,56 @@ impl<A: AsRawFd + 'static> Drop for AtomicDrmSurface<A> {
     }
 }
 
+pub(crate) fn conn_prop_handle(
+    prop_mapping: &Mapping,
+    handle: connector::Handle,
+    name: &'static str,
+) -> Result<property::Handle, Error> {
+    prop_mapping
+        .0
+        .get(&handle)
+        .expect("Unknown handle")
+        .get(name)
+        .ok_or_else(|| Error::UnknownProperty {
+            handle: handle.into(),
+            name,
+        })
+        .map(|x| *x)
+}
+
+pub(crate) fn crtc_prop_handle(
+    prop_mapping: &Mapping,
+    handle: crtc::Handle,
+    name: &'static str,
+) -> Result<property::Handle, Error> {
+    prop_mapping
+        .1
+        .get(&handle)
+        .expect("Unknown handle")
+        .get(name)
+        .ok_or_else(|| Error::UnknownProperty {
+            handle: handle.into(),
+            name,
+        })
+        .map(|x| *x)
+}
+
+pub(crate) fn plane_prop_handle(
+    prop_mapping: &Mapping,
+    handle: plane::Handle,
+    name: &'static str,
+) -> Result<property::Handle, Error> {
+    prop_mapping
+        .2
+        .get(&handle)
+        .expect("Unknown handle")
+        .get(name)
+        .ok_or_else(|| Error::UnknownProperty {
+            handle: handle.into(),
+            name,
+        })
+        .map(|x| *x)
+}
 #[cfg(test)]
 mod test {
     use super::AtomicDrmSurface;

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -750,31 +750,13 @@ impl<A: AsRawFd + 'static> AtomicDrmSurface<A> {
             .map(|x| *x)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn fb_prop_handle(
-        &self,
-        handle: framebuffer::Handle,
-        name: &'static str,
-    ) -> Result<property::Handle, Error> {
-        self.prop_mapping
-            .2
-            .get(&handle)
-            .expect("Unknown handle")
-            .get(name)
-            .ok_or_else(|| Error::UnknownProperty {
-                handle: handle.into(),
-                name,
-            })
-            .map(|x| *x)
-    }
-
     pub(crate) fn plane_prop_handle(
         &self,
         handle: plane::Handle,
         name: &'static str,
     ) -> Result<property::Handle, Error> {
         self.prop_mapping
-            .3
+            .2
             .get(&handle)
             .expect("Unknown handle")
             .get(name)


### PR DESCRIPTION
Apparently the drm-interface is allowed to dynamically add connectors during runtime, for example to represent daisy-chained display port connections and a few other special cases.

smithay currently does not handle this correctly in the atomic backend, as it assumes a static set of resources to cache their properties.

The first commit fixes the enumeration of properties for framebuffers. They are created by processes and inherently dynamic in nature. It was luckily never used in the code, but that piece of code makes no sense and shouldn't exist. Properties of framebuffers need to be queried from the drm-interface, when they are needed and should not be cached (at least not globally).

The second commit mostly shifts methods around to make them more accessible, the big change is that `prop_mapping` is now also encapsulated by a ReadWrite-lock. This is a little unfortunate given that `build_request` needs to access it and that this function is in the hot-path of both `commit` and `page_flip`. Extra care has been taken to make sure locks are only taken when needed (especially write locks are very few and far between) to hopefully make the performance costs negligible.

If proven necessary the read-write lock can be replaced by an append-only HashMap implementation such as provided by [`elsa`](crates.io/crates/elsa), but the drm-surface already contains quite a few locks and given the recent performance optimizations around these in stable rust I can hardly imagine this being an actual problem until proven otherwise by a profiler.

~Marked as Draft until actually tested on real hardware, but reviews are already very welcome.~