### PR TITLE
output: Split wayland::output

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -15,6 +15,7 @@ use smithay::{
         keyboard::{keysyms as xkb, FilterResult, Keysym, ModifiersState},
         pointer::{AxisFrame, ButtonEvent, MotionEvent},
     },
+    output::Scale,
     reexports::wayland_server::{
         protocol::{wl_pointer, wl_surface::WlSurface},
         DisplayHandle,
@@ -24,7 +25,6 @@ use smithay::{
         compositor::with_states,
         input_method::InputMethodSeat,
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
-        output::Scale,
         shell::wlr_layer::{KeyboardInteractivity, Layer as WlrLayer, LayerSurfaceCachedState},
     },
 };
@@ -33,7 +33,7 @@ use smithay::{
 use smithay::backend::input::AbsolutePositionEvent;
 
 #[cfg(any(feature = "winit", feature = "x11"))]
-use smithay::wayland::output::Output;
+use smithay::output::Output;
 
 #[cfg(feature = "udev")]
 use crate::state::Backend;

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -4,8 +4,8 @@ use smithay::{
         draw_window, draw_window_popups,
         space::{RenderElement, RenderError, Space},
     },
+    output::Output,
     utils::{Physical, Rectangle},
-    wayland::output::Output,
 };
 
 use crate::{drawing::*, shell::FullscreenSurface};
@@ -28,7 +28,7 @@ where
         .get::<FullscreenSurface>()
         .and_then(|f| f.get())
     {
-        let transform = output.current_transform().into();
+        let transform = output.current_transform();
         let mode = output.current_mode().unwrap();
         let scale = output.current_scale().fractional_scale();
         let output_geo = space

--- a/anvil/src/shell.rs
+++ b/anvil/src/shell.rs
@@ -13,6 +13,7 @@ use smithay::{
         },
         Seat,
     },
+    output::Output,
     reexports::{
         wayland_protocols::xdg::shell::server::xdg_toplevel,
         wayland_server::{
@@ -26,7 +27,6 @@ use smithay::{
         compositor::{
             with_states, with_surface_tree_upward, CompositorHandler, CompositorState, TraversalAction,
         },
-        output::Output,
         shell::{
             wlr_layer::{
                 Layer, LayerSurface as WlrLayerSurface, LayerSurfaceData, WlrLayerShellHandler,

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -10,6 +10,7 @@ use smithay::{
     delegate_xdg_activation, delegate_xdg_decoration, delegate_xdg_shell,
     desktop::{PopupManager, Space, WindowSurfaceType},
     input::{keyboard::XkbConfig, pointer::CursorImageStatus, Seat, SeatHandler, SeatState},
+    output::Output,
     reexports::{
         calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
         wayland_protocols::xdg::decoration::{
@@ -32,7 +33,7 @@ use smithay::{
         keyboard_shortcuts_inhibit::{
             KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
         },
-        output::{Output, OutputManagerState},
+        output::OutputManagerState,
         primary_selection::{set_primary_focus, PrimarySelectionHandler, PrimarySelectionState},
         shell::{
             wlr_layer::WlrLayerShellState,

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -40,6 +40,7 @@ use smithay::{
     },
     desktop::space::{RenderError, Space, SurfaceTree},
     input::pointer::CursorImageStatus,
+    output::{Mode, Output, PhysicalProperties, Subpixel},
     reexports::{
         calloop::{
             timer::{TimeoutAction, Timer},
@@ -57,17 +58,12 @@ use smithay::{
         gbm::Device as GbmDevice,
         input::Libinput,
         nix::{fcntl::OFlag, sys::stat::dev_t},
-        wayland_server::{
-            backend::GlobalId,
-            protocol::{wl_output, wl_surface},
-            Display, DisplayHandle,
-        },
+        wayland_server::{backend::GlobalId, protocol::wl_surface, Display, DisplayHandle},
     },
     utils::{
         signaling::{Linkable, SignalToken, Signaler},
         IsAlive, Logical, Point, Rectangle, Transform,
     },
-    wayland::output::{Mode, Output, PhysicalProperties},
 };
 
 type UdevRenderer<'a> = MultiRenderer<'a, 'a, EglGlesBackend, EglGlesBackend, Gles2Renderbuffer>;
@@ -465,7 +461,7 @@ fn scan_connectors(
                 output_name,
                 PhysicalProperties {
                     size: (phys_w as i32, phys_h as i32).into(),
-                    subpixel: wl_output::Subpixel::Unknown,
+                    subpixel: Subpixel::Unknown,
                     make: "Smithay".into(),
                     model: "Generic DRM".into(),
                 },

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -20,18 +20,13 @@ use smithay::{
     },
     desktop::space::RenderError,
     input::pointer::CursorImageStatus,
+    output::{Mode, Output, PhysicalProperties, Subpixel},
     reexports::{
         calloop::EventLoop,
-        wayland_server::{
-            protocol::{wl_output, wl_surface},
-            Display,
-        },
+        wayland_server::{protocol::wl_surface, Display},
     },
-    utils::IsAlive,
-    wayland::{
-        input_method::InputMethodSeat,
-        output::{Mode, Output, PhysicalProperties},
-    },
+    utils::{IsAlive, Transform},
+    wayland::input_method::InputMethodSeat,
 };
 
 use crate::{
@@ -146,19 +141,14 @@ pub fn run_winit(log: Logger) {
         OUTPUT_NAME.to_string(),
         PhysicalProperties {
             size: (0, 0).into(),
-            subpixel: wl_output::Subpixel::Unknown,
+            subpixel: Subpixel::Unknown,
             make: "Smithay".into(),
             model: "Winit".into(),
         },
         log.clone(),
     );
     let _global = output.create_global::<AnvilState<WinitData>>(&display.handle());
-    output.change_current_state(
-        Some(mode),
-        Some(wl_output::Transform::Flipped180),
-        None,
-        Some((0, 0).into()),
-    );
+    output.change_current_state(Some(mode), Some(Transform::Flipped180), None, Some((0, 0).into()));
     output.set_preferred(mode);
     state.space.map_output(&output, (0, 0));
 

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -26,16 +26,13 @@ use smithay::{
         x11::{WindowBuilder, X11Backend, X11Event, X11Surface},
     },
     input::pointer::CursorImageStatus,
+    output::{Mode, Output, PhysicalProperties, Subpixel},
     reexports::{
         calloop::EventLoop,
         gbm,
-        wayland_server::{
-            protocol::{wl_output, wl_surface},
-            Display,
-        },
+        wayland_server::{protocol::wl_surface, Display},
     },
     utils::IsAlive,
-    wayland::output::{Mode, Output, PhysicalProperties},
 };
 
 pub const OUTPUT_NAME: &str = "x11";
@@ -179,7 +176,7 @@ pub fn run_x11(log: Logger) {
         OUTPUT_NAME.to_string(),
         PhysicalProperties {
             size: (0, 0).into(),
-            subpixel: wl_output::Subpixel::Unknown,
+            subpixel: Subpixel::Unknown,
             make: "Smithay".into(),
             model: "X11".into(),
         },

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -6,15 +6,12 @@ use smithay::{
         winit::{self, WinitError, WinitEvent, WinitEventLoop, WinitGraphicsBackend},
     },
     desktop::space::SurfaceTree,
-    reexports::{
-        calloop::{
-            timer::{TimeoutAction, Timer},
-            EventLoop,
-        },
-        wayland_server::protocol::wl_output,
+    output::{Mode, Output, PhysicalProperties, Subpixel},
+    reexports::calloop::{
+        timer::{TimeoutAction, Timer},
+        EventLoop,
     },
-    utils::Rectangle,
-    wayland::output::{Mode, Output, PhysicalProperties},
+    utils::{Rectangle, Transform},
 };
 
 use slog::Logger;
@@ -40,19 +37,14 @@ pub fn init_winit(
         "winit".to_string(),
         PhysicalProperties {
             size: (0, 0).into(),
-            subpixel: wl_output::Subpixel::Unknown,
+            subpixel: Subpixel::Unknown,
             make: "Smithay".into(),
             model: "Winit".into(),
         },
         log.clone(),
     );
     let _global = output.create_global::<Smallvil>(&display.handle());
-    output.change_current_state(
-        Some(mode),
-        Some(wl_output::Transform::Flipped180),
-        None,
-        Some((0, 0).into()),
-    );
+    output.change_current_state(Some(mode), Some(Transform::Flipped180), None, Some((0, 0).into()));
     output.set_preferred(mode);
 
     state.space.map_output(&output, (0, 0));

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -1,10 +1,10 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
     desktop::{utils::*, PopupManager, Space},
+    output::{Inner as OutputInner, Output, OutputData},
     utils::{user_data::UserDataMap, IsAlive, Logical, Physical, Point, Rectangle, Scale},
     wayland::{
         compositor::{with_states, with_surface_tree_downward, TraversalAction},
-        output::{Inner as OutputInner, Output, OutputData},
         shell::wlr_layer::{
             Anchor, ExclusiveZone, KeyboardInteractivity, Layer as WlrLayer, LayerSurface as WlrLayerSurface,
             LayerSurfaceCachedState,

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -2,8 +2,8 @@ use crate::desktop::space::popup::RenderPopup;
 use crate::{
     backend::renderer::{ImportAll, Renderer, Texture},
     desktop::{space::*, utils::*},
+    output::Output,
     utils::{Logical, Physical, Point, Rectangle, Scale},
-    wayland::output::Output,
 };
 use std::{
     any::{Any, TypeId},

--- a/src/desktop/space/layer.rs
+++ b/src/desktop/space/layer.rs
@@ -4,8 +4,9 @@ use crate::{
         layer::{layer_state as output_layer_state, *},
         space::Space,
     },
+    output::Output,
     utils::{Physical, Point, Rectangle, Scale},
-    wayland::{output::Output, shell::wlr_layer::Layer},
+    wayland::shell::wlr_layer::Layer,
 };
 use std::{
     any::TypeId,

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -9,11 +9,9 @@ use crate::{
         utils::{output_leave, output_update},
         window::Window,
     },
+    output::Output,
     utils::{IsAlive, Logical, Physical, Point, Rectangle, Transform},
-    wayland::{
-        compositor::{get_parent, is_sync_subsurface, with_surface_tree_downward, TraversalAction},
-        output::Output,
-    },
+    wayland::compositor::{get_parent, is_sync_subsurface, with_surface_tree_downward, TraversalAction},
 };
 use indexmap::{IndexMap, IndexSet};
 use std::{collections::VecDeque, fmt};
@@ -324,7 +322,7 @@ impl Space {
             return None;
         }
 
-        let transform: Transform = o.current_transform().into();
+        let transform: Transform = o.current_transform();
         let state = output_state(self.id, o);
         o.current_mode().map(|mode| {
             Rectangle::from_loc_and_size(
@@ -619,7 +617,7 @@ impl Space {
             return Ok(None);
         }
 
-        let output_transform: Transform = output.current_transform().into();
+        let output_transform: Transform = output.current_transform();
         let res = renderer.render(
             output_transform.transform_size(output_size),
             output_transform,

--- a/src/desktop/space/output.rs
+++ b/src/desktop/space/output.rs
@@ -1,8 +1,8 @@
 use crate::{
     backend::renderer::{ImportAll, Renderer},
     desktop::space::{RenderElement, SpaceElement},
+    output::Output,
     utils::{Logical, Physical, Point, Rectangle},
-    wayland::output::Output,
 };
 use indexmap::IndexMap;
 use wayland_server::backend::ObjectId;

--- a/src/desktop/space/popup.rs
+++ b/src/desktop/space/popup.rs
@@ -11,8 +11,9 @@ use crate::{
         },
         window::Window,
     },
+    output::Output,
     utils::{Logical, Physical, Point, Rectangle, Scale},
-    wayland::{output::Output, shell::wlr_layer::Layer},
+    wayland::shell::wlr_layer::Layer,
 };
 use std::any::TypeId;
 

--- a/src/desktop/space/window.rs
+++ b/src/desktop/space/window.rs
@@ -4,8 +4,8 @@ use crate::{
         space::Space,
         window::{draw_window, Window},
     },
+    output::Output,
     utils::{Logical, Physical, Point, Rectangle, Scale},
-    wayland::output::Output,
 };
 use std::{
     any::TypeId,

--- a/src/desktop/utils.rs
+++ b/src/desktop/utils.rs
@@ -3,12 +3,10 @@
 use crate::{
     backend::renderer::utils::RendererSurfaceState,
     desktop::Space,
+    output::Output,
     utils::{Logical, Physical, Point, Rectangle, Scale},
-    wayland::{
-        compositor::{
-            with_surface_tree_downward, with_surface_tree_upward, SurfaceAttributes, TraversalAction,
-        },
-        output::Output,
+    wayland::compositor::{
+        with_surface_tree_downward, with_surface_tree_upward, SurfaceAttributes, TraversalAction,
     },
 };
 use wayland_server::{backend::ObjectId, protocol::wl_surface, DisplayHandle, Resource};

--- a/src/desktop/window.rs
+++ b/src/desktop/window.rs
@@ -1,10 +1,10 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
     desktop::{utils::*, PopupManager, Space},
+    output::Output,
     utils::{user_data::UserDataMap, IsAlive, Logical, Physical, Point, Rectangle, Scale},
     wayland::{
         compositor::with_states,
-        output::Output,
         shell::xdg::{SurfaceCachedState, ToplevelSurface},
     },
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod backend;
 #[cfg(feature = "desktop")]
 pub mod desktop;
 pub mod input;
+pub mod output;
 pub mod utils;
 #[cfg(feature = "wayland_frontend")]
 pub mod wayland;

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,368 @@
+//! Output
+//!
+//! This module provides a type helping you to abstract over various
+//! properties, that make up an [`Output`] of your compositor.
+//!
+//! # How to use it
+//!
+//! You need to instantiate an [`Output`].
+//!
+//! To advertise a new output global to wayland clients take a look at [`crate::wayland::output`],
+//! you need to have the `wayland_frontend` feature enabled to use it.
+//!
+//! Additionally outputs are used to by the desktop abstractions (see [`crate::desktop`], needs the
+//! `desktop` feature) to represent views into your window grid.
+//!
+//! You can use the returned [`Output`] to change
+//! the properties of your output (if the current resolution mode changes for example).
+//! These may influence how contents will be rendered to your output, when used in conjunction
+//! with the desktop abstractions.
+//!
+//! You can attach additional properties to your `Output`s by using [`Output::user_data`].
+//!
+//! ```
+//! # extern crate smithay;
+//! use smithay::output::{Output, PhysicalProperties, Scale, Mode, Subpixel};
+//! use smithay::utils::Transform;
+//!
+//! // Create the Output with given name and physical properties.
+//! let output = Output::new(
+//!     "output-0".into(), // the name of this output,
+//!     PhysicalProperties {
+//!         size: (200, 150).into(),        // dimensions (width, height) in mm
+//!         subpixel: Subpixel::HorizontalRgb,  // subpixel information
+//!         make: "Screens Inc".into(),     // make of the monitor
+//!         model: "Monitor Ultra".into(),  // model of the monitor
+//!     },
+//!     None // insert a logger here
+//! );
+//! // Now you can configure it
+//! output.change_current_state(
+//!     Some(Mode { size: (1920, 1080).into(), refresh: 60000 }), // the resolution mode,
+//!     Some(Transform::Normal), // global screen transformation
+//!     Some(Scale::Integer(1)), // global screen scaling factor
+//!     Some((0,0).into()) // output position
+//! );
+//! // set the preferred mode
+//! output.set_preferred(Mode { size: (1920, 1080).into(), refresh: 60000 });
+//! // add other supported modes
+//! output.add_mode(Mode { size: (800, 600).into(), refresh: 60000 });
+//! output.add_mode(Mode { size: (1024, 768).into(), refresh: 60000 });
+//! ```
+
+use std::{
+    hash::{Hash, Hasher},
+    sync::{Arc, Mutex},
+};
+
+use slog::{info, o};
+
+#[cfg(feature = "wayland_frontend")]
+use crate::wayland::output::xdg::XdgOutput;
+#[cfg(feature = "wayland_frontend")]
+use wayland_server::protocol::wl_output::WlOutput;
+
+use crate::utils::{user_data::UserDataMap, Logical, Physical, Point, Raw, Size, Transform};
+
+/// An output mode
+///
+/// A possible combination of dimensions and refresh rate for an output.
+///
+/// This should only describe the characteristics of the video driver,
+/// not taking into account any global scaling.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Mode {
+    /// The size of the mode, in pixels
+    pub size: Size<i32, Physical>,
+    /// The refresh rate in millihertz
+    ///
+    /// `1000` is one fps (frame per second), `2000` is 2 fps, etc...
+    pub refresh: i32,
+}
+
+/// Subpixel geometry information
+///
+/// This enumeration describes how the physical pixels on an output are laid out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Subpixel {
+    /// Unknown subpixel geometry
+    Unknown,
+    /// No subpixel geometry
+    None,
+    /// Subpixels are arranged horizontally starting with
+    /// red, then green, last blue
+    HorizontalRgb,
+    /// Subpixels are arranged horizontally starting with
+    /// blue, then green, last red
+    HorizontalBgr,
+    /// Subpixels are arranged vertically starting with
+    /// red, then green, last blue
+    VerticalRgb,
+    /// Subpixels are arranged verically starting with
+    /// blue, then green, last red
+    VerticalBgr,
+}
+
+/// The physical properties of an output
+#[derive(Debug, Clone)]
+pub struct PhysicalProperties {
+    /// The size of the monitor, in millimeters
+    pub size: Size<i32, Raw>,
+    /// The subpixel geometry
+    pub subpixel: Subpixel,
+    /// Textual representation of the make
+    pub make: String,
+    /// Textual representation of the model
+    pub model: String,
+}
+
+/// Describes the scale advertised to clients.
+#[derive(Debug, Clone, Copy)]
+pub enum Scale {
+    /// Integer based scaling
+    Integer(i32),
+    /// Fractional scaling
+    ///
+    /// *Note*: Protocols only supporting integer-scales (e.g. wl_output),
+    /// will be rounded **up** to the next integer value. To control the value
+    /// send to those clients use `Scale::Custom` instead.
+    Fractional(f64),
+    /// Split scale values advertised to clients
+    Custom {
+        /// Integer value for protocols not supporting fractional scaling
+        advertised_integer: i32,
+        /// Fractional scaling value used elsewhere
+        fractional: f64,
+    },
+}
+
+impl Scale {
+    /// Returns the integer scale as advertised for this `Scale` variant
+    pub fn integer_scale(&self) -> i32 {
+        match self {
+            Scale::Integer(scale) => *scale,
+            Scale::Fractional(scale) => scale.ceil() as i32,
+            Scale::Custom {
+                advertised_integer, ..
+            } => *advertised_integer,
+        }
+    }
+
+    /// Returns the fractional scale (calculated if necessary)
+    pub fn fractional_scale(&self) -> f64 {
+        match self {
+            Scale::Integer(scale) => *scale as f64,
+            Scale::Fractional(scale) => *scale,
+            Scale::Custom { fractional, .. } => *fractional,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Inner {
+    pub(crate) name: String,
+    pub(crate) description: String,
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) instances: Vec<WlOutput>,
+    pub(crate) physical: PhysicalProperties,
+    pub(crate) location: Point<i32, Logical>,
+    pub(crate) transform: Transform,
+    pub(crate) scale: Scale,
+    pub(crate) modes: Vec<Mode>,
+    pub(crate) current_mode: Option<Mode>,
+    pub(crate) preferred_mode: Option<Mode>,
+
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) xdg_output: Option<XdgOutput>,
+    #[allow(dead_code)]
+    pub(crate) log: ::slog::Logger,
+}
+
+/// Clonable Data of an Outut
+#[derive(Debug, Clone)]
+pub struct OutputData {
+    pub(crate) inner: Arc<(Mutex<Inner>, UserDataMap)>,
+}
+
+/// An abstract output.
+///
+/// This handle is stored in the event loop, and allows you to notify clients
+/// about any change in the properties of this output.
+#[derive(Debug, Clone)]
+pub struct Output {
+    pub(crate) data: OutputData,
+}
+
+impl Output {
+    /// Create a new output with given name and physical properties.
+    pub fn new<L>(name: String, physical: PhysicalProperties, logger: L) -> Output
+    where
+        L: Into<Option<::slog::Logger>>,
+    {
+        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "output_handler"));
+
+        info!(log, "Creating new wl_output"; "name" => &name);
+
+        let data = OutputData {
+            inner: Arc::new((
+                Mutex::new(Inner {
+                    name: name.clone(),
+                    description: format!("{} - {} - {}", physical.make, physical.model, name),
+                    #[cfg(feature = "wayland_frontend")]
+                    instances: Vec::new(),
+                    physical,
+                    location: (0, 0).into(),
+                    transform: Transform::Normal,
+                    scale: Scale::Integer(1),
+                    modes: Vec::new(),
+                    current_mode: None,
+                    preferred_mode: None,
+                    #[cfg(feature = "wayland_frontend")]
+                    xdg_output: None,
+                    log,
+                }),
+                UserDataMap::default(),
+            )),
+        };
+
+        Output { data }
+    }
+
+    /// Sets the preferred mode of this output
+    ///
+    /// If the provided mode was not previously known to this output, it is added to its
+    /// internal list.
+    pub fn set_preferred(&self, mode: Mode) {
+        let mut inner = self.data.inner.0.lock().unwrap();
+        inner.preferred_mode = Some(mode);
+        if inner.modes.iter().all(|&m| m != mode) {
+            inner.modes.push(mode);
+        }
+    }
+
+    /// Adds a mode to the list of known modes to this output
+    pub fn add_mode(&self, mode: Mode) {
+        let mut inner = self.data.inner.0.lock().unwrap();
+        if inner.modes.iter().all(|&m| m != mode) {
+            inner.modes.push(mode);
+        }
+    }
+
+    /// Returns the currently advertised mode of the output
+    pub fn current_mode(&self) -> Option<Mode> {
+        self.data.inner.0.lock().unwrap().current_mode
+    }
+
+    /// Returns the preferred mode of the output
+    pub fn preferred_mode(&self) -> Option<Mode> {
+        self.data.inner.0.lock().unwrap().preferred_mode
+    }
+
+    /// Returns the currently advertised transformation of the output
+    pub fn current_transform(&self) -> Transform {
+        self.data.inner.0.lock().unwrap().transform
+    }
+
+    /// Returns the currenly set scale of the output
+    pub fn current_scale(&self) -> Scale {
+        self.data.inner.0.lock().unwrap().scale
+    }
+
+    /// Returns the currenly advertised location of the output
+    pub fn current_location(&self) -> Point<i32, Logical> {
+        self.data.inner.0.lock().unwrap().location
+    }
+
+    /// Returns the name of the output
+    pub fn name(&self) -> String {
+        self.data.inner.0.lock().unwrap().name.clone()
+    }
+
+    /// Returns the description of the output, if xdg-output is initialized
+    pub fn description(&self) -> String {
+        self.data.inner.0.lock().unwrap().description.clone()
+    }
+
+    /// Returns the physical properties of the output
+    pub fn physical_properties(&self) -> PhysicalProperties {
+        self.data.inner.0.lock().unwrap().physical.clone()
+    }
+
+    /// Returns the currently advertised modes of the output
+    pub fn modes(&self) -> Vec<Mode> {
+        self.data.inner.0.lock().unwrap().modes.clone()
+    }
+
+    /// Removes a mode from the list of known modes
+    ///
+    /// It will not de-advertise it from existing clients (the protocol does not
+    /// allow it), but it won't be advertised to now clients from now on.
+    pub fn delete_mode(&self, mode: Mode) {
+        let mut inner = self.data.inner.0.lock().unwrap();
+        inner.modes.retain(|&m| m != mode);
+        if inner.current_mode == Some(mode) {
+            inner.current_mode = None;
+        }
+        if inner.preferred_mode == Some(mode) {
+            inner.preferred_mode = None;
+        }
+    }
+
+    /// Change the current state of this output
+    ///
+    /// You can changed the current mode, transform status, location or scale of this output. Providing
+    /// `None` to any of these field means that the value does not change.
+    ///
+    /// If the provided mode was not previously known to this output, it is added to its
+    /// internal list.
+    ///
+    /// By default, transform status is `Normal`, and scale is `1`.
+    pub fn change_current_state(
+        &self,
+        new_mode: Option<Mode>,
+        new_transform: Option<Transform>,
+        new_scale: Option<Scale>,
+        new_location: Option<Point<i32, Logical>>,
+    ) {
+        {
+            let mut inner = self.data.inner.0.lock().unwrap();
+            if let Some(mode) = new_mode {
+                if inner.modes.iter().all(|&m| m != mode) {
+                    inner.modes.push(mode);
+                }
+                inner.current_mode = new_mode;
+            }
+            if let Some(transform) = new_transform {
+                inner.transform = transform;
+            }
+            if let Some(scale) = new_scale {
+                inner.scale = scale;
+            }
+            if let Some(new_location) = new_location {
+                inner.location = new_location;
+            }
+        }
+
+        #[cfg(feature = "wayland_frontend")]
+        self.wl_change_current_state(new_mode, new_transform.map(Into::into), new_scale, new_location)
+    }
+
+    /// Returns the user data of this output
+    pub fn user_data(&self) -> &UserDataMap {
+        &self.data.inner.1
+    }
+}
+
+impl PartialEq for Output {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.data.inner, &other.data.inner)
+    }
+}
+
+impl Eq for Output {}
+
+impl Hash for Output {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.data.inner).hash(state);
+    }
+}

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -1,35 +1,29 @@
-//! Output advertising capabilities
+//! WlOutput advertising capabilities
 //!
-//! This module provides a type helping you to abstract over various
-//! properties, that make up an [`Output`] of your compositor.
-//!
-//! Additionally the [`Output`] may handle advertising of your compositor's
-//! output and their capabilities to your client, as well as mapping your
-//! clients output request to your physical outputs.
+//! This module provides additional implementations for [`crate::output::Output`]
+//! to handle advertising of your compositor's output and their capabilities to your client,
+//! as well as mapping your clients output request to your physical outputs.
 //!
 //! # How to use it
 //!
-//! You need to instantiate an [`Output`].
-//! To advertise a new output global to clients you then need to use [`Output::create_global`].
+//! After you have instantiated an [`Output`] you need to use [`Output::create_global`]
+//! to advertise a new output global to clients.
 //! The resulting `GlobalId` can later be destroyed again to stop advertising it
 //! without destroying it's state. E.g. in case the matching physical output got disabled at runtime.
 //!
-//! You can use the returned [`Output`] to change
-//! the properties of your output (if the current resolution mode changes for example),
+//! If you change the properties of your output (if the current resolution mode changes for example),
 //! it'll automatically forward any changes to the clients.
 //!
 //! Additional protocols may piggy-back on this type.
 //! E.g. to also advertise an xdg-output for every wl-output you can use
 //! [`OutputManagerState::new_with_xdg_output`].
 //!
-//! You can attach additional properties to your `Output`s by using [`Output::user_data`].
-//!
 //! ```
 //! # extern crate wayland_server;
 //! # extern crate smithay;
 //! use smithay::delegate_output;
-//! use smithay::wayland::output::{Output, PhysicalProperties, Scale, Mode};
-//! use wayland_server::protocol::wl_output;
+//! use smithay::output::{Output, PhysicalProperties, Scale, Mode, Subpixel};
+//! use smithay::utils::Transform;
 //!
 //! # struct State;
 //! # let mut display = wayland_server::Display::<State>::new().unwrap();
@@ -39,7 +33,7 @@
 //!     "output-0".into(), // the name of this output,
 //!     PhysicalProperties {
 //!         size: (200, 150).into(),        // dimensions (width, height) in mm
-//!         subpixel: wl_output::Subpixel::HorizontalRgb,  // subpixel information
+//!         subpixel: Subpixel::HorizontalRgb,  // subpixel information
 //!         make: "Screens Inc".into(),     // make of the monitor
 //!         model: "Monitor Ultra".into(),  // model of the monitor
 //!     },
@@ -52,7 +46,7 @@
 //! // Now you can configure it
 //! output.change_current_state(
 //!     Some(Mode { size: (1920, 1080).into(), refresh: 60000 }), // the resolution mode,
-//!     Some(wl_output::Transform::Normal), // global screen transformation
+//!     Some(Transform::Normal), // global screen transformation
 //!     Some(Scale::Integer(1)), // global screen scaling factor
 //!     Some((0,0).into()) // output position
 //! );
@@ -66,29 +60,22 @@
 //! ```
 
 mod handlers;
-mod xdg;
-
-use std::{
-    hash::{Hash, Hasher},
-    sync::{Arc, Mutex},
-};
+pub(crate) mod xdg;
+use crate::output::{Inner, Mode, Output, OutputData, Scale, Subpixel};
 
 use wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_manager_v1::ZxdgOutputManagerV1;
 use wayland_server::{
     backend::GlobalId,
     protocol::{
-        wl_output::{Mode as WMode, Subpixel, Transform, WlOutput},
+        wl_output::{Mode as WMode, Subpixel as WlSubpixel, Transform, WlOutput},
         wl_surface,
     },
     Client, DisplayHandle, GlobalDispatch, Resource,
 };
 
-use slog::{info, o};
-
-use crate::utils::{user_data::UserDataMap, Logical, Physical, Point, Raw, Size};
+use crate::utils::{Logical, Point};
 
 pub use self::handlers::XdgOutputUserData;
-use self::xdg::XdgOutput;
 
 /// State of Smithay output manager
 #[derive(Debug, Default)]
@@ -124,100 +111,6 @@ impl OutputManagerState {
     }
 }
 
-/// An output mode
-///
-/// A possible combination of dimensions and refresh rate for an output.
-///
-/// This should only describe the characteristics of the video driver,
-/// not taking into account any global scaling.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct Mode {
-    /// The size of the mode, in pixels
-    pub size: Size<i32, Physical>,
-    /// The refresh rate in millihertz
-    ///
-    /// `1000` is one fps (frame per second), `2000` is 2 fps, etc...
-    pub refresh: i32,
-}
-
-/// The physical properties of an output
-#[derive(Debug, Clone)]
-pub struct PhysicalProperties {
-    /// The size of the monitor, in millimeters
-    pub size: Size<i32, Raw>,
-    /// The subpixel geometry
-    pub subpixel: Subpixel,
-    /// Textual representation of the make
-    pub make: String,
-    /// Textual representation of the model
-    pub model: String,
-}
-
-/// Describes the scale advertised to clients.
-#[derive(Debug, Clone, Copy)]
-pub enum Scale {
-    /// Integer based scaling
-    Integer(i32),
-    /// Fractional scaling
-    ///
-    /// *Note*: Protocols only supporting integer-scales (e.g. wl_output),
-    /// will be rounded **up** to the next integer value. To control the value
-    /// send to those clients use `Scale::Custom` instead.
-    Fractional(f64),
-    /// Split scale values advertised to clients
-    Custom {
-        /// Integer value for protocols not supporting fractional scaling
-        advertised_integer: i32,
-        /// Fractional scaling value used elsewhere
-        fractional: f64,
-    },
-}
-
-impl Scale {
-    /// Returns the integer scale as advertised for this `Scale` variant
-    pub fn integer_scale(&self) -> i32 {
-        match self {
-            Scale::Integer(scale) => *scale,
-            Scale::Fractional(scale) => scale.ceil() as i32,
-            Scale::Custom {
-                advertised_integer, ..
-            } => *advertised_integer,
-        }
-    }
-
-    /// Returns the fractional scale (calculated if necessary)
-    pub fn fractional_scale(&self) -> f64 {
-        match self {
-            Scale::Integer(scale) => *scale as f64,
-            Scale::Fractional(scale) => *scale,
-            Scale::Custom { fractional, .. } => *fractional,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct Inner {
-    name: String,
-    description: String,
-    instances: Vec<WlOutput>,
-    physical: PhysicalProperties,
-    location: Point<i32, Logical>,
-    transform: Transform,
-    scale: Scale,
-    modes: Vec<Mode>,
-    current_mode: Option<Mode>,
-    preferred_mode: Option<Mode>,
-
-    pub(crate) xdg_output: Option<XdgOutput>,
-    pub(crate) log: ::slog::Logger,
-}
-
-/// Data for WlOutput global
-#[derive(Debug, Clone)]
-pub struct OutputData {
-    pub(crate) inner: Arc<(Mutex<Inner>, UserDataMap)>,
-}
-
 /// User data for WlOutput
 #[derive(Debug, Clone)]
 pub struct OutputUserData {
@@ -231,60 +124,28 @@ impl Inner {
             self.location.y,
             self.physical.size.w,
             self.physical.size.h,
-            self.physical.subpixel,
+            self.physical.subpixel.into(),
             self.physical.make.clone(),
             self.physical.model.clone(),
-            self.transform,
+            self.transform.into(),
         );
     }
 }
 
-/// An abstract output.
-///
-/// This handle is stored in the event loop, and allows you to notify clients
-/// about any change in the properties of this output.
-#[derive(Debug, Clone)]
-pub struct Output {
-    pub(crate) data: OutputData,
+impl From<Subpixel> for WlSubpixel {
+    fn from(s: Subpixel) -> Self {
+        match s {
+            Subpixel::HorizontalBgr => WlSubpixel::HorizontalBgr,
+            Subpixel::HorizontalRgb => WlSubpixel::HorizontalRgb,
+            Subpixel::None => WlSubpixel::None,
+            Subpixel::Unknown => WlSubpixel::Unknown,
+            Subpixel::VerticalBgr => WlSubpixel::VerticalBgr,
+            Subpixel::VerticalRgb => WlSubpixel::VerticalRgb,
+        }
+    }
 }
 
 impl Output {
-    /// Create a new output global with given name and physical properties.
-    ///
-    /// The global is directly registered into the event loop, and this function
-    /// returns the state token allowing you to access it, as well as the global handle,
-    /// in case you wish to remove this global in the future.
-    pub fn new<L>(name: String, physical: PhysicalProperties, logger: L) -> Output
-    where
-        L: Into<Option<::slog::Logger>>,
-    {
-        let log = crate::slog_or_fallback(logger).new(o!("smithay_module" => "output_handler"));
-
-        info!(log, "Creating new wl_output"; "name" => &name);
-
-        let data = OutputData {
-            inner: Arc::new((
-                Mutex::new(Inner {
-                    name: name.clone(),
-                    description: format!("{} - {} - {}", physical.make, physical.model, name),
-                    instances: Vec::new(),
-                    physical,
-                    location: (0, 0).into(),
-                    transform: Transform::Normal,
-                    scale: Scale::Integer(1),
-                    modes: Vec::new(),
-                    current_mode: None,
-                    preferred_mode: None,
-                    xdg_output: None,
-                    log,
-                }),
-                UserDataMap::default(),
-            )),
-        };
-
-        Output { data }
-    }
-
     /// Create a new output global.
     ///
     /// The global is directly registered into the event loop, and this function
@@ -308,127 +169,23 @@ impl Output {
         })
     }
 
-    /// Sets the preferred mode of this output
-    ///
-    /// If the provided mode was not previously known to this output, it is added to its
-    /// internal list.
-    pub fn set_preferred(&self, mode: Mode) {
-        let mut inner = self.data.inner.0.lock().unwrap();
-        inner.preferred_mode = Some(mode);
-        if inner.modes.iter().all(|&m| m != mode) {
-            inner.modes.push(mode);
-        }
-    }
-
-    /// Adds a mode to the list of known modes to this output
-    pub fn add_mode(&self, mode: Mode) {
-        let mut inner = self.data.inner.0.lock().unwrap();
-        if inner.modes.iter().all(|&m| m != mode) {
-            inner.modes.push(mode);
-        }
-    }
-
-    /// Returns the currently advertised mode of the output
-    pub fn current_mode(&self) -> Option<Mode> {
-        self.data.inner.0.lock().unwrap().current_mode
-    }
-
-    /// Returns the preferred mode of the output
-    pub fn preferred_mode(&self) -> Option<Mode> {
-        self.data.inner.0.lock().unwrap().preferred_mode
-    }
-
-    /// Returns the currently advertised transformation of the output
-    pub fn current_transform(&self) -> Transform {
-        self.data.inner.0.lock().unwrap().transform
-    }
-
-    /// Returns the currenly set scale of the output
-    pub fn current_scale(&self) -> Scale {
-        self.data.inner.0.lock().unwrap().scale
-    }
-
-    /// Returns the currenly advertised location of the output
-    pub fn current_location(&self) -> Point<i32, Logical> {
-        self.data.inner.0.lock().unwrap().location
-    }
-
-    /// Returns the name of the output
-    pub fn name(&self) -> String {
-        self.data.inner.0.lock().unwrap().name.clone()
-    }
-
-    /// Returns the description of the output, if xdg-output is initialized
-    pub fn description(&self) -> String {
-        self.data.inner.0.lock().unwrap().description.clone()
-    }
-
-    /// Returns the physical properties of the output
-    pub fn physical_properties(&self) -> PhysicalProperties {
-        self.data.inner.0.lock().unwrap().physical.clone()
-    }
-
-    /// Returns the currently advertised modes of the output
-    pub fn modes(&self) -> Vec<Mode> {
-        self.data.inner.0.lock().unwrap().modes.clone()
-    }
-
-    /// Removes a mode from the list of known modes
-    ///
-    /// It will not de-advertise it from existing clients (the protocol does not
-    /// allow it), but it won't be advertised to now clients from now on.
-    pub fn delete_mode(&self, mode: Mode) {
-        let mut inner = self.data.inner.0.lock().unwrap();
-        inner.modes.retain(|&m| m != mode);
-        if inner.current_mode == Some(mode) {
-            inner.current_mode = None;
-        }
-        if inner.preferred_mode == Some(mode) {
-            inner.preferred_mode = None;
-        }
-    }
-
-    /// Change the current state of this output
-    ///
-    /// You can changed the current mode, transform status, location or scale of this output. Providing
-    /// `None` to any of these field means that the value does not change.
-    ///
-    /// If the provided mode was not previously known to this output, it is added to its
-    /// internal list.
-    ///
-    /// By default, transform status is `Normal`, and scale is `1`.
-    pub fn change_current_state(
+    pub(crate) fn wl_change_current_state(
         &self,
         new_mode: Option<Mode>,
         new_transform: Option<Transform>,
         new_scale: Option<Scale>,
         new_location: Option<Point<i32, Logical>>,
     ) {
-        let mut inner = self.data.inner.0.lock().unwrap();
-        if let Some(mode) = new_mode {
-            if inner.modes.iter().all(|&m| m != mode) {
-                inner.modes.push(mode);
-            }
-            inner.current_mode = new_mode;
-        }
-        if let Some(transform) = new_transform {
-            inner.transform = transform;
-        }
-        if let Some(scale) = new_scale {
-            inner.scale = scale;
-        }
-        let mut flags = WMode::Current;
-        if inner.preferred_mode == new_mode {
-            flags |= WMode::Preferred;
-        }
-        if let Some(new_location) = new_location {
-            inner.location = new_location;
-        }
-
+        let inner = self.data.inner.0.lock().unwrap();
         // XdgOutput has to be updated before WlOutput
         // Because WlOutput::done() has to allways be called last
         if let Some(xdg_output) = inner.xdg_output.as_ref() {
             xdg_output.change_current_state(new_mode, new_scale, new_location);
+        }
+
+        let mut flags = WMode::Current;
+        if inner.preferred_mode == new_mode {
+            flags |= WMode::Preferred;
         }
 
         for output in &inner.instances {
@@ -503,25 +260,6 @@ impl Output {
             self.with_client_outputs(dh, &client, |_dh, output| surface.leave(output))
         }
     }
-
-    /// Returns the user data of this output
-    pub fn user_data(&self) -> &UserDataMap {
-        &self.data.inner.1
-    }
-}
-
-impl PartialEq for Output {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.data.inner, &other.data.inner)
-    }
-}
-
-impl Eq for Output {}
-
-impl Hash for Output {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        Arc::as_ptr(&self.data.inner).hash(state);
-    }
 }
 
 #[allow(missing_docs)] // TODO
@@ -529,7 +267,7 @@ impl Hash for Output {
 macro_rules! delegate_output {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
         $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_output::WlOutput: $crate::wayland::output::OutputData
+            $crate::reexports::wayland_server::protocol::wl_output::WlOutput: $crate::output::OutputData
         ] => $crate::wayland::output::OutputManagerState);
         $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::reexports::wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_manager_v1::ZxdgOutputManagerV1: ()

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -8,21 +8,16 @@ use smithay::{
     backend::input::ButtonState,
     desktop::WindowSurfaceType,
     input::pointer::{ButtonEvent, CursorImageStatus, MotionEvent},
+    output::{Mode, Output, PhysicalProperties, Subpixel},
     reexports::{
         calloop::{
             channel::{Channel, Event as ChannelEvent},
             EventLoop,
         },
-        wayland_server::{
-            protocol::{wl_output, wl_surface},
-            Client, Display, Resource,
-        },
+        wayland_server::{protocol::wl_surface, Client, Display, Resource},
     },
     utils::{IsAlive, SERIAL_COUNTER as SCOUNTER},
-    wayland::{
-        input_method::InputMethodSeat,
-        output::{Mode, Output, PhysicalProperties},
-    },
+    wayland::input_method::InputMethodSeat,
 };
 
 use anvil::{
@@ -89,7 +84,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
         OUTPUT_NAME.to_string(),
         PhysicalProperties {
             size: (0, 0).into(),
-            subpixel: wl_output::Subpixel::Unknown,
+            subpixel: Subpixel::Unknown,
             make: "Smithay".into(),
             model: "WLCS".into(),
         },
@@ -121,16 +116,13 @@ pub fn run(channel: Channel<WlcsEvent>) {
             let input_method = state.seat.input_method().unwrap();
             let rectangle = input_method.coordinates();
             input_method.with_surface(|surface| {
-                elements.push(
-                    draw_input_popup_surface(
-                        surface.clone(),
-                        (
-                            rectangle.loc.x + rectangle.size.w,
-                            (rectangle.loc.y + rectangle.size.h),
-                        ),
-                    )
-                    .into(),
-                );
+                elements.push(draw_input_popup_surface(
+                    surface.clone(),
+                    (
+                        rectangle.loc.x + rectangle.size.w,
+                        (rectangle.loc.y + rectangle.size.h),
+                    ),
+                ));
             });
 
             // draw the cursor as relevant


### PR DESCRIPTION
Splits the wayland::output module into wayland specific parts and a new toplevel output-module, that can be used without any wayland functionality.

After my recent changes to the input system, I don't expect this change to be very controversial, but here are some motivations for it anyway.

The `Output` struct has got a second use-case apart from advertising to wayland_clients with our inclusion of the desktop-abstractions as a rendering helper. It represents a view into the compositors grid, that shall be rendered.

With the upcoming generic-space rework, there is no reason for the `Space` and it's rendering helpers for damage-tracking to depend on the `wayland_frontend` feature anymore. But because the rendering depends on the `Output` as a helper , there needs to be a way to use the `Output` without `wayland_frontend` to allow this.

I also think in general we should split responsibilities and make sure all parts of smithay, that have any use-case outside of the wayland-protocol are also usable without our wayland frontend.
