### PR TITLE
egl: Add EGLDisplay::from_raw and EGLContext::from_raw

### DIFF
--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -44,7 +44,7 @@ impl EGLContext {
     ///
     /// # Safety
     ///
-    /// - Not using the system default EGL library (`dlopen("libEGL.so")`) as loaded by smithay might cause undefined behavior
+    /// - The context must be created from the system default EGL library (`dlopen("libEGL.so")`)
     /// - Display, config, and context handles must be externally managed to ensure they do not become invalid before the compositor is shut down
     pub unsafe fn from_raw<L>(
         display: *const c_void,

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -44,8 +44,8 @@ impl EGLContext {
     ///
     /// # Safety
     ///
-    /// This function is marked unsafe, because the context cannot be made current on another thread without
-    /// being unbound again (see [`EGLContext::unbind`]).
+    /// - Not using the system default EGL library (`dlopen("libEGL.so")`) as loaded by smithay might cause undefined behavior
+    /// - Display, config, and context handles must be externally managed to ensure they do not become invalid before the compositor is shut down
     pub unsafe fn from_raw<L>(
         display: *const c_void,
         config_id: *const c_void,
@@ -55,6 +55,9 @@ impl EGLContext {
     where
         L: Into<Option<::slog::Logger>>,
     {
+        assert!(!display.is_null(), "EGLDisplay pointer is null");
+        assert!(!config_id.is_null(), "EGL configuration id pointer is null");
+        assert!(!context.is_null(), "EGLContext pointer is null");
         let log = crate::slog_or_fallback(log.into()).new(o!("smithay_module" => "backend_egl"));
 
         let display = EGLDisplay::from_raw(display, config_id, log)?;

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -45,7 +45,7 @@ impl EGLContext {
     /// # Safety
     ///
     /// - The context must be created from the system default EGL library (`dlopen("libEGL.so")`)
-    /// - Display, config, and context handles must be externally managed to ensure they do not become invalid before the compositor is shut down
+    /// - The `display`, `config`, and `context` must be valid for the lifetime of the returned context.
     pub unsafe fn from_raw<L>(
         display: *const c_void,
         config_id: *const c_void,

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -205,8 +205,8 @@ impl EGLDisplay {
     ///
     /// # Safety
     ///
-    /// - Not using the system default EGL library (`dlopen("libEGL.so")`) as loaded by smithay might cause undefined behavior
-    /// - Display and config handles must be externally managed to ensure they do not become invalid before the compositor is shut down
+    /// - The display must be created from the system default EGL library (`dlopen("libEGL.so")`)
+    /// - The `display` and `config` must be valid for the lifetime of the returned display and any handles created by this display (using [`EGLDisplay::get_display_handle`])
     pub unsafe fn from_raw<L>(
         display: *const c_void,
         config_id: *const c_void,

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -177,18 +177,7 @@ impl EGLDisplay {
 
         // the list of extensions supported by the client once initialized is different from the
         // list of extensions obtained earlier
-        let extensions = if egl_version >= (1, 2) {
-            let p = unsafe {
-                CStr::from_ptr(
-                    wrap_egl_call(|| ffi::egl::QueryString(display, ffi::egl::EXTENSIONS as i32))
-                        .map_err(Error::InitFailed)?,
-                )
-            };
-            let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| String::new());
-            list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>()
-        } else {
-            vec![]
-        };
+        let extensions = EGLDisplay::get_extensions(egl_version, display)?;
         info!(log, "Supported EGL display extensions: {:?}", extensions);
 
         let (dmabuf_import_formats, dmabuf_render_formats) =
@@ -210,6 +199,97 @@ impl EGLDisplay {
             dmabuf_render_formats,
             logger: log,
         })
+    }
+
+    /// Create a new [`EGLDisplay`] from an already initialized EGLDisplay and EGLConfig handle
+    pub unsafe fn from_raw<L>(
+        display: *const c_void,
+        config: *const c_void,
+        logger: L,
+    ) -> Result<EGLDisplay, Error>
+    where
+        L: Into<Option<::slog::Logger>>,
+    {
+        let log = crate::slog_or_fallback(logger.into()).new(o!("smithay_module" => "backend_egl"));
+
+        let egl_version = {
+            let p = CStr::from_ptr(
+                wrap_egl_call(|| ffi::egl::QueryString(display, ffi::egl::VERSION as i32))
+                    .map_err(|_| Error::DisplayQueryResultInvalid)?,
+            );
+
+            let version_string = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| String::new());
+            let mut version_iterator = version_string
+                .split(' ')
+                .next()
+                .ok_or(Error::DisplayQueryResultInvalid)?
+                .split('.');
+
+            let major = version_iterator
+                .next()
+                .and_then(|v| v.parse::<i32>().ok())
+                .ok_or(Error::DisplayQueryResultInvalid)?;
+            let minor = version_iterator
+                .next()
+                .and_then(|v| v.parse::<i32>().ok())
+                .ok_or(Error::DisplayQueryResultInvalid)?;
+
+            info!(log, "EGL Version: {:?}", (major, minor));
+            (major, minor)
+        };
+
+        let extensions = EGLDisplay::get_extensions(egl_version, display)?;
+        info!(log, "Supported EGL display extensions: {:?}", extensions);
+
+        let (dmabuf_import_formats, dmabuf_render_formats) =
+            get_dmabuf_formats(&display, &extensions, &log).map_err(Error::DisplayCreationError)?;
+
+        let egl_api =
+            wrap_egl_call(|| ffi::egl::QueryAPI()).map_err(|_| Error::OpenGlesNotSupported(None))?;
+        if egl_api != ffi::egl::OPENGL_ES_API {
+            return Err(Error::OpenGlesNotSupported(None));
+        }
+
+        let surface_type = {
+            let mut surface_type: MaybeUninit<ffi::egl::types::EGLint> = MaybeUninit::uninit();
+
+            wrap_egl_call(|| {
+                ffi::egl::GetConfigAttrib(
+                    display,
+                    config,
+                    ffi::egl::SURFACE_TYPE as i32,
+                    surface_type.as_mut_ptr(),
+                )
+            })
+            .map_err(|_| Error::OpenGlesNotSupported(None))?;
+
+            surface_type.assume_init()
+        };
+
+        Ok(EGLDisplay {
+            display: Arc::new(EGLDisplayHandle { handle: display }),
+            surface_type,
+            egl_version,
+            extensions,
+            dmabuf_import_formats,
+            dmabuf_render_formats,
+            logger: log,
+        })
+    }
+
+    fn get_extensions(egl_version: (i32, i32), display: *const c_void) -> Result<Vec<String>, Error> {
+        if egl_version >= (1, 2) {
+            let p = unsafe {
+                CStr::from_ptr(
+                    wrap_egl_call(|| ffi::egl::QueryString(display, ffi::egl::EXTENSIONS as i32))
+                        .map_err(Error::InitFailed)?,
+                )
+            };
+            let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| String::new());
+            Ok(list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>())
+        } else {
+            Ok(vec![])
+        }
     }
 
     /// Finds a compatible EGLConfig for a given set of requirements

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -202,6 +202,10 @@ impl EGLDisplay {
     }
 
     /// Create a new [`EGLDisplay`] from an already initialized EGLDisplay and EGLConfig handle
+    ///
+    /// # Safety
+    ///
+    /// Display and config handles must be externally managed to ensure they do not become invalid before the compositor is shut down
     pub unsafe fn from_raw<L>(
         display: *const c_void,
         config: *const c_void,
@@ -443,7 +447,7 @@ impl EGLDisplay {
     }
 
     /// Gets a PixelFormat from a configured EGLConfig
-    pub unsafe fn get_pixel_format(&self, config_id: *const c_void) -> Result<PixelFormat, Error> {
+    pub(super) unsafe fn get_pixel_format(&self, config_id: *const c_void) -> Result<PixelFormat, Error> {
         // analyzing each config
         macro_rules! attrib {
             ($display:expr, $config:expr, $attr:expr) => {{

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -212,6 +212,9 @@ impl EGLDisplay {
     {
         let log = crate::slog_or_fallback(logger.into()).new(o!("smithay_module" => "backend_egl"));
 
+        let dp_extensions = ffi::make_sure_egl_is_loaded()?;
+        debug!(log, "Supported EGL client extensions: {:?}", dp_extensions);
+
         let egl_version = {
             let p = CStr::from_ptr(
                 wrap_egl_call(|| ffi::egl::QueryString(display, ffi::egl::VERSION as i32))

--- a/src/backend/egl/error.rs
+++ b/src/backend/egl/error.rs
@@ -18,6 +18,9 @@ pub enum Error {
     /// Display creation failed
     #[error("Display creation failed with error: {0:}")]
     DisplayCreationError(#[source] EGLError),
+    /// Display query result invalid
+    #[error("Display query result invalid")]
+    DisplayQueryResultInvalid,
     /// Unable to obtain a valid EGL Display
     #[error("Unable to obtain a valid EGL Display.")]
     DisplayNotSupported,


### PR DESCRIPTION
Confirmed working using this example:

```rs
struct EGLRawHandles {
	display: *const c_void,
	config: *const c_void,
	context: *const c_void,
}
```

```rs
let mut renderer = unsafe {
	Gles2Renderer::new(
		EGLContext::from_raw(
			egl_raw_handles.display,
			egl_raw_handles.config,
			egl_raw_handles.context,
			log.clone(),
		)?,
		log.clone(),
	)?
};
let smithay_tex_image =
	image::io::Reader::with_format(std::io::Cursor::new(STARDUST_PNG), image::ImageFormat::Png)
		.decode()
		.unwrap();
let smithay_tex = renderer
	.import_memory(
		&smithay_tex_image.to_rgba8(),
		(
			smithay_tex_image.width() as i32,
			smithay_tex_image.height() as i32,
		)
			.into(),
		false,
	)
	.unwrap();
```
https://github.com/StardustXR/stardust-assets/blob/main/icon.png
![image](https://user-images.githubusercontent.com/4541968/184501619-bbf078e9-3c3d-4751-a5c6-c74565872d57.png)
(The gamma issue is due to the renderer I am using, https://github.com/StereoKit/StereoKit)