### PR TITLE
Fix/egl buffer segfault

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,7 +515,7 @@ jobs:
         with:
           command: doc
           # TODO: Update nix when drm-rs is updated
-          args: --no-deps --features "test_all_features" -p smithay -p calloop:0.10.1 -p dbus -p drm -p gbm -p input -p nix:0.24.2 -p udev -p slog -p wayland-server:0.30.0-beta.9 -p wayland-backend -p wayland-protocols:0.30.0-beta.9 -p winit -p x11rb
+          args: --no-deps --features "test_all_features" -p smithay -p calloop:0.10.1 -p dbus -p drm -p gbm -p input -p nix:0.24.2 -p udev -p slog -p wayland-server:0.30.0-beta.10 -p wayland-backend -p wayland-protocols:0.30.0-beta.10 -p winit -p x11rb
 
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,17 +50,18 @@ slog-stdlog = { version = "4", optional = true }
 tempfile = { version = "3.0", optional = true }
 thiserror = "1.0.25"
 udev = { version = "0.6", optional = true }
-wayland-egl = { version = "=0.30.0-beta.9", optional = true }
-wayland-protocols = { version = "=0.30.0-beta.9", features = ["unstable", "staging", "server"], optional = true }
-wayland-protocols-wlr = { version = "=0.1.0-beta.9", features = ["server"]}
-wayland-protocols-misc = { version = "=0.1.0-beta.9", features = ["server"]}
-wayland-server = { version = "=0.30.0-beta.9", optional = true }
-wayland-sys = { version = "=0.30.0-beta.9", optional = true }
-wayland-backend = { version = "=0.1.0-beta.9", optional = true }
+wayland-egl = { version = "=0.30.0-beta.10", optional = true }
+wayland-protocols = { version = "=0.30.0-beta.10", features = ["unstable", "staging", "server"], optional = true }
+wayland-protocols-wlr = { version = "=0.1.0-beta.10", features = ["server"]}
+wayland-protocols-misc = { version = "=0.1.0-beta.10", features = ["server"]}
+wayland-server = { version = "=0.30.0-beta.10", optional = true }
+wayland-sys = { version = "=0.30.0-beta.10", optional = true }
+wayland-backend = { version = "=0.1.0-beta.10", optional = true }
 winit = { version = "0.27.1", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
 x11rb = { version = "0.10.0", optional = true }
 xkbcommon = "0.5.0"
 scan_fmt = { version = "0.2.3", default-features = false }
+io-lifetimes = "=1.0.0-rc1"
 
 [dev-dependencies]
 slog-term = "2.3"

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -1,5 +1,5 @@
 use std::{
-    os::unix::io::RawFd,
+    os::unix::prelude::AsRawFd,
     sync::{atomic::AtomicBool, Arc, Mutex},
 };
 
@@ -13,6 +13,7 @@ use smithay::{
     output::Output,
     reexports::{
         calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
+        io_lifetimes::OwnedFd,
         wayland_protocols::xdg::decoration::{
             self as xdg_decoration, zv1::server::zxdg_toplevel_decoration_v1::Mode as DecorationMode,
         },
@@ -121,7 +122,7 @@ impl<BackendData> DataDeviceHandler for AnvilState<BackendData> {
     fn data_device_state(&self) -> &DataDeviceState {
         &self.data_device_state
     }
-    fn send_selection(&mut self, _mime_type: String, _fd: RawFd) {
+    fn send_selection(&mut self, _mime_type: String, _fd: OwnedFd) {
         unreachable!("Anvil doesn't do server-side selections");
     }
 }
@@ -134,7 +135,7 @@ impl<BackendData> ClientDndGrabHandler for AnvilState<BackendData> {
     }
 }
 impl<BackendData> ServerDndGrabHandler for AnvilState<BackendData> {
-    fn send(&mut self, _mime_type: String, _fd: RawFd) {
+    fn send(&mut self, _mime_type: String, _fd: OwnedFd) {
         unreachable!("Anvil doesn't do server-side grabs");
     }
 }
@@ -282,7 +283,11 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
         };
         handle
             .insert_source(
-                Generic::new(display.backend().poll_fd(), Interest::READ, Mode::Level),
+                Generic::new(
+                    display.backend().poll_fd().as_raw_fd(),
+                    Interest::READ,
+                    Mode::Level,
+                ),
                 |_, _, data| {
                     data.display.dispatch_clients(&mut data.state).unwrap();
                     Ok(PostAction::Continue)

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,4 +1,4 @@
-use std::{os::unix::prelude::RawFd, sync::Arc};
+use std::sync::Arc;
 
 use smithay::{
     backend::{
@@ -11,7 +11,10 @@ use smithay::{
     },
     delegate_compositor, delegate_data_device, delegate_seat, delegate_shm, delegate_xdg_shell,
     input::{keyboard::FilterResult, Seat, SeatHandler, SeatState},
-    reexports::wayland_server::{protocol::wl_seat, Display},
+    reexports::{
+        io_lifetimes::OwnedFd,
+        wayland_server::{protocol::wl_seat, Display},
+    },
     utils::{Rectangle, Serial, Transform},
     wayland::{
         buffer::BufferHandler,
@@ -67,7 +70,7 @@ impl DataDeviceHandler for App {
 
 impl ClientDndGrabHandler for App {}
 impl ServerDndGrabHandler for App {
-    fn send(&mut self, _mime_type: String, _fd: RawFd) {}
+    fn send(&mut self, _mime_type: String, _fd: OwnedFd) {}
 }
 
 impl CompositorHandler for App {

--- a/smallvil/src/state.rs
+++ b/smallvil/src/state.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsString, sync::Arc};
+use std::{ffi::OsString, os::unix::prelude::AsRawFd, sync::Arc};
 
 use slog::Logger;
 use smithay::{
@@ -125,7 +125,11 @@ impl Smallvil {
         // You also need to add the display itself to the event loop, so that client events will be processed by wayland-server.
         handle
             .insert_source(
-                Generic::new(display.backend().poll_fd(), Interest::READ, Mode::Level),
+                Generic::new(
+                    display.backend().poll_fd().as_raw_fd(),
+                    Interest::READ,
+                    Mode::Level,
+                ),
                 |_, _, state| {
                     state.display.dispatch_clients(&mut state.state).unwrap();
                     Ok(PostAction::Continue)

--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -12,8 +12,9 @@
 
 use super::{Buffer, Format, Fourcc, Modifier};
 use crate::utils::{Buffer as BufferCoords, Size};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use std::hash::{Hash, Hasher};
-use std::os::unix::io::{IntoRawFd, RawFd};
+use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
 use std::sync::{Arc, Weak};
 
 /// Maximum amount of planes this implementation supports
@@ -35,7 +36,7 @@ pub(crate) struct DmabufInternal {
 
 #[derive(Debug)]
 pub(crate) struct Plane {
-    pub fd: Option<RawFd>,
+    pub fd: OwnedFd,
     /// The plane index
     pub plane_idx: u32,
     /// Offset from the start of the Fd
@@ -47,16 +48,8 @@ pub(crate) struct Plane {
 }
 
 impl IntoRawFd for Plane {
-    fn into_raw_fd(mut self) -> RawFd {
-        self.fd.take().unwrap()
-    }
-}
-
-impl Drop for Plane {
-    fn drop(&mut self) {
-        if let Some(fd) = self.fd.take() {
-            let _ = nix::unistd::close(fd);
-        }
+    fn into_raw_fd(self) -> RawFd {
+        self.fd.into_raw_fd()
     }
 }
 
@@ -134,7 +127,7 @@ impl DmabufBuilder {
             return false;
         }
         self.internal.planes.push(Plane {
-            fd: Some(fd),
+            fd: unsafe { OwnedFd::from_raw_fd(fd) },
             plane_idx: idx,
             offset,
             stride,
@@ -196,8 +189,8 @@ impl Dmabuf {
     }
 
     /// Returns raw handles of the planes of this buffer
-    pub fn handles(&self) -> impl Iterator<Item = RawFd> + '_ {
-        self.0.planes.iter().map(|p| *p.fd.as_ref().unwrap())
+    pub fn handles(&self) -> impl Iterator<Item = BorrowedFd<'_>> + '_ {
+        self.0.planes.iter().map(|p| p.fd.as_fd())
     }
 
     /// Returns offsets for the planes of this buffer

--- a/src/backend/allocator/gbm.rs
+++ b/src/backend/allocator/gbm.rs
@@ -128,7 +128,7 @@ impl Dmabuf {
     ) -> std::io::Result<GbmBuffer<T>> {
         let mut handles = [0; MAX_PLANES];
         for (i, handle) in self.handles().take(MAX_PLANES).enumerate() {
-            handles[i] = handle;
+            handles[i] = handle.as_raw_fd();
         }
         let mut strides = [0i32; MAX_PLANES];
         for (i, stride) in self.strides().take(MAX_PLANES).enumerate() {

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -1,12 +1,12 @@
 //! Type safe native types for safe egl initialisation
 
-use std::collections::HashSet;
 use std::ffi::CStr;
 use std::mem::MaybeUninit;
 use std::ops::Deref;
 use std::sync::Arc;
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
 use std::sync::{Mutex, Weak};
+use std::{collections::HashSet, os::unix::prelude::AsRawFd};
 
 use libc::c_void;
 use nix::libc::c_int;
@@ -668,7 +668,7 @@ impl EGLDisplay {
         {
             out.extend(&[
                 names[i][0] as i32,
-                fd,
+                fd.as_raw_fd(),
                 names[i][1] as i32,
                 offset as i32,
                 names[i][2] as i32,

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -906,6 +906,10 @@ impl EGLBufferReader {
         &self,
         buffer: &WlBuffer,
     ) -> ::std::result::Result<EGLBuffer, BufferAccessError> {
+        if !buffer.is_alive() {
+            return Err(BufferAccessError::Destroyed);
+        }
+
         let mut format: i32 = 0;
         let query = wrap_egl_call(|| unsafe {
             ffi::egl::QueryWaylandBufferWL(
@@ -1022,6 +1026,10 @@ impl EGLBufferReader {
         &self,
         buffer: &WlBuffer,
     ) -> Option<crate::utils::Size<i32, crate::utils::Buffer>> {
+        if !buffer.is_alive() {
+            return None;
+        }
+
         let mut width: i32 = 0;
         if unsafe {
             ffi::egl::QueryWaylandBufferWL(

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -105,6 +105,9 @@ pub enum BufferAccessError {
     /// We currently do not support multi-planar buffers
     #[error("Multi-planar formats (like {0:?}) are unsupported")]
     UnsupportedMultiPlanarFormat(Format),
+    /// This buffer has been destroyed
+    #[error("This buffer has been destroyed")]
+    Destroyed,
 }
 
 #[cfg(feature = "wayland_frontend")]
@@ -122,6 +125,7 @@ impl fmt::Debug for BufferAccessError {
                 "BufferAccessError::UnsupportedMultiPlanerFormat({:?})",
                 fmt
             ),
+            BufferAccessError::Destroyed => write!(formatter, "BufferAccessError::Destroyed"),
         }
     }
 }

--- a/src/backend/x11/buffer.rs
+++ b/src/backend/x11/buffer.rs
@@ -27,7 +27,7 @@
 //! ensure you read the `presentproto.txt` file (link in the non-public comments of the
 //! x11 mod.rs).
 
-use std::sync::atomic::Ordering;
+use std::{os::unix::prelude::AsRawFd, sync::atomic::Ordering};
 
 use super::{PresentError, Window, X11Error};
 use drm_fourcc::DrmFourcc;
@@ -87,7 +87,7 @@ where
         // XCB closes the file descriptor after sending, so duplicate the file descriptors.
         for handle in dmabuf.handles() {
             let fd = fcntl::fcntl(
-                handle,
+                handle.as_raw_fd(),
                 fcntl::FcntlArg::F_DUPFD_CLOEXEC(3), // Set to 3 so the fd cannot become stdin, stdout or stderr
             )
             .map_err(|e| PresentError::DupFailed(e.to_string()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,6 @@
 //! `log` crate. If not, the logs will discarded. This cargo feature is part of the default set of
 //! features of Smithay.
 
-#[doc(hidden)]
-pub extern crate nix;
-
 pub mod backend;
 #[cfg(feature = "desktop")]
 pub mod desktop;

--- a/src/reexports.rs
+++ b/src/reexports.rs
@@ -11,7 +11,7 @@ pub use drm;
 pub use gbm;
 #[cfg(feature = "backend_libinput")]
 pub use input;
-#[cfg(any(feature = "backend_udev", feature = "backend_drm"))]
+pub use io_lifetimes;
 pub use nix;
 #[cfg(feature = "backend_udev")]
 pub use udev;

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -64,8 +64,9 @@
 //! // You're now ready to go!
 //! ```
 
-use std::{cell::RefCell, os::unix::prelude::RawFd};
+use std::cell::RefCell;
 
+use io_lifetimes::OwnedFd;
 use wayland_server::{
     backend::GlobalId,
     protocol::{
@@ -114,7 +115,7 @@ pub trait DataDeviceHandler: Sized + ClientDndGrabHandler + ServerDndGrabHandler
     ///
     /// * `mime_type` - the requested mime type
     /// * `fd` - the fd to write into
-    fn send_selection(&mut self, mime_type: String, fd: RawFd) {}
+    fn send_selection(&mut self, mime_type: String, fd: OwnedFd) {}
 }
 
 /// Events that are generated during client initiated drag'n'drop
@@ -160,7 +161,7 @@ pub trait ServerDndGrabHandler {
     ///
     /// * `mime_type` - The requested mime type
     /// * `fd` - The FD to write into
-    fn send(&mut self, mime_type: String, fd: RawFd) {}
+    fn send(&mut self, mime_type: String, fd: OwnedFd) {}
 
     /// The client has finished interacting with the resource
     ///

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use io_lifetimes::OwnedFd;
 use wayland_server::{
     backend::{protocol::Message, ClientId, Handle, ObjectData, ObjectId},
     protocol::{
@@ -239,7 +240,7 @@ where
         dh: &Handle,
         handler: &mut D,
         _client_id: ClientId,
-        msg: Message<ObjectId>,
+        msg: Message<ObjectId, OwnedFd>,
     ) -> Option<Arc<dyn ObjectData<D>>> {
         let dh = DisplayHandle::from(dh.clone());
         if let Ok((resource, request)) = WlDataOffer::parse_request(&dh, msg) {

--- a/src/wayland/dmabuf/dispatch.rs
+++ b/src/wayland/dmabuf/dispatch.rs
@@ -176,7 +176,7 @@ where
 
                 let modifier = ((modifier_hi as u64) << 32) + (modifier_lo as u64);
                 planes.push(Plane {
-                    fd: Some(fd),
+                    fd,
                     plane_idx,
                     offset,
                     stride,

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -94,7 +94,7 @@ mod dispatch;
 use std::{
     collections::HashMap,
     convert::TryFrom,
-    os::unix::io::IntoRawFd,
+    os::unix::{io::IntoRawFd, prelude::AsRawFd},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -425,9 +425,9 @@ impl DmabufParamsData {
                 }
             };
 
-            if let Ok(size) = unistd::lseek(plane.fd.unwrap(), 0, unistd::Whence::SeekEnd) {
+            if let Ok(size) = unistd::lseek(plane.fd.as_raw_fd(), 0, unistd::Whence::SeekEnd) {
                 // Reset seek point
-                let _ = unistd::lseek(plane.fd.unwrap(), 0, unistd::Whence::SeekSet);
+                let _ = unistd::lseek(plane.fd.as_raw_fd(), 0, unistd::Whence::SeekSet);
 
                 if plane.offset as libc::off_t > size {
                     params.post_error(

--- a/src/wayland/primary_selection/mod.rs
+++ b/src/wayland/primary_selection/mod.rs
@@ -59,8 +59,9 @@
 //! // You're now ready to go!
 //! ```
 
-use std::{cell::RefCell, os::unix::prelude::RawFd};
+use std::cell::RefCell;
 
+use io_lifetimes::OwnedFd;
 use wayland_protocols::wp::primary_selection::zv1::server::{
     zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1 as PrimaryDeviceManager,
     zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1 as PrimarySource,
@@ -92,7 +93,7 @@ pub trait PrimarySelectionHandler: Sized {
     /// * `mime_type` - the requested mime type
     /// * `fd` - the fd to write into
     #[allow(unused_variables)]
-    fn send_selection(&mut self, mime_type: String, fd: RawFd) {}
+    fn send_selection(&mut self, mime_type: String, fd: OwnedFd) {}
 }
 
 /// State of data device

--- a/src/wayland/primary_selection/seat_data.rs
+++ b/src/wayland/primary_selection/seat_data.rs
@@ -1,5 +1,6 @@
-use std::sync::Arc;
+use std::{os::unix::prelude::AsRawFd, sync::Arc};
 
+use io_lifetimes::OwnedFd;
 use slog::debug;
 use wayland_protocols::wp::primary_selection::zv1::server::{
     zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1 as PrimaryDevice,
@@ -188,7 +189,7 @@ where
         dh: &Handle,
         handler: &mut D,
         _client_id: ClientId,
-        msg: Message<ObjectId>,
+        msg: Message<ObjectId, OwnedFd>,
     ) -> Option<Arc<dyn ObjectData<D>>> {
         let dh = DisplayHandle::from(dh.clone());
         if let Ok((_resource, request)) = PrimaryOffer::parse_request(&dh, msg) {
@@ -221,9 +222,8 @@ where
                 "Denying a zwp_primary_selection_offer_v1.receive with invalid source."
             );
         } else {
-            source.send(mime_type, fd);
+            source.send(mime_type, fd.as_raw_fd());
         }
-        let _ = ::nix::unistd::close(fd);
     }
 }
 
@@ -240,7 +240,7 @@ where
         dh: &Handle,
         handler: &mut D,
         _client_id: ClientId,
-        msg: Message<ObjectId>,
+        msg: Message<ObjectId, OwnedFd>,
     ) -> Option<Arc<dyn ObjectData<D>>> {
         let dh = DisplayHandle::from(dh.clone());
         if let Ok((_resource, request)) = PrimaryOffer::parse_request(&dh, msg) {
@@ -271,7 +271,6 @@ pub fn handle_server_selection<D>(
                 primary_selection_state.log,
                 "Denying a zwp_primary_selection_offer_v1.receive with invalid source."
             );
-            let _ = ::nix::unistd::close(fd);
         } else {
             handler.send_selection(mime_type, fd);
         }

--- a/src/wayland/shm/handlers.rs
+++ b/src/wayland/shm/handlers.rs
@@ -5,7 +5,7 @@ use super::{
     BufferData, ShmHandler, ShmPoolUserData, ShmState,
 };
 
-use std::sync::Arc;
+use std::{os::unix::prelude::AsRawFd, sync::Arc};
 use wayland_server::{
     protocol::{
         wl_buffer,
@@ -67,8 +67,11 @@ where
 
         let mmap_pool = match Pool::new(fd, size as usize, state.shm_state().log.clone()) {
             Ok(p) => p,
-            Err(()) => {
-                shm.post_error(wl_shm::Error::InvalidFd, format!("Failed to mmap fd {}", fd));
+            Err(fd) => {
+                shm.post_error(
+                    wl_shm::Error::InvalidFd,
+                    format!("Failed to mmap fd {}", fd.as_raw_fd()),
+                );
                 return;
             }
         };

--- a/wlcs_anvil/Cargo.toml
+++ b/wlcs_anvil/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 smithay = { path = "..", default-features=false, features=["wayland_frontend", "use_system_lib"] }
 anvil = { path = "../anvil", default-features=false }
-wayland-sys = { version = "=0.30.0-beta.9", features = ["client", "server"] }
+wayland-sys = { version = "=0.30.0-beta.10", features = ["client", "server"] }
 libc = "0.2"
 memoffset = "0.6"
 slog = "2.0"


### PR DESCRIPTION
This PR fixes some segfaults for egl clients that have disconnected

- [9b8b86a](https://github.com/Smithay/smithay/commit/9b8b86ad43b2bf0bbed65312fcb3efd1a2d9245d) updates `wayland-rs` to `0.30.0-beta10` and makes use of `io_lifetimes`
- [05b1606](https://github.com/Smithay/smithay/commit/05b1606eb534b593789bb6fe263e77402f565bdd) fixes a race in the renderer accessing a destroyed EGL Buffer