### PR TITLE
MultiGPU fixes round three

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1153,7 +1153,18 @@ impl MultiTexture {
             .filter(|(old_src, _)| *old_src == source)
             .map(|(_, mappings)| mappings)
             .unwrap_or_default();
-        mappings.extend(new_mappings.map(|(r, m)| (r, Box::new(m) as Box<_>)));
+
+        // don't keep old mappings that are superseeded by new ones
+        let new_mappings = new_mappings
+            .map(|(r, m)| (r, Box::new(m) as Box<_>))
+            .collect::<Vec<_>>();
+        mappings.retain(|(region, _)| {
+            !new_mappings
+                .iter()
+                .any(|(new_region, _)| new_region.contains_rect(*region))
+        });
+        mappings.extend(new_mappings);
+
         textures.insert(
             render,
             GpuSingleTexture {

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1609,10 +1609,12 @@ where
                     .renderer_mut()
                     .map_texture(mapping)
                     .map_err(Error::Target)?;
-                self.render
-                    .renderer_mut()
-                    .import_memory(mapped, mapping.size(), false)
-                    .ok()
+                Some(
+                    self.render
+                        .renderer_mut()
+                        .import_memory(mapped, mapping.size(), false)
+                        .map_err(Error::Render)?,
+                )
             } else if let Some(source) = self
                 .other_renderers
                 .iter_mut()
@@ -1634,10 +1636,12 @@ where
                     .renderer_mut()
                     .map_texture(mapping)
                     .map_err(Error::Render)?;
-                self.render
-                    .renderer_mut()
-                    .import_memory(mapped, mapping.size(), false)
-                    .ok()
+                Some(
+                    self.render
+                        .renderer_mut()
+                        .import_memory(mapped, mapping.size(), false)
+                        .map_err(Error::Render)?,
+                )
             } else {
                 None
             };
@@ -1666,9 +1670,14 @@ where
                         texture.size(),
                         region
                     );
-                    if let Ok(mapped) = source.renderer_mut().map_texture(mapping) {
-                        let _ = self.render.renderer_mut().update_memory(texture, mapped, region);
-                    }
+                    let mapped = source
+                        .renderer_mut()
+                        .map_texture(mapping)
+                        .map_err(Error::Target)?;
+                    self.render
+                        .renderer_mut()
+                        .update_memory(texture, mapped, region)
+                        .map_err(Error::Render)?;
                 }
             } else if let Some(source) = self
                 .other_renderers
@@ -1686,9 +1695,14 @@ where
                         texture.size(),
                         region
                     );
-                    if let Ok(mapped) = source.renderer_mut().map_texture(mapping) {
-                        let _ = self.render.renderer_mut().update_memory(texture, mapped, region);
-                    }
+                    let mapped = source
+                        .renderer_mut()
+                        .map_texture(mapping)
+                        .map_err(Error::Render)?;
+                    self.render
+                        .renderer_mut()
+                        .update_memory(texture, mapped, region)
+                        .map_err(Error::Render)?;
                 }
             };
         }

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1051,7 +1051,13 @@ impl MultiTexture {
                     size,
                 }))
             });
-        internal.borrow_mut().size = size;
+        {
+            let mut internal = internal.borrow_mut();
+            if internal.size != size {
+                internal.textures.clear();
+                internal.size = size;
+            }
+        }
         MultiTexture(internal)
     }
 


### PR DESCRIPTION
Firefox strikes at it again...

First three commits fix code in the multigpu renderer, mostly related to usage of early_import.
- 38f3cf5480df7fc367d691642c4e0735f9bf6ca9 Adds a new check to make sure early_import does nothing if there was no new buffer. Otherwise it might clear the *internal* textures and we have nothing to render, because the `on_commit_buffer_handler` still has the empty `MultiTexture` and won't call `import_surface_tree`.
- 7e6473f1ca892586974ed1a522b95f00888fd37b Makes the MultiTexture reset it's internal textures, when the size changes. Otherwise the multigpu renderer could end up trying to update a texture with different dimensions, resulting in rendering errors
- 26454a0cccdd21bae9c52f5e356fd111b9cbdaf9 Clears the mappings on consequent imports (before they are actually imported), that overlap. Newer imports thus replace old mappings that are contained in the new ones. Otherwise unnecessary (and expensive) imports might happen and we can run into some assertions.
-  6e917d7c5ef78f6fa07a43c7069e32242039b6b8 Lets `import_dmabuf_internal` propagate more errors, so they don't are completely ignored.
- 0257d85c1cf10dcf34c49361a825fe563044d302 Adds a bunch of new logging statements I found helpful to fix the above errors.