### PR TITLE
Remove magic type signatures in favor of public type aliases 

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -1,14 +1,12 @@
 #![allow(clippy::too_many_arguments)]
 
-use std::sync::Mutex;
-
 use slog::Logger;
 #[cfg(feature = "debug")]
 use smithay::utils::Buffer;
 use smithay::{
     backend::renderer::{Frame, ImportAll, Renderer, Texture},
     desktop::space::{RenderElement, SpaceOutputTuple, SurfaceTree},
-    input::pointer::CursorImageAttributes,
+    input::pointer::CursorImageSurfaceData,
     reexports::wayland_server::protocol::wl_surface,
     utils::{Logical, Physical, Point, Rectangle, Scale, Size, Transform},
     wayland::compositor::{get_role, with_states},
@@ -33,7 +31,7 @@ pub fn draw_cursor(
     position -= with_states(&surface, |states| {
         states
             .data_map
-            .get::<Mutex<CursorImageAttributes>>()
+            .get::<CursorImageSurfaceData>()
             .unwrap()
             .lock()
             .unwrap()

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, sync::Mutex};
+use std::cell::RefCell;
 
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
@@ -29,13 +29,12 @@ use smithay::{
         output::Output,
         shell::{
             wlr_layer::{
-                Layer, LayerSurface as WlrLayerSurface, LayerSurfaceAttributes, WlrLayerShellHandler,
+                Layer, LayerSurface as WlrLayerSurface, LayerSurfaceData, WlrLayerShellHandler,
                 WlrLayerShellState,
             },
             xdg::{
                 Configure, PopupSurface, PositionerState, SurfaceCachedState, ToplevelSurface,
-                XdgPopupSurfaceRoleAttributes, XdgShellHandler, XdgShellState,
-                XdgToplevelSurfaceRoleAttributes,
+                XdgPopupSurfaceData, XdgShellHandler, XdgShellState, XdgToplevelSurfaceData,
             },
         },
     },
@@ -552,7 +551,7 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
                 let is_resizing = with_states(&surface, |states| {
                     states
                         .data_map
-                        .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+                        .get::<XdgToplevelSurfaceData>()
                         .unwrap()
                         .lock()
                         .unwrap()
@@ -787,7 +786,7 @@ fn ensure_initial_configure(
             let initial_configure_sent = with_states(surface, |states| {
                 states
                     .data_map
-                    .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+                    .get::<XdgToplevelSurfaceData>()
                     .unwrap()
                     .lock()
                     .unwrap()
@@ -819,7 +818,7 @@ fn ensure_initial_configure(
         let initial_configure_sent = with_states(surface, |states| {
             states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()
@@ -848,7 +847,7 @@ fn ensure_initial_configure(
         let initial_configure_sent = with_states(surface, |states| {
             states
                 .data_map
-                .get::<Mutex<LayerSurfaceAttributes>>()
+                .get::<LayerSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()

--- a/smallvil/src/handlers/xdg_shell.rs
+++ b/smallvil/src/handlers/xdg_shell.rs
@@ -1,5 +1,3 @@
-use std::sync::Mutex;
-
 use smithay::{
     delegate_xdg_shell,
     desktop::{Kind, Space, Window, WindowSurfaceType},
@@ -19,7 +17,7 @@ use smithay::{
         compositor::with_states,
         shell::xdg::{
             PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler, XdgShellState,
-            XdgToplevelSurfaceRoleAttributes,
+            XdgToplevelSurfaceData,
         },
     },
 };
@@ -148,7 +146,7 @@ pub fn handle_commit(space: &Space, surface: &WlSurface) -> Option<()> {
         let initial_configure_sent = with_states(surface, |states| {
             states
                 .data_map
-                .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+                .get::<XdgToplevelSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()

--- a/src/desktop/popup/manager.rs
+++ b/src/desktop/popup/manager.rs
@@ -4,7 +4,7 @@ use crate::{
     wayland::{
         compositor::{get_role, with_states},
         seat::WaylandFocus,
-        shell::xdg::{XdgPopupSurfaceRoleAttributes, XDG_POPUP_ROLE},
+        shell::xdg::{XdgPopupSurfaceData, XDG_POPUP_ROLE},
     },
 };
 use std::{
@@ -99,7 +99,7 @@ impl PopupManager {
                 let committed = with_states(surface, |states| {
                     states
                         .data_map
-                        .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                        .get::<XdgPopupSurfaceData>()
                         .unwrap()
                         .lock()
                         .unwrap()
@@ -235,7 +235,7 @@ fn find_popup_root_surface(popup: &PopupKind) -> Result<WlSurface, DeadResource>
         parent = with_states(&parent, |states| {
             states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()

--- a/src/desktop/popup/mod.rs
+++ b/src/desktop/popup/mod.rs
@@ -1,8 +1,6 @@
 mod grab;
 mod manager;
 
-use std::sync::Mutex;
-
 pub use grab::*;
 pub use manager::*;
 use wayland_server::protocol::wl_surface::WlSurface;
@@ -14,7 +12,7 @@ use crate::{
     wayland::{
         compositor::with_states,
         seat::WaylandFocus,
-        shell::xdg::{PopupSurface, SurfaceCachedState, XdgPopupSurfaceRoleAttributes},
+        shell::xdg::{PopupSurface, SurfaceCachedState, XdgPopupSurfaceData},
     },
 };
 
@@ -90,7 +88,7 @@ impl PopupKind {
         with_states(wl_surface, |states| {
             states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()

--- a/src/input/pointer/cursor_image.rs
+++ b/src/input/pointer/cursor_image.rs
@@ -2,6 +2,7 @@
 use wayland_server::protocol::wl_surface::WlSurface;
 
 use crate::utils::{Logical, Point};
+use std::sync::Mutex;
 
 /// The role representing a surface set as the pointer cursor
 #[derive(Debug, Default, Copy, Clone)]
@@ -9,6 +10,21 @@ pub struct CursorImageAttributes {
     /// Location of the hotspot of the pointer in the surface
     pub hotspot: Point<i32, Logical>,
 }
+
+/// Data associated with XDG toplevel surface  
+///
+/// ```no_run
+/// # #[cfg(feature = "wayland_frontend")]
+/// use smithay::wayland::compositor;
+/// use smithay::input::pointer::CursorImageSurfaceData;
+///
+/// # let wl_surface = todo!();
+/// # #[cfg(feature = "wayland_frontend")]
+/// compositor::with_states(&wl_surface, |states| {
+///     states.data_map.get::<CursorImageSurfaceData>();
+/// });
+/// ```
+pub type CursorImageSurfaceData = Mutex<CursorImageAttributes>;
 
 /// Possible status of a cursor as requested by clients
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 mod cursor_image;
-pub use cursor_image::{CursorImageAttributes, CursorImageStatus};
+pub use cursor_image::{CursorImageAttributes, CursorImageStatus, CursorImageSurfaceData};
 
 mod grab;
 use grab::{DefaultGrab, GrabStatus};

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -10,11 +10,12 @@ use crate::utils::{
     alive_tracker::{AliveTracker, IsAlive},
     Serial,
 };
+use crate::wayland::shell::xdg::XdgPopupSurfaceData;
 use crate::wayland::{compositor, shell::wlr_layer::Layer};
 
 use super::{
-    Anchor, KeyboardInteractivity, LayerSurfaceAttributes, LayerSurfaceCachedState, Margins,
-    WlrLayerShellHandler, WlrLayerShellState,
+    Anchor, KeyboardInteractivity, LayerSurfaceAttributes, LayerSurfaceCachedState, LayerSurfaceData,
+    Margins, WlrLayerShellHandler, WlrLayerShellState,
 };
 
 use super::LAYER_SURFACE_ROLE;
@@ -262,7 +263,7 @@ where
                 compositor::with_states(&data.wl_surface, move |states| {
                     states
                         .data_map
-                        .get::<Mutex<crate::wayland::shell::xdg::XdgPopupSurfaceRoleAttributes>>()
+                        .get::<XdgPopupSurfaceData>()
                         .unwrap()
                         .lock()
                         .unwrap()
@@ -282,7 +283,7 @@ where
                 let found_configure = compositor::with_states(surface, |states| {
                     states
                         .data_map
-                        .get::<Mutex<LayerSurfaceAttributes>>()
+                        .get::<LayerSurfaceData>()
                         .unwrap()
                         .lock()
                         .unwrap()

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -75,6 +75,19 @@ pub use types::{Anchor, ExclusiveZone, KeyboardInteractivity, Layer, Margins};
 /// The role of a wlr_layer_shell_surface
 pub const LAYER_SURFACE_ROLE: &str = "zwlr_layer_surface_v1";
 
+/// Data associated with XDG popup surface  
+///
+/// ```no_run
+/// use smithay::wayland::compositor;
+/// use smithay::wayland::shell::wlr_layer::LayerSurfaceData;
+///
+/// # let wl_surface = todo!();
+/// compositor::with_states(&wl_surface, |states| {
+///     states.data_map.get::<LayerSurfaceData>();
+/// });
+/// ```
+pub type LayerSurfaceData = Mutex<LayerSurfaceAttributes>;
+
 /// Attributes for layer surface
 #[derive(Debug)]
 pub struct LayerSurfaceAttributes {

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use crate::utils::alive_tracker::{AliveTracker, IsAlive};
+use crate::wayland::shell::xdg::{XdgPopupSurfaceData, XdgToplevelSurfaceData};
 use crate::{
     utils::{Rectangle, Serial},
     wayland::{
@@ -165,7 +166,7 @@ where
                     });
                     *states
                         .data_map
-                        .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                        .get::<XdgPopupSurfaceData>()
                         .unwrap()
                         .lock()
                         .unwrap() = attributes;
@@ -256,7 +257,7 @@ where
                     if states.role == Some(XDG_TOPLEVEL_ROLE) {
                         Ok(states
                             .data_map
-                            .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+                            .get::<XdgToplevelSurfaceData>()
                             .unwrap()
                             .lock()
                             .unwrap()
@@ -264,7 +265,7 @@ where
                     } else if states.role == Some(XDG_POPUP_ROLE) {
                         Ok(states
                             .data_map
-                            .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                            .get::<XdgPopupSurfaceData>()
                             .unwrap()
                             .lock()
                             .unwrap()

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -1,6 +1,9 @@
-use std::sync::{atomic::Ordering, Mutex};
+use std::sync::atomic::Ordering;
 
-use crate::{utils::Serial, wayland::compositor};
+use crate::{
+    utils::Serial,
+    wayland::{compositor, shell::xdg::XdgToplevelSurfaceData},
+};
 
 use wayland_protocols::xdg::shell::server::xdg_toplevel::{self, XdgToplevel};
 
@@ -140,7 +143,7 @@ where
     compositor::with_states(&data.wl_surface, |states| {
         f(&mut *states
             .data_map
-            .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+            .get::<XdgToplevelSurfaceData>()
             .unwrap()
             .lock()
             .unwrap())

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -333,6 +333,19 @@ xdg_role!(
     }
 );
 
+/// Data associated with XDG toplevel surface  
+///
+/// ```no_run
+/// use smithay::wayland::compositor;
+/// use smithay::wayland::shell::xdg::XdgToplevelSurfaceData;
+///
+/// # let wl_surface = todo!();
+/// compositor::with_states(&wl_surface, |states| {
+///     states.data_map.get::<XdgToplevelSurfaceData>();
+/// });
+/// ```
+pub type XdgToplevelSurfaceData = Mutex<XdgToplevelSurfaceRoleAttributes>;
+
 xdg_role!(
     PopupState,
     /// A configure message for popup surface
@@ -393,6 +406,19 @@ xdg_role!(
         popup_handle: Option<xdg_popup::XdgPopup>
     }
 );
+
+/// Data associated with XDG popup surface  
+///
+/// ```no_run
+/// use smithay::wayland::compositor;
+/// use smithay::wayland::shell::xdg::XdgPopupSurfaceData;
+///
+/// # let wl_surface = todo!();
+/// compositor::with_states(&wl_surface, |states| {
+///     states.data_map.get::<XdgPopupSurfaceData>();
+/// });
+/// ```
+pub type XdgPopupSurfaceData = Mutex<XdgPopupSurfaceRoleAttributes>;
 
 /// Represents the state of the popup
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -1070,7 +1096,7 @@ impl ToplevelSurface {
         let configure = compositor::with_states(&self.wl_surface, |states| {
             let mut attributes = states
                 .data_map
-                .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+                .get::<XdgToplevelSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap();
@@ -1122,7 +1148,7 @@ impl ToplevelSurface {
         compositor::with_states(surface, |states| {
             let mut guard = states
                 .data_map
-                .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+                .get::<XdgToplevelSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap();
@@ -1144,7 +1170,7 @@ impl ToplevelSurface {
         let configured = compositor::with_states(&self.wl_surface, |states| {
             states
                 .data_map
-                .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+                .get::<XdgToplevelSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()
@@ -1192,7 +1218,7 @@ impl ToplevelSurface {
         compositor::with_states(&self.wl_surface, |states| {
             let mut attributes = states
                 .data_map
-                .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+                .get::<XdgToplevelSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap();
@@ -1210,7 +1236,7 @@ impl ToplevelSurface {
         compositor::with_states(&self.wl_surface, |states| {
             let attributes = states
                 .data_map
-                .get::<Mutex<XdgToplevelSurfaceRoleAttributes>>()
+                .get::<XdgToplevelSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap();
@@ -1287,7 +1313,7 @@ impl PopupSurface {
         compositor::with_states(&self.wl_surface, |states| {
             states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()
@@ -1320,7 +1346,7 @@ impl PopupSurface {
         let next_configure = compositor::with_states(&self.wl_surface, |states| {
             let mut attributes = states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap();
@@ -1368,7 +1394,7 @@ impl PopupSurface {
         compositor::with_states(&self.wl_surface, |states| {
             let attributes = states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap();
@@ -1410,7 +1436,7 @@ impl PopupSurface {
         let send_error_to = compositor::with_states(surface, |states| {
             let attributes = states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap();
@@ -1432,7 +1458,7 @@ impl PopupSurface {
         compositor::with_states(surface, |states| {
             let mut attributes = states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap();
@@ -1460,7 +1486,7 @@ impl PopupSurface {
         let configured = compositor::with_states(&self.wl_surface, |states| {
             states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()
@@ -1511,7 +1537,7 @@ impl PopupSurface {
         compositor::with_states(&self.wl_surface, |states| {
             let mut attributes = states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap();


### PR DESCRIPTION
Replaces cases of `data_map.get::<Mutex<Type>>()` with type alias `.get::<NameSurfaceData>()`

So it should be a lot easier to figure out what can be extracted from surface states