### PR TITLE
keyboard: refactor to improve keymapfile api and sealedfile api

### DIFF
--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -5,8 +5,6 @@ use xkbcommon::xkb::{Keymap, KEYMAP_FORMAT_TEXT_V1};
 use std::ffi::CString;
 #[cfg(feature = "wayland_frontend")]
 use std::os::unix::prelude::RawFd;
-#[cfg(feature = "wayland_frontend")]
-use wayland_server::protocol::wl_keyboard::WlKeyboard;
 
 /// Wraps an XKB keymap into a sealed file or stores as just a string for sending to WlKeyboard over an fd
 #[cfg(feature = "wayland_frontend")]
@@ -61,7 +59,10 @@ impl KeymapFile {
     }
 
     /// Send the keymap contained within to a WlKeyboard
-    pub fn send(&self, keyboard: &WlKeyboard) -> Result<(), std::io::Error> {
+    pub fn send(
+        &self,
+        keyboard: &wayland_server::protocol::wl_keyboard::WlKeyboard,
+    ) -> Result<(), std::io::Error> {
         use wayland_server::{protocol::wl_keyboard::KeymapFormat, Resource};
 
         self.with_fd(keyboard.version() >= 7, |fd, size| {

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -8,7 +8,6 @@ use std::os::unix::prelude::RawFd;
 use wayland_server::protocol::wl_keyboard::WlKeyboard;
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct KeymapFile {
     sealed: Option<SealedFile>,
     keymap: String,

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -34,7 +34,6 @@ impl KeymapFile {
     }
 
     /// Run a closure with the file descriptor to ensure safety
-
     pub fn with_fd<F>(&self, supports_sealed: bool, cb: F) -> Result<(), std::io::Error>
     where
         F: FnOnce(RawFd, usize),
@@ -58,7 +57,6 @@ impl KeymapFile {
     }
 
     /// Send the keymap contained within to a WlKeyboard
-
     pub fn send(
         &self,
         keyboard: &wayland_server::protocol::wl_keyboard::WlKeyboard,

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -32,6 +32,7 @@ impl KeymapFile {
         }
     }
 
+    #[cfg(feature = "wayland_frontend")]
     pub fn with_fd<F>(&self, supports_sealed: bool, cb: F) -> Result<(), std::io::Error>
     where
         F: FnOnce(RawFd, usize),

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -3,18 +3,15 @@ use slog::error;
 use xkbcommon::xkb::{Keymap, KEYMAP_FORMAT_TEXT_V1};
 
 use std::ffi::CString;
-#[cfg(feature = "wayland_frontend")]
 use std::os::unix::prelude::RawFd;
 
 /// Wraps an XKB keymap into a sealed file or stores as just a string for sending to WlKeyboard over an fd
-#[cfg(feature = "wayland_frontend")]
 #[derive(Debug)]
 pub struct KeymapFile {
     sealed: Option<SealedFile>,
     keymap: String,
 }
 
-#[cfg(feature = "wayland_frontend")]
 impl KeymapFile {
     /// Turn the keymap into a string using KEYMAP_FORMAT_TEXT_V1, create a sealed file for it, and store the string
     pub fn new<L>(keymap: &Keymap, logger: L) -> Self
@@ -37,7 +34,7 @@ impl KeymapFile {
     }
 
     /// Run a closure with the file descriptor to ensure safety
-    #[cfg(feature = "wayland_frontend")]
+
     pub fn with_fd<F>(&self, supports_sealed: bool, cb: F) -> Result<(), std::io::Error>
     where
         F: FnOnce(RawFd, usize),
@@ -61,7 +58,7 @@ impl KeymapFile {
     }
 
     /// Send the keymap contained within to a WlKeyboard
-    #[cfg(feature = "wayland_frontend")]
+
     pub fn send(
         &self,
         keyboard: &wayland_server::protocol::wl_keyboard::WlKeyboard,

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -9,6 +9,7 @@ use std::os::unix::prelude::RawFd;
 use wayland_server::protocol::wl_keyboard::WlKeyboard;
 
 /// Wraps an XKB keymap into a sealed file or stores as just a string for sending to WlKeyboard over an fd
+#[cfg(feature = "wayland_frontend")]
 #[derive(Debug)]
 pub struct KeymapFile {
     sealed: Option<SealedFile>,
@@ -37,7 +38,6 @@ impl KeymapFile {
     }
 
     /// Run a closure with the file descriptor to ensure safety
-    #[cfg(feature = "wayland_frontend")]
     pub fn with_fd<F>(&self, supports_sealed: bool, cb: F) -> Result<(), std::io::Error>
     where
         F: FnOnce(RawFd, usize),
@@ -61,7 +61,6 @@ impl KeymapFile {
     }
 
     /// Send the keymap contained within to a WlKeyboard
-    #[cfg(feature = "wayland_frontend")]
     pub fn send(&self, keyboard: &WlKeyboard) -> Result<(), std::io::Error> {
         use wayland_server::{protocol::wl_keyboard::KeymapFormat, Resource};
 

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::utils::sealed_file::SealedFile;
 use slog::error;
 use xkbcommon::xkb::{Keymap, KEYMAP_FORMAT_TEXT_V1};

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -1,12 +1,9 @@
 use crate::utils::sealed_file::SealedFile;
 use slog::error;
-use std::{
-    io::Write,
-    os::unix::prelude::{AsRawFd, RawFd},
-    path::PathBuf,
-};
 use xkbcommon::xkb::{Keymap, KEYMAP_FORMAT_TEXT_V1};
 
+#[cfg(feature = "wayland_frontend")]
+use std::os::unix::prelude::RawFd;
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::protocol::wl_keyboard::WlKeyboard;
 
@@ -37,6 +34,8 @@ impl KeymapFile {
     where
         F: FnOnce(RawFd, usize),
     {
+        use std::{io::Write, os::unix::prelude::AsRawFd, path::PathBuf};
+
         if let Some(file) = supports_sealed.then(|| self.sealed.as_ref()).flatten() {
             cb(file.as_raw_fd(), file.size());
         } else {

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -14,6 +14,7 @@ pub struct KeymapFile {
     keymap: String,
 }
 
+#[cfg(feature = "wayland_frontend")]
 impl KeymapFile {
     /// Turn the keymap into a string using KEYMAP_FORMAT_TEXT_V1, create a sealed file for it, and store the string
     pub fn new<L>(keymap: &Keymap, logger: L) -> Self
@@ -36,6 +37,7 @@ impl KeymapFile {
     }
 
     /// Run a closure with the file descriptor to ensure safety
+    #[cfg(feature = "wayland_frontend")]
     pub fn with_fd<F>(&self, supports_sealed: bool, cb: F) -> Result<(), std::io::Error>
     where
         F: FnOnce(RawFd, usize),
@@ -59,6 +61,7 @@ impl KeymapFile {
     }
 
     /// Send the keymap contained within to a WlKeyboard
+    #[cfg(feature = "wayland_frontend")]
     pub fn send(
         &self,
         keyboard: &wayland_server::protocol::wl_keyboard::WlKeyboard,

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -18,7 +18,7 @@ pub struct KeymapFile {
 
 impl KeymapFile {
     /// Turn the keymap into a string using KEYMAP_FORMAT_TEXT_V1, create a sealed file for it, and store the string
-    pub fn new(keymap: Keymap, log: slog::Logger) -> Self {
+    pub fn new(keymap: &Keymap, log: slog::Logger) -> Self {
         let keymap = keymap.get_as_string(KEYMAP_FORMAT_TEXT_V1);
         let sealed = SealedFile::new("smithay-keymap", &keymap);
 

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -214,7 +214,7 @@ pub enum Error {
 
 pub(crate) struct KbdRc<D: SeatHandler> {
     pub(crate) internal: Mutex<KbdInternal<D>>,
-    #[allow(dead_code)]
+    #[cfg(feature = "wayland_frontend")]
     pub(crate) keymap: KeymapFile,
     pub(crate) logger: ::slog::Logger,
     #[cfg(feature = "wayland_frontend")]
@@ -427,6 +427,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
 
         Ok(Self {
             arc: Arc::new(KbdRc {
+                #[cfg(feature = "wayland_frontend")]
                 keymap: KeymapFile::new(&internal.keymap, log.clone()),
                 internal: Mutex::new(internal),
                 logger: log,

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -16,7 +16,7 @@ pub use xkbcommon::xkb::{self, keysyms, Keysym};
 use super::{Seat, SeatHandler};
 
 mod keymap_file;
-pub(crate) use keymap_file::KeymapFile;
+pub use keymap_file::KeymapFile;
 
 mod modifiers_state;
 pub use modifiers_state::ModifiersState;

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -6,7 +6,6 @@ use slog::{debug, error, info, o, trace};
 use std::collections::HashSet;
 use std::{
     default::Default,
-    ffi::CString,
     fmt, io,
     sync::{Arc, Mutex},
 };
@@ -424,13 +423,10 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
 
         info!(log, "Loaded Keymap"; "name" => internal.keymap.layouts().next());
 
-        let keymap = internal.keymap.get_as_string(xkb::KEYMAP_FORMAT_TEXT_V1);
-        let keymap = CString::new(keymap).expect("Keymap should not contain interior nul bytes");
-
         Ok(Self {
             arc: Arc::new(KbdRc {
+                keymap: KeymapFile::new(internal.keymap.clone(), log.clone()),
                 internal: Mutex::new(internal),
-                keymap: KeymapFile::new(keymap, log.clone()),
                 logger: log,
                 #[cfg(feature = "wayland_frontend")]
                 known_kbds: Mutex::new(Vec::new()),

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -16,6 +16,7 @@ pub use xkbcommon::xkb::{self, keysyms, Keysym};
 use super::{Seat, SeatHandler};
 
 mod keymap_file;
+#[cfg(feature = "wayland_frontend")]
 pub use keymap_file::KeymapFile;
 
 mod modifiers_state;

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -425,7 +425,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
 
         Ok(Self {
             arc: Arc::new(KbdRc {
-                keymap: KeymapFile::new(internal.keymap.clone(), log.clone()),
+                keymap: KeymapFile::new(&internal.keymap, log.clone()),
                 internal: Mutex::new(internal),
                 logger: log,
                 #[cfg(feature = "wayland_frontend")]

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -229,7 +229,6 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("KbdRc")
             .field("internal", &self.internal)
-            .field("keymap", &self.keymap)
             .field("logger", &self.logger)
             .finish()
     }

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -15,6 +15,7 @@ pub use xkbcommon::xkb::{self, keysyms, Keysym};
 
 use super::{Seat, SeatHandler};
 
+#[cfg(feature = "wayland_frontend")]
 mod keymap_file;
 #[cfg(feature = "wayland_frontend")]
 pub use keymap_file::KeymapFile;

--- a/src/input/keyboard/modifiers_state.rs
+++ b/src/input/keyboard/modifiers_state.rs
@@ -28,7 +28,8 @@ pub struct ModifiersState {
 }
 
 impl ModifiersState {
-    pub(super) fn update_with(&mut self, state: &xkb::State) {
+    /// Update the modifiers state from an xkb state
+    pub fn update_with(&mut self, state: &xkb::State) {
         self.ctrl = state.mod_name_is_active(&xkb::MOD_NAME_CTRL, xkb::STATE_MODS_EFFECTIVE);
         self.alt = state.mod_name_is_active(&xkb::MOD_NAME_ALT, xkb::STATE_MODS_EFFECTIVE);
         self.shift = state.mod_name_is_active(&xkb::MOD_NAME_SHIFT, xkb::STATE_MODS_EFFECTIVE);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,6 +12,8 @@ pub mod user_data;
 pub(crate) mod alive_tracker;
 pub use self::alive_tracker::IsAlive;
 
+pub(crate) mod sealed_file;
+
 pub use self::geometry::{
     Buffer, Coordinate, Logical, Physical, Point, Raw, Rectangle, Scale, Size, Transform,
 };

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,6 +12,7 @@ pub mod user_data;
 pub(crate) mod alive_tracker;
 pub use self::alive_tracker::IsAlive;
 
+#[cfg(feature = "wayland_frontend")]
 pub(crate) mod sealed_file;
 
 pub use self::geometry::{

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -21,10 +21,7 @@ pub(crate) struct SealedFile {
 }
 
 impl SealedFile {
-    pub fn new(name: &str, contents: &str) -> Result<Self, std::io::Error> {
-        let name = CString::new(name).expect("File name should not contain interior null bytes");
-        let contents =
-            CString::new(contents).expect("Sealed file contents should not contain interior null bytes");
+    pub fn new(name: CString, contents: CString) -> Result<Self, std::io::Error> {
         let contents = contents.as_bytes_with_nul();
 
         let fd = nix::sys::memfd::memfd_create(

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -21,8 +21,8 @@ pub(crate) struct SealedFile {
 }
 
 impl SealedFile {
-    pub fn new(contents: &str) -> Result<Self, std::io::Error> {
-        let name = CString::new("smithay-keymap").expect("File name should not contain interior null bytes");
+    pub fn new(name: &str, contents: &str) -> Result<Self, std::io::Error> {
+        let name = CString::new(name).expect("File name should not contain interior null bytes");
         let contents =
             CString::new(contents).expect("Sealed file contents should not contain interior null bytes");
         let contents = contents.as_bytes_with_nul();

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -51,6 +51,7 @@ impl SealedFile {
         })
     }
 
+    // Only used in KeymapFile which is under the wayland_frontend feature
     #[allow(dead_code)]
     pub fn size(&self) -> usize {
         self.size

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -21,6 +21,7 @@ pub(crate) struct SealedFile {
 }
 
 impl SealedFile {
+    #[allow(dead_code)]
     pub fn new(name: CString, contents: CString) -> Result<Self, std::io::Error> {
         let contents = contents.as_bytes_with_nul();
 

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -17,7 +17,6 @@ use std::{
 #[derive(Debug)]
 pub(crate) struct SealedFile {
     file: File,
-    #[allow(dead_code)]
     size: usize,
 }
 
@@ -55,6 +54,7 @@ impl SealedFile {
         })
     }
 
+    #[allow(dead_code)]
     pub fn size(&self) -> usize {
         self.size
     }

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -1,0 +1,67 @@
+//! A file whose fd cannot be written by other processes
+//!
+//! This mechanism is useful for giving clients access to large amounts of
+//! information such as keymaps without them being able to write to the handle.
+
+use nix::{
+    fcntl::{FcntlArg, SealFlag},
+    sys::memfd::MemFdCreateFlag,
+};
+use std::{
+    ffi::CString,
+    fs::File,
+    io::{Seek, Write},
+    os::unix::prelude::{AsRawFd, FromRawFd, RawFd},
+};
+
+#[derive(Debug)]
+pub(crate) struct SealedFile {
+    file: File,
+    #[allow(dead_code)]
+    size: usize,
+}
+
+impl SealedFile {
+    pub fn new(contents: &str) -> Result<Self, std::io::Error> {
+        let name = CString::new("smithay-keymap").expect("File name should not contain interior null bytes");
+        let contents =
+            CString::new(contents).expect("Sealed file contents should not contain interior null bytes");
+        let contents = contents.as_bytes_with_nul();
+
+        let fd = nix::sys::memfd::memfd_create(
+            &name,
+            MemFdCreateFlag::MFD_CLOEXEC | MemFdCreateFlag::MFD_ALLOW_SEALING,
+        )?;
+
+        let mut file = unsafe { File::from_raw_fd(fd) };
+        file.write_all(contents)?;
+        file.flush()?;
+
+        file.seek(std::io::SeekFrom::Start(0))?;
+
+        nix::fcntl::fcntl(
+            file.as_raw_fd(),
+            FcntlArg::F_ADD_SEALS(
+                SealFlag::F_SEAL_SEAL
+                    | SealFlag::F_SEAL_SHRINK
+                    | SealFlag::F_SEAL_GROW
+                    | SealFlag::F_SEAL_WRITE,
+            ),
+        )?;
+
+        Ok(Self {
+            file,
+            size: contents.len(),
+        })
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+}
+
+impl AsRawFd for SealedFile {
+    fn as_raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
+}

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -21,7 +21,6 @@ pub(crate) struct SealedFile {
 }
 
 impl SealedFile {
-    #[allow(dead_code)]
     pub fn new(name: CString, contents: CString) -> Result<Self, std::io::Error> {
         let contents = contents.as_bytes_with_nul();
 
@@ -53,7 +52,6 @@ impl SealedFile {
     }
 
     // Only used in KeymapFile which is under the wayland_frontend feature
-    #[allow(dead_code)]
     pub fn size(&self) -> usize {
         self.size
     }

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -1,5 +1,4 @@
 use std::{
-    ffi::CString,
     fmt,
     sync::{Arc, Mutex},
 };
@@ -72,8 +71,6 @@ impl InputMethodHandle {
         )
         .ok_or(())
         .unwrap();
-        let keymap = keymap.get_as_string(xkb::KEYMAP_FORMAT_TEXT_V1);
-        let keymap = CString::new(keymap).expect("Keymap should not contain interior null bytes");
         let log = crate::slog_or_fallback(None);
         keyboard_inner.keymap_file = Some(KeymapFile::new(keymap, log));
     }

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -72,7 +72,7 @@ impl InputMethodHandle {
         .ok_or(())
         .unwrap();
         let log = crate::slog_or_fallback(None);
-        keyboard_inner.keymap_file = Some(KeymapFile::new(keymap, log));
+        keyboard_inner.keymap_file = Some(KeymapFile::new(&keymap, log));
     }
 
     /// Callback function to access the input method object

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use wayland_server::{
     backend::{ClientId, ObjectId},
     protocol::{
-        wl_keyboard::{self, KeyState as WlKeyState, KeymapFormat, WlKeyboard},
+        wl_keyboard::{self, KeyState as WlKeyState, WlKeyboard},
         wl_surface::WlSurface,
     },
     Dispatch, DisplayHandle, Resource,
@@ -45,9 +45,7 @@ where
         trace!(self.arc.logger, "Sending keymap to client");
 
         // prepare a tempfile with the keymap, to send it to the client
-        let ret = self.arc.keymap.with_fd(kbd.version() >= 7, |fd, size| {
-            kbd.keymap(KeymapFormat::XkbV1, fd, size as u32);
-        });
+        let ret = self.arc.keymap.send(&kbd);
 
         if let Err(e) = ret {
             warn!(self.arc.logger,


### PR DESCRIPTION
This is needed so Stardust can accept in keymaps, and I figured cleaning up the APIs would be nicer too since this is partially public.