### PR TITLE
vulkan: add PhysicalDevice::get_format_properties

### DIFF
--- a/src/backend/allocator/vulkan/mod.rs
+++ b/src/backend/allocator/vulkan/mod.rs
@@ -541,10 +541,7 @@ impl VulkanAllocator {
                 .format_properties(format_properties)
                 .push_next(&mut list);
 
-            self.phd
-                .instance()
-                .handle()
-                .get_physical_device_format_properties2(self.phd.handle(), format, &mut format_properties2)
+            self.phd.get_format_properties(format, &mut format_properties2)
         };
 
         let mut data = Vec::with_capacity(list.drm_format_modifier_count as usize);
@@ -556,10 +553,7 @@ impl VulkanAllocator {
                 .format_properties(format_properties)
                 .push_next(&mut list);
 
-            self.phd
-                .instance()
-                .handle()
-                .get_physical_device_format_properties2(self.phd.handle(), format, &mut format_properties2);
+            self.phd.get_format_properties(format, &mut format_properties2);
 
             // SAFETY: Vulkan just initialized the elements of the vector.
             data.set_len(list.drm_format_modifier_count as usize);

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -513,10 +513,9 @@ impl PhysicalDevice {
             })
     }
 
-    /// Gets some physical device properties.
+    /// Get physical device properties.
     ///
-    /// This function is used to get some physical device data associated with an extension and is
-    /// equivalent to calling [`vkGetPhysicalDeviceProperties2`].
+    /// This function is equivalent to calling [`vkGetPhysicalDeviceProperties2`].
     ///
     /// # Safety
     ///
@@ -529,6 +528,23 @@ impl PhysicalDevice {
         // SAFETY: The caller has garunteed all valid usage requirements for vkGetPhysicalDeviceProperties2
         // are satisfied.
         unsafe { instance.get_physical_device_properties2(self.handle(), props) }
+    }
+
+    /// Get physical device format properties.
+    ///
+    /// This function is equivalent to calling [`vkGetPhysicalDeviceFormatProperties2`].
+    ///
+    /// # Safety
+    ///
+    /// - All valid usage requirements for [`vkGetPhysicalDeviceFormatProperties2`] apply. Read the specification
+    ///   for more information.
+    ///
+    /// [`vkGetPhysicalDeviceProperties2`]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceFormatProperties2.html
+    pub unsafe fn get_format_properties(&self, format: vk::Format, props: &mut vk::FormatProperties2) {
+        let instance = self.instance().handle();
+        // SAFETY: The caller has garunteed all valid usage requirements for vkGetPhysicalDeviceFormatProperties2
+        // are satisfied.
+        unsafe { instance.get_physical_device_format_properties2(self.handle(), format, props) }
     }
 
     /// Returns the device extensions supported by the physical device.


### PR DESCRIPTION
This function is used in the vulkan allocator and the WIP vulkan renderer, so it should be exposed on PhysicalDevice.