### PR TITLE
Add destroy hooks to XDG/Layer shell handlers

### DIFF
--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -308,18 +308,21 @@ where
     }
 
     fn destroyed(
-        _state: &mut D,
+        state: &mut D,
         _client_id: wayland_server::backend::ClientId,
         object_id: wayland_server::backend::ObjectId,
         data: &WlrLayerSurfaceUserData,
     ) {
         data.alive_tracker.destroy_notify();
+
         // remove this surface from the known ones (as well as any leftover dead surface)
         data.shell_data
             .known_layers
             .lock()
             .unwrap()
             .retain(|other| other.shell_surface.id() != object_id);
+
+        WlrLayerShellHandler::destroyed(state);
     }
 }
 

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -316,13 +316,14 @@ where
         data.alive_tracker.destroy_notify();
 
         // remove this surface from the known ones (as well as any leftover dead surface)
-        data.shell_data
-            .known_layers
-            .lock()
-            .unwrap()
-            .retain(|other| other.shell_surface.id() != object_id);
-
-        WlrLayerShellHandler::destroyed(state);
+        let layers = &mut data.shell_data.known_layers.lock().unwrap();
+        if let Some(index) = layers
+            .iter()
+            .position(|layer| layer.shell_surface.id() == object_id)
+        {
+            let layer = layers.remove(index);
+            WlrLayerShellHandler::layer_destroyed(state, layer);
+        }
     }
 }
 

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -322,6 +322,7 @@ where
             .position(|layer| layer.shell_surface.id() == object_id)
         {
             let layer = layers.remove(index);
+            drop(layers);
             WlrLayerShellHandler::layer_destroyed(state, layer);
         }
     }

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -316,7 +316,7 @@ where
         data.alive_tracker.destroy_notify();
 
         // remove this surface from the known ones (as well as any leftover dead surface)
-        let layers = &mut data.shell_data.known_layers.lock().unwrap();
+        let mut layers = data.shell_data.known_layers.lock().unwrap();
         if let Some(index) = layers
             .iter()
             .position(|layer| layer.shell_surface.id() == object_id)

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -246,6 +246,9 @@ pub trait WlrLayerShellHandler {
 
     /// A surface has acknowledged a configure serial.
     fn ack_configure(&mut self, surface: wl_surface::WlSurface, configure: LayerSurfaceConfigure) {}
+
+    /// A layer surface was destroyed.
+    fn destroyed(&mut self) {}
 }
 
 /// A handle to a layer surface

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -248,7 +248,7 @@ pub trait WlrLayerShellHandler {
     fn ack_configure(&mut self, surface: wl_surface::WlSurface, configure: LayerSurfaceConfigure) {}
 
     /// A layer surface was destroyed.
-    fn destroyed(&mut self) {}
+    fn layer_destroyed(&mut self, surface: LayerSurface) {}
 }
 
 /// A handle to a layer surface

--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -61,7 +61,7 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _client_id: ClientId, object_id: ObjectId, data: &XdgShellSurfaceUserData) {
+    fn destroyed(state: &mut D, _client_id: ClientId, object_id: ObjectId, data: &XdgShellSurfaceUserData) {
         data.alive_tracker.destroy_notify();
 
         // remove this surface from the known ones (as well as any leftover dead surface)
@@ -70,6 +70,8 @@ where
             .unwrap()
             .known_popups
             .retain(|other| other.shell_surface.id() != object_id);
+
+        XdgShellHandler::popup_destroyed(state);
     }
 }
 

--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -65,13 +65,11 @@ where
         data.alive_tracker.destroy_notify();
 
         // remove this surface from the known ones (as well as any leftover dead surface)
-        data.shell_data
-            .lock()
-            .unwrap()
-            .known_popups
-            .retain(|other| other.shell_surface.id() != object_id);
-
-        XdgShellHandler::popup_destroyed(state);
+        let popups = &mut data.shell_data.lock().unwrap().known_popups;
+        if let Some(index) = popups.iter().position(|pop| pop.shell_surface.id() == object_id) {
+            let popup = popups.remove(index);
+            XdgShellHandler::popup_destroyed(state, popup);
+        }
     }
 }
 

--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -65,10 +65,14 @@ where
         data.alive_tracker.destroy_notify();
 
         // remove this surface from the known ones (as well as any leftover dead surface)
-        let popups = &mut data.shell_data.lock().unwrap().known_popups;
-        if let Some(index) = popups.iter().position(|pop| pop.shell_surface.id() == object_id) {
-            let popup = popups.remove(index);
-            drop(popups);
+        let mut shell_data = data.shell_data.lock().unwrap();
+        if let Some(index) = shell_data
+            .known_popups
+            .iter()
+            .position(|pop| pop.shell_surface.id() == object_id)
+        {
+            let popup = shell_data.known_popups.remove(index);
+            drop(shell_data);
             XdgShellHandler::popup_destroyed(state, popup);
         }
     }

--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -68,6 +68,7 @@ where
         let popups = &mut data.shell_data.lock().unwrap().known_popups;
         if let Some(index) = popups.iter().position(|pop| pop.shell_surface.id() == object_id) {
             let popup = popups.remove(index);
+            drop(popups);
             XdgShellHandler::popup_destroyed(state, popup);
         }
     }

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -122,7 +122,7 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _client_id: ClientId, object_id: ObjectId, data: &XdgShellSurfaceUserData) {
+    fn destroyed(state: &mut D, _client_id: ClientId, object_id: ObjectId, data: &XdgShellSurfaceUserData) {
         data.alive_tracker.destroy_notify();
         data.decoration.lock().unwrap().take();
 
@@ -132,6 +132,8 @@ where
             .unwrap()
             .known_toplevels
             .retain(|other| other.shell_surface.id() != object_id);
+
+        XdgShellHandler::toplevel_destroyed(state);
     }
 }
 

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -133,7 +133,11 @@ where
             .known_toplevels
             .retain(|other| other.shell_surface.id() != object_id);
 
-        XdgShellHandler::toplevel_destroyed(state);
+        let toplevels = &mut data.shell_data.lock().unwrap().known_toplevels;
+        if let Some(index) = toplevels.iter().position(|top| top.shell_surface.id() == object_id) {
+            let toplevel = toplevels.remove(index);
+            XdgShellHandler::toplevel_destroyed(state, toplevel);
+        }
     }
 }
 

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -136,6 +136,7 @@ where
         let toplevels = &mut data.shell_data.lock().unwrap().known_toplevels;
         if let Some(index) = toplevels.iter().position(|top| top.shell_surface.id() == object_id) {
             let toplevel = toplevels.remove(index);
+            drop(toplevels);
             XdgShellHandler::toplevel_destroyed(state, toplevel);
         }
     }

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -134,7 +134,10 @@ where
             .retain(|other| other.shell_surface.id() != object_id);
 
         let toplevels = &mut data.shell_data.lock().unwrap().known_toplevels;
-        if let Some(index) = toplevels.iter().position(|top| top.shell_surface.id() == object_id) {
+        if let Some(index) = toplevels
+            .iter()
+            .position(|top| top.shell_surface.id() == object_id)
+        {
             let toplevel = toplevels.remove(index);
             drop(toplevels);
             XdgShellHandler::toplevel_destroyed(state, toplevel);

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -133,13 +133,14 @@ where
             .known_toplevels
             .retain(|other| other.shell_surface.id() != object_id);
 
-        let toplevels = &mut data.shell_data.lock().unwrap().known_toplevels;
-        if let Some(index) = toplevels
+        let mut shell_data = data.shell_data.lock().unwrap();
+        if let Some(index) = shell_data
+            .known_toplevels
             .iter()
             .position(|top| top.shell_surface.id() == object_id)
         {
-            let toplevel = toplevels.remove(index);
-            drop(toplevels);
+            let toplevel = shell_data.known_toplevels.remove(index);
+            drop(shell_data);
             XdgShellHandler::toplevel_destroyed(state, toplevel);
         }
     }

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -872,10 +872,10 @@ pub trait XdgShellHandler {
     fn reposition_request(&mut self, surface: PopupSurface, positioner: PositionerState, token: u32) {}
 
     /// A toplevel surface was destroyed.
-    fn toplevel_destroyed(&mut self) {}
+    fn toplevel_destroyed(&mut self, surface: ToplevelSurface) {}
 
     /// A popup surface was destroyed.
-    fn popup_destroyed(&mut self) {}
+    fn popup_destroyed(&mut self, surface: PopupSurface) {}
 }
 
 #[derive(Debug)]

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -43,7 +43,7 @@
 //! // implement the necessary traits
 //! impl XdgShellHandler for State {
 //!     fn xdg_shell_state(&mut self) -> &mut XdgShellState {
-//!         &mut self.xdg_shell_state    
+//!         &mut self.xdg_shell_state
 //!     }
 //!
 //!     // handle the shell requests here.
@@ -870,6 +870,12 @@ pub trait XdgShellHandler {
     ///     is acknowledged by the client. See xdg_popup.repositioned for details.
     ///     The token itself is opaque, and has no other special meaning.
     fn reposition_request(&mut self, surface: PopupSurface, positioner: PositionerState, token: u32) {}
+
+    /// A toplevel surface was destroyed.
+    fn toplevel_destroyed(&mut self) {}
+
+    /// A popup surface was destroyed.
+    fn popup_destroyed(&mut self) {}
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This adds `destroyed` methods for handling the death of XDG
toplevel, XDG popup and layer shell surfaces.

Providing these methods for the handlers directly allows for easy state
access and should simplify the likely different handling for the
individual shell surface types.