### PR TITLE
vulkan-alloc: ensure images with COLOR_ATTACHMENT usage are valid

### DIFF
--- a/src/backend/allocator/vulkan/mod.rs
+++ b/src/backend/allocator/vulkan/mod.rs
@@ -281,6 +281,15 @@ impl VulkanAllocator {
             return Err(Error::InvalidSize);
         }
 
+        // VUID-VkImageCreateInfo-usage-00964, VUID-VkImageCreateInfo-usage-00965
+        if usage.contains(ImageUsageFlags::COLOR_ATTACHMENT) {
+            let limits = self.phd.limits();
+
+            if width > limits.max_framebuffer_width || height > limits.max_framebuffer_height {
+                return Err(Error::InvalidSize);
+            }
+        }
+
         // Filter out any format + modifier combinations that are not supported
         let modifiers = self.filter_modifiers(width, height, vk_usage, fourcc, modifiers);
 


### PR DESCRIPTION
Per the Vulkan specification, if an image has the COLOR_ATTACHMENT usage, the width and height of the image must be less than or equal to maxFramebufferWidth and maxFramebufferHeight respectively.

See VUID-VkImageCreateInfo-usage-00964 and VUID-VkImageCreateInfo-usage-00965 for more information.