### PR TITLE
Bump winit to 0.27.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ wayland-protocols-wlr = { version = "=0.1.0-beta.8", features = ["server"]}
 wayland-server = { version = "=0.30.0-beta.8", optional = true }
 wayland-sys = { version = "=0.30.0-beta.8", optional = true }
 wayland-backend = { version = "=0.1.0-beta.8", optional = true }
-winit = { version = "0.26", optional = true }
+winit = { version = "0.27.1", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
 x11rb = { version = "0.10.0", optional = true }
 xkbcommon = "0.4.0"
 scan_fmt = { version = "0.2.3", default-features = false }


### PR DESCRIPTION
This resolves issues when running smithay with winit
backend on Wayland.