### PR TITLE
vulkan-alloc: fix validation error related to empty usage flags

### DIFF
--- a/examples/vulkan.rs
+++ b/examples/vulkan.rs
@@ -37,8 +37,8 @@ fn main() {
         .next()
         .expect("No physical devices");
 
-    // We don't actually use any buffers created by the allocator in this example.
-    let mut allocator = VulkanAllocator::new(&physical_device, ImageUsageFlags::empty()).unwrap();
+    // The allocator should create buffers that are suitable as render targets.
+    let mut allocator = VulkanAllocator::new(&physical_device, ImageUsageFlags::COLOR_ATTACHMENT).unwrap();
 
     let image = allocator
         .create_buffer(100, 200, DrmFourcc::Argb8888, &[DrmModifier::Linear])


### PR DESCRIPTION
Empty image usage flags are not allowed in Vulkan. This pull request changes VulkanAllocator to panic if it's default usage flags are empty.

VulkanAllocator::is_format_supported and VulkanAllocator::create_buffer_with_usage now return false and fail respectively if the usage flags are empty.