### PR TITLE
fix: add arm for primary_device_manager::Request::Destroy

### DIFF
--- a/src/wayland/primary_selection/mod.rs
+++ b/src/wayland/primary_selection/mod.rs
@@ -235,6 +235,7 @@ mod handlers {
                         }
                     }
                 }
+                primary_device_manager::Request::Destroy => {}
                 _ => unreachable!(),
             }
         }


### PR DESCRIPTION
I noticed when using cosmic-comp that this unreachable!() arm would be triggered sometimes when closing a window. I assume that handling Destroy will help prevent that from happening.