### PR TITLE
egl: make EGLDisplay::new unsafe

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -378,7 +378,7 @@ fn scan_connectors(
     let mut backends = HashMap::new();
 
     let (render_node, formats) = {
-        let display = EGLDisplay::new(&*gbm.borrow(), logger.clone()).unwrap();
+        let display = unsafe { EGLDisplay::new(&*gbm.borrow(), logger.clone()).unwrap() };
         let node = match EGLDevice::device_for_display(&display)
             .ok()
             .and_then(|x| x.try_get_render_node().ok().flatten())

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -95,7 +95,7 @@ pub fn run_x11(log: Logger) {
     // Create the gbm device for buffer allocation.
     let device = gbm::Device::new(fd).expect("Failed to create gbm device");
     // Initialize EGL using the GBM device.
-    let egl = EGLDisplay::new(&device, log.clone()).expect("Failed to create EGLDisplay");
+    let egl = unsafe { EGLDisplay::new(&device, log.clone()).expect("Failed to create EGLDisplay") };
     // Create the OpenGL context
     let context = EGLContext::new(&egl, log.clone()).expect("Failed to create EGLContext");
 

--- a/src/backend/renderer/multigpu/egl.rs
+++ b/src/backend/renderer/multigpu/egl.rs
@@ -78,7 +78,7 @@ impl GraphicsApi for EglGlesBackend {
             .filter(|(_, node)| !list.iter().any(|renderer| &renderer.node == node))
             .map(|(device, node)| {
                 slog::info!(log, "Trying to initialize {:?} from {}", device, node);
-                let display = EGLDisplay::new(&device, None).map_err(Error::Egl)?;
+                let display = unsafe { EGLDisplay::new(&device, None).map_err(Error::Egl)? };
                 let context = EGLContext::new(&display, None).map_err(Error::Egl)?;
                 let renderer = unsafe { Gles2Renderer::new(context, None).map_err(Error::Gl)? };
 

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -176,7 +176,7 @@ where
 
     let reqs = Default::default();
     let (display, context, surface, is_x11) = {
-        let display = EGLDisplay::new(&winit_window, log.clone())?;
+        let display = unsafe { EGLDisplay::new(&winit_window, log.clone())? };
         let context = EGLContext::new_with_config(&display, attributes, reqs, log.clone())?;
 
         let (surface, is_x11) = if let Some(wl_surface) = winit_window.wayland_surface() {

--- a/src/backend/x11/mod.rs
+++ b/src/backend/x11/mod.rs
@@ -41,7 +41,7 @@
 //!     // Create the gbm device for allocating buffers
 //!     let device = gbm::Device::new(fd)?;
 //!     // Initialize EGL to retrieve the support modifier list
-//!     let egl = EGLDisplay::new(&device, logger.clone()).expect("Failed to create EGLDisplay");
+//!     let egl = unsafe { EGLDisplay::new(&device, logger.clone()).expect("Failed to create EGLDisplay") };
 //!     let context = EGLContext::new(&egl, logger).expect("Failed to create EGLContext");
 //!     let modifiers = context.dmabuf_render_formats().iter().map(|format| format.modifier).collect::<HashSet<_>>();
 //!
@@ -927,7 +927,7 @@ impl X11Inner {
 }
 
 fn egl_init(_: &X11Inner) -> Result<(DrmNode, RawFd), EGLInitError> {
-    let display = EGLDisplay::new(&X11DefaultDisplay, None)?;
+    let display = unsafe { EGLDisplay::new(&X11DefaultDisplay, None)? };
     let device = EGLDevice::device_for_display(&display)?;
     let path = path_to_type(device.drm_device_path()?, NodeType::Render)?;
     let node = DrmNode::from_path(&path)


### PR DESCRIPTION
`EGLDisplay::new` raised some safety concerns, it happened a few times that the provided `EGLNativeDisplay` has been dropped before the created `EGLDisplay`. Dropping the `EGLNativeDisplay` before the  `EGLDisplay` most likely ends in a segfault at some point. To better express that this PR makes `EGLDisplay::new` unsafe and documents the safety requirements.