### PR TITLE
anvil: Fix crash in `maximize_request`

### DIFF
--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -664,14 +664,13 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
             .window_for_surface(surface.wl_surface(), WindowSurfaceType::TOPLEVEL)
             .unwrap()
             .clone();
-        let output = self.space.outputs_for_window(&window).into_iter().next();
-        let mut output = output.as_ref();
-        if output.is_none() {
+        let outputs_for_window = self.space.outputs_for_window(&window);
+        let output = outputs_for_window
+            .first()
             // The window hasn't been mapped yet, use the primary output instead
-            output = self.space.outputs().next();
-        }
-        // Assumes that at least one output exists
-        let output = output.unwrap();
+            .or_else(|| self.space.outputs().next())
+            // Assumes that at least one output exists
+            .expect("No outputs found");
         let geometry = self.space.output_geometry(output).unwrap();
 
         self.space.map_window(&window, geometry.loc, None, true);

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -664,7 +664,14 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
             .window_for_surface(surface.wl_surface(), WindowSurfaceType::TOPLEVEL)
             .unwrap()
             .clone();
-        let output = &self.space.outputs_for_window(&window)[0];
+        let output = self.space.outputs_for_window(&window).into_iter().next();
+        let mut output = output.as_ref();
+        if output.is_none() {
+            // The window hasn't been mapped yet, use the primary output instead
+            output = self.space.outputs().next();
+        }
+        // Assumes that at least one output exists
+        let output = output.unwrap();
         let geometry = self.space.output_geometry(output).unwrap();
 
         self.space.map_window(&window, geometry.loc, None, true);


### PR DESCRIPTION
It's possible that a surface wants to be maximized before the window has actually been mapped yet, and therefore `outputs_for_window` returns an empty `Vec`. In that case, it's fine to use the first output available, instead.

I've been able to actually produce the crash in Anvil using Firefox with `MOZ_ENABLE_WAYLAND=1` set in the environment, using a fresh Firefox profile.

For reference, here is what Weston does in the same case:
https://gitlab.freedesktop.org/wayland/weston/-/blob/d615abdffdb0b3f69c937c577cbd3855ed382a74/desktop-shell/shell.c#L2302