### PR TITLE
Bugfix/input method popup surface must stay on focused surface

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -183,14 +183,12 @@ impl<Backend> AnvilState<Backend> {
                     .get::<FullscreenSurface>()
                     .and_then(|f| f.get())
                 {
-                    if let Some((_, point)) = window
-                        .surface_under(
-                            self.pointer_location - output_geo.loc.to_f64(),
-                            WindowSurfaceType::ALL,
-                        )
-                    {
-                        keyboard.set_focus(self, Some(window.toplevel().wl_surface().clone()), serial);
+                    if let Some((_, point)) = window.surface_under(
+                        self.pointer_location - output_geo.loc.to_f64(),
+                        WindowSurfaceType::ALL,
+                    ) {
                         input_method.set_point(&point);
+                        keyboard.set_focus(self, Some(window.toplevel().wl_surface().clone()), serial);
                         return;
                     }
                 }
@@ -200,21 +198,18 @@ impl<Backend> AnvilState<Backend> {
                     .layer_under(WlrLayer::Overlay, self.pointer_location)
                     .or_else(|| layers.layer_under(WlrLayer::Top, self.pointer_location))
                 {
-                    if layer.can_receive_keyboard_focus(){
-                        if let Some((_, point)) = layer
-                            .surface_under(
-                                self.pointer_location
-                                    - output_geo.loc.to_f64()
-                                    - layers.layer_geometry(layer).unwrap().loc.to_f64(),
-                                WindowSurfaceType::ALL,
-                            )
-                            
-                    {
-                        keyboard.set_focus(self, Some(layer.wl_surface().clone()), serial);
-                        input_method.set_point(&point);
-                        return;
+                    if layer.can_receive_keyboard_focus() {
+                        if let Some((_, point)) = layer.surface_under(
+                            self.pointer_location
+                                - output_geo.loc.to_f64()
+                                - layers.layer_geometry(layer).unwrap().loc.to_f64(),
+                            WindowSurfaceType::ALL,
+                        ) {
+                            input_method.set_point(&point);
+                            keyboard.set_focus(self, Some(layer.wl_surface().clone()), serial);
+                            return;
+                        }
                     }
-                }
                 }
             }
 
@@ -223,8 +218,8 @@ impl<Backend> AnvilState<Backend> {
                 .surface_under(self.pointer_location, WindowSurfaceType::ALL)
             {
                 self.space.raise_window(&window, true);
-                keyboard.set_focus(self, Some(window.toplevel().wl_surface().clone()), serial);
                 input_method.set_point(&point);
+                keyboard.set_focus(self, Some(window.toplevel().wl_surface().clone()), serial);
                 return;
             }
 
@@ -235,19 +230,17 @@ impl<Backend> AnvilState<Backend> {
                     .layer_under(WlrLayer::Bottom, self.pointer_location)
                     .or_else(|| layers.layer_under(WlrLayer::Background, self.pointer_location))
                 {
-                    if layer.can_receive_keyboard_focus(){
-                    if let Some((_, point)) = layer
-                            .surface_under(
-                                self.pointer_location
-                                    - output_geo.loc.to_f64()
-                                    - layers.layer_geometry(layer).unwrap().loc.to_f64(),
-                                WindowSurfaceType::ALL,
-                            )
-                    {
-                        keyboard.set_focus(self, Some(layer.wl_surface().clone()), serial);
-                        input_method.set_point(&point);
+                    if layer.can_receive_keyboard_focus() {
+                        if let Some((_, point)) = layer.surface_under(
+                            self.pointer_location
+                                - output_geo.loc.to_f64()
+                                - layers.layer_geometry(layer).unwrap().loc.to_f64(),
+                            WindowSurfaceType::ALL,
+                        ) {
+                            input_method.set_point(&point);
+                            keyboard.set_focus(self, Some(layer.wl_surface().clone()), serial);
+                        }
                     }
-                }
                 }
             };
         }

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -224,5 +224,8 @@ where
 
     fn destroyed(_state: &mut D, _client: ClientId, _input_method: ObjectId, data: &InputMethodUserData<D>) {
         data.handle.inner.lock().unwrap().instance = None;
+        data.text_input_handle.with_focused_text_input(|ti,surface,_| {
+            ti.leave(surface);
+        });
     }
 }

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -224,7 +224,7 @@ where
 
     fn destroyed(_state: &mut D, _client: ClientId, _input_method: ObjectId, data: &InputMethodUserData<D>) {
         data.handle.inner.lock().unwrap().instance = None;
-        data.text_input_handle.with_focused_text_input(|ti,surface,_| {
+        data.text_input_handle.with_focused_text_input(|ti, surface, _| {
             ti.leave(surface);
         });
     }

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -203,7 +203,7 @@ where
                 );
                 let mut keyboard = input_method.keyboard_grab.inner.lock().unwrap();
                 keyboard.grab = Some(instance.clone());
-                keyboard.text_input_handle = Some(data.text_input_handle.clone());
+                keyboard.text_input_handle = data.text_input_handle.clone();
                 keyboard.popup_handle = input_method.popup.clone();
                 instance.repeat_info(keyboard.repeat_rate, keyboard.repeat_delay);
                 keyboard

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -204,7 +204,7 @@ where
                 let mut keyboard = input_method.keyboard_grab.inner.lock().unwrap();
                 keyboard.grab = Some(instance.clone());
                 keyboard.text_input_handle = Some(data.text_input_handle.clone());
-                keyboard.popup = input_method.popup.clone();
+                keyboard.popup_handle = input_method.popup.clone();
                 instance.repeat_info(keyboard.repeat_rate, keyboard.repeat_delay);
                 keyboard
                     .keymap_file

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -204,6 +204,7 @@ where
                 let mut keyboard = input_method.keyboard_grab.inner.lock().unwrap();
                 keyboard.grab = Some(instance.clone());
                 keyboard.text_input_handle = Some(data.text_input_handle.clone());
+                keyboard.popup = input_method.popup.clone();
                 instance.repeat_info(keyboard.repeat_rate, keyboard.repeat_delay);
                 keyboard
                     .keymap_file

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -16,8 +16,8 @@ use crate::input::{
 };
 use crate::wayland::{seat::WaylandFocus, text_input::TextInputHandle};
 
-use super::InputMethodManagerState;
 use super::input_method_popup_surface::InputMethodPopupSurfaceHandle;
+use super::InputMethodManagerState;
 
 #[derive(Default, Debug)]
 pub(crate) struct InputMethodKeyboard {
@@ -26,7 +26,7 @@ pub(crate) struct InputMethodKeyboard {
     pub repeat_rate: i32,
     pub keymap_file: Option<KeymapFile>,
     pub text_input_handle: Option<TextInputHandle>,
-    pub popup: InputMethodPopupSurfaceHandle
+    pub popup: InputMethodPopupSurfaceHandle,
 }
 
 /// Handle to an input method instance

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -17,6 +17,7 @@ use crate::input::{
 use crate::wayland::{seat::WaylandFocus, text_input::TextInputHandle};
 
 use super::InputMethodManagerState;
+use super::input_method_popup_surface::InputMethodPopupSurfaceHandle;
 
 #[derive(Default, Debug)]
 pub(crate) struct InputMethodKeyboard {
@@ -25,6 +26,7 @@ pub(crate) struct InputMethodKeyboard {
     pub repeat_rate: i32,
     pub keymap_file: Option<KeymapFile>,
     pub text_input_handle: Option<TextInputHandle>,
+    pub popup: InputMethodPopupSurfaceHandle
 }
 
 /// Handle to an input method instance
@@ -76,11 +78,12 @@ where
         serial: crate::utils::Serial,
     ) {
         let inner = self.inner.lock().unwrap();
+        let popup = &inner.popup;
         inner
             .text_input_handle
             .as_ref()
             .unwrap()
-            .set_focus(focus.as_ref().and_then(|f| f.wl_surface()));
+            .set_focus(focus.as_ref().and_then(|f| f.wl_surface()), popup);
         handle.set_focus(data, focus, serial)
     }
 

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -25,7 +25,7 @@ pub(crate) struct InputMethodKeyboard {
     pub repeat_delay: i32,
     pub repeat_rate: i32,
     pub keymap_file: Option<KeymapFile>,
-    pub text_input_handle: Option<TextInputHandle>,
+    pub text_input_handle: TextInputHandle,
     pub popup_handle: InputMethodPopupSurfaceHandle,
 }
 
@@ -52,22 +52,18 @@ where
     ) {
         let inner = self.inner.lock().unwrap();
         let keyboard = inner.grab.as_ref().unwrap();
-        inner
-            .text_input_handle
-            .as_ref()
-            .unwrap()
-            .with_focused_text_input(|_, _, serial| {
-                if let Some(serialized) = modifiers.map(|m| m.serialized) {
-                    keyboard.modifiers(
-                        *serial,
-                        serialized.depressed,
-                        serialized.latched,
-                        serialized.locked,
-                        serialized.layout_locked,
-                    )
-                }
-                keyboard.key(*serial, time, keycode, key_state.into());
-            });
+        inner.text_input_handle.with_focused_text_input(|_, _, serial| {
+            if let Some(serialized) = modifiers.map(|m| m.serialized) {
+                keyboard.modifiers(
+                    *serial,
+                    serialized.depressed,
+                    serialized.latched,
+                    serialized.locked,
+                    serialized.layout_locked,
+                )
+            }
+            keyboard.key(*serial, time, keycode, key_state.into());
+        });
     }
 
     fn set_focus(
@@ -78,13 +74,12 @@ where
         serial: crate::utils::Serial,
     ) {
         let inner = self.inner.lock().unwrap();
-        inner.text_input_handle.as_ref().unwrap().set_focus(
-            focus.as_ref().and_then(|f| f.wl_surface()),
-            || {
+        inner
+            .text_input_handle
+            .set_focus(focus.as_ref().and_then(|f| f.wl_surface()), || {
                 let mut popup = inner.popup_handle.inner.lock().unwrap();
                 popup.surface_role = None;
-            },
-        );
+            });
         handle.set_focus(data, focus, serial)
     }
 

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -26,7 +26,7 @@ pub(crate) struct InputMethodKeyboard {
     pub repeat_rate: i32,
     pub keymap_file: Option<KeymapFile>,
     pub text_input_handle: Option<TextInputHandle>,
-    pub popup: InputMethodPopupSurfaceHandle,
+    pub popup_handle: InputMethodPopupSurfaceHandle,
 }
 
 /// Handle to an input method instance
@@ -83,7 +83,7 @@ where
             .as_ref()
             .unwrap()
             .set_focus(focus.as_ref().and_then(|f| f.wl_surface()), || {
-            let mut popup = inner.popup.inner.lock().unwrap();
+            let mut popup = inner.popup_handle.inner.lock().unwrap();
             popup.surface_role = None;
         });
         handle.set_focus(data, focus, serial)

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -78,14 +78,13 @@ where
         serial: crate::utils::Serial,
     ) {
         let inner = self.inner.lock().unwrap();
-        inner
-            .text_input_handle
-            .as_ref()
-            .unwrap()
-            .set_focus(focus.as_ref().and_then(|f| f.wl_surface()), || {
-            let mut popup = inner.popup_handle.inner.lock().unwrap();
-            popup.surface_role = None;
-        });
+        inner.text_input_handle.as_ref().unwrap().set_focus(
+            focus.as_ref().and_then(|f| f.wl_surface()),
+            || {
+                let mut popup = inner.popup_handle.inner.lock().unwrap();
+                popup.surface_role = None;
+            },
+        );
         handle.set_focus(data, focus, serial)
     }
 

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -78,12 +78,14 @@ where
         serial: crate::utils::Serial,
     ) {
         let inner = self.inner.lock().unwrap();
-        let popup = &inner.popup;
         inner
             .text_input_handle
             .as_ref()
             .unwrap()
-            .set_focus(focus.as_ref().and_then(|f| f.wl_surface()), popup);
+            .set_focus(focus.as_ref().and_then(|f| f.wl_surface()), || {
+            let mut popup = inner.popup.inner.lock().unwrap();
+            popup.surface_role = None;
+        });
         handle.set_focus(data, focus, serial)
     }
 

--- a/src/wayland/input_method/mod.rs
+++ b/src/wayland/input_method/mod.rs
@@ -183,6 +183,9 @@ where
                 user_data.insert_if_missing(TextInputHandle::default);
                 let handle = user_data.get::<InputMethodHandle>().unwrap();
                 let text_input_handle = user_data.get::<TextInputHandle>().unwrap();
+                text_input_handle.with_focused_text_input(|ti, surface, _| {
+                    ti.enter(surface);
+                });
                 let keyboard_handle = seat.get_keyboard().unwrap();
                 let instance = data_init.init(
                     input_method,

--- a/src/wayland/input_method/mod.rs
+++ b/src/wayland/input_method/mod.rs
@@ -76,7 +76,7 @@ use crate::input::{keyboard::XkbConfig, Seat, SeatHandler};
 
 pub use input_method_handle::{InputMethodHandle, InputMethodUserData};
 pub use input_method_keyboard_grab::InputMethodKeyboardUserData;
-pub use input_method_popup_surface::InputMethodPopupSurfaceUserData;
+pub use input_method_popup_surface::{InputMethodPopupSurfaceHandle, InputMethodPopupSurfaceUserData};
 
 use super::text_input::TextInputHandle;
 

--- a/src/wayland/input_method/mod.rs
+++ b/src/wayland/input_method/mod.rs
@@ -76,7 +76,7 @@ use crate::input::{keyboard::XkbConfig, Seat, SeatHandler};
 
 pub use input_method_handle::{InputMethodHandle, InputMethodUserData};
 pub use input_method_keyboard_grab::InputMethodKeyboardUserData;
-pub use input_method_popup_surface::{InputMethodPopupSurfaceHandle, InputMethodPopupSurfaceUserData};
+pub use input_method_popup_surface::InputMethodPopupSurfaceUserData;
 
 use super::text_input::TextInputHandle;
 

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -5,7 +5,7 @@ use wayland_server::backend::{ClientId, ObjectId};
 use wayland_server::{protocol::wl_surface::WlSurface, Dispatch, Resource};
 
 use crate::utils::IsAlive;
-use crate::wayland::input_method::{InputMethodHandle, InputMethodPopupSurfaceHandle};
+use crate::wayland::input_method::InputMethodHandle;
 
 use super::TextInputManagerState;
 
@@ -64,12 +64,14 @@ impl TextInputHandle {
     }
 
     /// Sets text input focus to a surface
-    pub fn set_focus(&self, focus: Option<&WlSurface>, popup: &InputMethodPopupSurfaceHandle) {
+    pub fn set_focus<F>(&self, focus: Option<&WlSurface>, f: F)
+    where
+        F: Fn(),
+    {
         let mut inner = self.inner.lock().unwrap();
         let same = inner.focus.as_ref() == focus;
         if !same {
-            let mut popup = popup.inner.lock().unwrap();
-            popup.surface_role = None;
+            f();
             inner.with_focused_text_input(|ti, surface, _serial| {
                 ti.leave(surface);
             });

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -63,15 +63,16 @@ impl TextInputHandle {
         }
     }
 
-    /// Sets text input focus to a surface
-    pub fn set_focus<F>(&self, focus: Option<&WlSurface>, f: F)
+    /// Sets text input focus to a surface, the hook can be used to e.g. 
+    /// delete the popup surface role so it does not flicker between focused surfaces
+    pub fn set_focus<F>(&self, focus: Option<&WlSurface>, focus_changed_hook: F)
     where
         F: Fn(),
     {
         let mut inner = self.inner.lock().unwrap();
         let same = inner.focus.as_ref() == focus;
         if !same {
-            f();
+            focus_changed_hook();
             inner.with_focused_text_input(|ti, surface, _serial| {
                 ti.leave(surface);
             });

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -5,7 +5,7 @@ use wayland_server::backend::{ClientId, ObjectId};
 use wayland_server::{protocol::wl_surface::WlSurface, Dispatch, Resource};
 
 use crate::utils::IsAlive;
-use crate::wayland::input_method::InputMethodHandle;
+use crate::wayland::input_method::{InputMethodHandle, InputMethodPopupSurfaceHandle};
 
 use super::TextInputManagerState;
 
@@ -63,11 +63,13 @@ impl TextInputHandle {
         }
     }
 
-    /// Sets text input focus to a surfacee
-    pub fn set_focus(&self, focus: Option<&WlSurface>) {
+    /// Sets text input focus to a surface
+    pub fn set_focus(&self, focus: Option<&WlSurface>, popup: &InputMethodPopupSurfaceHandle) {
         let mut inner = self.inner.lock().unwrap();
         let same = inner.focus.as_ref() == focus;
         if !same {
+            let mut popup = popup.inner.lock().unwrap();
+            popup.surface_role = None;
             inner.with_focused_text_input(|ti, surface, _serial| {
                 ti.leave(surface);
             });

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -63,7 +63,7 @@ impl TextInputHandle {
         }
     }
 
-    /// Sets text input focus to a surface, the hook can be used to e.g. 
+    /// Sets text input focus to a surface, the hook can be used to e.g.
     /// delete the popup surface role so it does not flicker between focused surfaces
     pub fn set_focus<F>(&self, focus: Option<&WlSurface>, focus_changed_hook: F)
     where


### PR DESCRIPTION
This fixes input method popup surface moving between surfaces by mouse focus, it now stays put on a focused surface. 
The popup surface would also flicker before it disappears(happens when one has not closed the popup surface before changing focus), this has also been fixed. :) 
Edit: Also fixes leaving a text input when an input method is destroyed
Edit: Also fixes entering a focused text input when an IME is started on a focused surface