### PR TITLE
Fix new seat module ergonomics

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -95,13 +95,15 @@ impl<Backend> AnvilState<Backend> {
                 && (data.layer == WlrLayer::Top || data.layer == WlrLayer::Overlay)
             {
                 keyboard.set_focus(self, Some(layer.wl_surface().clone()), serial);
-                keyboard.input::<(), _>(self, keycode, state, serial, time, |_, _| FilterResult::Forward);
+                keyboard.input::<(), _>(self, keycode, state, serial, time, |_, _, _| {
+                    FilterResult::Forward
+                });
                 return KeyAction::None;
             }
         }
 
         let action = keyboard
-            .input(self, keycode, state, serial, time, |modifiers, handle| {
+            .input(self, keycode, state, serial, time, |_, modifiers, handle| {
                 let keysym = handle.modified_sym();
 
                 debug!(log, "keysym";

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -160,7 +160,7 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
                         event.state(),
                         0.into(),
                         0,
-                        |_, _| {
+                        |_, _, _| {
                             //
                             FilterResult::Forward
                         },

--- a/examples/seat.rs
+++ b/examples/seat.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             smithay::backend::input::KeyState::Pressed,
             0.into(),
             0,
-            |_, _| {
+            |_, _, _| {
                 if false {
                     FilterResult::Intercept(0)
                 } else {

--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -26,7 +26,7 @@ impl Smallvil {
                     event.state(),
                     serial,
                     time,
-                    |_, _| FilterResult::Forward,
+                    |_, _, _| FilterResult::Forward,
                 );
             }
             InputEvent::PointerMotion { .. } => {}

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -455,7 +455,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         filter: F,
     ) -> Option<T>
     where
-        F: FnOnce(&ModifiersState, KeysymHandle<'_>) -> FilterResult<T>,
+        F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> FilterResult<T>,
     {
         trace!(self.arc.logger, "Handling keystroke"; "keycode" => keycode, "state" => format_args!("{:?}", state));
         let mut guard = self.arc.internal.lock().unwrap();
@@ -472,7 +472,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
             "mods_state" => format_args!("{:?}", guard.mods_state), "sym" => xkb::keysym_get_name(key_handle.modified_sym())
         );
 
-        if let FilterResult::Intercept(val) = filter(&guard.mods_state, key_handle) {
+        if let FilterResult::Intercept(val) = filter(data, &guard.mods_state, key_handle) {
             // the filter returned false, we do not forward to client
             trace!(self.arc.logger, "Input was intercepted by filter");
             return Some(val);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -12,7 +12,7 @@
 //!
 //! To start using this module you need to create a [`SeatState`] and use that to create [`Seat`]s.
 //! Additionally you need to implement the [`SeatHandler`] trait.
-//!  
+//!
 //! ### Initialization
 //!
 //! ```
@@ -77,7 +77,7 @@
 //!         // handle focus changes, if you need to ...
 //!     }
 //!     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) {
-//!         // handle new images for the cursor ...   
+//!         // handle new images for the cursor ...
 //!     }
 //! }
 //! ```
@@ -99,13 +99,12 @@
 
 use std::sync::{Arc, Mutex};
 
+use self::keyboard::{Error as KeyboardError, KeyboardHandle, KeyboardTarget};
+use self::pointer::{CursorImageStatus, PointerHandle, PointerTarget};
 use crate::utils::user_data::UserDataMap;
 
 pub mod keyboard;
 pub mod pointer;
-
-use self::keyboard::{Error as KeyboardError, KeyboardHandle, KeyboardTarget};
-use self::pointer::{CursorImageStatus, PointerHandle, PointerTarget};
 
 /// Handler trait for Seats
 pub trait SeatHandler: Sized {
@@ -118,9 +117,10 @@ pub trait SeatHandler: Sized {
     fn seat_state(&mut self) -> &mut SeatState<Self>;
 
     /// Callback that will be notified whenever the focus of the seat changes.
-    fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&Self::KeyboardFocus>);
+    fn focus_changed(&mut self, _seat: &Seat<Self>, _focused: Option<&Self::KeyboardFocus>) {}
+
     /// Callback that will be notified whenever a client requests to set a custom cursor image.
-    fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus);
+    fn cursor_image(&mut self, _seat: &Seat<Self>, _image: CursorImageStatus) {}
 }
 /// Delegate type for all [Seat] globals.
 ///


### PR DESCRIPTION
The recent seat handling changes made in 78ebaa6 have added some
friction to the way input and specifically the keyboard is handled. This
patch aims at making it easier to migrate to the new design.

To allow for easy access to the compositor state, the state is now
passed to the closure in the keyboard's `input` function. While this
makes sense as the simplest solution to this problem, a possible
alternative would be to move this function to the seat handler in the
future.