### PR TITLE
Feature/drm planes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ drm-ffi = { version = "0.4.0", optional = true }
 gbm = { version = "0.11.0", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.11.2", optional = true }
 input = { version = "0.8.2", default-features = false, features=["libinput_1_14"], optional = true }
-indexmap = "1.7"
+indexmap = "1.9"
 lazy_static = "1"
 libc = "0.2.103"
 libseat= { version = "0.1.7", optional = true }
@@ -93,7 +93,7 @@ libinput_1_19 = ["input/libinput_1_19"]
 renderer_gl = ["gl_generator", "backend_egl"]
 renderer_glow = ["renderer_gl", "glow"]
 renderer_multi = ["backend_drm"]
-use_system_lib = ["wayland_frontend", "wayland-backend/server_system", "wayland-sys"]
+use_system_lib = ["wayland_frontend", "wayland-backend/server_system", "wayland-sys", "gbm?/import-wayland"]
 wayland_frontend = ["wayland-server", "wayland-protocols", "tempfile"]
 x11rb_event_source = ["x11rb"]
 xwayland = ["encoding", "wayland_frontend", "x11rb/composite", "x11rb_event_source", "scopeguard"]

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -24,6 +24,8 @@ use smithay::{
 };
 
 pub static CLEAR_COLOR: [f32; 4] = [0.8, 0.8, 0.9, 1.0];
+pub static CLEAR_COLOR_FULLSCREEN: [f32; 4] = [0.0, 0.0, 0.0, 0.0];
+
 pub struct PointerElement<T: Texture> {
     texture: Option<TextureBuffer<T>>,
     status: CursorImageStatus,

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -57,6 +57,19 @@ render_elements! {
     Texture=TextureRenderElement<<R as Renderer>::TextureId>,
 }
 
+impl<R: Renderer> std::fmt::Debug for PointerRenderElement<R>
+where
+    <R as Renderer>::TextureId: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Surface(arg0) => f.debug_tuple("Surface").field(arg0).finish(),
+            Self::Texture(arg0) => f.debug_tuple("Texture").field(arg0).finish(),
+            Self::_GenericCatcher(arg0) => f.debug_tuple("_GenericCatcher").field(arg0).finish(),
+        }
+    }
+}
+
 impl<T: Texture + Clone + 'static, R> AsRenderElements<R> for PointerElement<T>
 where
     R: Renderer<TextureId = T> + ImportAll,
@@ -104,7 +117,7 @@ where
 pub static FPS_NUMBERS_PNG: &[u8] = include_bytes!("../resources/numbers.png");
 
 #[cfg(feature = "debug")]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FpsElement<T: Texture> {
     id: Id,
     value: u32,

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -4,6 +4,8 @@ use crate::{focus::FocusTarget, shell::FullscreenSurface, AnvilState};
 
 #[cfg(feature = "udev")]
 use crate::udev::UdevData;
+#[cfg(feature = "udev")]
+use smithay::backend::renderer::DebugFlags;
 
 use smithay::{
     backend::input::{
@@ -607,6 +609,11 @@ impl AnvilState<UdevData> {
                         self.backend_data.reset_buffers(&output);
                     }
                 }
+                KeyAction::ToggleTint => {
+                    let mut debug_flags = self.backend_data.debug_flags();
+                    debug_flags.toggle(DebugFlags::TINT);
+                    self.backend_data.set_debug_flags(debug_flags);
+                }
 
                 action => match action {
                     KeyAction::None | KeyAction::Quit | KeyAction::Run(_) | KeyAction::TogglePreview => {
@@ -886,6 +893,7 @@ enum KeyAction {
     ScaleDown,
     TogglePreview,
     RotateOutput,
+    ToggleTint,
     /// Do nothing more
     None,
 }
@@ -915,6 +923,8 @@ fn process_keyboard_shortcut(modifiers: ModifiersState, keysym: Keysym) -> Optio
         Some(KeyAction::TogglePreview)
     } else if modifiers.logo && modifiers.shift && keysym == xkb::KEY_R {
         Some(KeyAction::RotateOutput)
+    } else if modifiers.logo && modifiers.shift && keysym == xkb::KEY_T {
+        Some(KeyAction::ToggleTint)
     } else {
         None
     }

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -7,7 +7,7 @@ use smithay::{
                 ConstrainAlign, ConstrainScaleBehavior, CropRenderElement, RelocateRenderElement,
                 RescaleRenderElement,
             },
-            AsRenderElements, RenderElementStates, Wrap,
+            AsRenderElements, RenderElement, RenderElementStates, Wrap,
         },
         ImportAll, ImportMem, Renderer,
     },
@@ -38,12 +38,43 @@ smithay::backend::renderer::element::render_elements! {
     Fps=FpsElement<<R as Renderer>::TextureId>,
 }
 
+impl<R: Renderer + std::fmt::Debug> std::fmt::Debug for CustomRenderElements<R>
+where
+    <R as Renderer>::TextureId: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pointer(arg0) => f.debug_tuple("Pointer").field(arg0).finish(),
+            Self::Surface(arg0) => f.debug_tuple("Surface").field(arg0).finish(),
+            #[cfg(feature = "debug")]
+            Self::Fps(arg0) => f.debug_tuple("Fps").field(arg0).finish(),
+            Self::_GenericCatcher(arg0) => f.debug_tuple("_GenericCatcher").field(arg0).finish(),
+        }
+    }
+}
+
 smithay::backend::renderer::element::render_elements! {
     pub OutputRenderElements<R, E> where R: ImportAll + ImportMem;
     Space=SpaceRenderElements<R, E>,
     Window=Wrap<E>,
     Custom=CustomRenderElements<R>,
     Preview=CropRenderElement<RelocateRenderElement<RescaleRenderElement<WindowRenderElement<R>>>>,
+}
+
+impl<R: Renderer + ImportAll + ImportMem + std::fmt::Debug, E: RenderElement<R> + std::fmt::Debug>
+    std::fmt::Debug for OutputRenderElements<R, E>
+where
+    <R as Renderer>::TextureId: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Space(arg0) => f.debug_tuple("Space").field(arg0).finish(),
+            Self::Window(arg0) => f.debug_tuple("Window").field(arg0).finish(),
+            Self::Custom(arg0) => f.debug_tuple("Custom").field(arg0).finish(),
+            Self::Preview(arg0) => f.debug_tuple("Preview").field(arg0).finish(),
+            Self::_GenericCatcher(arg0) => f.debug_tuple("_GenericCatcher").field(arg0).finish(),
+        }
+    }
 }
 
 pub fn space_preview_elements<'a, R, C>(

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -1,19 +1,18 @@
 use smithay::{
     backend::renderer::{
-        damage::{DamageTrackedRenderer, DamageTrackedRendererError, DamageTrackedRendererMode},
+        damage::{DamageTrackedRenderer, DamageTrackedRendererError},
         element::{
             surface::WaylandSurfaceRenderElement,
             utils::{
                 ConstrainAlign, ConstrainScaleBehavior, CropRenderElement, RelocateRenderElement,
                 RescaleRenderElement,
             },
-            AsRenderElements, RenderElementStates,
+            AsRenderElements, RenderElementStates, Wrap,
         },
         ImportAll, ImportMem, Renderer,
     },
-    desktop::{
-        self,
-        space::{constrain_space_element, ConstrainBehavior, ConstrainReference, Space},
+    desktop::space::{
+        constrain_space_element, ConstrainBehavior, ConstrainReference, Space, SpaceRenderElements,
     },
     output::Output,
     utils::{Physical, Point, Rectangle, Size},
@@ -22,7 +21,7 @@ use smithay::{
 #[cfg(feature = "debug")]
 use crate::drawing::FpsElement;
 use crate::{
-    drawing::{PointerRenderElement, CLEAR_COLOR},
+    drawing::{PointerRenderElement, CLEAR_COLOR, CLEAR_COLOR_FULLSCREEN},
     shell::{FullscreenSurface, WindowElement, WindowRenderElement},
 };
 
@@ -31,7 +30,6 @@ smithay::backend::renderer::element::render_elements! {
         R: ImportAll + ImportMem;
     Pointer=PointerRenderElement<R>,
     Surface=WaylandSurfaceRenderElement<R>,
-    Window=WindowRenderElement<R>,
     #[cfg(feature = "debug")]
     // Note: We would like to borrow this element instead, but that would introduce
     // a feature-dependent lifetime, which introduces a lot more feature bounds
@@ -41,17 +39,129 @@ smithay::backend::renderer::element::render_elements! {
 }
 
 smithay::backend::renderer::element::render_elements! {
-    pub OutputRenderElements<'a, R> where
-        R: ImportAll + ImportMem;
-    Custom=&'a CustomRenderElements<R>,
+    pub OutputRenderElements<R, E> where R: ImportAll + ImportMem;
+    Space=SpaceRenderElements<R, E>,
+    Window=Wrap<E>,
+    Custom=CustomRenderElements<R>,
     Preview=CropRenderElement<RelocateRenderElement<RescaleRenderElement<WindowRenderElement<R>>>>,
+}
+
+pub fn space_preview_elements<'a, R, C>(
+    renderer: &'a mut R,
+    space: &'a Space<WindowElement>,
+    output: &'a Output,
+) -> impl Iterator<Item = C> + 'a
+where
+    R: Renderer + ImportAll + ImportMem,
+    R::TextureId: Clone + 'static,
+    C: From<CropRenderElement<RelocateRenderElement<RescaleRenderElement<WindowRenderElement<R>>>>> + 'a,
+{
+    let constrain_behavior = ConstrainBehavior {
+        reference: ConstrainReference::BoundingBox,
+        behavior: ConstrainScaleBehavior::Fit,
+        align: ConstrainAlign::CENTER,
+    };
+
+    let preview_padding = 10;
+
+    let elements_on_space = space.elements_for_output(output).count();
+    let output_scale = output.current_scale().fractional_scale();
+    let output_transform = output.current_transform();
+    let output_size = output
+        .current_mode()
+        .map(|mode| {
+            output_transform
+                .transform_size(mode.size)
+                .to_f64()
+                .to_logical(output_scale)
+        })
+        .unwrap_or_default();
+
+    let max_elements_per_row = 4;
+    let elements_per_row = usize::min(elements_on_space, max_elements_per_row);
+    let rows = f64::ceil(elements_on_space as f64 / elements_per_row as f64);
+
+    let preview_size = Size::from((
+        f64::round(output_size.w / elements_per_row as f64) as i32 - preview_padding * 2,
+        f64::round(output_size.h / rows) as i32 - preview_padding * 2,
+    ));
+
+    space
+        .elements_for_output(output)
+        .enumerate()
+        .flat_map(move |(element_index, window)| {
+            let column = element_index % elements_per_row;
+            let row = element_index / elements_per_row;
+            let preview_location = Point::from((
+                preview_padding + (preview_padding + preview_size.w) * column as i32,
+                preview_padding + (preview_padding + preview_size.h) * row as i32,
+            ));
+            let constrain = Rectangle::from_loc_and_size(preview_location, preview_size);
+            constrain_space_element(
+                renderer,
+                window,
+                preview_location,
+                output_scale,
+                constrain,
+                constrain_behavior,
+            )
+        })
+}
+
+pub fn output_elements<'a, R>(
+    output: &Output,
+    space: &'a Space<WindowElement>,
+    custom_elements: impl IntoIterator<Item = CustomRenderElements<R>>,
+    renderer: &mut R,
+    show_window_preview: bool,
+) -> (Vec<OutputRenderElements<R, WindowRenderElement<R>>>, [f32; 4])
+where
+    R: Renderer + ImportAll + ImportMem,
+    R::TextureId: Clone + 'static,
+{
+    if let Some(window) = output
+        .user_data()
+        .get::<FullscreenSurface>()
+        .and_then(|f| f.get())
+    {
+        let scale = output.current_scale().fractional_scale().into();
+        let window_render_elements: Vec<WindowRenderElement<R>> =
+            AsRenderElements::<R>::render_elements(&window, renderer, (0, 0).into(), scale);
+
+        let elements = custom_elements
+            .into_iter()
+            .map(OutputRenderElements::from)
+            .chain(
+                window_render_elements
+                    .into_iter()
+                    .map(|e| OutputRenderElements::Window(Wrap::from(e))),
+            )
+            .collect::<Vec<_>>();
+        (elements, CLEAR_COLOR_FULLSCREEN)
+    } else {
+        let mut output_render_elements = custom_elements
+            .into_iter()
+            .map(OutputRenderElements::from)
+            .collect::<Vec<_>>();
+
+        if show_window_preview && space.elements_for_output(output).count() > 0 {
+            output_render_elements.extend(space_preview_elements(renderer, space, output));
+        }
+
+        let space_elements =
+            smithay::desktop::space::space_render_elements::<_, WindowElement, _>(renderer, [space], output)
+                .expect("output without mode?");
+        output_render_elements.extend(space_elements.into_iter().map(OutputRenderElements::Space));
+
+        (output_render_elements, CLEAR_COLOR)
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
 pub fn render_output<'a, R>(
     output: &Output,
     space: &'a Space<WindowElement>,
-    custom_elements: &'a [CustomRenderElements<R>],
+    custom_elements: impl IntoIterator<Item = CustomRenderElements<R>>,
     renderer: &mut R,
     damage_tracked_renderer: &mut DamageTrackedRenderer,
     age: usize,
@@ -62,93 +172,7 @@ where
     R: Renderer + ImportAll + ImportMem,
     R::TextureId: Clone + 'static,
 {
-    let output_scale = output.current_scale().fractional_scale().into();
-
-    if let Some(window) = output
-        .user_data()
-        .get::<FullscreenSurface>()
-        .and_then(|f| f.get())
-    {
-        if let DamageTrackedRendererMode::Auto(renderer_output) = damage_tracked_renderer.mode() {
-            assert!(renderer_output == output);
-        }
-
-        let window_render_elements =
-            AsRenderElements::<R>::render_elements(&window, renderer, (0, 0).into(), output_scale);
-
-        let render_elements = custom_elements
-            .iter()
-            .chain(window_render_elements.iter())
-            .collect::<Vec<_>>();
-
-        damage_tracked_renderer.render_output(renderer, age, &render_elements, CLEAR_COLOR, log.clone())
-    } else {
-        let mut output_render_elements = custom_elements
-            .iter()
-            .map(OutputRenderElements::from)
-            .collect::<Vec<_>>();
-
-        if show_window_preview && space.elements_for_output(output).count() > 0 {
-            let constrain_behavior = ConstrainBehavior {
-                reference: ConstrainReference::BoundingBox,
-                behavior: ConstrainScaleBehavior::Fit,
-                align: ConstrainAlign::CENTER,
-            };
-
-            let preview_padding = 10;
-
-            let elements_on_space = space.elements_for_output(output).count();
-            let output_scale = output.current_scale().fractional_scale();
-            let output_transform = output.current_transform();
-            let output_size = output
-                .current_mode()
-                .map(|mode| {
-                    output_transform
-                        .transform_size(mode.size)
-                        .to_f64()
-                        .to_logical(output_scale)
-                })
-                .unwrap_or_default();
-
-            let max_elements_per_row = 4;
-            let elements_per_row = usize::min(elements_on_space, max_elements_per_row);
-            let rows = f64::ceil(elements_on_space as f64 / elements_per_row as f64);
-
-            let preview_size = Size::from((
-                f64::round(output_size.w / elements_per_row as f64) as i32 - preview_padding * 2,
-                f64::round(output_size.h / rows) as i32 - preview_padding * 2,
-            ));
-
-            output_render_elements.extend(space.elements_for_output(output).enumerate().flat_map(
-                |(element_index, window)| {
-                    let column = element_index % elements_per_row;
-                    let row = element_index / elements_per_row;
-                    let preview_location = Point::from((
-                        preview_padding + (preview_padding + preview_size.w) * column as i32,
-                        preview_padding + (preview_padding + preview_size.h) * row as i32,
-                    ));
-                    let constrain = Rectangle::from_loc_and_size(preview_location, preview_size);
-                    constrain_space_element(
-                        renderer,
-                        window,
-                        preview_location,
-                        output_scale,
-                        constrain,
-                        constrain_behavior,
-                    )
-                },
-            ));
-        }
-
-        desktop::space::render_output(
-            output,
-            renderer,
-            age,
-            [space],
-            &output_render_elements,
-            damage_tracked_renderer,
-            CLEAR_COLOR,
-            log.clone(),
-        )
-    }
+    let (elements, clear_color) =
+        output_elements(output, space, custom_elements, renderer, show_window_preview);
+    damage_tracked_renderer.render_output(renderer, age, &elements, clear_color, log.clone())
 }

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -441,6 +441,16 @@ render_elements!(
     Decoration=MemoryRenderBufferRenderElement<R>,
 );
 
+impl<R: Renderer + std::fmt::Debug> std::fmt::Debug for WindowRenderElement<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Window(arg0) => f.debug_tuple("Window").field(arg0).finish(),
+            Self::Decoration(arg0) => f.debug_tuple("Decoration").field(arg0).finish(),
+            Self::_GenericCatcher(arg0) => f.debug_tuple("_GenericCatcher").field(arg0).finish(),
+        }
+    }
+}
+
 impl<R> AsRenderElements<R> for WindowElement
 where
     R: Renderer + ImportAll + ImportMem,

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -1209,7 +1209,7 @@ fn render_surface<'a, 'b>(
     }
 
     // and draw to our buffer
-    let (rendered, states) = render_output(
+    let (damage, states) = render_output(
         output,
         space,
         &elements,
@@ -1219,7 +1219,6 @@ fn render_surface<'a, 'b>(
         show_window_preview,
         logger,
     )
-    .map(|(damage, states)| (damage.is_some(), states))
     .map_err(|err| match err {
         DamageTrackedRendererError::Rendering(err) => SwapBuffersError::from(err),
         _ => unreachable!(),
@@ -1227,15 +1226,16 @@ fn render_surface<'a, 'b>(
 
     post_repaint(output, &states, space, clock.now());
 
-    if rendered {
+    if let Some(damage) = damage {
         let output_presentation_feedback = take_presentation_feedback(output, space, &states);
         surface
             .surface
-            .queue_buffer(Some(output_presentation_feedback))
+            .queue_buffer(Some(damage), Some(output_presentation_feedback))
             .map_err(Into::<SwapBuffersError>::into)?;
+        Ok(true)
+    } else {
+        Ok(false)
     }
-
-    Ok(rendered)
 }
 
 fn schedule_initial_render(
@@ -1278,7 +1278,7 @@ fn initial_render(
         .map_err(Into::<SwapBuffersError>::into)?;
     frame.clear(CLEAR_COLOR, &[Rectangle::from_loc_and_size((0, 0), (1, 1))])?;
     frame.finish().map_err(Into::<SwapBuffersError>::into)?;
-    surface.queue_buffer(None)?;
+    surface.queue_buffer(None, None)?;
     surface.reset_buffers();
     Ok(())
 }

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -297,7 +297,7 @@ pub fn run_winit(log: Logger) {
                 render_output(
                     &output,
                     space,
-                    &elements,
+                    elements,
                     renderer,
                     damage_tracked_renderer,
                     age,

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -382,7 +382,7 @@ pub fn run_x11(log: Logger) {
             let render_res = render_output(
                 &output,
                 &state.space,
-                &elements,
+                elements,
                 &mut backend_data.renderer,
                 &mut backend_data.damage_tracked_renderer,
                 age.into(),

--- a/src/backend/drm/compositor/elements.rs
+++ b/src/backend/drm/compositor/elements.rs
@@ -1,0 +1,162 @@
+use crate::{
+    backend::renderer::{
+        element::{Element, Id, RenderElement},
+        utils::CommitCounter,
+        Frame, Renderer,
+    },
+    render_elements,
+    utils::{Buffer, Physical, Point, Rectangle, Scale, Transform},
+};
+
+pub const COLOR_TRANSPARENT: [f32; 4] = [0f32, 0f32, 0f32, 0f32];
+
+render_elements! {
+    pub DrmRenderElements<'a, R, E>;
+    Holepunch=HolepunchRenderElement,
+    Overlay=OverlayPlaneElement<'a, E>,
+    Other=&'a E,
+}
+
+pub struct HolepunchRenderElement {
+    id: Id,
+    geometry: Rectangle<i32, Physical>,
+}
+
+impl HolepunchRenderElement {
+    pub fn from_render_element<R, E>(element: &E, scale: impl Into<Scale<f64>>) -> Self
+    where
+        R: Renderer,
+        E: RenderElement<R>,
+    {
+        HolepunchRenderElement {
+            id: element.id().clone(),
+            geometry: element.geometry(scale.into()),
+        }
+    }
+}
+
+impl<R> RenderElement<R> for HolepunchRenderElement
+where
+    R: Renderer,
+{
+    fn draw<'frame>(
+        &self,
+        frame: &mut <R as Renderer>::Frame<'frame>,
+        _src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        _log: &slog::Logger,
+    ) -> Result<(), <R as Renderer>::Error> {
+        frame.clear(
+            COLOR_TRANSPARENT,
+            &damage
+                .iter()
+                .cloned()
+                .map(|mut d| {
+                    d.loc += dst.loc;
+                    d
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
+impl Element for HolepunchRenderElement {
+    fn id(&self) -> &Id {
+        &self.id
+    }
+
+    fn current_commit(&self) -> CommitCounter {
+        CommitCounter::default()
+    }
+
+    fn src(&self) -> Rectangle<f64, Buffer> {
+        Rectangle::default()
+    }
+
+    fn geometry(&self, _scale: Scale<f64>) -> Rectangle<i32, Physical> {
+        self.geometry
+    }
+
+    fn transform(&self) -> Transform {
+        Transform::Normal
+    }
+
+    fn opaque_regions(&self, _scale: Scale<f64>) -> Vec<Rectangle<i32, Physical>> {
+        vec![Rectangle::from_loc_and_size(Point::default(), self.geometry.size)]
+    }
+}
+
+pub struct OverlayPlaneElement<'a, E> {
+    element: &'a E,
+}
+
+impl<'a, E> OverlayPlaneElement<'a, E> {
+    pub fn from_render_element<R>(element: &'a E) -> Self
+    where
+        R: Renderer,
+        E: RenderElement<R>,
+    {
+        OverlayPlaneElement { element }
+    }
+}
+
+impl<'a, E> Element for OverlayPlaneElement<'a, E>
+where
+    E: Element,
+{
+    fn id(&self) -> &Id {
+        self.element.id()
+    }
+
+    fn current_commit(&self) -> CommitCounter {
+        self.element.current_commit()
+    }
+
+    fn src(&self) -> Rectangle<f64, Buffer> {
+        self.element.src()
+    }
+
+    fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
+        self.element.geometry(scale)
+    }
+
+    fn transform(&self) -> Transform {
+        self.element.transform()
+    }
+
+    fn damage_since(
+        &self,
+        _scale: Scale<f64>,
+        _commit: Option<CommitCounter>,
+    ) -> Vec<Rectangle<i32, Physical>> {
+        // We do not report damage
+        vec![]
+    }
+
+    fn opaque_regions(&self, scale: Scale<f64>) -> Vec<Rectangle<i32, Physical>> {
+        self.element.opaque_regions(scale)
+    }
+
+    fn location(&self, scale: Scale<f64>) -> Point<i32, Physical> {
+        self.element.location(scale)
+    }
+}
+
+impl<'a, E, R> RenderElement<R> for OverlayPlaneElement<'a, E>
+where
+    E: Element,
+    R: Renderer,
+{
+    fn draw<'draw>(
+        &self,
+        _frame: &mut <R as Renderer>::Frame<'draw>,
+        _src: Rectangle<f64, Buffer>,
+        _dst: Rectangle<i32, Physical>,
+        _damage: &[Rectangle<i32, Physical>],
+        _log: &slog::Logger,
+    ) -> Result<(), <R as Renderer>::Error> {
+        // We do not actually draw anything here
+        Ok(())
+    }
+}

--- a/src/backend/drm/compositor/gbm.rs
+++ b/src/backend/drm/compositor/gbm.rs
@@ -1,0 +1,293 @@
+//! Utilities to attach [`framebuffer::Handle`]s to gbm backed buffers
+
+use std::os::unix::io::AsFd;
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use drm::{
+    buffer::PlanarBuffer,
+    control::{framebuffer, Device},
+};
+#[cfg(feature = "wayland_frontend")]
+use drm_fourcc::DrmModifier;
+use gbm::BufferObject;
+#[cfg(feature = "wayland_frontend")]
+use wayland_server::protocol::wl_buffer::WlBuffer;
+
+use super::{ExportBuffer, ExportFramebuffer};
+use crate::backend::{
+    allocator::{
+        dmabuf::Dmabuf,
+        format::{get_bpp, get_depth},
+        Buffer,
+    },
+    drm::DrmDeviceFd,
+};
+use crate::utils::DevPath;
+
+/// A GBM backed framebuffer
+#[derive(Debug)]
+pub struct GbmFramebuffer {
+    _bo: Option<BufferObject<()>>,
+    fb: framebuffer::Handle,
+    drm: DrmDeviceFd,
+}
+
+impl Drop for GbmFramebuffer {
+    fn drop(&mut self) {
+        let _ = self.drm.destroy_framebuffer(self.fb);
+    }
+}
+
+impl AsRef<framebuffer::Handle> for GbmFramebuffer {
+    fn as_ref(&self) -> &framebuffer::Handle {
+        &self.fb
+    }
+}
+
+impl<A: AsFd + 'static, T> ExportFramebuffer<BufferObject<T>> for gbm::Device<A> {
+    type Framebuffer = GbmFramebuffer;
+    type Error = Error;
+
+    fn add_framebuffer(
+        &self,
+        drm: &DrmDeviceFd,
+        buffer: ExportBuffer<'_, BufferObject<T>>,
+    ) -> Result<Option<Self::Framebuffer>, Self::Error> {
+        match buffer {
+            #[cfg(feature = "wayland_frontend")]
+            ExportBuffer::Wayland(wl_buffer) => framebuffer_from_wayland_buffer(drm, self, wl_buffer),
+            ExportBuffer::Allocator(buffer) => framebuffer_from_bo(drm, buffer).map_err(Error::Drm).map(Some),
+        }
+    }
+}
+
+/// Attach a framebuffer for a [`WlBuffer`]
+///
+/// This tries to import the buffer to gbm and attach a [`framebuffer::Handle`] for
+/// the imported [`BufferObject`].
+///
+/// Returns `Ok(None)` for unknown buffer types and buffer types that do not
+/// support attaching a framebuffer (e.g. shm-buffers)
+#[cfg(feature = "wayland_frontend")]
+pub fn framebuffer_from_wayland_buffer<A: AsFd + 'static>(
+    drm: &DrmDeviceFd,
+    gbm: &gbm::Device<A>,
+    buffer: &WlBuffer,
+) -> Result<Option<GbmFramebuffer>, Error> {
+    if let Ok(dmabuf) = crate::wayland::dmabuf::get_dmabuf(buffer) {
+        // From weston:
+        /* We should not import to KMS a buffer that has been allocated using no
+         * modifiers. Usually drivers use linear layouts to allocate with no
+         * modifiers, but this is not a rule. The driver could use, for
+         * instance, a tiling layout under the hood - and both Weston and the
+         * KMS driver can't know. So giving the buffer to KMS is not safe, as
+         * not knowing its layout can result in garbage being displayed. In
+         * short, importing a buffer to KMS requires explicit modifiers. */
+        if dmabuf.format().modifier != DrmModifier::Invalid {
+            return Ok(Some(framebuffer_from_dmabuf(drm, gbm, &dmabuf)?));
+        }
+    }
+
+    #[cfg(all(feature = "backend_egl", feature = "use_system_lib"))]
+    if matches!(
+        crate::backend::renderer::buffer_type(buffer),
+        Some(crate::backend::renderer::BufferType::Egl)
+    ) {
+        let bo = gbm
+            .import_buffer_object_from_wayland::<()>(buffer, gbm::BufferObjectFlags::SCANOUT)
+            .map_err(Error::Import)?;
+        let fb = framebuffer_from_bo_internal(
+            drm,
+            BufferObjectInternal {
+                bo: &bo,
+                offsets: None,
+                pitches: None,
+            },
+        )
+        .map_err(Error::Drm)?;
+
+        return Ok(Some(GbmFramebuffer {
+            _bo: Some(bo),
+            fb,
+            drm: drm.clone(),
+        }));
+    }
+
+    Ok(None)
+}
+
+/// Possible errors for attaching a [`framebuffer::Handle`]
+#[derive(Error, Debug)]
+pub enum Error {
+    /// Importing the [`Dmabuf`] to gbm failed
+    #[error("failed to import the dmabuf to gbm")]
+    Import(std::io::Error),
+    /// Failed to add a framebuffer for the bo
+    #[error("failed to add a framebuffer for the bo")]
+    Drm(DrmError),
+}
+
+/// Attach a framebuffer for a [`Dmabuf`]
+///
+/// This tries to import the [`Dmabuf`] using gbm and attach
+/// a [`framebuffer::Handle`] for the imported [`BufferObject`]
+pub fn framebuffer_from_dmabuf<A: AsFd + 'static>(
+    drm: &DrmDeviceFd,
+    gbm: &gbm::Device<A>,
+    dmabuf: &Dmabuf,
+) -> Result<GbmFramebuffer, Error> {
+    let bo: BufferObject<()> = dmabuf
+        .import_to(gbm, gbm::BufferObjectFlags::SCANOUT)
+        .map_err(Error::Import)?;
+
+    // We override the offsets and pitches here cause the imported bo
+    // can return the wrong values. bo will only return the correct values
+    // for buffers we have allocated, but not for all client provided buffers.
+    let mut offsets: [u32; 4] = [0; 4];
+    let mut pitches: [u32; 4] = [0; 4];
+
+    for (index, offset) in dmabuf.offsets().enumerate() {
+        offsets[index] = offset;
+    }
+
+    for (index, stride) in dmabuf.strides().enumerate() {
+        pitches[index] = stride;
+    }
+
+    framebuffer_from_bo_internal(
+        drm,
+        BufferObjectInternal {
+            bo: &bo,
+            offsets: Some(offsets),
+            pitches: Some(pitches),
+        },
+    )
+    .map_err(Error::Drm)
+    .map(|fb| GbmFramebuffer {
+        _bo: Some(bo),
+        fb,
+        drm: drm.clone(),
+    })
+}
+
+/// Possible errors for attaching a [`framebuffer::Handle`] with [`framebuffer_from_bo`]
+#[derive(Debug, Error)]
+#[error("failed to add a framebuffer")]
+pub struct DrmError {
+    /// Error message associated to the access error
+    pub errmsg: &'static str,
+    /// Device on which the error was generated
+    pub dev: Option<PathBuf>,
+    /// Underlying device error
+    pub source: drm::SystemError,
+}
+
+/// Attach a [`framebuffer::Handle`] to an [`BufferObject`]
+pub fn framebuffer_from_bo<T>(drm: &DrmDeviceFd, bo: &BufferObject<T>) -> Result<GbmFramebuffer, DrmError> {
+    framebuffer_from_bo_internal(
+        drm,
+        BufferObjectInternal {
+            bo,
+            offsets: None,
+            pitches: None,
+        },
+    )
+    .map(|fb| GbmFramebuffer {
+        _bo: None,
+        fb,
+        drm: drm.clone(),
+    })
+}
+
+struct BufferObjectInternal<'a, T: 'static> {
+    bo: &'a BufferObject<T>,
+    pitches: Option<[u32; 4]>,
+    offsets: Option<[u32; 4]>,
+}
+
+impl<'a, T: 'static> std::ops::Deref for BufferObjectInternal<'a, T> {
+    type Target = BufferObject<T>;
+
+    fn deref(&self) -> &Self::Target {
+        self.bo
+    }
+}
+
+impl<'a, T: 'static> PlanarBuffer for BufferObjectInternal<'a, T> {
+    fn size(&self) -> (u32, u32) {
+        PlanarBuffer::size(self.bo)
+    }
+
+    fn format(&self) -> drm_fourcc::DrmFourcc {
+        PlanarBuffer::format(self.bo)
+    }
+
+    fn pitches(&self) -> [u32; 4] {
+        self.pitches.unwrap_or_else(|| PlanarBuffer::pitches(self.bo))
+    }
+
+    fn handles(&self) -> [Option<drm::buffer::Handle>; 4] {
+        PlanarBuffer::handles(self.bo)
+    }
+
+    fn offsets(&self) -> [u32; 4] {
+        self.offsets.unwrap_or_else(|| PlanarBuffer::offsets(self.bo))
+    }
+}
+
+fn framebuffer_from_bo_internal<D, T>(
+    drm: &D,
+    bo: BufferObjectInternal<'_, T>,
+) -> Result<framebuffer::Handle, DrmError>
+where
+    D: drm::control::Device + DevPath,
+{
+    let modifier = match bo.modifier().unwrap() {
+        DrmModifier::Invalid => None,
+        x => Some(x),
+    };
+
+    let fb = match if modifier.is_some() {
+        let num = bo.plane_count().unwrap();
+        let modifiers = [
+            modifier,
+            if num > 1 { modifier } else { None },
+            if num > 2 { modifier } else { None },
+            if num > 3 { modifier } else { None },
+        ];
+        drm.add_planar_framebuffer(&bo, &modifiers, drm_ffi::DRM_MODE_FB_MODIFIERS)
+    } else {
+        drm.add_planar_framebuffer(&bo, &[None, None, None, None], 0)
+    } {
+        Ok(fb) => fb,
+        Err(source) => {
+            // We only support this as a fallback of last resort like xf86-video-modesetting does.
+            if bo.plane_count().unwrap() > 1 {
+                return Err(DrmError {
+                    errmsg: "Failed to add framebuffer",
+                    dev: drm.dev_path(),
+                    source,
+                });
+            }
+
+            let fourcc = bo.format();
+            let (depth, bpp) = get_depth(fourcc)
+                .and_then(|d| get_bpp(fourcc).map(|b| (d, b)))
+                .ok_or_else(|| DrmError {
+                    errmsg: "Unknown format for legacy framebuffer",
+                    dev: drm.dev_path(),
+                    source,
+                })?;
+
+            drm.add_framebuffer(&*bo, depth as u32, bpp as u32)
+                .map_err(|source| DrmError {
+                    errmsg: "Failed to add framebuffer",
+                    dev: drm.dev_path(),
+                    source,
+                })?
+        }
+    };
+    Ok(fb)
+}

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1,0 +1,3113 @@
+//! Composition for [`Element`]s using drm planes
+//!
+//! When possible composition can be (partially) offloaded to the display driver by assigning
+//! elements to drm planes. This is especially important for latency intensive fullscreen clients
+//! like video renderers or games.
+//!
+//! The [`DrmCompositor`] does so by walking the stack of provided [`Element`]s from front to back
+//! while trying to assign each element to a drm overlay plane. Each item that fails the plane test
+//! will be rendered on the primary plane using the provided [`Renderer`].
+//! Additionally it will try to assign the top most element that fit's into the cursor size (as specified
+//! by the [`DrmDevice`](crate::backend::drm::DrmDevice)) on the cursor plane. If the element can not be
+//! directly scanned out the renderer will be used to render the element into an [`Offscreen`] buffer that
+//! is copied over to the allocated gbm buffer for the cursor plane.
+//!
+//! Note: While the [`DrmCompositor`] also works on *legacy* drm the use of overlay and cursor planes is disabled in that case.
+//! Direct scan-out will only work with an atomic [`DrmSurface`].
+//!
+//! ## What makes a [`Element`] eligible for direct scan-out
+//!
+//! ### General
+//!
+//! First the element has to provide a [`UnderlyingStorage`] which can be exported as a drm framebuffer.
+//! Currently this is limited to wayland buffers, but may be extended in the future.
+//! This module provides a default exporter based on [`gbm`] which should fit most use-cases.
+//!
+//! If a certain combination of elements works can only be determined by asking the driver by submitting
+//! a atomic commit test. If that test fails the element is scheduled to be rendered on the primary plane.
+//!
+//! ### Overlay planes
+//!
+//! The element can only be directly scanned out if it's geometry does not overlap with an already assigned
+//! element on a plane higher in the stack.
+//!
+//! ### Underlay planes
+//!
+//! An underlay plane is only used if it does not overlap with an already assigned plane lower in the stack
+//! and the element is fully opaque.
+//!
+//! ### Primary plane
+//!
+//! For an element to be considered to be directly scanned out on the primary plane it has to be the last remaining
+//! visible element on the output and no other element has been assigned to the primary plane. If there are multiple
+//! element assigned to the primary plane the renderer will be used to composite the primary plane into a allocator
+//! provided buffer. Additionally the element has to be either fully opaque or the clear color has to match the CRTC
+//! background color and no overlap with an underlay is found.
+//!
+//! # How to use it
+//!
+//! ```no_run
+//! # use smithay::backend::{
+//! #     allocator::gbm::{GbmAllocator, GbmDevice},
+//! #     drm::{DrmDevice, DrmDeviceFd},
+//! #     renderer::{
+//! #       element::surface::WaylandSurfaceRenderElement,
+//! #       gles2::{Gles2Renderbuffer, Gles2Renderer},
+//! #     },
+//! # };
+//! # use drm_fourcc::{DrmFormat, DrmFourcc, DrmModifier};
+//! # use std::{collections::HashSet, mem::MaybeUninit};
+//! #
+//! use smithay::{
+//!     backend::drm::{compositor::DrmCompositor, DrmSurface},
+//!     output::{Output, PhysicalProperties, Subpixel},
+//!     utils::Size,
+//! };
+//!
+//! // ...initialize the output, drm device, drm surface and allocator
+//! #
+//! # const CLEAR_COLOR: [f32; 4] = [0f32, 0f32, 0f32, 0f32];
+//! #
+//! let output = Output::new(
+//!     "e-DP".into(),
+//!     PhysicalProperties {
+//!         size: Size::from((800, 600)),
+//!         make: "N/A".into(),
+//!         model: "N/A".into(),
+//!         subpixel: Subpixel::Unknown,
+//!     },
+//!     None,
+//! );
+//!
+//! # let device: DrmDevice = todo!();
+//! # let surface: DrmSurface = todo!();
+//! # let allocator: GbmAllocator<DrmDeviceFd> = todo!();
+//! # let exporter: GbmDevice<DrmDeviceFd> = todo!();
+//! # let renderer_formats = HashSet::from([DrmFormat {
+//! #     code: DrmFourcc::Argb8888,
+//! #     modifier: DrmModifier::Linear,
+//! # }]);
+//! # let gbm: GbmDevice<DrmDeviceFd> = todo!();
+//! # let mut renderer: Gles2Renderer = todo!();
+//! #
+//! let mut compositor: DrmCompositor<_, _, (), _> = DrmCompositor::new(
+//!     &output,
+//!     surface,
+//!     None,
+//!     allocator,
+//!     exporter,
+//!     renderer_formats,
+//!     device.cursor_size(),
+//!     Some(gbm),
+//!     None,
+//! )
+//! .expect("failed to initialize drm compositor");
+//!
+//! # let elements: Vec<WaylandSurfaceRenderElement<Gles2Renderer>> = Vec::new();
+//! let render_frame_result = compositor
+//!     .render_frame::<_, _, Gles2Renderbuffer, _>(&mut renderer, &elements, CLEAR_COLOR, None)
+//!     .expect("failed to render frame");
+//!
+//! compositor.queue_frame(()).expect("failed to queue frame");
+//!
+//! // ...wait for VBlank event
+//!
+//! compositor
+//!     .frame_submitted()
+//!     .expect("failed to mark frame as submitted");
+//! ```
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    os::unix::io::AsFd,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
+
+use ::gbm::{BufferObject, BufferObjectFlags};
+use drm::control::{connector, crtc, framebuffer, plane, Mode};
+use drm_fourcc::{DrmFormat, DrmFourcc, DrmModifier};
+use indexmap::IndexMap;
+use wayland_server::{protocol::wl_buffer::WlBuffer, Resource};
+
+use crate::{
+    backend::{
+        allocator::{
+            dmabuf::{AsDmabuf, Dmabuf},
+            gbm::{GbmAllocator, GbmDevice},
+            Allocator, Buffer, Slot, Swapchain,
+        },
+        drm::{DrmError, PlaneDamageClips},
+        renderer::{
+            buffer_y_inverted,
+            damage::{DamageTrackedRenderer, DamageTrackedRendererError, OutputNoMode},
+            element::{
+                Element, Id, RenderElement, RenderElementPresentationState, RenderElementState,
+                RenderElementStates, UnderlyingStorage,
+            },
+            utils::{CommitCounter, DamageTracker, DamageTrackerSnapshot},
+            Bind, Blit, DebugFlags, ExportMem, Frame as RendererFrame, Offscreen, Renderer, Texture,
+        },
+        SwapBuffersError,
+    },
+    output::Output,
+    utils::{Buffer as BufferCoords, Physical, Point, Rectangle, Scale, Size, Transform},
+};
+
+use super::{DrmDeviceFd, DrmSurface, PlaneClaim, PlaneInfo, Planes};
+
+mod elements;
+pub mod gbm;
+
+use elements::*;
+
+impl RenderElementState {
+    pub(crate) fn zero_copy(visible_area: usize) -> Self {
+        RenderElementState {
+            visible_area,
+            presentation_state: RenderElementPresentationState::ZeroCopy,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ScanoutBuffer<B: Buffer> {
+    Wayland(crate::backend::renderer::utils::Buffer),
+    Swapchain(Slot<B>),
+    Cursor(BufferObject<()>),
+}
+
+impl<B: Buffer> From<UnderlyingStorage> for ScanoutBuffer<B> {
+    fn from(storage: UnderlyingStorage) -> Self {
+        match storage {
+            UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer),
+        }
+    }
+}
+
+enum DrmFramebuffer<F: AsRef<framebuffer::Handle>> {
+    Exporter(F),
+    Gbm(gbm::GbmFramebuffer),
+}
+
+impl<F> AsRef<framebuffer::Handle> for DrmFramebuffer<F>
+where
+    F: AsRef<framebuffer::Handle>,
+{
+    fn as_ref(&self) -> &framebuffer::Handle {
+        match self {
+            DrmFramebuffer::Exporter(e) => e.as_ref(),
+            DrmFramebuffer::Gbm(g) => g.as_ref(),
+        }
+    }
+}
+
+impl<F> std::fmt::Debug for DrmFramebuffer<F>
+where
+    F: AsRef<framebuffer::Handle> + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Exporter(arg0) => f.debug_tuple("Exporter").field(arg0).finish(),
+            Self::Gbm(arg0) => f.debug_tuple("Gbm").field(arg0).finish(),
+        }
+    }
+}
+
+struct DrmScanoutBuffer<B: Buffer, F: AsRef<framebuffer::Handle>> {
+    buffer: ScanoutBuffer<B>,
+    fb: OwnedFramebuffer<DrmFramebuffer<F>>,
+}
+
+impl<B, F> std::fmt::Debug for DrmScanoutBuffer<B, F>
+where
+    B: Buffer + std::fmt::Debug,
+    F: AsRef<framebuffer::Handle> + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DrmScanoutBuffer")
+            .field("buffer", &self.buffer)
+            .field("fb", &self.fb)
+            .finish()
+    }
+}
+
+impl<B: Buffer, F: AsRef<framebuffer::Handle>> AsRef<framebuffer::Handle> for DrmScanoutBuffer<B, F> {
+    fn as_ref(&self) -> &drm::control::framebuffer::Handle {
+        self.fb.as_ref()
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+enum ElementFramebufferCacheKey {
+    Wayland(wayland_server::Weak<WlBuffer>),
+}
+
+impl ElementFramebufferCacheKey {
+    fn is_alive(&self) -> bool {
+        match self {
+            ElementFramebufferCacheKey::Wayland(buffer) => buffer.upgrade().is_ok(),
+        }
+    }
+}
+
+impl From<&UnderlyingStorage> for ElementFramebufferCacheKey {
+    fn from(storage: &UnderlyingStorage) -> Self {
+        match storage {
+            UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer.downgrade()),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ElementFramebufferCache<B>
+where
+    B: AsRef<framebuffer::Handle>,
+{
+    /// Cache for framebuffer handles per cache key (e.g. wayland buffer)
+    fb_cache: HashMap<ElementFramebufferCacheKey, Option<OwnedFramebuffer<B>>>,
+}
+
+impl<B> ElementFramebufferCache<B>
+where
+    B: AsRef<framebuffer::Handle>,
+{
+    fn get(&self, buffer: &UnderlyingStorage) -> Option<Option<OwnedFramebuffer<B>>> {
+        self.fb_cache
+            .get(&ElementFramebufferCacheKey::from(buffer))
+            .cloned()
+    }
+
+    fn insert(&mut self, buffer: &UnderlyingStorage, fb: Option<OwnedFramebuffer<B>>) {
+        self.fb_cache.insert(ElementFramebufferCacheKey::from(buffer), fb);
+    }
+
+    fn cleanup(&mut self) {
+        self.fb_cache.retain(|key, _| key.is_alive());
+    }
+}
+
+impl<B> Clone for ElementFramebufferCache<B>
+where
+    B: AsRef<framebuffer::Handle>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            fb_cache: self.fb_cache.clone(),
+        }
+    }
+}
+
+impl<B> Default for ElementFramebufferCache<B>
+where
+    B: AsRef<framebuffer::Handle>,
+{
+    fn default() -> Self {
+        Self {
+            fb_cache: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PlaneConfig<B> {
+    pub src: Rectangle<f64, BufferCoords>,
+    pub dst: Rectangle<i32, Physical>,
+    pub transform: Transform,
+    pub damage_clips: Option<PlaneDamageClips>,
+    pub buffer: Owned<B>,
+    pub plane_claim: PlaneClaim,
+}
+
+impl<B> Clone for PlaneConfig<B> {
+    fn clone(&self) -> Self {
+        Self {
+            src: self.src,
+            dst: self.dst,
+            transform: self.transform,
+            damage_clips: self.damage_clips.clone(),
+            buffer: self.buffer.clone(),
+            plane_claim: self.plane_claim.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PlaneState<B> {
+    skip: bool,
+    element_state: Option<(Id, CommitCounter)>,
+    config: Option<PlaneConfig<B>>,
+}
+
+impl<B> Default for PlaneState<B> {
+    fn default() -> Self {
+        Self {
+            skip: true,
+            element_state: Default::default(),
+            config: Default::default(),
+        }
+    }
+}
+
+impl<B> PlaneState<B> {
+    fn buffer(&self) -> Option<&B> {
+        self.config.as_ref().map(|config| &*config.buffer)
+    }
+}
+
+impl<B> Clone for PlaneState<B> {
+    fn clone(&self) -> Self {
+        Self {
+            skip: self.skip,
+            element_state: self.element_state.clone(),
+            config: self.config.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FrameState<B: AsRef<framebuffer::Handle>> {
+    planes: HashMap<plane::Handle, PlaneState<B>>,
+}
+
+impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
+    fn is_assigned(&self, handle: plane::Handle) -> bool {
+        self.planes
+            .get(&handle)
+            .map(|config| config.config.is_some())
+            .unwrap_or(false)
+    }
+
+    fn overlaps(&self, handle: plane::Handle, element_geometry: Rectangle<i32, Physical>) -> bool {
+        self.planes
+            .get(&handle)
+            .and_then(|state| {
+                state
+                    .config
+                    .as_ref()
+                    .map(|config| config.dst.overlaps(element_geometry))
+            })
+            .unwrap_or(false)
+    }
+
+    fn plane_state(&self, handle: plane::Handle) -> Option<&PlaneState<B>> {
+        self.planes.get(&handle)
+    }
+
+    fn plane_state_mut(&mut self, handle: plane::Handle) -> Option<&mut PlaneState<B>> {
+        self.planes.get_mut(&handle)
+    }
+
+    fn plane_buffer(&self, handle: plane::Handle) -> Option<&B> {
+        self.plane_state(handle)
+            .and_then(|state| state.config.as_ref().map(|config| &*config.buffer))
+    }
+}
+
+#[derive(Debug)]
+struct Owned<B>(Rc<B>);
+
+impl<B> std::ops::Deref for Owned<B> {
+    type Target = B;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<B> From<B> for Owned<B> {
+    fn from(outer: B) -> Self {
+        Self(Rc::new(outer))
+    }
+}
+
+impl<B> AsRef<framebuffer::Handle> for Owned<B>
+where
+    B: AsRef<framebuffer::Handle>,
+{
+    fn as_ref(&self) -> &framebuffer::Handle {
+        (*self.0).as_ref()
+    }
+}
+
+impl<B> Clone for Owned<B> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
+    fn from_planes(planes: &Planes) -> Self {
+        let cursor_plane_count = usize::from(planes.cursor.is_some());
+        let mut tmp = HashMap::with_capacity(planes.overlay.len() + cursor_plane_count + 1);
+        tmp.insert(planes.primary.handle, PlaneState::default());
+        if let Some(info) = planes.cursor.as_ref() {
+            tmp.insert(info.handle, PlaneState::default());
+        }
+        tmp.extend(
+            planes
+                .overlay
+                .iter()
+                .map(|info| (info.handle, PlaneState::default())),
+        );
+
+        FrameState { planes: tmp }
+    }
+}
+
+impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
+    fn test_state(
+        &mut self,
+        surface: &DrmSurface,
+        plane: plane::Handle,
+        state: PlaneState<B>,
+        allow_modeset: bool,
+    ) -> Result<bool, DrmError> {
+        let current_config = match self.planes.get_mut(&plane) {
+            Some(config) => config,
+            None => return Ok(false),
+        };
+        let backup = current_config.clone();
+        *current_config = state;
+
+        let res = surface.test_state(
+            self.planes
+                .iter()
+                // Filter out any skipped planes
+                .filter(|(_, state)| !state.skip)
+                .map(|(handle, state)| super::surface::PlaneState {
+                    handle: *handle,
+                    config: state.config.as_ref().map(|config| super::PlaneConfig {
+                        src: config.src,
+                        dst: config.dst,
+                        transform: config.transform,
+                        damage_clips: config.damage_clips.as_ref().map(|d| d.blob()),
+                        fb: *config.buffer.as_ref(),
+                    }),
+                }),
+            allow_modeset,
+        );
+
+        match res {
+            Ok(true) => Ok(true),
+            Ok(false) => {
+                self.planes.insert(plane, backup);
+                Ok(false)
+            }
+            Err(err) => {
+                self.planes.insert(plane, backup);
+                Err(err)
+            }
+        }
+    }
+
+    fn commit(&self, surface: &DrmSurface, event: bool) -> Result<(), crate::backend::drm::error::Error> {
+        surface.commit(
+            self.planes
+                .iter()
+                // Filter out any skipped planes
+                .filter(|(_, state)| !state.skip)
+                .map(|(handle, state)| super::surface::PlaneState {
+                    handle: *handle,
+                    config: state.config.as_ref().map(|config| super::PlaneConfig {
+                        src: config.src,
+                        dst: config.dst,
+                        transform: config.transform,
+                        damage_clips: config.damage_clips.as_ref().map(|d| d.blob()),
+                        fb: *config.buffer.as_ref(),
+                    }),
+                }),
+            event,
+        )
+    }
+
+    fn page_flip(&self, surface: &DrmSurface, event: bool) -> Result<(), crate::backend::drm::error::Error> {
+        surface.page_flip(
+            self.planes
+                .iter()
+                // Filter out any skipped planes
+                .filter(|(_, state)| !state.skip)
+                .map(|(handle, state)| super::surface::PlaneState {
+                    handle: *handle,
+                    config: state.config.as_ref().map(|config| super::PlaneConfig {
+                        src: config.src,
+                        dst: config.dst,
+                        transform: config.transform,
+                        damage_clips: config.damage_clips.as_ref().map(|d| d.blob()),
+                        fb: *config.buffer.as_ref(),
+                    }),
+                }),
+            event,
+        )
+    }
+}
+
+/// Possible buffers to export as a framebuffer using [`ExportFramebuffer`]
+#[derive(Debug)]
+pub enum ExportBuffer<'a, B: Buffer> {
+    /// A wayland buffer
+    Wayland(&'a WlBuffer),
+    /// A [`Allocator`] buffer
+    Allocator(&'a B),
+}
+
+impl<'a, B: Buffer> From<&'a UnderlyingStorage> for ExportBuffer<'a, B> {
+    fn from(storage: &'a UnderlyingStorage) -> Self {
+        match storage {
+            UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer),
+        }
+    }
+}
+
+/// Export a [`ExportBuffer`] as a framebuffer
+pub trait ExportFramebuffer<B: Buffer>
+where
+    B: Buffer,
+{
+    /// Type of the framebuffer
+    type Framebuffer: AsRef<framebuffer::Handle>;
+
+    /// Type of the error
+    type Error: std::error::Error;
+
+    /// Add a framebuffer for the specified buffer
+    fn add_framebuffer(
+        &self,
+        drm: &DrmDeviceFd,
+        buffer: ExportBuffer<'_, B>,
+    ) -> Result<Option<Self::Framebuffer>, Self::Error>;
+}
+
+impl<F, B> ExportFramebuffer<B> for Arc<Mutex<F>>
+where
+    F: ExportFramebuffer<B>,
+    B: Buffer,
+{
+    type Framebuffer = <F as ExportFramebuffer<B>>::Framebuffer;
+    type Error = <F as ExportFramebuffer<B>>::Error;
+
+    fn add_framebuffer(
+        &self,
+        drm: &DrmDeviceFd,
+        buffer: ExportBuffer<'_, B>,
+    ) -> Result<Option<Self::Framebuffer>, Self::Error> {
+        let guard = self.lock().unwrap();
+        guard.add_framebuffer(drm, buffer)
+    }
+}
+
+impl<F, B> ExportFramebuffer<B> for Rc<RefCell<F>>
+where
+    F: ExportFramebuffer<B>,
+    B: Buffer,
+{
+    type Framebuffer = <F as ExportFramebuffer<B>>::Framebuffer;
+    type Error = <F as ExportFramebuffer<B>>::Error;
+
+    fn add_framebuffer(
+        &self,
+        drm: &DrmDeviceFd,
+        buffer: ExportBuffer<'_, B>,
+    ) -> Result<Option<Self::Framebuffer>, Self::Error> {
+        self.borrow().add_framebuffer(drm, buffer)
+    }
+}
+
+type Frame<A, F> = FrameState<
+    DrmScanoutBuffer<
+        <A as Allocator>::Buffer,
+        <F as ExportFramebuffer<<A as Allocator>::Buffer>>::Framebuffer,
+    >,
+>;
+
+type FrameErrorType<A, F> = FrameError<
+    <A as Allocator>::Error,
+    <<A as Allocator>::Buffer as AsDmabuf>::Error,
+    <F as ExportFramebuffer<<A as Allocator>::Buffer>>::Error,
+>;
+
+type FrameResult<T, A, F> = Result<T, FrameErrorType<A, F>>;
+
+type RenderFrameErrorType<A, F, R> = RenderFrameError<
+    <A as Allocator>::Error,
+    <<A as Allocator>::Buffer as AsDmabuf>::Error,
+    <F as ExportFramebuffer<<A as Allocator>::Buffer>>::Error,
+    R,
+>;
+
+/// Defines the element for the primary plane
+pub enum PrimaryPlaneElement<'a, B: Buffer, E> {
+    /// A slot from the swapchain was used for rendering
+    /// the primary plane
+    Swapchain {
+        /// The slot from the swapchain
+        slot: &'a Slot<B>,
+        /// The transform applied during rendering
+        transform: Transform,
+        /// The damage on the primary plane
+        damage: DamageTrackerSnapshot<i32, BufferCoords>,
+    },
+    /// An element has been assigned for direct scan-out
+    Element(&'a E),
+}
+
+impl<'a, B: Buffer + std::fmt::Debug, E: std::fmt::Debug> std::fmt::Debug for PrimaryPlaneElement<'a, B, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Swapchain {
+                slot,
+                transform,
+                damage,
+            } => f
+                .debug_struct("Swapchain")
+                .field("slot", slot)
+                .field("transform", transform)
+                .field("damage", damage)
+                .finish(),
+            Self::Element(arg0) => f.debug_tuple("Element").field(arg0).finish(),
+        }
+    }
+}
+
+/// Result for [`DrmCompositor::render_frame`]
+pub struct RenderFrameResult<'a, B: Buffer, E> {
+    /// Damage of this frame
+    pub damage: Option<Vec<Rectangle<i32, Physical>>>,
+    /// The render element states of this frame
+    pub states: RenderElementStates,
+    /// Element for the primary plane
+    pub primary_element: PrimaryPlaneElement<'a, B, E>,
+    /// Overlay elements in front to back order
+    pub overlay_elements: Vec<&'a E>,
+    /// Optional cursor plane element
+    ///
+    /// If set always above all other elements
+    pub cursor_element: Option<&'a E>,
+
+    primary_plane_element_id: Id,
+}
+
+struct SwapchainElement<'a, B: Buffer> {
+    id: Id,
+    slot: &'a Slot<B>,
+    transform: Transform,
+    damage: &'a DamageTrackerSnapshot<i32, BufferCoords>,
+}
+
+impl<'a, B: Buffer> Element for SwapchainElement<'a, B> {
+    fn id(&self) -> &Id {
+        &self.id
+    }
+
+    fn current_commit(&self) -> CommitCounter {
+        self.damage.current_commit()
+    }
+
+    fn src(&self) -> Rectangle<f64, BufferCoords> {
+        Rectangle::from_loc_and_size((0, 0), self.slot.size()).to_f64()
+    }
+
+    fn geometry(&self, _scale: Scale<f64>) -> Rectangle<i32, Physical> {
+        Rectangle::from_loc_and_size(
+            (0, 0),
+            self.slot.size().to_logical(1, self.transform).to_physical(1),
+        )
+    }
+
+    fn transform(&self) -> Transform {
+        self.transform
+    }
+
+    fn damage_since(
+        &self,
+        scale: Scale<f64>,
+        commit: Option<CommitCounter>,
+    ) -> Vec<Rectangle<i32, Physical>> {
+        self.damage
+            .damage_since(commit)
+            .map(|d| {
+                d.into_iter()
+                    .map(|d| d.to_logical(1, self.transform, &self.slot.size()).to_physical(1))
+                    .collect()
+            })
+            .unwrap_or_else(|| vec![self.geometry(scale)])
+    }
+
+    fn opaque_regions(&self, scale: Scale<f64>) -> Vec<Rectangle<i32, Physical>> {
+        vec![self.geometry(scale)]
+    }
+}
+
+enum FrameResultDamageElement<'a, E, B: Buffer> {
+    Element(&'a E),
+    Swapchain(SwapchainElement<'a, B>),
+}
+
+impl<'a, E, B> Element for FrameResultDamageElement<'a, E, B>
+where
+    E: Element,
+    B: Buffer,
+{
+    fn id(&self) -> &Id {
+        match self {
+            FrameResultDamageElement::Element(e) => e.id(),
+            FrameResultDamageElement::Swapchain(e) => e.id(),
+        }
+    }
+
+    fn current_commit(&self) -> CommitCounter {
+        match self {
+            FrameResultDamageElement::Element(e) => e.current_commit(),
+            FrameResultDamageElement::Swapchain(e) => e.current_commit(),
+        }
+    }
+
+    fn src(&self) -> Rectangle<f64, BufferCoords> {
+        match self {
+            FrameResultDamageElement::Element(e) => e.src(),
+            FrameResultDamageElement::Swapchain(e) => e.src(),
+        }
+    }
+
+    fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
+        match self {
+            FrameResultDamageElement::Element(e) => e.geometry(scale),
+            FrameResultDamageElement::Swapchain(e) => e.geometry(scale),
+        }
+    }
+
+    fn location(&self, scale: Scale<f64>) -> Point<i32, Physical> {
+        match self {
+            FrameResultDamageElement::Element(e) => e.location(scale),
+            FrameResultDamageElement::Swapchain(e) => e.location(scale),
+        }
+    }
+
+    fn transform(&self) -> Transform {
+        match self {
+            FrameResultDamageElement::Element(e) => e.transform(),
+            FrameResultDamageElement::Swapchain(e) => e.transform(),
+        }
+    }
+
+    fn damage_since(
+        &self,
+        scale: Scale<f64>,
+        commit: Option<CommitCounter>,
+    ) -> Vec<Rectangle<i32, Physical>> {
+        match self {
+            FrameResultDamageElement::Element(e) => e.damage_since(scale, commit),
+            FrameResultDamageElement::Swapchain(e) => e.damage_since(scale, commit),
+        }
+    }
+
+    fn opaque_regions(&self, scale: Scale<f64>) -> Vec<Rectangle<i32, Physical>> {
+        match self {
+            FrameResultDamageElement::Element(e) => e.opaque_regions(scale),
+            FrameResultDamageElement::Swapchain(e) => e.opaque_regions(scale),
+        }
+    }
+}
+
+/// Error for [`RenderFrameResult::blit_frame_result`]
+#[derive(Debug, thiserror::Error)]
+pub enum BlitFrameResultError<R: std::error::Error, E: std::error::Error> {
+    /// A render error occurred
+    #[error(transparent)]
+    Rendering(R),
+    /// A error occurred during exporting the buffer
+    #[error(transparent)]
+    Export(E),
+}
+
+impl<'a, B, E> RenderFrameResult<'a, B, E>
+where
+    B: Buffer,
+{
+    /// Get the damage of this frame for the specified dtr and age
+    pub fn damage_from_age(
+        &self,
+        dtr: &mut DamageTrackedRenderer,
+        age: usize,
+        filter: impl IntoIterator<Item = Id>,
+        log: slog::Logger,
+    ) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), OutputNoMode>
+    where
+        E: Element,
+    {
+        let filter_ids: HashSet<Id> = filter.into_iter().collect();
+
+        let mut elements: Vec<FrameResultDamageElement<'_, E, B>> =
+            Vec::with_capacity(usize::from(self.cursor_element.is_some()) + self.overlay_elements.len() + 1);
+        if let Some(cursor) = self.cursor_element {
+            if !filter_ids.contains(cursor.id()) {
+                elements.push(FrameResultDamageElement::Element(cursor));
+            }
+        }
+
+        elements.extend(
+            self.overlay_elements
+                .iter()
+                .filter(|e| !filter_ids.contains(e.id()))
+                .map(|e| FrameResultDamageElement::Element(*e)),
+        );
+
+        let primary_render_element = match &self.primary_element {
+            PrimaryPlaneElement::Swapchain {
+                slot,
+                transform,
+                damage,
+            } => FrameResultDamageElement::Swapchain(SwapchainElement {
+                id: self.primary_plane_element_id.clone(),
+                transform: *transform,
+                slot: *slot,
+                damage,
+            }),
+            PrimaryPlaneElement::Element(e) => FrameResultDamageElement::Element(*e),
+        };
+
+        elements.push(primary_render_element);
+
+        dtr.damage_output(age, &elements, log)
+    }
+}
+
+impl<'a, B, E> RenderFrameResult<'a, B, E>
+where
+    B: Buffer + AsDmabuf,
+    <B as AsDmabuf>::Error: std::fmt::Debug,
+{
+    /// Blit the frame result into a currently bound buffer
+    #[allow(clippy::too_many_arguments)]
+    pub fn blit_frame_result<R>(
+        &self,
+        size: impl Into<Size<i32, Physical>>,
+        transform: Transform,
+        scale: impl Into<Scale<f64>>,
+        renderer: &mut R,
+        damage: impl IntoIterator<Item = Rectangle<i32, Physical>>,
+        filter: impl IntoIterator<Item = Id>,
+        log: &slog::Logger,
+    ) -> Result<(), BlitFrameResultError<<R as Renderer>::Error, <B as AsDmabuf>::Error>>
+    where
+        R: Renderer + Blit<Dmabuf>,
+        <R as Renderer>::TextureId: 'static,
+        E: Element + RenderElement<R>,
+    {
+        let size = size.into();
+        let scale = scale.into();
+        let filter_ids: HashSet<Id> = filter.into_iter().collect();
+        let damage = damage.into_iter().collect::<Vec<_>>();
+
+        // If we have no damage we can exit early
+        if damage.is_empty() {
+            return Ok(());
+        }
+
+        let mut opaque_regions: Vec<Rectangle<i32, Physical>> = Vec::new();
+
+        let mut elements_to_render: Vec<&'a E> =
+            Vec::with_capacity(usize::from(self.cursor_element.is_some()) + self.overlay_elements.len() + 1);
+
+        if let Some(cursor_element) = self.cursor_element.as_ref() {
+            if !filter_ids.contains(cursor_element.id()) {
+                elements_to_render.push(*cursor_element);
+                opaque_regions.extend(cursor_element.opaque_regions(scale));
+            }
+        }
+
+        for element in self
+            .overlay_elements
+            .iter()
+            .filter(|e| !filter_ids.contains(e.id()))
+        {
+            elements_to_render.push(element);
+            opaque_regions.extend(element.opaque_regions(scale));
+        }
+
+        let primary_dmabuf = match &self.primary_element {
+            PrimaryPlaneElement::Swapchain { slot, .. } => {
+                let dmabuf = slot.export().map_err(BlitFrameResultError::Export)?;
+                let size = dmabuf.size();
+                let geometry = Rectangle::from_loc_and_size(
+                    (0, 0),
+                    size.to_logical(1, Transform::Normal).to_physical(1),
+                );
+                opaque_regions.push(geometry);
+                Some((dmabuf, geometry))
+            }
+            PrimaryPlaneElement::Element(e) => {
+                elements_to_render.push(*e);
+                opaque_regions.extend(e.opaque_regions(scale));
+                None
+            }
+        };
+
+        let clear_damage = opaque_regions.iter().fold(damage.clone(), |damage, region| {
+            damage
+                .into_iter()
+                .flat_map(|geo| geo.subtract_rect(*region))
+                .collect::<Vec<_>>()
+        });
+
+        if !clear_damage.is_empty() {
+            slog::trace!(log, "clearing frame damage {:#?}", clear_damage);
+
+            let mut frame = renderer
+                .render(size, transform)
+                .map_err(BlitFrameResultError::Rendering)?;
+
+            frame
+                .clear([0f32, 0f32, 0f32, 1f32], &clear_damage)
+                .map_err(BlitFrameResultError::Rendering)?;
+
+            frame.finish().map_err(BlitFrameResultError::Rendering)?;
+        }
+
+        // first do the potential blit
+        if let Some((dmabuf, geometry)) = primary_dmabuf {
+            let blit_damage = damage
+                .iter()
+                .filter_map(|d| d.intersection(geometry))
+                .collect::<Vec<_>>();
+
+            slog::trace!(log, "blitting frame with damage: {:#?}", blit_damage);
+
+            for rect in blit_damage {
+                renderer
+                    .blit_from(
+                        dmabuf.clone(),
+                        rect,
+                        rect,
+                        crate::backend::renderer::TextureFilter::Linear,
+                    )
+                    .map_err(BlitFrameResultError::Rendering)?;
+            }
+        }
+
+        // then render the remaining elements if any
+        if !elements_to_render.is_empty() {
+            slog::trace!(log, "drawing {} frame element(s)", elements_to_render.len());
+
+            let mut frame = renderer
+                .render(size, transform)
+                .map_err(BlitFrameResultError::Rendering)?;
+
+            for element in elements_to_render.iter().rev() {
+                let src = element.src();
+                let dst = element.geometry(scale);
+                let element_damage = damage
+                    .iter()
+                    .filter_map(|d| {
+                        d.intersection(dst).map(|mut d| {
+                            d.loc -= dst.loc;
+                            d
+                        })
+                    })
+                    .collect::<Vec<_>>();
+
+                // no need to render without damage
+                if element_damage.is_empty() {
+                    continue;
+                }
+
+                slog::trace!(log, "drawing frame element with damage: {:#?}", element_damage);
+
+                element
+                    .draw(&mut frame, src, dst, &element_damage, log)
+                    .map_err(BlitFrameResultError::Rendering)?;
+            }
+
+            frame.finish().map_err(BlitFrameResultError::Rendering)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<'a, B: Buffer + std::fmt::Debug, E: std::fmt::Debug> std::fmt::Debug for RenderFrameResult<'a, B, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderFrameResult")
+            .field("damage", &self.damage)
+            .field("states", &self.states)
+            .field("primary_element", &self.primary_element)
+            .field("overlay_elements", &self.overlay_elements)
+            .field("cursor_element", &self.cursor_element)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+struct CursorState<G: AsFd + 'static> {
+    allocator: GbmAllocator<G>,
+    framebuffer_exporter: GbmDevice<G>,
+    previous_output_transform: Option<Transform>,
+    previous_output_scale: Option<Scale<f64>>,
+}
+
+/// Composite an output using a combination of planes and rendering
+///
+/// see the [`module docs`](crate::backend::drm::compositor) for more information
+#[derive(Debug)]
+pub struct DrmCompositor<A, F, U, G>
+where
+    A: Allocator,
+    F: ExportFramebuffer<A::Buffer>,
+    <F as ExportFramebuffer<A::Buffer>>::Framebuffer: std::fmt::Debug + 'static,
+    G: AsFd + 'static,
+{
+    output: Output,
+    surface: Arc<DrmSurface>,
+    planes: Planes,
+    damage_tracked_renderer: DamageTrackedRenderer,
+    primary_plane_element_id: Id,
+    primary_plane_damage_tracker: DamageTracker<i32, BufferCoords>,
+
+    framebuffer_exporter: F,
+
+    current_frame: Frame<A, F>,
+    pending_frame: Option<(Frame<A, F>, U)>,
+    queued_frame: Option<(Frame<A, F>, U)>,
+    next_frame: Option<Frame<A, F>>,
+
+    swapchain: Swapchain<A>,
+
+    cursor_size: Size<i32, Physical>,
+    cursor_state: Option<CursorState<G>>,
+
+    element_states: IndexMap<
+        Id,
+        ElementFramebufferCache<DrmFramebuffer<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>,
+    >,
+
+    debug_flags: DebugFlags,
+}
+
+// we cannot simply pick the first supported format of the intersection of *all* formats, because:
+// - we do not want something like Abgr4444, which looses color information, if something better is available
+// - some formats might perform terribly
+// - we might need some work-arounds, if one supports modifiers, but the other does not
+//
+// So lets just pick `ARGB8888` or `XRGB8888` for now, they are widely supported.
+// Once we have proper color management and possibly HDR support,
+// we need to have a more sophisticated picker.
+// (Or maybe just select A/XRGB2101010, if available, we will see.)
+const SUPPORTED_FORMATS: &[DrmFourcc] = &[DrmFourcc::Argb8888, DrmFourcc::Xrgb8888];
+
+impl<A, F, U, G> DrmCompositor<A, F, U, G>
+where
+    A: Allocator,
+    <A as Allocator>::Error: std::error::Error + Send + Sync,
+    <A as Allocator>::Buffer: AsDmabuf,
+    <A::Buffer as AsDmabuf>::Error: std::error::Error + Send + Sync + std::fmt::Debug,
+    F: ExportFramebuffer<A::Buffer>,
+    <F as ExportFramebuffer<A::Buffer>>::Framebuffer: std::fmt::Debug + 'static,
+    <F as ExportFramebuffer<A::Buffer>>::Error: std::error::Error + Send + Sync,
+    G: AsFd + Clone,
+{
+    /// Initialize a new [`DrmCompositor`]
+    ///
+    /// - `output` is used to determine the current mode, scale and transform
+    /// - `surface` for the compositor to use
+    /// - `planes` defines which planes the compositor is allowed to use for direct scan-out.
+    ///           `None` will result in the compositor to use all planes as specified by [`DrmSurface::planes`]
+    /// - `allocator` used for the primary plane swapchain
+    /// - `renderer_formats` as reported by the used renderer, used to build the intersection between
+    ///                      the possible scan-out formats of the primary plane and the renderer
+    /// - `framebuffer_exporter` is used to create drm framebuffers for the swapchain buffers (and if possible
+    ///                          for element buffers) for scan-out
+    /// - `cursor_size` as reported by the drm device, used for creating buffer for the cursor plane
+    /// - `gbm` device used for creating buffers for the cursor plane, `None` will disable the cursor plane
+    #[allow(clippy::too_many_arguments)]
+    pub fn new<L>(
+        output: &Output,
+        surface: DrmSurface,
+        planes: Option<Planes>,
+        mut allocator: A,
+        framebuffer_exporter: F,
+        renderer_formats: HashSet<DrmFormat>,
+        cursor_size: Size<u32, BufferCoords>,
+        gbm: Option<GbmDevice<G>>,
+        log: L,
+    ) -> FrameResult<Self, A, F>
+    where
+        L: Into<Option<::slog::Logger>>,
+    {
+        let log = crate::slog_or_fallback(log).new(slog::o!("backend" => "drm_render"));
+
+        let mut error = None;
+        let surface = Arc::new(surface);
+        let mut planes = match planes {
+            Some(planes) => planes,
+            None => surface.planes()?,
+        };
+
+        // The selection algorithm expects the planes to be ordered form front to back
+        planes
+            .overlay
+            .sort_by_key(|p| std::cmp::Reverse(p.zpos.unwrap_or_default()));
+
+        let cursor_size = Size::from((cursor_size.w as i32, cursor_size.h as i32));
+        let damage_tracked_renderer = DamageTrackedRenderer::from_output(output);
+
+        for format in SUPPORTED_FORMATS {
+            slog::debug!(log, "Testing color format: {}", format);
+            match Self::find_supported_format(
+                surface.clone(),
+                &planes,
+                allocator,
+                &framebuffer_exporter,
+                renderer_formats.clone(),
+                *format,
+                log.clone(),
+            ) {
+                Ok((swapchain, current_frame)) => {
+                    let cursor_state = gbm.map(|gbm| {
+                        let cursor_allocator = GbmAllocator::new(
+                            gbm.clone(),
+                            BufferObjectFlags::CURSOR | BufferObjectFlags::WRITE,
+                        );
+                        CursorState {
+                            allocator: cursor_allocator,
+                            framebuffer_exporter: gbm,
+                            previous_output_scale: None,
+                            previous_output_transform: None,
+                        }
+                    });
+
+                    let drm_renderer = DrmCompositor {
+                        primary_plane_element_id: Id::new(),
+                        primary_plane_damage_tracker: DamageTracker::new(4),
+                        current_frame,
+                        pending_frame: None,
+                        queued_frame: None,
+                        next_frame: None,
+                        swapchain,
+                        framebuffer_exporter,
+                        cursor_size,
+                        cursor_state,
+                        surface,
+                        damage_tracked_renderer,
+                        output: output.clone(),
+                        planes,
+                        element_states: IndexMap::new(),
+                        debug_flags: DebugFlags::empty(),
+                    };
+
+                    return Ok(drm_renderer);
+                }
+                Err((alloc, err)) => {
+                    slog::warn!(log, "Preferred format {} not available: {:?}", format, err);
+                    allocator = alloc;
+                    error = Some(err);
+                }
+            }
+        }
+        Err(error.unwrap())
+    }
+
+    fn find_supported_format(
+        drm: Arc<DrmSurface>,
+        planes: &Planes,
+        allocator: A,
+        framebuffer_exporter: &F,
+        mut renderer_formats: HashSet<DrmFormat>,
+        code: DrmFourcc,
+        logger: slog::Logger,
+    ) -> Result<(Swapchain<A>, Frame<A, F>), (A, FrameErrorType<A, F>)> {
+        // select a format
+        let mut plane_formats = match drm.supported_formats(drm.plane()) {
+            Ok(formats) => formats.iter().cloned().collect::<HashSet<_>>(),
+            Err(err) => return Err((allocator, err.into())),
+        };
+
+        if !plane_formats.iter().any(|fmt| fmt.code == code) {
+            return Err((allocator, FrameError::NoSupportedPlaneFormat));
+        }
+        plane_formats.retain(|fmt| fmt.code == code);
+        renderer_formats.retain(|fmt| fmt.code == code);
+
+        slog::trace!(logger, "Plane formats: {:?}", plane_formats);
+        slog::trace!(logger, "Renderer formats: {:?}", renderer_formats);
+        slog::debug!(
+            logger,
+            "Remaining intersected formats: {:?}",
+            plane_formats
+                .intersection(&renderer_formats)
+                .collect::<HashSet<_>>()
+        );
+
+        if plane_formats.is_empty() {
+            return Err((allocator, FrameError::NoSupportedPlaneFormat));
+        } else if renderer_formats.is_empty() {
+            return Err((allocator, FrameError::NoSupportedRendererFormat));
+        }
+
+        let formats = {
+            // Special case: if a format supports explicit LINEAR (but no implicit Modifiers)
+            // and the other doesn't support any modifier, force Implicit.
+            // This should at least result in a working pipeline possibly with a linear buffer,
+            // but we cannot be sure.
+            if (plane_formats.len() == 1
+                && plane_formats.iter().next().unwrap().modifier == DrmModifier::Invalid
+                && renderer_formats
+                    .iter()
+                    .all(|x| x.modifier != DrmModifier::Invalid)
+                && renderer_formats.iter().any(|x| x.modifier == DrmModifier::Linear))
+                || (renderer_formats.len() == 1
+                    && renderer_formats.iter().next().unwrap().modifier == DrmModifier::Invalid
+                    && plane_formats.iter().all(|x| x.modifier != DrmModifier::Invalid)
+                    && plane_formats.iter().any(|x| x.modifier == DrmModifier::Linear))
+            {
+                vec![DrmFormat {
+                    code,
+                    modifier: DrmModifier::Invalid,
+                }]
+            } else {
+                plane_formats
+                    .intersection(&renderer_formats)
+                    .cloned()
+                    .collect::<Vec<_>>()
+            }
+        };
+        slog::debug!(logger, "Testing Formats: {:?}", formats);
+
+        let modifiers = formats.iter().map(|x| x.modifier).collect::<Vec<_>>();
+        let mode = drm.pending_mode();
+
+        let mut swapchain: Swapchain<A> = Swapchain::new(
+            allocator,
+            mode.size().0 as u32,
+            mode.size().1 as u32,
+            code,
+            modifiers,
+        );
+
+        // Test format
+        let buffer = match swapchain.acquire() {
+            Ok(buffer) => buffer.unwrap(),
+            Err(err) => return Err((swapchain.allocator, FrameError::Allocator(err))),
+        };
+
+        let dmabuf = match buffer.export() {
+            Ok(dmabuf) => dmabuf,
+            Err(err) => {
+                return Err((swapchain.allocator, FrameError::AsDmabufError(err)));
+            }
+        };
+
+        let fb_buffer =
+            match framebuffer_exporter.add_framebuffer(drm.device_fd(), ExportBuffer::Allocator(&buffer)) {
+                Ok(Some(fb_buffer)) => fb_buffer,
+                Ok(None) => return Err((swapchain.allocator, FrameError::NoFramebuffer)),
+                Err(err) => return Err((swapchain.allocator, FrameError::FramebufferExport(err))),
+            };
+        buffer
+            .userdata()
+            .insert_if_missing(|| OwnedFramebuffer::new(DrmFramebuffer::Exporter(fb_buffer)));
+
+        let mode = drm.pending_mode();
+        let handle = buffer
+            .userdata()
+            .get::<OwnedFramebuffer<DrmFramebuffer<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>>()
+            .unwrap()
+            .clone();
+
+        let mode_size = Size::from((mode.size().0 as i32, mode.size().1 as i32));
+
+        let mut current_frame_state = FrameState::from_planes(planes);
+        let plane_claim = match drm.claim_plane(planes.primary.handle) {
+            Some(claim) => claim,
+            None => {
+                slog::warn!(logger, "failed to claim primary plane",);
+                return Err((swapchain.allocator, FrameError::PrimaryPlaneTestFailed));
+            }
+        };
+
+        let plane_state = PlaneState {
+            skip: false,
+            element_state: None,
+            config: Some(PlaneConfig {
+                src: Rectangle::from_loc_and_size(Point::default(), dmabuf.size()).to_f64(),
+                dst: Rectangle::from_loc_and_size(Point::default(), mode_size),
+                transform: Transform::Normal,
+                damage_clips: None,
+                buffer: Owned::from(DrmScanoutBuffer {
+                    buffer: ScanoutBuffer::Swapchain(buffer),
+                    fb: handle,
+                }),
+                plane_claim,
+            }),
+        };
+
+        match current_frame_state.test_state(&drm, planes.primary.handle, plane_state, true) {
+            Ok(true) => {
+                slog::debug!(logger, "Chosen format: {:?}", dmabuf.format());
+                Ok((swapchain, current_frame_state))
+            }
+            Ok(false) => {
+                slog::warn!(
+                    logger,
+                    "Mode-setting failed with automatically selected buffer format {:?}: test state failed",
+                    dmabuf.format()
+                );
+                Err((swapchain.allocator, FrameError::PrimaryPlaneTestFailed))
+            }
+            Err(err) => {
+                slog::warn!(
+                    logger,
+                    "Mode-setting failed with automatically selected buffer format {:?}: {}",
+                    dmabuf.format(),
+                    err
+                );
+                Err((swapchain.allocator, err.into()))
+            }
+        }
+    }
+
+    /// Render the next frame
+    pub fn render_frame<'a, R, E, Target, L>(
+        &'a mut self,
+        renderer: &mut R,
+        elements: &'a [E],
+        clear_color: [f32; 4],
+        log: L,
+    ) -> Result<RenderFrameResult<'a, A::Buffer, E>, RenderFrameErrorType<A, F, R>>
+    where
+        E: RenderElement<R>,
+        R: Renderer + Bind<Dmabuf> + Offscreen<Target> + ExportMem,
+        <R as Renderer>::TextureId: Texture + 'static,
+        L: Into<Option<slog::Logger>>,
+    {
+        let log = crate::slog_or_fallback(log);
+
+        // Just reset any next state, this will put
+        // any already acquired slot back to the swapchain
+        self.next_frame.take();
+
+        let current_size = self.output.current_mode().unwrap().size;
+        let output_scale = self.output.current_scale().fractional_scale().into();
+        let output_transform = self.output.current_transform();
+        // Geometry of the output derived from the output mode including the transform
+        // This is used to calculate the intersection between elements and the output.
+        // The renderer (and also the logic for direct scan-out) will take care of the
+        // actual transform during rendering
+        let output_geometry: Rectangle<_, Physical> =
+            Rectangle::from_loc_and_size((0, 0), output_transform.transform_size(current_size));
+
+        // We always acquire a buffer from the swapchain even
+        // if we could end up doing direct scan-out on the primary plane.
+        // The reason is that we can't know upfront and we need a framebuffer
+        // on the primary plane to test overlay/cursor planes
+        let primary_plane_buffer = self
+            .swapchain
+            .acquire()
+            .map_err(FrameError::Allocator)?
+            .ok_or(FrameError::NoFreeSlotsError)?;
+
+        // It is safe to call export multiple times as the Slot will cache the dmabuf for us
+        let dmabuf = primary_plane_buffer.export().map_err(FrameError::AsDmabufError)?;
+
+        // Let's check if we already have a cached framebuffer for this Slot, if not try to export
+        // it and use the Slot userdata to cache it
+        let maybe_buffer = primary_plane_buffer
+            .userdata()
+            .get::<OwnedFramebuffer<DrmFramebuffer<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>>();
+        if maybe_buffer.is_none() {
+            let fb_buffer = self
+                .framebuffer_exporter
+                .add_framebuffer(
+                    self.surface.device_fd(),
+                    ExportBuffer::Allocator(&primary_plane_buffer),
+                )
+                .map_err(FrameError::FramebufferExport)?
+                .ok_or(FrameError::NoFramebuffer)?;
+            primary_plane_buffer
+                .userdata()
+                .insert_if_missing(|| OwnedFramebuffer::new(DrmFramebuffer::Exporter(fb_buffer)));
+        }
+
+        // This unwrap is safe as we error out above if we were unable to export a framebuffer
+        let fb = primary_plane_buffer
+            .userdata()
+            .get::<OwnedFramebuffer<DrmFramebuffer<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>>()
+            .unwrap()
+            .clone();
+
+        let mut output_damage: Vec<Rectangle<i32, Physical>> = Vec::new();
+        let mut opaque_regions: Vec<Rectangle<i32, Physical>> = Vec::new();
+        let mut element_states = IndexMap::new();
+        let mut render_element_states = RenderElementStates {
+            states: Default::default(),
+        };
+
+        // So first we want to create a clean state, for that we have to reset all overlay and cursor planes
+        // to nothing. We only want to test if the primary plane alone can be used for scan-out.
+        let mut next_frame_state = {
+            let previous_state = self
+                .pending_frame
+                .as_ref()
+                .map(|(state, _)| state)
+                .unwrap_or(&self.current_frame);
+
+            // This will create an empty frame state, all planes are skipped by default
+            let mut next_frame_state = FrameState::from_planes(&self.planes);
+
+            // We want to set skip to false on all planes that previously had something assigned so that
+            // they get cleared when they are not longer used
+            for (handle, plane_state) in next_frame_state.planes.iter_mut() {
+                let reset_state = previous_state
+                    .plane_state(*handle)
+                    .map(|state| state.config.is_some())
+                    .unwrap_or(false);
+
+                if reset_state {
+                    plane_state.skip = false;
+                }
+            }
+
+            next_frame_state
+        };
+
+        // We want to make sure we can actually scan-out the primary plane, so
+        // explicitly set skip to false
+        let plane_claim = self
+            .surface
+            .claim_plane(self.planes.primary.handle)
+            .ok_or(FrameError::PrimaryPlaneTestFailed)?;
+        let primary_plane_state = PlaneState {
+            skip: false,
+            element_state: None,
+            config: Some(PlaneConfig {
+                src: Rectangle::from_loc_and_size(Point::default(), dmabuf.size()).to_f64(),
+                dst: Rectangle::from_loc_and_size(Point::default(), current_size),
+                // NOTE: We do not apply the transform to the primary plane as this is handled by the dtr/renderer
+                transform: Transform::Normal,
+                damage_clips: None,
+                buffer: Owned::from(DrmScanoutBuffer {
+                    buffer: ScanoutBuffer::Swapchain(primary_plane_buffer),
+                    fb,
+                }),
+                plane_claim,
+            }),
+        };
+
+        if !next_frame_state
+            .test_state(
+                &self.surface,
+                self.planes.primary.handle,
+                primary_plane_state,
+                self.surface.commit_pending(),
+            )
+            .map_err(FrameError::DrmError)?
+        {
+            return Err(RenderFrameError::PrepareFrame(FrameError::PrimaryPlaneTestFailed));
+        }
+
+        // This holds all elements that are visible on the output
+        // A element is considered visible if it intersects with the output geometry
+        // AND is not completely hidden behind opaque regions
+        let mut output_elements: Vec<(&'a E, usize)> = Vec::with_capacity(elements.len());
+
+        for element in elements.iter() {
+            let element_id = element.id();
+            let element_geometry = element.geometry(output_scale);
+            let element_loc = element_geometry.loc;
+
+            // First test if the element overlaps with the output
+            // if not we can skip it
+            let element_output_geometry = match element_geometry.intersection(output_geometry) {
+                Some(geo) => geo,
+                None => continue,
+            };
+
+            // Then test if the element is completely hidden behind opaque regions
+            let element_visible_area = opaque_regions
+                .iter()
+                .fold([element_output_geometry].to_vec(), |geometry, opaque_region| {
+                    geometry
+                        .into_iter()
+                        .flat_map(|g| g.subtract_rect(*opaque_region))
+                        .collect::<Vec<_>>()
+                })
+                .into_iter()
+                .fold(0usize, |acc, item| acc + (item.size.w * item.size.h) as usize);
+
+            if element_visible_area == 0 {
+                // No need to draw a completely hidden element
+                slog::trace!(log, "skipping completely obscured element {:?}", element.id());
+
+                // We allow multiple instance of a single element, so do not
+                // override the state if we already have one
+                if !render_element_states.states.contains_key(element_id) {
+                    render_element_states
+                        .states
+                        .insert(element_id.clone(), RenderElementState::skipped());
+                }
+                continue;
+            }
+
+            output_elements.push((element, element_visible_area));
+
+            let element_opaque_regions = element
+                .opaque_regions(output_scale)
+                .into_iter()
+                .map(|mut region| {
+                    region.loc += element_loc;
+                    region
+                })
+                .filter_map(|geo| geo.intersection(output_geometry))
+                .collect::<Vec<_>>();
+
+            opaque_regions.extend(element_opaque_regions);
+        }
+
+        let overlay_plane_lookup: HashMap<plane::Handle, PlaneInfo> =
+            self.planes.overlay.iter().map(|p| (p.handle, *p)).collect();
+
+        // This will hold the element that has been selected for direct scan-out on
+        // the primary plane if any
+        let mut primary_plane_scanout_element: Option<&'a E> = None;
+        // This will hold all elements that have been assigned to the primary plane
+        // for rendering
+        let mut primary_plane_elements: Vec<&'a E> = Vec::with_capacity(elements.len());
+        // This will hold the element per plane that has been assigned to a overlay/underlay
+        // plane for direct scan-out
+        let mut overlay_plane_elements: IndexMap<plane::Handle, &'a E> =
+            IndexMap::with_capacity(self.planes.overlay.len());
+        // This will hold the element assigned on the cursor plane if any
+        let mut cursor_plane_element: Option<&'a E> = None;
+
+        let output_elements_len = output_elements.len();
+        for (index, (element, element_visible_area)) in output_elements.into_iter().enumerate() {
+            let element_id = element.id();
+            let element_geometry = element.geometry(output_scale);
+            let remaining_elements = output_elements_len - index;
+
+            // Check if we found our last item, we can try to do
+            // direct scan-out on the primary plane
+            // If we already assigned an element to
+            // an underlay plane we will have a hole punch element
+            // on the primary plane, this will disable direct scan-out
+            // on the primary plane.
+            let try_assign_primary_plane = if remaining_elements == 1 && primary_plane_elements.is_empty() {
+                let element_is_opaque = element_is_opaque(element, output_scale);
+                let crtc_background_matches_clear_color =
+                    (clear_color[0] == 0f32 && clear_color[1] == 0f32 && clear_color[2] == 0f32)
+                        || clear_color[3] == 0f32;
+                let element_spans_complete_output = element_geometry.contains_rect(output_geometry);
+                let overlaps_with_underlay = self
+                    .planes
+                    .overlay
+                    .iter()
+                    .filter(|p| p.zpos.unwrap_or_default() <= self.planes.primary.zpos.unwrap_or_default())
+                    .any(|p| next_frame_state.overlaps(p.handle, element_geometry));
+                !overlaps_with_underlay
+                    && (crtc_background_matches_clear_color
+                        || (element_spans_complete_output && element_is_opaque))
+            } else {
+                false
+            };
+
+            let direct_scan_out_plane = self.try_assign_element(
+                renderer,
+                element,
+                &mut element_states,
+                &primary_plane_elements,
+                output_scale,
+                &mut next_frame_state,
+                &mut output_damage,
+                output_transform,
+                output_geometry,
+                try_assign_primary_plane,
+                &log,
+            );
+
+            if let Some(direct_scan_out_plane) = direct_scan_out_plane {
+                match direct_scan_out_plane.type_ {
+                    drm::control::PlaneType::Overlay => {
+                        overlay_plane_elements.insert(direct_scan_out_plane.handle, element);
+                    }
+                    drm::control::PlaneType::Primary => primary_plane_scanout_element = Some(element),
+                    drm::control::PlaneType::Cursor => cursor_plane_element = Some(element),
+                }
+
+                if let Some(state) = render_element_states.states.get_mut(element_id) {
+                    state.presentation_state = RenderElementPresentationState::ZeroCopy;
+                    state.visible_area += element_visible_area;
+                } else {
+                    render_element_states.states.insert(
+                        element_id.clone(),
+                        RenderElementState::zero_copy(element_visible_area),
+                    );
+                }
+            } else {
+                // No need to insert a state, this will be done by the dtr
+                primary_plane_elements.push(element);
+            }
+        }
+
+        // Cleanup old state (e.g. old dmabuffers)
+        for element_state in element_states.values_mut() {
+            element_state.cleanup();
+        }
+        self.element_states = element_states;
+
+        let previous_state = self
+            .pending_frame
+            .as_ref()
+            .map(|(state, _)| state)
+            .unwrap_or(&self.current_frame);
+
+        // If a plane has been moved or no longer has a buffer we need to report that as damage
+        for (handle, previous_plane_state) in previous_state.planes.iter() {
+            if let Some(previous_config) = previous_plane_state.config.as_ref() {
+                let next_state = next_frame_state
+                    .plane_state(*handle)
+                    .as_ref()
+                    .and_then(|state| state.config.as_ref());
+
+                if next_state
+                    .map(|next_config| next_config.dst != previous_config.dst)
+                    .unwrap_or(true)
+                {
+                    output_damage.push(previous_config.dst);
+
+                    if let Some(next_config) = next_state {
+                        slog::trace!(
+                            log,
+                            "damaging move plane {:?}: {:?} -> {:?}",
+                            handle,
+                            previous_config.dst,
+                            next_config.dst
+                        );
+                        output_damage.push(next_config.dst);
+                    } else {
+                        slog::trace!(
+                            log,
+                            "damaging removed plane {:?}: {:?}",
+                            handle,
+                            previous_config.dst
+                        );
+                    }
+                }
+            }
+        }
+
+        let render = next_frame_state
+            .plane_buffer(self.planes.primary.handle)
+            .map(|config| matches!(&config.buffer, ScanoutBuffer::Swapchain(_)))
+            .unwrap_or(false);
+
+        if render {
+            slog::trace!(
+                log,
+                "rendering {} elements on the primary plane {:?}",
+                primary_plane_elements.len(),
+                self.planes.primary.handle,
+            );
+            let (dmabuf, age) = {
+                let primary_plane_state = next_frame_state.plane_state(self.planes.primary.handle).unwrap();
+                let config = primary_plane_state.config.as_ref().unwrap();
+                let slot = match &config.buffer.buffer {
+                    ScanoutBuffer::Swapchain(slot) => slot,
+                    _ => unreachable!(),
+                };
+
+                // It is safe to call export multiple times as the Slot will cache the dmabuf for us
+                let dmabuf = slot.export().map_err(FrameError::AsDmabufError)?;
+                let age = slot.age().into();
+                (dmabuf, age)
+            };
+
+            renderer
+                .bind(dmabuf)
+                .map_err(DamageTrackedRendererError::Rendering)?;
+
+            // store the current renderer debug flags and replace them
+            // with our own
+            let renderer_debug_flags = renderer.debug_flags();
+            renderer.set_debug_flags(self.debug_flags);
+
+            // First we collect all our fake elements for overlay and underlays
+            // This is used to transport the opaque regions for elements that
+            // have been assigned to planes and to realize hole punching for
+            // underlays
+            let mut elements = overlay_plane_elements
+                .iter()
+                .map(|(p, element)| {
+                    let is_underlay = overlay_plane_lookup.get(p).unwrap().zpos.unwrap_or_default()
+                        <= self.planes.primary.zpos.unwrap_or_default();
+                    if is_underlay {
+                        HolepunchRenderElement::from_render_element(element, output_scale).into()
+                    } else {
+                        OverlayPlaneElement::from_render_element(*element).into()
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            // Then render all remaining elements assigned to the primary plane
+            elements.extend(
+                primary_plane_elements
+                    .iter()
+                    .map(|e| DrmRenderElements::Other(*e)),
+            );
+
+            let render_res = self.damage_tracked_renderer.render_output(
+                renderer,
+                age,
+                &elements,
+                clear_color,
+                log.clone(),
+            );
+
+            // restore the renderer debug flags
+            renderer.set_debug_flags(renderer_debug_flags);
+
+            match render_res {
+                Ok((render_damage, states)) => {
+                    for (id, mut state) in states.states.into_iter() {
+                        if let Some(existing_state) = render_element_states.states.get_mut(&id) {
+                            // Our overlay plane element and the holepunch element would result in double accounting of
+                            // the visible area, so we just reduce the renderer visible area by the visible are of the
+                            // overlay plane/holepunch element
+                            state.visible_area =
+                                state.visible_area.saturating_sub(existing_state.visible_area);
+
+                            if matches!(
+                                existing_state.presentation_state,
+                                RenderElementPresentationState::Skipped
+                            ) {
+                                *existing_state = state;
+                            } else {
+                                existing_state.visible_area += state.visible_area;
+                            }
+                        } else {
+                            render_element_states.states.insert(id.clone(), state);
+                        }
+                    }
+
+                    // Fixup damage on plane, if we used the plane for direct scan-out before
+                    // but now use it for rendering we do not replace the damage which is
+                    // the whole plane initially.
+                    let had_direct_scan_out = previous_state
+                        .plane_state(self.planes.primary.handle)
+                        .map(|state| state.element_state.is_some())
+                        .unwrap_or(true);
+
+                    let primary_plane_state = next_frame_state
+                        .plane_state_mut(self.planes.primary.handle)
+                        .unwrap();
+                    let config = primary_plane_state.config.as_mut().unwrap();
+
+                    if !had_direct_scan_out {
+                        if let Some(render_damage) = render_damage {
+                            slog::trace!(log, "rendering damage: {:?}", render_damage);
+
+                            self.primary_plane_damage_tracker
+                                .add(render_damage.iter().map(|d| {
+                                    d.to_logical(1).to_buffer(
+                                        1,
+                                        Transform::Normal,
+                                        &output_geometry.size.to_logical(1),
+                                    )
+                                }));
+                            output_damage.extend(render_damage.clone());
+                            config.damage_clips = PlaneDamageClips::from_damage(
+                                self.surface.device_fd(),
+                                config.src,
+                                config.dst,
+                                render_damage,
+                            )
+                            .ok()
+                            .flatten();
+                        } else {
+                            slog::trace!(log, "skipping primary plane, no damage");
+
+                            primary_plane_state.skip = true;
+                            *config = previous_state
+                                .plane_state(self.planes.primary.handle)
+                                .and_then(|state| state.config.as_ref().cloned())
+                                .unwrap_or_else(|| config.clone());
+                        }
+                    } else {
+                        slog::trace!(
+                            log,
+                            "clearing previous direct scan-out on primary plane, damaging complete output"
+                        );
+                        output_damage.push(output_geometry);
+                        self.primary_plane_damage_tracker
+                            .add([output_geometry.to_logical(1).to_buffer(
+                                1,
+                                Transform::Normal,
+                                &output_geometry.size.to_logical(1),
+                            )]);
+                    }
+                }
+                Err(err) => {
+                    // Rendering failed at some point, reset the buffers
+                    // as we probably now have some half drawn buffer
+                    self.swapchain.reset_buffers();
+                    return Err(RenderFrameError::from(err));
+                }
+            }
+        }
+
+        self.next_frame = Some(next_frame_state);
+
+        let primary_plane_element = if render {
+            let slot = {
+                let primary_plane_state = self
+                    .next_frame
+                    .as_ref()
+                    .unwrap()
+                    .plane_state(self.planes.primary.handle)
+                    .unwrap();
+                let config = primary_plane_state.config.as_ref().unwrap();
+                match &config.buffer.buffer {
+                    ScanoutBuffer::Swapchain(slot) => slot,
+                    _ => unreachable!(),
+                }
+            };
+            PrimaryPlaneElement::Swapchain {
+                slot,
+                transform: output_transform,
+                damage: self.primary_plane_damage_tracker.snapshot(),
+            }
+        } else {
+            PrimaryPlaneElement::Element(primary_plane_scanout_element.unwrap())
+        };
+
+        let damage = if output_damage.is_empty() {
+            None
+        } else {
+            Some(output_damage)
+        };
+        let frame_reference: RenderFrameResult<'a, A::Buffer, E> = RenderFrameResult {
+            primary_element: primary_plane_element,
+            damage,
+            overlay_elements: overlay_plane_elements.into_values().collect(),
+            cursor_element: cursor_plane_element,
+            states: render_element_states,
+            primary_plane_element_id: self.primary_plane_element_id.clone(),
+        };
+
+        Ok(frame_reference)
+    }
+
+    /// Queues the current frame for rendering.
+    ///
+    /// *Note*: This function needs to be followed up with [`DrmCompositor::frame_submitted`]
+    /// when a vblank event is received, that denotes successful scan-out of the frame.
+    /// Otherwise the underlying swapchain will eventually run out of buffers.
+    ///
+    /// `user_data` can be used to attach some data to a specific buffer and later retrieved with [`DrmCompositor::frame_submitted`]
+    pub fn queue_frame(&mut self, user_data: U) -> FrameResult<(), A, F> {
+        self.queued_frame = self.next_frame.take().map(|state| {
+            if let Some(plane_state) = state.plane_state(self.planes.primary.handle) {
+                if !plane_state.skip {
+                    let slot = plane_state.buffer().and_then(|config| match &config.buffer {
+                        ScanoutBuffer::Swapchain(slot) => Some(slot),
+                        _ => None,
+                    });
+
+                    if let Some(slot) = slot {
+                        self.swapchain.submitted(slot);
+                    }
+                }
+            }
+
+            (state, user_data)
+        });
+        if self.pending_frame.is_none() && self.queued_frame.is_some() {
+            self.submit()?;
+        }
+        Ok(())
+    }
+
+    fn submit(&mut self) -> FrameResult<(), A, F> {
+        let (state, user_data) = self.queued_frame.take().unwrap();
+
+        let flip = if self.surface.commit_pending() {
+            state.commit(&self.surface, true)
+        } else {
+            state.page_flip(&self.surface, true)
+        };
+        if flip.is_ok() {
+            self.pending_frame = Some((state, user_data));
+        }
+
+        flip.map_err(FrameError::DrmError)
+    }
+
+    /// Marks the current frame as submitted.
+    ///
+    /// *Note*: Needs to be called, after the vblank event of the matching [`DrmDevice`](super::super::DrmDevice)
+    /// was received after calling [`DrmCompositor::queue_frame`] on this surface.
+    /// Otherwise the underlying swapchain will run out of buffers eventually.
+    pub fn frame_submitted(&mut self) -> FrameResult<Option<U>, A, F> {
+        if let Some((mut pending, user_data)) = self.pending_frame.take() {
+            std::mem::swap(&mut pending, &mut self.current_frame);
+            if self.queued_frame.is_some() {
+                self.submit()?;
+            }
+            Ok(Some(user_data))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Reset the underlying buffers
+    pub fn reset_buffers(&mut self) {
+        self.swapchain.reset_buffers();
+    }
+
+    /// Returns the underlying [`crtc`](drm::control::crtc) of this surface
+    pub fn crtc(&self) -> crtc::Handle {
+        self.surface.crtc()
+    }
+
+    /// Returns the underlying [`plane`](drm::control::plane) of this surface
+    pub fn plane(&self) -> plane::Handle {
+        self.surface.plane()
+    }
+
+    /// Currently used [`connector`](drm::control::connector)s of this `Surface`
+    pub fn current_connectors(&self) -> impl IntoIterator<Item = connector::Handle> {
+        self.surface.current_connectors()
+    }
+
+    /// Returns the pending [`connector`](drm::control::connector)s
+    /// used for the next frame queued via [`queue_buffer`](GbmBufferedSurface::queue_buffer).
+    pub fn pending_connectors(&self) -> impl IntoIterator<Item = connector::Handle> {
+        self.surface.pending_connectors()
+    }
+
+    /// Tries to add a new [`connector`](drm::control::connector)
+    /// to be used after the next commit.
+    ///
+    /// **Warning**: You need to make sure, that the connector is not used with another surface
+    /// or was properly removed via `remove_connector` + `commit` before adding it to another surface.
+    /// Behavior if failing to do so is undefined, but might result in rendering errors or the connector
+    /// getting removed from the other surface without updating it's internal state.
+    ///
+    /// Fails if the `connector` is not compatible with the underlying [`crtc`](drm::control::crtc)
+    /// (e.g. no suitable [`encoder`](drm::control::encoder) may be found)
+    /// or is not compatible with the currently pending
+    /// [`Mode`](drm::control::Mode).
+    pub fn add_connector(&self, connector: connector::Handle) -> FrameResult<(), A, F> {
+        self.surface
+            .add_connector(connector)
+            .map_err(FrameError::DrmError)
+    }
+
+    /// Tries to mark a [`connector`](drm::control::connector)
+    /// for removal on the next commit.    
+    pub fn remove_connector(&self, connector: connector::Handle) -> FrameResult<(), A, F> {
+        self.surface
+            .remove_connector(connector)
+            .map_err(FrameError::DrmError)
+    }
+
+    /// Tries to replace the current connector set with the newly provided one on the next commit.
+    ///
+    /// Fails if one new `connector` is not compatible with the underlying [`crtc`](drm::control::crtc)
+    /// (e.g. no suitable [`encoder`](drm::control::encoder) may be found)
+    /// or is not compatible with the currently pending
+    /// [`Mode`](drm::control::Mode).    
+    pub fn set_connectors(&self, connectors: &[connector::Handle]) -> FrameResult<(), A, F> {
+        self.surface
+            .set_connectors(connectors)
+            .map_err(FrameError::DrmError)
+    }
+
+    /// Returns the currently active [`Mode`](drm::control::Mode)
+    /// of the underlying [`crtc`](drm::control::crtc)    
+    pub fn current_mode(&self) -> Mode {
+        self.surface.current_mode()
+    }
+
+    /// Returns the currently pending [`Mode`](drm::control::Mode)
+    /// to be used after the next commit.    
+    pub fn pending_mode(&self) -> Mode {
+        self.surface.pending_mode()
+    }
+
+    /// Tries to set a new [`Mode`](drm::control::Mode)
+    /// to be used after the next commit.
+    ///
+    /// Fails if the mode is not compatible with the underlying
+    /// [`crtc`](drm::control::crtc) or any of the
+    /// pending [`connector`](drm::control::connector)s.
+    pub fn use_mode(&mut self, mode: Mode) -> FrameResult<(), A, F> {
+        self.surface.use_mode(mode).map_err(FrameError::DrmError)?;
+        let (w, h) = mode.size();
+        self.swapchain.resize(w as _, h as _);
+        Ok(())
+    }
+
+    /// Set the [`DebugFlags`] to use
+    ///
+    /// Note: This will reset the primary plane swapchain if
+    /// the flags differ from the current flags
+    pub fn set_debug_flags(&mut self, flags: DebugFlags) {
+        if self.debug_flags != flags {
+            self.debug_flags = flags;
+            self.swapchain.reset_buffers();
+        }
+    }
+
+    /// Returns the current enabled [`DebugFlags`]
+    pub fn debug_flags(&self) -> DebugFlags {
+        self.debug_flags
+    }
+
+    /// Returns a reference to the underlying drm surface
+    pub fn surface(&self) -> &DrmSurface {
+        &self.surface
+    }
+
+    /// Get the format of the underlying swapchain
+    pub fn format(&self) -> DrmFourcc {
+        self.swapchain.format()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_assign_element<'a, R, E, Target>(
+        &mut self,
+        renderer: &mut R,
+        element: &'a E,
+        element_states: &mut IndexMap<
+            Id,
+            ElementFramebufferCache<DrmFramebuffer<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>,
+        >,
+        primary_plane_elements: &[&'a E],
+        scale: Scale<f64>,
+        frame_state: &mut Frame<A, F>,
+        output_damage: &mut Vec<Rectangle<i32, Physical>>,
+        output_transform: Transform,
+        output_geometry: Rectangle<i32, Physical>,
+        try_assign_primary_plane: bool,
+        log: &slog::Logger,
+    ) -> Option<PlaneInfo>
+    where
+        R: Renderer + Bind<Dmabuf> + Offscreen<Target> + ExportMem,
+        E: RenderElement<R>,
+    {
+        if try_assign_primary_plane {
+            if let Some(plane) = self.try_assign_primary_plane(
+                renderer,
+                element,
+                element_states,
+                scale,
+                frame_state,
+                output_damage,
+                output_geometry,
+                log,
+            ) {
+                slog::trace!(
+                    log,
+                    "assigned element {:?} to primary plane {:?}",
+                    element.id(),
+                    self.planes.primary.handle
+                );
+                return Some(plane);
+            }
+        }
+
+        if let Some(plane) = self.try_assign_cursor_plane(
+            renderer,
+            element,
+            element_states,
+            scale,
+            frame_state,
+            output_damage,
+            output_transform,
+            output_geometry,
+            log,
+        ) {
+            slog::trace!(
+                log,
+                "assigned element {:?} to cursor plane {:?}",
+                element.id(),
+                self.planes.cursor.as_ref().map(|p| p.handle)
+            );
+            return Some(plane);
+        }
+
+        if let Some(plane) = self.try_assign_overlay_plane(
+            renderer,
+            element,
+            element_states,
+            primary_plane_elements,
+            scale,
+            frame_state,
+            output_damage,
+            output_transform,
+            output_geometry,
+            log,
+        ) {
+            slog::trace!(log, "assigned element {:?} to overlay plane", element.id());
+            return Some(plane);
+        }
+
+        None
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_assign_cursor_plane<R, E, Target>(
+        &mut self,
+        renderer: &mut R,
+        element: &E,
+        element_states: &mut IndexMap<
+            Id,
+            ElementFramebufferCache<DrmFramebuffer<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>,
+        >,
+        scale: Scale<f64>,
+        frame_state: &mut Frame<A, F>,
+        output_damage: &mut Vec<Rectangle<i32, Physical>>,
+        output_transform: Transform,
+        output_geometry: Rectangle<i32, Physical>,
+        log: &slog::Logger,
+    ) -> Option<PlaneInfo>
+    where
+        R: Renderer + Offscreen<Target> + ExportMem,
+        E: RenderElement<R>,
+    {
+        // if we have no cursor plane we can exit early
+        let plane_info = match self.planes.cursor.as_ref() {
+            Some(plane_info) => plane_info,
+            None => return None,
+        };
+
+        // something is already assigned to our cursor plane
+        if frame_state.is_assigned(plane_info.handle) {
+            slog::trace!(
+                log,
+                "skipping element {:?} on cursor plane {:?}, plane already has element assigned",
+                element.id(),
+                plane_info.handle
+            );
+            return None;
+        }
+
+        let element_geometry = element.geometry(scale);
+        let element_size = output_transform.transform_size(element_geometry.size);
+
+        // if the element is greater than the cursor size we can not
+        // use the cursor plane to scan out the element
+        if element_size.w > self.cursor_size.w || element_size.h > self.cursor_size.h {
+            slog::trace!(
+                log,
+                "element {:?} too big for cursor plane {:?}, skipping",
+                element.id(),
+                plane_info.handle,
+            );
+            return None;
+        }
+
+        // if the element exposes the underlying storage we can try to do
+        // direct scan-out
+        if let Some(underlying_storage) = element.underlying_storage(renderer) {
+            slog::trace!(
+                log,
+                "trying to assign element {:?} for direct scan-out on cursor plane {:?}",
+                element.id(),
+                plane_info.handle,
+            );
+            if let Some(plane) = self.try_assign_plane(
+                element,
+                element_geometry,
+                &underlying_storage,
+                plane_info,
+                element_states,
+                scale,
+                frame_state,
+                output_damage,
+                output_transform,
+                output_geometry,
+                log,
+            ) {
+                slog::trace!(
+                    log,
+                    "assigned element {:?} for direct scan-out on cursor plane {:?}",
+                    element.id(),
+                    plane_info.handle,
+                );
+                return Some(plane);
+            }
+        }
+
+        let Some(cursor_state) = self.cursor_state.as_mut() else {
+            slog::trace!(log, "no cursor state, skipping cursor rendering");
+            return None
+        };
+
+        // this calculates the location of the cursor plane taking the simulated transform
+        // into consideration
+        let cursor_plane_location = output_transform
+            .transform_point_in(element.location(scale), &output_geometry.size)
+            - output_transform.transform_point_in(Point::default(), &self.cursor_size);
+
+        let previous_state = self
+            .pending_frame
+            .as_ref()
+            .map(|(state, _)| state)
+            .unwrap_or(&self.current_frame);
+
+        let previous_element_state = previous_state
+            .plane_state(plane_info.handle)
+            .and_then(|state| state.element_state.as_ref());
+
+        // if the output transform or scale change we have to (re-)render the cursor plane,
+        // also if the element changed or reports damage we have to render it
+        let render = cursor_state
+            .previous_output_transform
+            .map(|t| t != output_transform)
+            .unwrap_or(true)
+            || cursor_state
+                .previous_output_scale
+                .map(|s| s != scale)
+                .unwrap_or(true)
+            || previous_element_state
+                .map(|(id, commit_counter)| {
+                    id != element.id() || !element.damage_since(scale, Some(*commit_counter)).is_empty()
+                })
+                .unwrap_or(true);
+
+        // check if the cursor plane location changed
+        let reposition = previous_state
+            .plane_state(plane_info.handle)
+            .and_then(|state| {
+                state
+                    .config
+                    .as_ref()
+                    .map(|config| config.dst.loc != cursor_plane_location)
+            })
+            .unwrap_or_default();
+
+        // ok, nothing changed, try to keep the previous state
+        if !render && !reposition {
+            let mut plane_state = previous_state.plane_state(plane_info.handle).unwrap().clone();
+            plane_state.skip = true;
+
+            let res = frame_state
+                .test_state(&self.surface, plane_info.handle, plane_state, false)
+                .unwrap_or_default();
+
+            if res {
+                return Some(*plane_info);
+            } else {
+                return None;
+            }
+        }
+
+        // we no not have to re-render but update the planes location
+        if !render && reposition {
+            slog::info!(log, "repositioning cursor plane");
+            let mut plane_state = previous_state.plane_state(plane_info.handle).unwrap().clone();
+            plane_state.skip = false;
+            let mut config = plane_state.config.as_mut().unwrap();
+            config.dst.loc = cursor_plane_location;
+            let res = frame_state
+                .test_state(&self.surface, plane_info.handle, plane_state, false)
+                .unwrap_or_default();
+
+            if res {
+                return Some(*plane_info);
+            } else {
+                return None;
+            }
+        }
+
+        slog::trace!(
+            log,
+            "trying to render element {:?} on cursor plane {:?}",
+            element.id(),
+            plane_info.handle
+        );
+
+        // if we fail to create a buffer we can just return false and
+        // force the cursor to be rendered on the primary plane
+        let mut cursor_buffer = match cursor_state.allocator.create_buffer(
+            self.cursor_size.w as u32,
+            self.cursor_size.h as u32,
+            DrmFourcc::Argb8888,
+            &[DrmModifier::Linear],
+        ) {
+            Ok(buffer) => buffer,
+            Err(err) => {
+                slog::debug!(log, "failed to create cursor buffer: {}", err);
+                return None;
+            }
+        };
+
+        // if we fail to export a framebuffer for our buffer we can skip the rest
+        let framebuffer = match cursor_state
+            .framebuffer_exporter
+            .add_framebuffer(self.surface.device_fd(), ExportBuffer::Allocator(&cursor_buffer))
+        {
+            Ok(Some(fb)) => fb,
+            Ok(None) => {
+                slog::debug!(
+                    log,
+                    "failed to export framebuffer for cursor plane {:?}: no framebuffer available",
+                    plane_info.handle
+                );
+                return None;
+            }
+            Err(err) => {
+                slog::debug!(
+                    log,
+                    "failed to export framebuffer for cursor plane {:?}: {}",
+                    plane_info.handle,
+                    err
+                );
+                return None;
+            }
+        };
+
+        let cursor_buffer_size = self.cursor_size.to_logical(1).to_buffer(1, Transform::Normal);
+        let offscreen_buffer = match renderer.create_buffer(cursor_buffer_size) {
+            Ok(buffer) => buffer,
+            Err(err) => {
+                slog::debug!(
+                    log,
+                    "failed to create offscreen buffer for cursor plane {:?}: {}",
+                    plane_info.handle,
+                    err
+                );
+                return None;
+            }
+        };
+
+        if let Err(err) = renderer.bind(offscreen_buffer) {
+            slog::debug!(
+                log,
+                "failed to bind cursor buffer for cursor plane {:?}: {}",
+                plane_info.handle,
+                err
+            );
+            return None;
+        };
+
+        // Try to claim the plane, if this fails we can not use it
+        let plane_claim = match self.surface.claim_plane(plane_info.handle) {
+            Some(claim) => claim,
+            None => {
+                slog::trace!(log, "failed to claim plane {:?}", plane_info.handle);
+                return None;
+            }
+        };
+
+        // save the renderer debug flags and disable all for the cursor plane
+        let renderer_debug_flags = renderer.debug_flags();
+        renderer.set_debug_flags(DebugFlags::empty());
+
+        let mut render = || {
+            let mut frame = renderer.render(self.cursor_size, output_transform)?;
+
+            frame.clear(
+                [0f32, 0f32, 0f32, 0f32],
+                &[Rectangle::from_loc_and_size((0, 0), self.cursor_size)],
+            )?;
+
+            let src = element.src();
+            let dst = Rectangle::from_loc_and_size((0, 0), element_geometry.size);
+            element.draw(&mut frame, src, dst, &[dst], log)?;
+
+            frame.finish()?;
+
+            Ok::<(), <R as Renderer>::Error>(())
+        };
+
+        let render_res = render();
+
+        // restore the renderer debug flags
+        renderer.set_debug_flags(renderer_debug_flags);
+
+        if let Err(err) = render_res {
+            slog::debug!(log, "failed to render cursor element: {}", err);
+            return None;
+        }
+
+        let copy_rect = Rectangle::from_loc_and_size((0, 0), cursor_buffer_size);
+        let mapping = match renderer.copy_framebuffer(copy_rect) {
+            Ok(mapping) => mapping,
+            Err(err) => {
+                slog::info!(log, "failed to export cursor offscreen buffer: {}", err);
+                return None;
+            }
+        };
+        let data = match renderer.map_texture(&mapping) {
+            Ok(data) => data,
+            Err(err) => {
+                slog::info!(log, "failed to map exported cursor offscreen buffer: {}", err);
+                return None;
+            }
+        };
+
+        if let Err(err) = cursor_buffer.write(data) {
+            slog::info!(log, "failed to write cursor buffer; {}", err);
+            return None;
+        }
+
+        let src = Rectangle::from_loc_and_size(Point::default(), cursor_buffer_size).to_f64();
+        let dst = Rectangle::from_loc_and_size(cursor_plane_location, self.cursor_size);
+
+        let config = Some(PlaneConfig {
+            src,
+            dst,
+            transform: Transform::Normal,
+            damage_clips: None,
+            buffer: Owned::from(DrmScanoutBuffer {
+                buffer: ScanoutBuffer::Cursor(cursor_buffer),
+                fb: OwnedFramebuffer::new(DrmFramebuffer::Gbm(framebuffer)),
+            }),
+            plane_claim,
+        });
+
+        let plane_state = PlaneState {
+            skip: false,
+            element_state: Some((element.id().clone(), element.current_commit())),
+            config,
+        };
+
+        let res = frame_state
+            .test_state(&self.surface, plane_info.handle, plane_state, false)
+            .unwrap_or_default();
+
+        if res {
+            cursor_state.previous_output_scale = Some(scale);
+            cursor_state.previous_output_transform = Some(output_transform);
+            output_damage.push(dst);
+            Some(*plane_info)
+        } else {
+            slog::info!(log, "failed to test cursor plane {:?} state", plane_info.handle);
+            None
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_assign_overlay_plane<'a, R, E>(
+        &self,
+        renderer: &mut R,
+        element: &'a E,
+        element_states: &mut IndexMap<
+            Id,
+            ElementFramebufferCache<DrmFramebuffer<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>,
+        >,
+        primary_plane_elements: &[&'a E],
+        scale: Scale<f64>,
+        frame_state: &mut Frame<A, F>,
+        output_damage: &mut Vec<Rectangle<i32, Physical>>,
+        output_transform: Transform,
+        output_geometry: Rectangle<i32, Physical>,
+        log: &slog::Logger,
+    ) -> Option<PlaneInfo>
+    where
+        R: Renderer,
+        E: RenderElement<R>,
+    {
+        let element_id = element.id();
+
+        // Check if we have a free plane, otherwise we can exit early
+        if self.planes.overlay.is_empty()
+            || self
+                .planes
+                .overlay
+                .iter()
+                .all(|plane| frame_state.is_assigned(plane.handle))
+        {
+            slog::trace!(
+                log,
+                "skipping overlay planes for element {:?}, no free planes",
+                element_id
+            );
+        }
+
+        // We can only try to do direct scan-out for element that provide a underlying storage
+        let underlying_storage = match element.underlying_storage(renderer) {
+            Some(underlying_storage) => underlying_storage,
+            None => {
+                return None;
+            }
+        };
+
+        let element_geometry = element.geometry(scale);
+
+        let overlaps_with_primary_plane_element = primary_plane_elements.iter().any(|e| {
+            let other_geometry = e.geometry(scale);
+            other_geometry.overlaps(element_geometry)
+        });
+
+        for plane in self.planes.overlay.iter() {
+            // something is already assigned to our overlay plane
+            if frame_state.is_assigned(plane.handle) {
+                slog::trace!(
+                    log,
+                    "skipping plane {:?} with zpos {:?} for element {:?}, already has element assigned, skipping",
+                    plane.handle,
+                    plane.zpos,
+                    element_id,
+                );
+                continue;
+            }
+
+            // test if the plane represents an underlay
+            let is_underlay = self.planes.primary.zpos.unwrap_or_default() > plane.zpos.unwrap_or_default();
+
+            if is_underlay && !element_is_opaque(element, scale) {
+                slog::trace!(
+                    log,
+                    "skipping direct scan-out on plane plane {:?} with zpos {:?}, element {:?} is not opaque",
+                    plane.handle,
+                    plane.zpos,
+                    element_id
+                );
+                continue;
+            }
+
+            // if the element overlaps with an element on
+            // the primary plane and is not an underlay
+            // we can not assign it to any overlay plane
+            if overlaps_with_primary_plane_element && !is_underlay {
+                slog::trace!(
+                    log,
+                    "skipping direct scan-out on plane plane {:?} with zpos {:?}, element {:?} overlaps with element on primary plane", plane.handle, plane.zpos, element_id,
+                );
+                return None;
+            }
+
+            let overlaps_with_plane_underneath = self
+                .planes
+                .overlay
+                .iter()
+                .filter(|info| {
+                    info.handle != plane.handle
+                        && info.zpos.unwrap_or_default() <= plane.zpos.unwrap_or_default()
+                })
+                .any(|overlapping_plane| frame_state.overlaps(overlapping_plane.handle, element_geometry));
+
+            // if we overlap we a plane below which already
+            // has an element assigned we can not use the
+            // plane for direct scan-out
+            if overlaps_with_plane_underneath {
+                slog::trace!(
+                    log,
+                    "skipping direct scan-out on plane {:?} with zpos {:?}, element {:?} geometry {:?} overlaps with plane underneath", plane.handle, plane.zpos, element_id, element_geometry,
+                );
+                continue;
+            }
+
+            if let Some(plane) = self.try_assign_plane(
+                element,
+                element_geometry,
+                &underlying_storage,
+                plane,
+                element_states,
+                scale,
+                frame_state,
+                output_damage,
+                output_transform,
+                output_geometry,
+                log,
+            ) {
+                return Some(plane);
+            }
+        }
+
+        None
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_assign_primary_plane<R, E>(
+        &self,
+        renderer: &mut R,
+        element: &E,
+        element_states: &mut IndexMap<
+            Id,
+            ElementFramebufferCache<DrmFramebuffer<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>,
+        >,
+        scale: Scale<f64>,
+        frame_state: &mut Frame<A, F>,
+        output_damage: &mut Vec<Rectangle<i32, Physical>>,
+        output_geometry: Rectangle<i32, Physical>,
+        log: &slog::Logger,
+    ) -> Option<PlaneInfo>
+    where
+        R: Renderer,
+        E: RenderElement<R>,
+    {
+        // We can only try to do direct scan-out for element that provide a underlying storage
+        let underlying_storage = match element.underlying_storage(renderer) {
+            Some(underlying_storage) => underlying_storage,
+            None => {
+                return None;
+            }
+        };
+
+        slog::trace!(
+            log,
+            "trying to assign element {:?} to primary plane {:?}",
+            element.id(),
+            self.planes.primary.handle
+        );
+
+        let element_geometry = element.geometry(scale);
+
+        self.try_assign_plane(
+            element,
+            element_geometry,
+            &underlying_storage,
+            &self.planes.primary,
+            element_states,
+            scale,
+            frame_state,
+            output_damage,
+            Transform::Normal,
+            output_geometry,
+            log,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_assign_plane<R, E>(
+        &self,
+        element: &E,
+        element_geometry: Rectangle<i32, Physical>,
+        underlying_storage: &UnderlyingStorage,
+        plane: &PlaneInfo,
+        element_states: &mut IndexMap<
+            Id,
+            ElementFramebufferCache<DrmFramebuffer<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>,
+        >,
+        scale: Scale<f64>,
+        frame_state: &mut Frame<A, F>,
+        output_damage: &mut Vec<Rectangle<i32, Physical>>,
+        output_transform: Transform,
+        output_geometry: Rectangle<i32, Physical>,
+        log: &slog::Logger,
+    ) -> Option<PlaneInfo>
+    where
+        R: Renderer,
+        E: RenderElement<R>,
+    {
+        let element_id = element.id();
+
+        // First we try to find a state in our new states, this is important if
+        // we got the same id multiple times. If we can't find it we use the previous
+        // state if available
+        let mut element_state = element_states
+            .get(element_id)
+            .or_else(|| self.element_states.get(element_id))
+            .cloned()
+            .unwrap_or_default();
+
+        element_state.cleanup();
+
+        let cached_fb = element_state.get(underlying_storage);
+
+        if cached_fb.is_none() {
+            slog::trace!(
+                log,
+                "no cached fb, exporting new fb for element {:?} underlying storage {:?}",
+                element_id,
+                &underlying_storage
+            );
+
+            let fb = self
+                .framebuffer_exporter
+                .add_framebuffer(self.surface.device_fd(), ExportBuffer::from(underlying_storage))
+                .map(|fb| fb.map(|fb| OwnedFramebuffer::new(DrmFramebuffer::Exporter(fb))))
+                .unwrap_or_else(|err| {
+                    slog::trace!(log, "failed to add framebuffer: {:?}", err);
+                    None
+                });
+
+            if fb.is_none() {
+                slog::trace!(
+                    log,
+                    "could not import framebuffer for element {:?} underlying storage {:?}",
+                    element_id,
+                    &underlying_storage
+                );
+            }
+
+            element_state.insert(underlying_storage, fb);
+        } else {
+            slog::trace!(
+                log,
+                "using cached fb for element {:?} underlying storage {:?}",
+                element_id,
+                &underlying_storage
+            );
+        }
+
+        element_states.insert(element_id.clone(), element_state);
+
+        let fb = match element_states
+            .get(element_id)
+            .and_then(|state| state.get(underlying_storage).unwrap())
+        {
+            Some(fb) => fb,
+            None => {
+                return None;
+            }
+        };
+
+        let plane_claim = match self.surface.claim_plane(plane.handle) {
+            Some(claim) => claim,
+            None => {
+                slog::trace!(
+                    log,
+                    "failed to claim plane {:?} for element {:?}",
+                    plane.handle,
+                    element_id
+                );
+                return None;
+            }
+        };
+
+        // Try to assign the element to a plane
+        slog::trace!(log, "testing direct scan-out for element {:?} on plane {:?} with zpos {:?}: fb: {:?}, underlying storage: {:?}, element_geometry: {:?}", element_id, plane.handle, plane.zpos, &fb, &underlying_storage, element_geometry);
+
+        let transform = apply_output_transform(
+            apply_underlying_storage_transform(element.transform(), underlying_storage),
+            output_transform,
+        );
+
+        let previous_state = self
+            .pending_frame
+            .as_ref()
+            .map(|(state, _)| state)
+            .unwrap_or(&self.current_frame);
+
+        let previous_commit = previous_state.planes.get(&plane.handle).and_then(|state| {
+            state.element_state.as_ref().and_then(
+                |(id, counter)| {
+                    if id == element_id {
+                        Some(*counter)
+                    } else {
+                        None
+                    }
+                },
+            )
+        });
+
+        let element_damage = element.damage_since(scale, previous_commit);
+
+        let src = element.src();
+        let dst = output_transform.transform_rect_in(element_geometry, &output_geometry.size);
+
+        // We can only skip the plane update if we have no damage and if
+        // the src/dst properties are unchanged. Also we can not skip if
+        // the fb did change (this includes the case where we previously
+        // had not assigned anything to the plane)
+        let skip = element_damage.is_empty()
+            && previous_state
+                .plane_state(plane.handle)
+                .map(|state| {
+                    state
+                        .config
+                        .as_ref()
+                        .map(|config| {
+                            config.src == src
+                                && config.dst == dst
+                                && config.transform == transform
+                                && config.buffer.fb == fb
+                        })
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false);
+
+        let element_output_damage = element_damage
+            .iter()
+            .cloned()
+            .map(|mut rect| {
+                rect.loc += element_geometry.loc;
+                rect
+            })
+            .collect::<Vec<_>>();
+
+        let damage_clips = if element_damage.is_empty() {
+            None
+        } else {
+            PlaneDamageClips::from_damage(self.surface.device_fd(), src, element_geometry, element_damage)
+                .ok()
+                .flatten()
+        };
+
+        let plane_state = PlaneState {
+            skip,
+            element_state: Some((element_id.clone(), element.current_commit())),
+            config: Some(PlaneConfig {
+                src,
+                dst,
+                transform,
+                damage_clips,
+                buffer: Owned::from(DrmScanoutBuffer {
+                    fb,
+                    buffer: ScanoutBuffer::from(underlying_storage.clone()),
+                }),
+                plane_claim,
+            }),
+        };
+
+        let res = frame_state
+            .test_state(&self.surface, plane.handle, plane_state, false)
+            .unwrap_or_default();
+
+        if res {
+            output_damage.extend(element_output_damage);
+
+            slog::trace!(
+                log,
+                "successfully assigned element {:?} to plane {:?} with zpos {:?} for direct scan-out",
+                element_id,
+                plane.handle,
+                plane.zpos,
+            );
+
+            Some(*plane)
+        } else {
+            slog::trace!(
+                log,
+                "skipping direct scan-out on plane {:?} with zpos {:?} for element {:?}, test failed",
+                plane.handle,
+                plane.zpos,
+                element_id
+            );
+
+            None
+        }
+    }
+}
+
+fn apply_underlying_storage_transform(
+    element_transform: Transform,
+    storage: &UnderlyingStorage,
+) -> Transform {
+    match storage {
+        UnderlyingStorage::Wayland(buffer) => {
+            if buffer_y_inverted(buffer).unwrap_or(false) {
+                match element_transform {
+                    Transform::Normal => Transform::Flipped,
+                    Transform::_90 => Transform::Flipped90,
+                    Transform::_180 => Transform::Flipped180,
+                    Transform::_270 => Transform::Flipped270,
+                    Transform::Flipped => Transform::Normal,
+                    Transform::Flipped90 => Transform::_90,
+                    Transform::Flipped180 => Transform::_180,
+                    Transform::Flipped270 => Transform::_270,
+                }
+            } else {
+                element_transform
+            }
+        }
+    }
+}
+
+fn apply_output_transform(transform: Transform, output_transform: Transform) -> Transform {
+    match (transform, output_transform) {
+        (Transform::Normal, output_transform) => output_transform,
+
+        (Transform::_90, Transform::Normal) => Transform::_270,
+        (Transform::_90, Transform::_90) => Transform::Normal,
+        (Transform::_90, Transform::_180) => Transform::_90,
+        (Transform::_90, Transform::_270) => Transform::_180,
+        (Transform::_90, Transform::Flipped) => Transform::Flipped270,
+        (Transform::_90, Transform::Flipped90) => Transform::Flipped,
+        (Transform::_90, Transform::Flipped180) => Transform::Flipped90,
+        (Transform::_90, Transform::Flipped270) => Transform::Flipped180,
+
+        (Transform::_180, Transform::Normal) => Transform::_180,
+        (Transform::_180, Transform::_90) => Transform::_270,
+        (Transform::_180, Transform::_180) => Transform::Normal,
+        (Transform::_180, Transform::_270) => Transform::_90,
+        (Transform::_180, Transform::Flipped) => Transform::Flipped180,
+        (Transform::_180, Transform::Flipped90) => Transform::Flipped270,
+        (Transform::_180, Transform::Flipped180) => Transform::Flipped,
+        (Transform::_180, Transform::Flipped270) => Transform::Flipped90,
+
+        (Transform::_270, Transform::Normal) => Transform::_90,
+        (Transform::_270, Transform::_90) => Transform::_180,
+        (Transform::_270, Transform::_180) => Transform::_270,
+        (Transform::_270, Transform::_270) => Transform::Normal,
+        (Transform::_270, Transform::Flipped) => Transform::Flipped90,
+        (Transform::_270, Transform::Flipped90) => Transform::Flipped180,
+        (Transform::_270, Transform::Flipped180) => Transform::Flipped270,
+        (Transform::_270, Transform::Flipped270) => Transform::Flipped,
+
+        (Transform::Flipped, Transform::Normal) => Transform::Flipped,
+        (Transform::Flipped, Transform::_90) => Transform::Flipped90,
+        (Transform::Flipped, Transform::_180) => Transform::Flipped180,
+        (Transform::Flipped, Transform::_270) => Transform::Flipped270,
+        (Transform::Flipped, Transform::Flipped) => Transform::Normal,
+        (Transform::Flipped, Transform::Flipped90) => Transform::_90,
+        (Transform::Flipped, Transform::Flipped180) => Transform::_180,
+        (Transform::Flipped, Transform::Flipped270) => Transform::_270,
+
+        (Transform::Flipped90, Transform::Normal) => Transform::Flipped270,
+        (Transform::Flipped90, Transform::_90) => Transform::Flipped,
+        (Transform::Flipped90, Transform::_180) => Transform::Flipped90,
+        (Transform::Flipped90, Transform::_270) => Transform::Flipped180,
+        (Transform::Flipped90, Transform::Flipped) => Transform::_270,
+        (Transform::Flipped90, Transform::Flipped90) => Transform::Normal,
+        (Transform::Flipped90, Transform::Flipped180) => Transform::_90,
+        (Transform::Flipped90, Transform::Flipped270) => Transform::_180,
+
+        (Transform::Flipped180, Transform::Normal) => Transform::Flipped180,
+        (Transform::Flipped180, Transform::_90) => Transform::Flipped270,
+        (Transform::Flipped180, Transform::_180) => Transform::Flipped,
+        (Transform::Flipped180, Transform::_270) => Transform::Flipped90,
+        (Transform::Flipped180, Transform::Flipped) => Transform::_180,
+        (Transform::Flipped180, Transform::Flipped90) => Transform::_270,
+        (Transform::Flipped180, Transform::Flipped180) => Transform::Normal,
+        (Transform::Flipped180, Transform::Flipped270) => Transform::_90,
+
+        (Transform::Flipped270, Transform::Normal) => Transform::Flipped90,
+        (Transform::Flipped270, Transform::_90) => Transform::Flipped180,
+        (Transform::Flipped270, Transform::_180) => Transform::Flipped270,
+        (Transform::Flipped270, Transform::_270) => Transform::Flipped,
+        (Transform::Flipped270, Transform::Flipped) => Transform::_90,
+        (Transform::Flipped270, Transform::Flipped90) => Transform::_180,
+        (Transform::Flipped270, Transform::Flipped180) => Transform::_270,
+        (Transform::Flipped270, Transform::Flipped270) => Transform::Normal,
+    }
+}
+
+fn element_is_opaque<E: Element>(element: &E, scale: Scale<f64>) -> bool {
+    let opaque_regions = element.opaque_regions(scale);
+    let element_geometry = Rectangle::from_loc_and_size(Point::default(), element.geometry(scale).size);
+
+    opaque_regions
+        .iter()
+        .fold([element_geometry].to_vec(), |geometry, opaque_region| {
+            geometry
+                .into_iter()
+                .flat_map(|g| g.subtract_rect(*opaque_region))
+                .collect::<Vec<_>>()
+        })
+        .is_empty()
+}
+
+struct OwnedFramebuffer<B: AsRef<framebuffer::Handle>>(Arc<B>);
+
+impl<B: AsRef<framebuffer::Handle>> PartialEq for OwnedFramebuffer<B> {
+    fn eq(&self, other: &Self) -> bool {
+        AsRef::<framebuffer::Handle>::as_ref(&self) == AsRef::<framebuffer::Handle>::as_ref(&other)
+    }
+}
+
+impl<B: AsRef<framebuffer::Handle> + std::fmt::Debug> std::fmt::Debug for OwnedFramebuffer<B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("OwnedFramebuffer").field(&self.0).finish()
+    }
+}
+
+impl<B: AsRef<framebuffer::Handle>> OwnedFramebuffer<B> {
+    fn new(buffer: B) -> Self {
+        OwnedFramebuffer(Arc::new(buffer))
+    }
+}
+
+impl<B: AsRef<framebuffer::Handle>> Clone for OwnedFramebuffer<B> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<B: AsRef<framebuffer::Handle>> AsRef<framebuffer::Handle> for OwnedFramebuffer<B> {
+    fn as_ref(&self) -> &framebuffer::Handle {
+        (*self.0).as_ref()
+    }
+}
+
+/// Errors thrown by a [`DrmCompositor`]
+#[derive(Debug, thiserror::Error)]
+pub enum FrameError<
+    A: std::error::Error + Send + Sync + 'static,
+    B: std::error::Error + Send + Sync + 'static,
+    F: std::error::Error + Send + Sync + 'static,
+> {
+    /// Testing the primary plane failed
+    #[error("Testing the primary plane failed")]
+    PrimaryPlaneTestFailed,
+    /// No supported pixel format for the given plane could be determined
+    #[error("No supported plane buffer format found")]
+    NoSupportedPlaneFormat,
+    /// No supported pixel format for the given renderer could be determined
+    #[error("No supported renderer buffer format found")]
+    NoSupportedRendererFormat,
+    /// The swapchain is exhausted, you need to call `frame_submitted`
+    #[error("Failed to allocate a new buffer")]
+    NoFreeSlotsError,
+    /// Error accessing the drm device
+    #[error("The underlying drm surface encountered an error: {0}")]
+    DrmError(#[from] DrmError),
+    /// Error during buffer allocation
+    #[error("The underlying allocator encountered an error: {0}")]
+    Allocator(#[source] A),
+    /// Error during exporting the buffer as dmabuf
+    #[error("Failed to export the allocated buffer as dmabuf: {0}")]
+    AsDmabufError(#[source] B),
+    /// Error during exporting a framebuffer
+    #[error("The framebuffer export encountered an error: {0}")]
+    FramebufferExport(#[source] F),
+    /// No framebuffer available
+    #[error("No framebuffer available")]
+    NoFramebuffer,
+}
+
+/// Error returned from [`DrmCompositor::render_frame`]
+#[derive(thiserror::Error)]
+pub enum RenderFrameError<
+    A: std::error::Error + Send + Sync + 'static,
+    B: std::error::Error + Send + Sync + 'static,
+    F: std::error::Error + Send + Sync + 'static,
+    R: Renderer,
+> {
+    /// Preparing the frame encountered an error
+    #[error(transparent)]
+    PrepareFrame(#[from] FrameError<A, B, F>),
+    /// Rendering the frame encountered en error
+    #[error(transparent)]
+    RenderFrame(#[from] DamageTrackedRendererError<R>),
+}
+
+impl<A, B, F, R> std::fmt::Debug for RenderFrameError<A, B, F, R>
+where
+    A: std::error::Error + Send + Sync + 'static,
+    B: std::error::Error + Send + Sync + 'static,
+    F: std::error::Error + Send + Sync + 'static,
+    R: Renderer,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PrepareFrame(arg0) => f.debug_tuple("PrepareFrame").field(arg0).finish(),
+            Self::RenderFrame(arg0) => f.debug_tuple("RenderFrame").field(arg0).finish(),
+        }
+    }
+}
+
+impl<
+        A: std::error::Error + Send + Sync + 'static,
+        B: std::error::Error + Send + Sync + 'static,
+        F: std::error::Error + Send + Sync + 'static,
+    > From<FrameError<A, B, F>> for SwapBuffersError
+{
+    fn from(err: FrameError<A, B, F>) -> SwapBuffersError {
+        match err {
+            x @ FrameError::NoSupportedPlaneFormat
+            | x @ FrameError::NoSupportedRendererFormat
+            | x @ FrameError::PrimaryPlaneTestFailed
+            | x @ FrameError::NoFramebuffer => SwapBuffersError::ContextLost(Box::new(x)),
+            x @ FrameError::NoFreeSlotsError => SwapBuffersError::TemporaryFailure(Box::new(x)),
+            FrameError::DrmError(err) => err.into(),
+            FrameError::Allocator(err) => SwapBuffersError::ContextLost(Box::new(err)),
+            FrameError::AsDmabufError(err) => SwapBuffersError::ContextLost(Box::new(err)),
+            FrameError::FramebufferExport(err) => SwapBuffersError::ContextLost(Box::new(err)),
+        }
+    }
+}

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -13,7 +13,7 @@ pub(super) mod atomic;
 mod fd;
 pub use self::fd::DrmDeviceFd;
 pub(super) mod legacy;
-use crate::utils::{DevPath, Physical, Size};
+use crate::utils::{Buffer, DevPath, Size};
 
 use super::surface::{atomic::AtomicDrmSurface, legacy::LegacyDrmSurface, DrmSurface, DrmSurfaceInternal};
 use super::{error::Error, planes, Planes};
@@ -29,7 +29,7 @@ pub struct DrmDevice {
     pub(crate) internal: Arc<DrmDeviceInternal>,
     has_universal_planes: bool,
     has_monotonic_timestamps: bool,
-    cursor_size: Size<u32, Physical>,
+    cursor_size: Size<u32, Buffer>,
     resources: ResourceHandles,
     pub(super) logger: ::slog::Logger,
     token: Option<Token>,
@@ -182,7 +182,7 @@ impl DrmDevice {
     /// Note: In case of universal planes this is the
     /// maximum size of a buffer that can be used on
     /// the cursor plane.
-    pub fn cursor_size(&self) -> Size<u32, Physical> {
+    pub fn cursor_size(&self) -> Size<u32, Buffer> {
         self.cursor_size
     }
 

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -54,6 +54,15 @@ pub enum DrmDeviceInternal {
     Legacy(LegacyDrmDevice),
 }
 
+impl DrmDeviceInternal {
+    pub(crate) fn device_fd(&self) -> &DrmDeviceFd {
+        match self {
+            DrmDeviceInternal::Atomic(dev) => &dev.fd,
+            DrmDeviceInternal::Legacy(dev) => &dev.fd,
+        }
+    }
+}
+
 impl AsFd for DrmDeviceInternal {
     fn as_fd(&self) -> BorrowedFd<'_> {
         match self {
@@ -272,11 +281,8 @@ impl DrmDevice {
     }
 
     /// Returns the underlying file descriptor
-    pub fn device_fd(&self) -> DrmDeviceFd {
-        match &*self.internal {
-            DrmDeviceInternal::Atomic(internal) => internal.fd.clone(),
-            DrmDeviceInternal::Legacy(internal) => internal.fd.clone(),
-        }
+    pub fn device_fd(&self) -> &DrmDeviceFd {
+        self.internal.device_fd()
     }
 
     /// Pauses the device.

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -317,14 +317,14 @@ impl DrmDevice {
         }
 
         let plane = planes(self, &crtc, self.has_universal_planes)?.primary;
-        let info = self.get_plane(plane).map_err(|source| Error::Access {
+        let info = self.get_plane(plane.handle).map_err(|source| Error::Access {
             errmsg: "Failed to get plane info",
             dev: self.dev_path(),
             source,
         })?;
         let filter = info.possible_crtcs();
         if !self.resources.filter_crtcs(filter).contains(&crtc) {
-            return Err(Error::PlaneNotCompatible(crtc, plane));
+            return Err(Error::PlaneNotCompatible(crtc, plane.handle));
         }
 
         let active = match &*self.internal {
@@ -342,7 +342,7 @@ impl DrmDevice {
                 self.internal.clone(),
                 active,
                 crtc,
-                plane,
+                plane.handle,
                 mapping,
                 mode,
                 connectors,
@@ -362,7 +362,7 @@ impl DrmDevice {
         Ok(DrmSurface {
             dev_id: self.dev_id,
             crtc,
-            primary: plane,
+            primary: plane.handle,
             internal: Arc::new(internal),
             has_universal_planes: self.has_universal_planes,
             plane_claim_storage: self.plane_claim_storage.clone(),

--- a/src/backend/drm/error.rs
+++ b/src/backend/drm/error.rs
@@ -37,9 +37,18 @@ pub enum Error {
     /// The given plane cannot be used with the given crtc
     #[error("Plane `{1:?}` is not compatible for use with crtc `{0:?}`")]
     PlaneNotCompatible(crtc::Handle, plane::Handle),
+    /// The given configuration does not specify a plane which is not supported by the underlying implementation
+    #[error("No Plane has been specified which is not supported by the underlying implementation")]
+    NoPlane,
     /// The given plane is not a primary plane and therefor not supported by the underlying implementation
     #[error("Non-Primary Planes (provided was `{0:?}`) are not available for use with legacy devices")]
     NonPrimaryPlane(plane::Handle),
+    /// The given plane does not allow to clear the framebuffer
+    #[error("Clearing the framebuffer on plane `{0:?}` is not supported")]
+    NoFramebuffer(plane::Handle),
+    /// The configuration is not supported on the given plane
+    #[error("The configuration is not supported on plane `{0:?}`")]
+    UnsupportedPlaneConfiguration(plane::Handle),
     /// No encoder was found for a given connector on the set crtc
     #[error("No encoder found for the given connector '{connector:?}' on crtc `{crtc:?}`")]
     NoSuitableEncoder {

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -76,7 +76,9 @@ pub mod node;
 pub(self) mod surface;
 
 use crate::utils::DevPath;
-pub use device::{DrmDevice, DrmDeviceFd, DrmEvent, EventMetadata as DrmEventMetadata, Time as DrmEventTime};
+pub use device::{
+    DrmDevice, DrmDeviceFd, DrmEvent, EventMetadata as DrmEventMetadata, PlaneClaim, Time as DrmEventTime,
+};
 pub use error::Error as DrmError;
 pub use node::{CreateDrmNodeError, DrmNode, NodeType};
 #[cfg(feature = "backend_gbm")]

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -88,14 +88,25 @@ pub use surface::{DrmSurface, PlaneConfig, PlaneDamageClips, PlaneState};
 use drm::control::{crtc, plane, Device as ControlDevice, PlaneType};
 
 /// A set of planes as supported by a crtc
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Planes {
     /// The primary plane of the crtc (automatically selected for [DrmDevice::create_surface])
-    pub primary: plane::Handle,
+    pub primary: PlaneInfo,
     /// The cursor plane of the crtc, if available
-    pub cursor: Option<plane::Handle>,
+    pub cursor: Option<PlaneInfo>,
     /// Overlay planes supported by the crtc, if available
-    pub overlay: Vec<plane::Handle>,
+    pub overlay: Vec<PlaneInfo>,
+}
+
+/// Info about a single plane
+#[derive(Debug, Copy, Clone)]
+pub struct PlaneInfo {
+    /// Handle of the plane
+    pub handle: plane::Handle,
+    /// Type of the plane
+    pub type_: PlaneType,
+    /// z-position of the plane if available
+    pub zpos: Option<i32>,
 }
 
 fn planes(
@@ -127,15 +138,22 @@ fn planes(
         })?;
         let filter = info.possible_crtcs();
         if resources.filter_crtcs(filter).contains(crtc) {
-            match plane_type(dev, plane)? {
+            let zpos = plane_zpos(dev, plane).ok().flatten();
+            let type_ = plane_type(dev, plane)?;
+            let plane_info = PlaneInfo {
+                handle: plane,
+                type_,
+                zpos,
+            };
+            match type_ {
                 PlaneType::Primary => {
-                    primary = Some(plane);
+                    primary = Some(plane_info);
                 }
                 PlaneType::Cursor => {
-                    cursor = Some(plane);
+                    cursor = Some(plane_info);
                 }
                 PlaneType::Overlay => {
-                    overlay.push(plane);
+                    overlay.push(plane_info);
                 }
             };
         }
@@ -170,4 +188,29 @@ fn plane_type(dev: &(impl ControlDevice + DevPath), plane: plane::Handle) -> Res
         }
     }
     unreachable!()
+}
+
+fn plane_zpos(dev: &(impl ControlDevice + DevPath), plane: plane::Handle) -> Result<Option<i32>, DrmError> {
+    let props = dev.get_properties(plane).map_err(|source| DrmError::Access {
+        errmsg: "Failed to get properties of plane",
+        dev: dev.dev_path(),
+        source,
+    })?;
+    let (ids, vals) = props.as_props_and_values();
+    for (&id, &val) in ids.iter().zip(vals.iter()) {
+        let info = dev.get_property(id).map_err(|source| DrmError::Access {
+            errmsg: "Failed to get property info",
+            dev: dev.dev_path(),
+            source,
+        })?;
+        if info.name().to_str().map(|x| x == "zpos").unwrap_or(false) {
+            let plane_zpos = match info.value_type().convert_value(val) {
+                drm::control::property::Value::UnsignedRange(u) => Some(u as i32),
+                drm::control::property::Value::SignedRange(i) => Some(i as i32),
+                _ => None,
+            };
+            return Ok(plane_zpos);
+        }
+    }
+    Ok(None)
 }

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -81,7 +81,7 @@ pub use error::Error as DrmError;
 pub use node::{CreateDrmNodeError, DrmNode, NodeType};
 #[cfg(feature = "backend_gbm")]
 pub use surface::gbm::{Error as GbmBufferedSurfaceError, GbmBufferedSurface};
-pub use surface::DrmSurface;
+pub use surface::{DrmSurface, PlaneConfig, PlaneDamageClips, PlaneState};
 
 use drm::control::{crtc, plane, Device as ControlDevice, PlaneType};
 

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -62,6 +62,12 @@
 //! Buffer management and details about the various types can be found in the [`allocator`-Module](crate::backend::allocator) and
 //! rendering abstractions, which can target these buffers can be found in the [`renderer`-Module](crate::backend::renderer).
 //!
+//! ### Hardware composition
+//!
+//! The [`DrmCompositor`](crate::backend::drm::compositor::DrmCompositor) provides a simplified way to utilize drm planes for
+//! using hardware composition.
+//! See the [`compositor`] module docs for more information on that topic.
+//!
 //! ## [`DrmNode`]
 //!
 //! A drm node refers to a drm device and the capabilities that may be performed using the node.
@@ -69,6 +75,8 @@
 //! to allocate buffers for use in X11 or Wayland. If you need to do mode setting, you should use
 //! [`DrmDevice`] instead.
 
+#[cfg(all(feature = "wayland_frontend", feature = "backend_gbm"))]
+pub mod compositor;
 pub(crate) mod device;
 pub(self) mod error;
 pub mod node;

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -17,7 +17,7 @@ use crate::{
             device::atomic::{map_props, Mapping},
             device::DrmDeviceInternal,
             error::Error,
-            plane_type,
+            plane_type, DrmDeviceFd,
         },
     },
     utils::DevPath,
@@ -962,6 +962,10 @@ impl AtomicDrmSurface {
             State::current_state(&*self.fd, self.crtc, &mut self.prop_mapping.write().unwrap())?
         };
         Ok(())
+    }
+
+    pub(crate) fn device_fd(&self) -> &DrmDeviceFd {
+        self.fd.device_fd()
     }
 }
 

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -5,11 +5,13 @@ use drm::control::{
 };
 
 use std::collections::HashSet;
+use std::sync::Mutex;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, Mutex, RwLock,
+    Arc, RwLock,
 };
 
+use crate::utils::{Coordinate, Point, Rectangle, Transform};
 use crate::{
     backend::{
         allocator::format::{get_bpp, get_depth},
@@ -24,6 +26,8 @@ use crate::{
 };
 
 use slog::{debug, info, o, trace, warn};
+
+use super::{PlaneConfig, PlaneState};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct State {
@@ -106,22 +110,13 @@ impl State {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct PlaneInfo {
-    handle: plane::Handle,
-    x: i32,
-    y: i32,
-    w: u32,
-    h: u32,
-}
-
 #[derive(Debug)]
 pub struct AtomicDrmSurface {
     pub(in crate::backend::drm) fd: Arc<DrmDeviceInternal>,
     pub(super) active: Arc<AtomicBool>,
     crtc: crtc::Handle,
     plane: plane::Handle,
-    additional_planes: Mutex<Vec<PlaneInfo>>,
+    used_planes: Mutex<HashSet<plane::Handle>>,
     prop_mapping: RwLock<Mapping>,
     state: RwLock<State>,
     pending: RwLock<State>,
@@ -167,7 +162,7 @@ impl AtomicDrmSurface {
             active,
             crtc,
             plane,
-            additional_planes: Mutex::new(Vec::new()),
+            used_planes: Mutex::new(HashSet::new()),
             prop_mapping: RwLock::new(prop_mapping),
             state: RwLock::new(state),
             pending: RwLock::new(pending),
@@ -285,10 +280,19 @@ impl AtomicDrmSurface {
             let req = self.build_request(
                 &mut [conn].iter(),
                 &mut [].iter(),
-                self.plane,
-                &[],
-                Some([(test_buffer.fb, self.plane)].iter()),
-                Some(pending.mode),
+                [&PlaneState {
+                    handle: self.plane,
+                    config: Some(PlaneConfig {
+                        src: Rectangle::from_loc_and_size(Point::default(), pending.mode.size()).to_f64(),
+                        dst: Rectangle::from_loc_and_size(
+                            Point::default(),
+                            (pending.mode.size().0 as i32, pending.mode.size().1 as i32),
+                        ),
+                        transform: Transform::Normal,
+                        damage_clips: None,
+                        fb: test_buffer.fb,
+                    }),
+                }],
                 Some(pending.blob),
             )?;
             self.fd
@@ -325,10 +329,19 @@ impl AtomicDrmSurface {
         let req = self.build_request(
             &mut [].iter(),
             &mut [conn].iter(),
-            self.plane,
-            &[],
-            Some([(test_buffer.fb, self.plane)].iter()),
-            Some(pending.mode),
+            [&PlaneState {
+                handle: self.plane,
+                config: Some(PlaneConfig {
+                    src: Rectangle::from_loc_and_size(Point::default(), pending.mode.size()).to_f64(),
+                    dst: Rectangle::from_loc_and_size(
+                        Point::default(),
+                        (pending.mode.size().0 as i32, pending.mode.size().1 as i32),
+                    ),
+                    transform: Transform::Normal,
+                    damage_clips: None,
+                    fb: test_buffer.fb,
+                }),
+            }],
             Some(pending.blob),
         )?;
         self.fd
@@ -367,10 +380,19 @@ impl AtomicDrmSurface {
         let req = self.build_request(
             &mut added,
             &mut removed,
-            self.plane,
-            &[],
-            Some([(test_buffer.fb, self.plane)].iter()),
-            Some(pending.mode),
+            [&PlaneState {
+                handle: self.plane,
+                config: Some(PlaneConfig {
+                    src: Rectangle::from_loc_and_size(Point::default(), pending.mode.size()).to_f64(),
+                    dst: Rectangle::from_loc_and_size(
+                        Point::default(),
+                        (pending.mode.size().0 as i32, pending.mode.size().1 as i32),
+                    ),
+                    transform: Transform::Normal,
+                    damage_clips: None,
+                    fb: test_buffer.fb,
+                }),
+            }],
             Some(pending.blob),
         )?;
 
@@ -404,13 +426,23 @@ impl AtomicDrmSurface {
             })?;
 
         let test_buffer = self.create_test_buffer(mode.size(), self.plane)?;
+
         let req = self.build_request(
             &mut pending.connectors.iter(),
             &mut [].iter(),
-            self.plane,
-            &[],
-            Some([(test_buffer.fb, self.plane)].iter()),
-            Some(mode),
+            [&PlaneState {
+                handle: self.plane,
+                config: Some(PlaneConfig {
+                    src: Rectangle::from_loc_and_size(Point::default(), pending.mode.size()).to_f64(),
+                    dst: Rectangle::from_loc_and_size(
+                        Point::default(),
+                        (pending.mode.size().0 as i32, pending.mode.size().1 as i32),
+                    ),
+                    transform: Transform::Normal,
+                    damage_clips: None,
+                    fb: test_buffer.fb,
+                }),
+            }],
             Some(new_blob),
         )?;
         if let Err(err) = self
@@ -432,78 +464,52 @@ impl AtomicDrmSurface {
         Ok(())
     }
 
-    pub fn use_plane(
-        &self,
-        plane: plane::Handle,
-        position: (i32, i32),
-        size: (u32, u32),
-    ) -> Result<(), Error> {
-        let info = PlaneInfo {
-            handle: plane,
-            x: position.0,
-            y: position.1,
-            w: size.0,
-            h: size.1,
-        };
-
-        let mut planes = self.additional_planes.lock().unwrap();
-        let mut new_planes = planes.clone();
-        new_planes.push(info);
-
-        let pending = self.pending.write().unwrap();
-        let primary_test_buffer = self.create_test_buffer(pending.mode.size(), self.plane)?;
-        let additional_test_buffers = new_planes
-            .iter()
-            .map(
-                |info| match self.create_test_buffer((info.w as u16, info.h as u16), info.handle) {
-                    Ok(test_buff) => Ok((test_buff, info.handle)),
-                    Err(err) => Err(err),
-                },
-            )
-            .collect::<Result<Vec<_>, _>>()?;
-        let req = self.build_request(
-            &mut pending.connectors.iter(),
-            &mut [].iter(),
-            self.plane,
-            &new_planes,
-            Some(
-                [(primary_test_buffer.fb, self.plane)].iter().chain(
-                    additional_test_buffers
-                        .iter()
-                        .map(|(b, p)| (b.fb, *p))
-                        .collect::<Vec<_>>()
-                        .iter(),
-                ),
-            ),
-            Some(pending.mode),
-            Some(pending.blob),
-        )?;
-        self.fd
-            .atomic_commit(
-                AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
-                req,
-            )
-            .map_err(|_| Error::TestFailed(self.crtc))?;
-
-        *planes = new_planes;
-
-        Ok(())
-    }
-
     pub fn commit_pending(&self) -> bool {
         *self.pending.read().unwrap() != *self.state.read().unwrap()
     }
 
+    pub fn test_state<'a>(
+        &self,
+        planes: impl IntoIterator<Item = PlaneState<'a>>,
+        allow_modeset: bool,
+    ) -> Result<bool, Error> {
+        if !self.active.load(Ordering::SeqCst) {
+            return Err(Error::DeviceInactive);
+        }
+
+        let planes = planes.into_iter().collect::<Vec<_>>();
+
+        let current = self.state.read().unwrap();
+        let pending = self.pending.read().unwrap();
+
+        let current_conns = current.connectors.clone();
+        let pending_conns = pending.connectors.clone();
+        let mut removed = current_conns.difference(&pending_conns);
+        let mut added = pending_conns.difference(&current_conns);
+
+        let req = self.build_request(&mut added, &mut removed, &*planes, Some(pending.blob))?;
+
+        let flags = if allow_modeset {
+            AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY
+        } else {
+            AtomicCommitFlags::TEST_ONLY
+        };
+        let result = self.fd.atomic_commit(flags, req).is_ok();
+        Ok(result)
+    }
+
     pub fn commit<'a>(
         &self,
-        framebuffers: impl Iterator<Item = &'a (framebuffer::Handle, plane::Handle)>,
+        planes: impl IntoIterator<Item = PlaneState<'a>>,
         event: bool,
     ) -> Result<(), Error> {
         if !self.active.load(Ordering::SeqCst) {
             return Err(Error::DeviceInactive);
         }
 
+        let planes = planes.into_iter().collect::<Vec<_>>();
         let mut current = self.state.write().unwrap();
+        let mut used_planes = self.used_planes.lock().unwrap();
         let pending = self.pending.write().unwrap();
 
         debug!(
@@ -541,15 +547,7 @@ impl AtomicDrmSurface {
 
         // test the new config and return the request if it would be accepted by the driver.
         let req = {
-            let req = self.build_request(
-                &mut added,
-                &mut removed,
-                self.plane,
-                &self.additional_planes.lock().unwrap(),
-                Some(framebuffers),
-                Some(pending.mode),
-                Some(pending.blob),
-            )?;
+            let req = self.build_request(&mut added, &mut removed, &*planes, Some(pending.blob))?;
 
             if let Err(err) = self
                 .fd
@@ -605,6 +603,13 @@ impl AtomicDrmSurface {
 
         if result.is_ok() {
             *current = pending.clone();
+            for plane in planes.iter() {
+                if plane.config.is_some() {
+                    used_planes.insert(plane.handle);
+                } else {
+                    used_planes.remove(&plane.handle);
+                }
+            }
         }
 
         result
@@ -612,29 +617,25 @@ impl AtomicDrmSurface {
 
     pub fn page_flip<'a>(
         &self,
-        framebuffers: impl Iterator<Item = &'a (framebuffer::Handle, plane::Handle)>,
+        planes: impl IntoIterator<Item = PlaneState<'a>>,
         event: bool,
     ) -> Result<(), Error> {
         if !self.active.load(Ordering::SeqCst) {
             return Err(Error::DeviceInactive);
         }
 
+        let mut used_planes = self.used_planes.lock().unwrap();
+        let planes = planes.into_iter().collect::<Vec<_>>();
+
         // page flips work just like commits with fewer parameters..
-        let req = self.build_request(
-            &mut [].iter(),
-            &mut [].iter(),
-            self.plane,
-            &self.additional_planes.lock().unwrap(),
-            Some(framebuffers),
-            None,
-            None,
-        )?;
+        let req = self.build_request(&mut [].iter(), &mut [].iter(), &*planes, None)?;
 
         // .. and without `AtomicCommitFlags::AllowModeset`.
         // If we would set anything here, that would require a modeset, this would fail,
         // indicating a problem in our assumptions.
         trace!(self.logger, "Queueing page flip: {:?}", req);
-        self.fd
+        let res = self
+            .fd
             .atomic_commit(
                 if event {
                     AtomicCommitFlags::PAGE_FLIP_EVENT | AtomicCommitFlags::NONBLOCK
@@ -647,89 +648,19 @@ impl AtomicDrmSurface {
                 errmsg: "Page flip commit failed",
                 dev: self.fd.dev_path(),
                 source,
-            })?;
+            });
 
-        Ok(())
-    }
-
-    pub fn test_buffer(&self, fb: framebuffer::Handle, mode: &Mode) -> Result<bool, Error> {
-        if !self.active.load(Ordering::SeqCst) {
-            return Err(Error::DeviceInactive);
+        if res.is_ok() {
+            for plane in planes.iter() {
+                if plane.config.is_some() {
+                    used_planes.insert(plane.handle);
+                } else {
+                    used_planes.remove(&plane.handle);
+                }
+            }
         }
 
-        let blob = self
-            .fd
-            .create_property_blob(&mode)
-            .map_err(|source| Error::Access {
-                errmsg: "Failed to create Property Blob for mode",
-                dev: self.fd.dev_path(),
-                source,
-            })?;
-
-        let current = self.state.read().unwrap();
-        let pending = self.pending.read().unwrap();
-
-        let current_conns = current.connectors.clone();
-        let pending_conns = pending.connectors.clone();
-        let mut removed = current_conns.difference(&pending_conns);
-        let mut added = pending_conns.difference(&current_conns);
-
-        let req = self.build_request(
-            &mut added,
-            &mut removed,
-            self.plane,
-            &[],
-            Some([(fb, self.plane)].iter()),
-            Some(*mode),
-            Some(blob),
-        )?;
-
-        let result = self
-            .fd
-            .atomic_commit(
-                AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
-                req,
-            )
-            .is_ok();
-        Ok(result)
-    }
-
-    pub fn test_plane_buffer(
-        &self,
-        fb: framebuffer::Handle,
-        plane: plane::Handle,
-        position: (i32, i32),
-        size: (u32, u32),
-    ) -> Result<bool, Error> {
-        if !self.active.load(Ordering::SeqCst) {
-            return Err(Error::DeviceInactive);
-        }
-
-        let pending = self.pending.read().unwrap();
-        let req = self.build_request(
-            &mut pending.connectors.iter(),
-            &mut [].iter(),
-            self.plane,
-            &[PlaneInfo {
-                handle: plane,
-                x: position.0,
-                y: position.1,
-                w: size.0,
-                h: size.1,
-            }],
-            Some([(fb, self.plane), (fb, plane)].iter()),
-            Some(pending.mode),
-            Some(pending.blob),
-        )?;
-
-        let result = self
-            .fd
-            .atomic_commit(
-                AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
-                req,
-            )
-            .is_ok();
-        Ok(result)
+        res
     }
 
     // If a mode is set a matching blob needs to be set (the inverse is not true)
@@ -738,10 +669,7 @@ impl AtomicDrmSurface {
         &self,
         new_connectors: &mut dyn Iterator<Item = &connector::Handle>,
         removed_connectors: &mut dyn Iterator<Item = &connector::Handle>,
-        primary: plane::Handle,
-        planes: &[PlaneInfo],
-        framebuffers: Option<impl Iterator<Item = &'a (framebuffer::Handle, plane::Handle)>>,
-        mode: Option<Mode>,
+        planes: impl IntoIterator<Item = &'a PlaneState<'a>>,
         blob: Option<property::Value<'static>>,
     ) -> Result<AtomicModeReq, Error> {
         let prop_mapping = self.prop_mapping.read().unwrap();
@@ -789,124 +717,154 @@ impl AtomicDrmSurface {
             property::Value::Boolean(true),
         );
 
-        // and we need to set the framebuffers for our planes
-        if let Some(fbs) = framebuffers {
-            for (fb, plane) in fbs {
+        for plane_state in planes.into_iter() {
+            let handle = &plane_state.handle;
+
+            if let Some(config) = plane_state.config.as_ref() {
+                // connect the plane to the CRTC
                 req.add_property(
-                    *plane,
-                    plane_prop_handle(&prop_mapping, *plane, "FB_ID")?,
-                    property::Value::Framebuffer(Some(*fb)),
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "CRTC_ID")?,
+                    property::Value::CRTC(Some(self.crtc)),
                 );
-            }
-        }
 
-        // we also need to connect the primary plane
-        req.add_property(
-            primary,
-            plane_prop_handle(&prop_mapping, primary, "CRTC_ID")?,
-            property::Value::CRTC(Some(self.crtc)),
-        );
+                // Set the fb for the plane
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "FB_ID")?,
+                    property::Value::Framebuffer(Some(config.fb)),
+                );
 
-        // if there is a new mode, we should also make sure the primary plane is sized correctly
-        if let Some(mode) = mode {
-            req.add_property(
-                primary,
-                plane_prop_handle(&prop_mapping, primary, "SRC_X")?,
-                property::Value::UnsignedRange(0),
-            );
-            req.add_property(
-                primary,
-                plane_prop_handle(&prop_mapping, primary, "SRC_Y")?,
-                property::Value::UnsignedRange(0),
-            );
-            req.add_property(
-                primary,
-                plane_prop_handle(&prop_mapping, primary, "SRC_W")?,
-                // these are 16.16. fixed point
-                property::Value::UnsignedRange((mode.size().0 as u64) << 16),
-            );
-            req.add_property(
-                primary,
-                plane_prop_handle(&prop_mapping, primary, "SRC_H")?,
-                property::Value::UnsignedRange((mode.size().1 as u64) << 16),
-            );
-            // we can map parts of the plane onto different coordinated on the crtc, but we just use a 1:1 mapping.
-            req.add_property(
-                primary,
-                plane_prop_handle(&prop_mapping, primary, "CRTC_X")?,
-                property::Value::SignedRange(0),
-            );
-            req.add_property(
-                primary,
-                plane_prop_handle(&prop_mapping, primary, "CRTC_Y")?,
-                property::Value::SignedRange(0),
-            );
-            req.add_property(
-                primary,
-                plane_prop_handle(&prop_mapping, primary, "CRTC_W")?,
-                property::Value::UnsignedRange(mode.size().0 as u64),
-            );
-            req.add_property(
-                primary,
-                plane_prop_handle(&prop_mapping, primary, "CRTC_H")?,
-                property::Value::UnsignedRange(mode.size().1 as u64),
-            );
-            if let Ok(prop) = plane_prop_handle(&prop_mapping, primary, "rotation") {
-                req.add_property(primary, prop, property::Value::Bitmask(1u64));
-            }
-        }
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "SRC_X")?,
+                    // these are 16.16. fixed point
+                    property::Value::UnsignedRange(to_fixed(config.src.loc.x) as u64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "SRC_Y")?,
+                    // these are 16.16. fixed point
+                    property::Value::UnsignedRange(to_fixed(config.src.loc.y) as u64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "SRC_W")?,
+                    // these are 16.16. fixed point
+                    property::Value::UnsignedRange(to_fixed(config.src.size.w) as u64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "SRC_H")?,
+                    // these are 16.16. fixed point
+                    property::Value::UnsignedRange(to_fixed(config.src.size.h) as u64),
+                );
 
-        // and finally the others
-        for plane_info in planes {
-            req.add_property(
-                plane_info.handle,
-                plane_prop_handle(&prop_mapping, plane_info.handle, "CRTC_ID")?,
-                property::Value::CRTC(Some(self.crtc)),
-            );
-            req.add_property(
-                plane_info.handle,
-                plane_prop_handle(&prop_mapping, plane_info.handle, "SRC_X")?,
-                property::Value::UnsignedRange(0),
-            );
-            req.add_property(
-                plane_info.handle,
-                plane_prop_handle(&prop_mapping, plane_info.handle, "SRC_Y")?,
-                property::Value::UnsignedRange(0),
-            );
-            req.add_property(
-                plane_info.handle,
-                plane_prop_handle(&prop_mapping, plane_info.handle, "SRC_W")?,
-                // these are 16.16. fixed point
-                property::Value::UnsignedRange((plane_info.w as u64) << 16),
-            );
-            req.add_property(
-                plane_info.handle,
-                plane_prop_handle(&prop_mapping, plane_info.handle, "SRC_H")?,
-                property::Value::UnsignedRange((plane_info.h as u64) << 16),
-            );
-            // we can map parts of the plane onto different coordinated on the crtc, but we just use a 1:1 mapping.
-            req.add_property(
-                plane_info.handle,
-                plane_prop_handle(&prop_mapping, plane_info.handle, "CRTC_X")?,
-                property::Value::SignedRange(plane_info.x as i64),
-            );
-            req.add_property(
-                plane_info.handle,
-                plane_prop_handle(&prop_mapping, plane_info.handle, "CRTC_Y")?,
-                property::Value::SignedRange(plane_info.y as i64),
-            );
-            req.add_property(
-                plane_info.handle,
-                plane_prop_handle(&prop_mapping, plane_info.handle, "CRTC_W")?,
-                property::Value::UnsignedRange(plane_info.w as u64),
-            );
-            req.add_property(
-                plane_info.handle,
-                plane_prop_handle(&prop_mapping, plane_info.handle, "CRTC_H")?,
-                property::Value::UnsignedRange(plane_info.h as u64),
-            );
-            if let Ok(prop) = plane_prop_handle(&prop_mapping, plane_info.handle, "rotation") {
-                req.add_property(plane_info.handle, prop, property::Value::Bitmask(1u64));
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "CRTC_X")?,
+                    property::Value::SignedRange(config.dst.loc.x as i64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "CRTC_Y")?,
+                    property::Value::SignedRange(config.dst.loc.y as i64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "CRTC_W")?,
+                    property::Value::UnsignedRange(config.dst.size.w as u64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "CRTC_H")?,
+                    property::Value::UnsignedRange(config.dst.size.h as u64),
+                );
+                if let Ok(prop) = plane_prop_handle(&prop_mapping, *handle, "rotation") {
+                    req.add_property(
+                        *handle,
+                        prop,
+                        property::Value::Bitmask(DrmRotation::from(config.transform).bits() as u64),
+                    );
+                }
+                if let Ok(prop) = plane_prop_handle(&prop_mapping, *handle, "FB_DAMAGE_CLIPS") {
+                    if let Some(damage) = config.damage_clips.as_ref() {
+                        req.add_property(*handle, prop, *damage);
+                    } else {
+                        req.add_property(*handle, prop, property::Value::Blob(0));
+                    }
+                }
+            } else {
+                // disconnect the plane from the CRTC
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "CRTC_ID")?,
+                    property::Value::CRTC(None),
+                );
+
+                // remove the fb from the plane
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "FB_ID")?,
+                    property::Value::Framebuffer(None),
+                );
+
+                // reset the plane properties
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "SRC_X")?,
+                    // these are 16.16. fixed point
+                    property::Value::UnsignedRange(0u64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "SRC_Y")?,
+                    // these are 16.16. fixed point
+                    property::Value::UnsignedRange(0u64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "SRC_W")?,
+                    // these are 16.16. fixed point
+                    property::Value::UnsignedRange(0u64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "SRC_H")?,
+                    // these are 16.16. fixed point
+                    property::Value::UnsignedRange(0u64),
+                );
+
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "CRTC_X")?,
+                    property::Value::SignedRange(0i64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "CRTC_Y")?,
+                    property::Value::SignedRange(0i64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "CRTC_W")?,
+                    property::Value::UnsignedRange(0u64),
+                );
+                req.add_property(
+                    *handle,
+                    plane_prop_handle(&prop_mapping, *handle, "CRTC_H")?,
+                    property::Value::UnsignedRange(0u64),
+                );
+                if let Ok(prop) = plane_prop_handle(&prop_mapping, *handle, "rotation") {
+                    req.add_property(
+                        *handle,
+                        prop,
+                        property::Value::Bitmask(DrmRotation::from(Transform::Normal).bits() as u64),
+                    );
+                }
+                if let Ok(prop) = plane_prop_handle(&prop_mapping, *handle, "FB_DAMAGE_CLIPS") {
+                    req.add_property(*handle, prop, property::Value::Blob(0));
+                }
             }
         }
 
@@ -933,6 +891,63 @@ impl AtomicDrmSurface {
             property::Value::Framebuffer(None),
         );
 
+        // reset the plane properties
+        req.add_property(
+            plane,
+            plane_prop_handle(&prop_mapping, plane, "SRC_X")?,
+            // these are 16.16. fixed point
+            property::Value::UnsignedRange(0u64),
+        );
+        req.add_property(
+            plane,
+            plane_prop_handle(&prop_mapping, plane, "SRC_Y")?,
+            // these are 16.16. fixed point
+            property::Value::UnsignedRange(0u64),
+        );
+        req.add_property(
+            plane,
+            plane_prop_handle(&prop_mapping, plane, "SRC_W")?,
+            // these are 16.16. fixed point
+            property::Value::UnsignedRange(0u64),
+        );
+        req.add_property(
+            plane,
+            plane_prop_handle(&prop_mapping, plane, "SRC_H")?,
+            // these are 16.16. fixed point
+            property::Value::UnsignedRange(0u64),
+        );
+
+        req.add_property(
+            plane,
+            plane_prop_handle(&prop_mapping, plane, "CRTC_X")?,
+            property::Value::SignedRange(0i64),
+        );
+        req.add_property(
+            plane,
+            plane_prop_handle(&prop_mapping, plane, "CRTC_Y")?,
+            property::Value::SignedRange(0i64),
+        );
+        req.add_property(
+            plane,
+            plane_prop_handle(&prop_mapping, plane, "CRTC_W")?,
+            property::Value::UnsignedRange(0u64),
+        );
+        req.add_property(
+            plane,
+            plane_prop_handle(&prop_mapping, plane, "CRTC_H")?,
+            property::Value::UnsignedRange(0u64),
+        );
+        if let Ok(prop) = plane_prop_handle(&prop_mapping, plane, "rotation") {
+            req.add_property(
+                plane,
+                prop,
+                property::Value::Bitmask(DrmRotation::from(Transform::Normal).bits() as u64),
+            );
+        }
+        if let Ok(prop) = plane_prop_handle(&prop_mapping, plane, "FB_DAMAGE_CLIPS") {
+            req.add_property(plane, prop, property::Value::Blob(0));
+        }
+
         let result = self
             .fd
             .atomic_commit(AtomicCommitFlags::NONBLOCK, req)
@@ -943,10 +958,7 @@ impl AtomicDrmSurface {
             });
 
         if result.is_ok() {
-            self.additional_planes
-                .lock()
-                .unwrap()
-                .retain(|info| info.handle != plane);
+            self.used_planes.lock().unwrap().remove(&plane);
         }
 
         result
@@ -975,6 +987,12 @@ struct TestBuffer {
     fb: framebuffer::Handle,
 }
 
+impl AsRef<framebuffer::Handle> for TestBuffer {
+    fn as_ref(&self) -> &framebuffer::Handle {
+        &self.fb
+    }
+}
+
 impl Drop for TestBuffer {
     fn drop(&mut self) {
         let _ = self.fd.destroy_framebuffer(self.fb);
@@ -994,19 +1012,12 @@ impl Drop for AtomicDrmSurface {
 
         // other ttys that use no cursor, might not clear it themselves.
         // This makes sure our cursor won't stay visible.
-        if let Err(err) = self.clear_plane(self.plane) {
-            warn!(
-                self.logger,
-                "Failed to clear plane {:?} on {:?}: {}", self.plane, self.crtc, err
-            );
-        }
-
-        let additional_planes = std::mem::take(&mut *self.additional_planes.lock().unwrap());
-        for plane_info in additional_planes {
-            if let Err(err) = self.clear_plane(plane_info.handle) {
+        let used_planes = std::mem::take(&mut *self.used_planes.lock().unwrap());
+        for plane in used_planes {
+            if let Err(err) = self.clear_plane(plane) {
                 warn!(
                     self.logger,
-                    "Failed to clear plane {:?} on {:?}: {}", plane_info.handle, self.crtc, err
+                    "Failed to clear plane {:?} on {:?}: {}", plane, self.crtc, err
                 );
             }
         }
@@ -1095,8 +1106,45 @@ pub(crate) fn plane_prop_handle(
         })
         .map(|x| *x)
 }
+
+#[inline]
+fn to_fixed<N: Coordinate>(n: N) -> u32 {
+    f64::round(n.to_f64() * (1 << 16) as f64) as u32
+}
+
+bitflags::bitflags! {
+    struct DrmRotation: u8 {
+        const ROTATE_0      =   0b00000001;
+        const ROTATE_90     =   0b00000010;
+        const ROTATE_180    =   0b00000100;
+        const ROTATE_270    =   0b00001000;
+        const REFLECT_X     =   0b00010000;
+        const REFLECT_Y     =   0b00100000;
+    }
+}
+
+impl From<Transform> for DrmRotation {
+    fn from(transform: Transform) -> Self {
+        match transform {
+            Transform::Normal => DrmRotation::ROTATE_0,
+            Transform::_90 => DrmRotation::ROTATE_90,
+            Transform::_180 => DrmRotation::ROTATE_180,
+            Transform::_270 => DrmRotation::ROTATE_270,
+            Transform::Flipped => DrmRotation::REFLECT_Y,
+            Transform::Flipped90 => DrmRotation::REFLECT_Y | DrmRotation::ROTATE_90,
+            Transform::Flipped180 => DrmRotation::REFLECT_Y | DrmRotation::ROTATE_180,
+            Transform::Flipped270 => DrmRotation::REFLECT_Y | DrmRotation::ROTATE_270,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use crate::{
+        backend::drm::surface::atomic::to_fixed,
+        utils::{Physical, Rectangle},
+    };
+
     use super::AtomicDrmSurface;
 
     fn is_send<S: Send>() {}
@@ -1104,5 +1152,19 @@ mod test {
     #[test]
     fn surface_is_send() {
         is_send::<AtomicDrmSurface>();
+    }
+
+    #[test]
+    fn test_fixed_point() {
+        let geometry: Rectangle<f64, Physical> = Rectangle::from_loc_and_size((0.0, 0.0), (1920.0, 1080.0));
+        let fixed = to_fixed(geometry.size.w) as u64;
+        assert_eq!(125829120, fixed);
+    }
+
+    #[test]
+    fn test_fractional_fixed_point() {
+        let geometry: Rectangle<f64, Physical> = Rectangle::from_loc_and_size((0.0, 0.0), (1920.1, 1080.0));
+        let fixed = to_fixed(geometry.size.w) as u64;
+        assert_eq!(125835674, fixed);
     }
 }

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -212,9 +212,16 @@ where
         };
 
         match drm.test_state([plane_state], true) {
-            Ok(_) => {
+            Ok(true) => {
                 debug!(logger, "Choosen format: {:?}", format);
                 Ok((buffer, swapchain))
+            }
+            Ok(false) => {
+                warn!(
+                    logger,
+                    "Mode-setting failed with automatically selected buffer format {:?}", format
+                );
+                Err((swapchain.allocator, Error::NoSupportedPlaneFormat))
             }
             Err(err) => {
                 warn!(

--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -7,7 +7,9 @@ use std::sync::{
 };
 
 use crate::{
-    backend::drm::{device::legacy::set_connector_state, device::DrmDeviceInternal, error::Error},
+    backend::drm::{
+        device::legacy::set_connector_state, device::DrmDeviceInternal, error::Error, DrmDeviceFd,
+    },
     utils::DevPath,
 };
 
@@ -410,6 +412,10 @@ impl LegacyDrmSurface {
             State::current_state(&*self.fd, self.crtc)?
         };
         Ok(())
+    }
+
+    pub(crate) fn device_fd(&self) -> &DrmDeviceFd {
+        self.fd.device_fd()
     }
 }
 

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -12,7 +12,7 @@ pub(super) mod atomic;
 #[cfg(feature = "backend_gbm")]
 pub(super) mod gbm;
 pub(super) mod legacy;
-use super::{error::Error, plane_type, planes, PlaneType, Planes};
+use super::{error::Error, plane_type, planes, DrmDeviceFd, PlaneType, Planes};
 use crate::{
     backend::allocator::{Format, Fourcc, Modifier},
     utils::DevPath,
@@ -53,6 +53,14 @@ impl BasicDevice for DrmSurface {}
 impl ControlDevice for DrmSurface {}
 
 impl DrmSurface {
+    /// Returns the underlying [`DrmDeviceFd`]
+    pub fn device_fd(&self) -> &DrmDeviceFd {
+        match &*self.internal {
+            DrmSurfaceInternal::Atomic(surf) => surf.device_fd(),
+            DrmSurfaceInternal::Legacy(surf) => surf.device_fd(),
+        }
+    }
+
     /// Returns the underlying [`crtc`](drm::control::crtc) of this surface
     pub fn crtc(&self) -> crtc::Handle {
         self.crtc

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::convert::TryFrom;
-use std::os::unix::io::{AsFd, BorrowedFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd};
 use std::sync::Arc;
 
 use drm::control::{connector, crtc, framebuffer, plane, property, Device as ControlDevice, Mode};
@@ -13,6 +13,7 @@ pub(super) mod atomic;
 pub(super) mod gbm;
 pub(super) mod legacy;
 use super::{error::Error, plane_type, planes, DrmDeviceFd, PlaneType, Planes};
+use crate::utils::{Buffer, Physical, Point, Rectangle, Transform};
 use crate::{
     backend::allocator::{Format, Fourcc, Modifier},
     utils::DevPath,
@@ -32,6 +33,124 @@ pub struct DrmSurface {
     pub(super) primary: plane::Handle,
     pub(super) internal: Arc<DrmSurfaceInternal>,
     pub(super) has_universal_planes: bool,
+}
+
+#[derive(Debug)]
+struct PlaneDamageInner {
+    drm: DrmDeviceFd,
+    blob: Option<drm::control::property::Value<'static>>,
+}
+
+impl Drop for PlaneDamageInner {
+    fn drop(&mut self) {
+        // There is nothing we can do if that fails
+        if let Some(drm::control::property::Value::Blob(id)) = self.blob.take() {
+            let _ = self.drm.destroy_property_blob(id);
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Helper for `FB_DAMAGE_CLIPS`
+pub struct PlaneDamageClips {
+    inner: Arc<PlaneDamageInner>,
+}
+
+impl PlaneDamageClips {
+    /// Returns the underlying blob
+    pub fn blob(&self) -> drm::control::property::Value<'_> {
+        self.inner.blob.unwrap()
+    }
+}
+
+impl PlaneDamageClips {
+    /// Initialize damage clips for a a plane
+    pub fn from_damage(
+        device: &DrmDeviceFd,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: impl IntoIterator<Item = Rectangle<i32, Physical>>,
+    ) -> Result<Option<Self>, drm_ffi::result::SystemError> {
+        let scale = src.size / dst.size.to_logical(1).to_buffer(1, Transform::Normal).to_f64();
+
+        let mut rects = damage
+            .into_iter()
+            .map(|rect| {
+                let mut rect = rect
+                    .to_f64()
+                    .to_logical(1f64)
+                    .to_buffer(
+                        1f64,
+                        Transform::Normal,
+                        &src.size.to_logical(1f64, Transform::Normal),
+                    )
+                    .upscale(scale);
+                rect.loc += src.loc;
+                let rect = rect.to_i32_up();
+
+                drm_ffi::drm_mode_rect {
+                    x1: rect.loc.x,
+                    y1: rect.loc.y,
+                    x2: rect.loc.x.saturating_add(rect.size.w),
+                    y2: rect.loc.y.saturating_add(rect.size.h),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if rects.is_empty() {
+            return Ok(None);
+        }
+
+        let data = unsafe {
+            std::slice::from_raw_parts_mut(
+                rects.as_mut_ptr() as *mut u8,
+                std::mem::size_of::<drm_ffi::drm_mode_rect>() * rects.len(),
+            )
+        };
+
+        let blob = drm_ffi::mode::create_property_blob(device.as_raw_fd(), data)?;
+
+        Ok(Some(PlaneDamageClips {
+            inner: Arc::new(PlaneDamageInner {
+                drm: device.clone(),
+                blob: Some(drm::control::property::Value::Blob(blob.blob_id as u64)),
+            }),
+        }))
+    }
+}
+
+impl Clone for PlaneDamageClips {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+/// State of a single plane
+#[derive(Debug, Clone)]
+pub struct PlaneState<'a> {
+    /// Handle of the plane
+    pub handle: plane::Handle,
+    /// Configuration for that plane
+    ///
+    /// Can be `None` if nothing is attached
+    pub config: Option<PlaneConfig<'a>>,
+}
+
+/// Configuration for a single plane
+#[derive(Debug, Copy, Clone)]
+pub struct PlaneConfig<'a> {
+    /// Source [`Rectangle`] of the attached framebuffer
+    pub src: Rectangle<f64, Buffer>,
+    /// Destination [`Rectangle`] on the CRTC
+    pub dst: Rectangle<i32, Physical>,
+    /// Transform for the attached framebuffer
+    pub transform: Transform,
+    /// Damage clips of the attached framebuffer
+    pub damage_clips: Option<drm::control::property::Value<'a>>,
+    /// Framebuffer handle
+    pub fb: framebuffer::Handle,
 }
 
 #[derive(Debug)]
@@ -160,29 +279,6 @@ impl DrmSurface {
         }
     }
 
-    /// Tries to setup a cursor or overlay [`Plane`](drm::control::plane)
-    /// to be set at the next commit/page_flip with the given position and size.
-    ///
-    /// Planes can have arbitrary hardware constraints, that cannot be expressed in the api,
-    /// like supporting only positions at even or odd values, allowing only certain sizes or disallowing overlapping planes.
-    /// Using planes should therefor be done in a best-efford manner. Failures on `page_flip` or `commit`
-    /// should be expected and alternative code paths without the usage of planes prepared.
-    ///
-    /// Fails if tests for the given plane fail, if the underlying
-    /// implementation does not support the use of planes or if the plane
-    /// is not supported by this crtc.
-    pub fn use_plane(
-        &self,
-        plane: plane::Handle,
-        position: (i32, i32),
-        size: (u32, u32),
-    ) -> Result<(), Error> {
-        match &*self.internal {
-            DrmSurfaceInternal::Atomic(surf) => surf.use_plane(plane, position, size),
-            DrmSurfaceInternal::Legacy(_) => Err(Error::NonPrimaryPlane(plane)),
-        }
-    }
-
     /// Disables the given plane.
     ///
     /// Errors if the plane is not supported by this crtc or if the underlying
@@ -207,7 +303,33 @@ impl DrmSurface {
         }
     }
 
-    /// Commit the pending state rendering a given framebuffer.
+    /// Test a state given a set of framebuffers.
+    ///
+    /// *Note*: This will always return `true` for legacy devices if `allow_modeset = false`.
+    /// The legacy drm api has no way to test a buffer without triggering a modeset.
+    pub fn test_state<'a>(
+        &self,
+        planes: impl IntoIterator<Item = PlaneState<'a>>,
+        allow_modeset: bool,
+    ) -> Result<bool, Error> {
+        match &*self.internal {
+            DrmSurfaceInternal::Atomic(surf) => surf.test_state(planes, allow_modeset),
+            DrmSurfaceInternal::Legacy(surf) => {
+                let fb = ensure_legacy_planes(self, planes)?;
+
+                if allow_modeset {
+                    surf.test_buffer(fb, &self.pending_mode())
+                } else {
+                    // Legacy can not test a buffer without triggering a modeset, so we can
+                    // only assume it works and hope for the best. A later call to commit or
+                    // page_flip will show the correct result
+                    Ok(true)
+                }
+            }
+        }
+    }
+
+    /// Commit the pending state rendering a given set of framebuffers.
     ///
     /// *Note*: This will trigger a full modeset on the underlying device,
     /// potentially causing some flickering. Check before performing this
@@ -219,26 +341,20 @@ impl DrmSurface {
     /// any generated event.
     pub fn commit<'a>(
         &self,
-        mut framebuffers: impl Iterator<Item = &'a (framebuffer::Handle, plane::Handle)>,
+        planes: impl IntoIterator<Item = PlaneState<'a>>,
         event: bool,
     ) -> Result<(), Error> {
         match &*self.internal {
-            DrmSurfaceInternal::Atomic(surf) => surf.commit(framebuffers, event),
+            DrmSurfaceInternal::Atomic(surf) => surf.commit(planes, event),
             DrmSurfaceInternal::Legacy(surf) => {
-                if let Some((fb, plane)) = framebuffers.next() {
-                    if plane_type(self, *plane)? != PlaneType::Primary {
-                        return Err(Error::NonPrimaryPlane(*plane));
-                    }
-                    surf.commit(*fb, event)
-                } else {
-                    Ok(())
-                }
+                let fb = ensure_legacy_planes(self, planes)?;
+                surf.commit(fb, event)
             }
         }
     }
 
     /// Page-flip the underlying [`crtc`](drm::control::crtc)
-    /// to a new given [`framebuffer`].
+    /// to a new given set of [`framebuffer`]s.
     ///
     /// This will not cause the crtc to modeset.
     ///
@@ -246,20 +362,14 @@ impl DrmSurface {
     /// Make sure to have the device registered in your event loop to not miss the event.
     pub fn page_flip<'a>(
         &self,
-        mut framebuffers: impl Iterator<Item = &'a (framebuffer::Handle, plane::Handle)>,
+        planes: impl IntoIterator<Item = PlaneState<'a>>,
         event: bool,
     ) -> Result<(), Error> {
         match &*self.internal {
-            DrmSurfaceInternal::Atomic(surf) => surf.page_flip(framebuffers, event),
+            DrmSurfaceInternal::Atomic(surf) => surf.page_flip(planes, event),
             DrmSurfaceInternal::Legacy(surf) => {
-                if let Some((fb, plane)) = framebuffers.next() {
-                    if plane_type(self, *plane)? != PlaneType::Primary {
-                        return Err(Error::NonPrimaryPlane(*plane));
-                    }
-                    surf.page_flip(*fb, event)
-                } else {
-                    Ok(())
-                }
+                let fb = ensure_legacy_planes(self, planes)?;
+                surf.page_flip(fb, event)
             }
         }
     }
@@ -394,58 +504,13 @@ impl DrmSurface {
 
     /// Returns a set of available planes for this surface
     pub fn planes(&self) -> Result<Planes, Error> {
-        planes(self, &self.crtc, self.has_universal_planes)
-    }
+        let has_universal_planes = match &*self.internal {
+            DrmSurfaceInternal::Atomic(_) => self.has_universal_planes,
+            // Disable the planes on legacy, we do not support them on legacy anyway
+            DrmSurfaceInternal::Legacy(_) => false,
+        };
 
-    /// Tests if a framebuffer can be used with this surface.
-    ///
-    /// # Arguments
-    ///
-    /// - `fb` - Framebuffer handle that has an attached buffer, that shall be tested
-    /// - `mode` - The mode that should be used to display the buffer
-    /// - `allow_screen_change` - If an actual screen change is permitted to carry out this test.
-    ///    If the test cannot be performed otherwise, this function returns false.
-    pub fn test_buffer(
-        &self,
-        fb: framebuffer::Handle,
-        mode: &Mode,
-        allow_screen_change: bool,
-    ) -> Result<bool, Error> {
-        match &*self.internal {
-            DrmSurfaceInternal::Atomic(surf) => surf.test_buffer(fb, mode),
-            DrmSurfaceInternal::Legacy(surf) => {
-                if allow_screen_change {
-                    surf.test_buffer(fb, mode)
-                } else {
-                    Ok(false)
-                }
-            } // There is no test-commiting with the legacy interface
-        }
-    }
-
-    /// Tests if a framebuffer can be used with this surface and a given plane.
-    ///
-    /// # Arguments
-    ///
-    /// - `fb` - Framebuffer handle that has an attached buffer, that shall be tested
-    /// - `plane` - The plane that should be used to display the buffer
-    ///     (only works for *cursor* and *overlay* planes - for primary planes use `test_buffer`)
-    /// - `position` - The position of the plane
-    /// - `size` - The size of the plane
-    ///
-    /// If the test cannot be performed, this function returns false.
-    /// This is always the case for non-atomic surfaces.
-    pub fn test_plane_buffer(
-        &self,
-        fb: framebuffer::Handle,
-        plane: plane::Handle,
-        position: (i32, i32),
-        size: (u32, u32),
-    ) -> Result<bool, Error> {
-        match &*self.internal {
-            DrmSurfaceInternal::Atomic(surf) => surf.test_plane_buffer(fb, plane, position, size),
-            DrmSurfaceInternal::Legacy(_) => Ok(false), // There is no test-commiting with the legacy interface
-        }
+        planes(self, &self.crtc, has_universal_planes)
     }
 
     /// Re-evaluates the current state of the crtc.
@@ -462,4 +527,46 @@ impl DrmSurface {
             DrmSurfaceInternal::Legacy(surf) => surf.reset_state::<Self>(None),
         }
     }
+}
+
+fn ensure_legacy_planes<'a>(
+    dev: &(impl ControlDevice + DevPath),
+    planes: impl IntoIterator<Item = PlaneState<'a>>,
+) -> Result<framebuffer::Handle, Error> {
+    let state = planes.into_iter().next().ok_or(Error::NoPlane)?;
+
+    if plane_type(dev, state.handle)? != PlaneType::Primary {
+        return Err(Error::NonPrimaryPlane(state.handle));
+    }
+
+    let Some(config) = state.config else {
+        // we need a config on the primary plane
+        return Err(Error::NoFramebuffer(state.handle));
+    };
+
+    if config.dst.loc != Point::default() {
+        // legacy does not support crtc position (technically we could do it,
+        // but the position can only be changed by commit, not by page-flip,
+        // so we just not allow it)
+        return Err(Error::UnsupportedPlaneConfiguration(state.handle));
+    }
+
+    if config.src.loc != Point::default()
+        || config
+            .src
+            .size
+            .to_logical(1.0, Transform::Normal)
+            .to_physical(1.0)
+            != config.dst.size.to_f64()
+    {
+        // legacy does not support crop nor scale
+        return Err(Error::UnsupportedPlaneConfiguration(state.handle));
+    }
+
+    if config.transform != Transform::Normal {
+        // legacy does not support transform
+        return Err(Error::UnsupportedPlaneConfiguration(state.handle));
+    }
+
+    Ok(config.fb)
 }

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -598,7 +598,7 @@ impl DamageTrackedRenderer {
                         state
                             .last_instances
                             .iter()
-                            .map(|i| i.last_geometry)
+                            .filter_map(|i| i.last_geometry.intersection(output_geo))
                             .collect::<Vec<_>>(),
                         |damage, opaque_region| {
                             damage
@@ -620,9 +620,18 @@ impl DamageTrackedRenderer {
                 .map(|s| !s.instance_matches(element_geometry, z_index))
                 .unwrap_or(true)
             {
-                let mut element_damage = vec![element_geometry];
+                let mut element_damage = if let Some(damage) = element_geometry.intersection(output_geo) {
+                    vec![damage]
+                } else {
+                    vec![]
+                };
                 if let Some(state) = element_last_state {
-                    element_damage.extend(state.last_instances.iter().map(|i| i.last_geometry));
+                    element_damage.extend(
+                        state
+                            .last_instances
+                            .iter()
+                            .filter_map(|i| i.last_geometry.intersection(output_geo)),
+                    );
                 }
                 damage.extend(
                     opaque_regions

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -687,7 +687,7 @@ impl DamageTrackedRenderer {
 
         // Optimize the damage for rendering
         damage.dedup();
-        damage.retain(|rect| rect.overlaps(output_geo));
+        damage.retain(|rect| rect.overlaps_or_touches(output_geo));
         damage.retain(|rect| !rect.is_empty());
         // filter damage outside of the output gep and merge overlapping rectangles
         *damage = damage
@@ -695,8 +695,9 @@ impl DamageTrackedRenderer {
             .filter_map(|rect| rect.intersection(output_geo))
             .fold(Vec::new(), |new_damage, mut rect| {
                 // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
-                let (overlapping, mut new_damage): (Vec<_>, Vec<_>) =
-                    new_damage.into_iter().partition(|other| other.overlaps(rect));
+                let (overlapping, mut new_damage): (Vec<_>, Vec<_>) = new_damage
+                    .into_iter()
+                    .partition(|other| other.overlaps_or_touches(rect));
 
                 for overlap in overlapping {
                     rect = rect.merge(overlap);

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -19,7 +19,7 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{Frame, ImportMem, Renderer, Texture, TextureFilter},
+//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter},
 //! #     utils::{Buffer, Physical, Rectangle, Size},
 //! # };
 //! # use slog::Drain;
@@ -77,6 +77,12 @@
 //! #         unimplemented!()
 //! #     }
 //! #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
+//! #         unimplemented!()
+//! #     }
+//! #     fn set_debug_flags(&mut self, _: DebugFlags) {
+//! #         unimplemented!()
+//! #     }
+//! #     fn debug_flags(&self) -> DebugFlags {
 //! #         unimplemented!()
 //! #     }
 //! #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -443,7 +443,7 @@ impl<'a> RenderContext<'a> {
 
 impl<'a> Drop for RenderContext<'a> {
     fn drop(&mut self) {
-        self.buffer.damage_tracker.add(&self.damage);
+        self.buffer.damage_tracker.add(std::mem::take(&mut self.damage));
         if let Some(opaque_regions) = self.opaque_regions.take() {
             self.buffer.opaque_regions = opaque_regions;
         }

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -23,7 +23,7 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{Frame, ImportMem, Renderer, Texture, TextureFilter},
+//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter},
 //! #     utils::{Buffer, Physical},
 //! # };
 //! # use slog::Drain;
@@ -81,6 +81,12 @@
 //! #         unimplemented!()
 //! #     }
 //! #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
+//! #         unimplemented!()
+//! #     }
+//! #     fn set_debug_flags(&mut self, _: DebugFlags) {
+//! #         unimplemented!()
+//! #     }
+//! #     fn debug_flags(&self) -> DebugFlags {
 //! #         unimplemented!()
 //! #     }
 //! #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -21,13 +21,15 @@
 use std::{collections::HashMap, sync::Arc};
 
 #[cfg(feature = "wayland_frontend")]
-use wayland_server::{backend::ObjectId, protocol::wl_buffer, Resource};
+use wayland_server::{backend::ObjectId, Resource};
 
 use crate::{
     output::{Output, WeakOutput},
     utils::{Buffer as BufferCoords, Physical, Point, Rectangle, Scale, Transform},
 };
 
+#[cfg(feature = "wayland_frontend")]
+use super::utils::Buffer;
 use super::{utils::CommitCounter, Renderer};
 
 pub mod memory;
@@ -95,7 +97,7 @@ impl<R: Resource> From<&R> for Id {
 pub enum UnderlyingStorage<'a, R: Renderer> {
     /// A wayland buffer
     #[cfg(feature = "wayland_frontend")]
-    Wayland(wl_buffer::WlBuffer),
+    Wayland(Buffer),
     /// A texture
     External(&'a R::TextureId),
 }

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -93,13 +93,11 @@ impl<R: Resource> From<&R> for Id {
 }
 
 /// The underlying storage for a element
-#[derive(Debug)]
-pub enum UnderlyingStorage<'a, R: Renderer> {
+#[derive(Debug, Clone)]
+pub enum UnderlyingStorage {
     /// A wayland buffer
     #[cfg(feature = "wayland_frontend")]
     Wayland(Buffer),
-    /// A texture
-    External(&'a R::TextureId),
 }
 
 /// Defines the presentation state of an element after rendering
@@ -350,7 +348,7 @@ pub trait RenderElement<R: Renderer>: Element {
     ) -> Result<(), R::Error>;
 
     /// Get the underlying storage of this element, may be used to optimize rendering (eg. drm planes)
-    fn underlying_storage(&self, renderer: &R) -> Option<UnderlyingStorage<'_, R>> {
+    fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage> {
         let _ = renderer;
         None
     }
@@ -418,7 +416,7 @@ where
     R: Renderer,
     E: RenderElement<R> + Element,
 {
-    fn underlying_storage(&self, renderer: &R) -> Option<UnderlyingStorage<'_, R>> {
+    fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage> {
         (*self).underlying_storage(renderer)
     }
 
@@ -709,7 +707,7 @@ macro_rules! render_elements_internal {
             }
         }
 
-        fn underlying_storage(&self, renderer: &$renderer) -> Option<$crate::backend::renderer::element::UnderlyingStorage<'_, $renderer>>
+        fn underlying_storage(&self, renderer: &mut $renderer) -> Option<$crate::backend::renderer::element::UnderlyingStorage>
         {
             match self {
                 $(
@@ -745,7 +743,7 @@ macro_rules! render_elements_internal {
             }
         }
 
-        fn underlying_storage(&self, renderer: &$renderer) -> Option<$crate::backend::renderer::element::UnderlyingStorage<'_, $renderer>>
+        fn underlying_storage(&self, renderer: &mut $renderer) -> Option<$crate::backend::renderer::element::UnderlyingStorage>
         {
             match self {
                 $(
@@ -1369,7 +1367,7 @@ where
         self.0.draw(frame, src, dst, damage, log)
     }
 
-    fn underlying_storage(&self, renderer: &R) -> Option<UnderlyingStorage<'_, R>> {
+    fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage> {
         self.0.underlying_storage(renderer)
     }
 }

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -1160,7 +1160,7 @@ macro_rules! render_elements_internal {
 ///
 /// ```
 /// # use smithay::{
-/// #     backend::renderer::{Frame, Renderer, Texture, TextureFilter},
+/// #     backend::renderer::{DebugFlags, Frame, Renderer, Texture, TextureFilter},
 /// #     utils::{Buffer, Physical, Rectangle, Size, Transform},
 /// # };
 /// #
@@ -1217,6 +1217,12 @@ macro_rules! render_elements_internal {
 /// #         unimplemented!()
 /// #     }
 /// #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
+/// #         unimplemented!()
+/// #     }
+/// #     fn set_debug_flags(&mut self, flags: DebugFlags) {
+/// #         unimplemented!()
+/// #     }
+/// #     fn debug_flags(&self) -> DebugFlags {
 /// #         unimplemented!()
 /// #     }
 /// #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -466,7 +466,7 @@ where
     fn underlying_storage(&self, _renderer: &R) -> Option<UnderlyingStorage<'_, R>> {
         compositor::with_states(&self.surface, |states| {
             let data = states.data_map.get::<RendererSurfaceStateUserData>();
-            data.and_then(|d| d.borrow().wl_buffer().cloned())
+            data.and_then(|d| d.borrow().buffer().cloned())
                 .map(|b| UnderlyingStorage::Wayland(b))
         })
     }

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -23,7 +23,7 @@
 //! # use smithay::{
 //! #     backend::allocator::dmabuf::Dmabuf,
 //! #     backend::renderer::{
-//! #         Frame, ImportDma, ImportDmaWl, ImportMem, ImportMemWl, Renderer, Texture,
+//! #         DebugFlags, Frame, ImportDma, ImportDmaWl, ImportMem, ImportMemWl, Renderer, Texture,
 //! #         TextureFilter,
 //! #     },
 //! #     utils::{Buffer, Physical},
@@ -84,6 +84,12 @@
 //! #         unimplemented!()
 //! #     }
 //! #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
+//! #         unimplemented!()
+//! #     }
+//! #     fn set_debug_flags(&mut self, _: DebugFlags) {
+//! #         unimplemented!()
+//! #     }
+//! #     fn debug_flags(&self) -> DebugFlags {
 //! #         unimplemented!()
 //! #     }
 //! #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -463,11 +463,11 @@ where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: Texture + 'static,
 {
-    fn underlying_storage(&self, _renderer: &R) -> Option<UnderlyingStorage<'_, R>> {
+    fn underlying_storage(&self, _renderer: &mut R) -> Option<UnderlyingStorage> {
         compositor::with_states(&self.surface, |states| {
             let data = states.data_map.get::<RendererSurfaceStateUserData>();
             data.and_then(|d| d.borrow().buffer().cloned())
-                .map(|b| UnderlyingStorage::Wayland(b))
+                .map(UnderlyingStorage::Wayland)
         })
     }
 

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -357,7 +357,7 @@ use crate::{
     utils::{Buffer, Coordinate, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
 };
 
-use super::{CommitCounter, Element, Id, RenderElement, UnderlyingStorage};
+use super::{CommitCounter, Element, Id, RenderElement};
 
 /// A single texture buffer
 #[derive(Debug, Clone)]
@@ -815,9 +815,5 @@ where
         }
 
         frame.render_texture_from_to(&self.texture, src, dst, damage, self.transform, self.alpha)
-    }
-
-    fn underlying_storage(&self, _renderer: &R) -> Option<UnderlyingStorage<'_, R>> {
-        Some(UnderlyingStorage::External(&self.texture))
     }
 }

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -501,7 +501,7 @@ impl<T: Texture> TextureRenderBuffer<T> {
     ) -> Result<(), <R as Renderer>::Error> {
         assert_eq!(self.renderer_id, renderer.id());
         renderer.update_memory(&self.texture, data, region)?;
-        self.damage_tracker.lock().unwrap().add(&[region]);
+        self.damage_tracker.lock().unwrap().add([region]);
         self.opaque_regions = opaque_regions;
         Ok(())
     }
@@ -543,7 +543,11 @@ impl<'a, T> RenderContext<'a, T> {
 
 impl<'a, T> Drop for RenderContext<'a, T> {
     fn drop(&mut self) {
-        self.buffer.damage_tracker.lock().unwrap().add(&self.damage);
+        self.buffer
+            .damage_tracker
+            .lock()
+            .unwrap()
+            .add(std::mem::take(&mut self.damage));
         if let Some(opaque_regions) = self.opaque_regions.take() {
             self.buffer.opaque_regions = opaque_regions;
         }

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -41,7 +41,7 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{Frame, ImportMem, Renderer, Texture, TextureFilter},
+//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter},
 //! #     utils::{Buffer, Physical, Rectangle, Size},
 //! # };
 //! # use slog::Drain;
@@ -99,6 +99,12 @@
 //! #         unimplemented!()
 //! #     }
 //! #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
+//! #         unimplemented!()
+//! #     }
+//! #     fn set_debug_flags(&mut self, _: DebugFlags) {
+//! #         unimplemented!()
+//! #     }
+//! #     fn debug_flags(&self) -> DebugFlags {
 //! #         unimplemented!()
 //! #     }
 //! #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>
@@ -172,7 +178,7 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{Frame, ImportMem, Renderer, Texture, TextureFilter},
+//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter},
 //! #     utils::{Buffer, Physical},
 //! # };
 //! # use slog::Drain;
@@ -230,6 +236,12 @@
 //! #         unimplemented!()
 //! #     }
 //! #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
+//! #         unimplemented!()
+//! #     }
+//! #     fn set_debug_flags(&mut self, _: DebugFlags) {
+//! #         unimplemented!()
+//! #     }
+//! #     fn debug_flags(&self) -> DebugFlags {
 //! #         unimplemented!()
 //! #     }
 //! #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>

--- a/src/backend/renderer/element/utils.rs
+++ b/src/backend/renderer/element/utils.rs
@@ -97,7 +97,7 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RescaleRenderElement
         self.element.draw(frame, src, dst, damage, log)
     }
 
-    fn underlying_storage(&self, renderer: &R) -> Option<super::UnderlyingStorage<'_, R>> {
+    fn underlying_storage(&self, renderer: &mut R) -> Option<super::UnderlyingStorage> {
         self.element.underlying_storage(renderer)
     }
 }
@@ -269,7 +269,7 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for CropRenderElement<E>
         self.element.draw(frame, src, dst, damage, log)
     }
 
-    fn underlying_storage(&self, renderer: &R) -> Option<super::UnderlyingStorage<'_, R>> {
+    fn underlying_storage(&self, renderer: &mut R) -> Option<super::UnderlyingStorage> {
         self.element.underlying_storage(renderer)
     }
 }
@@ -362,7 +362,7 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RelocateRenderElemen
         self.element.draw(frame, src, dst, damage, log)
     }
 
-    fn underlying_storage(&self, renderer: &R) -> Option<super::UnderlyingStorage<'_, R>> {
+    fn underlying_storage(&self, renderer: &mut R) -> Option<super::UnderlyingStorage> {
         self.element.underlying_storage(renderer)
     }
 }

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -24,7 +24,7 @@ mod shaders;
 mod version;
 
 use super::{
-    Bind, Blit, ExportDma, ExportMem, Frame, ImportDma, ImportMem, Offscreen, Renderer, Texture,
+    Bind, Blit, DebugFlags, ExportDma, ExportMem, Frame, ImportDma, ImportMem, Offscreen, Renderer, Texture,
     TextureFilter, TextureMapping, Unbind,
 };
 use crate::backend::allocator::{
@@ -63,6 +63,7 @@ struct Gles2TexProgram {
     uniform_tex_matrix: ffi::types::GLint,
     uniform_matrix: ffi::types::GLint,
     uniform_alpha: ffi::types::GLint,
+    uniform_tint: ffi::types::GLint,
     attrib_vert: ffi::types::GLint,
     attrib_vert_position: ffi::types::GLint,
 }
@@ -288,6 +289,7 @@ pub struct Gles2Renderer {
     supports_instancing: bool,
     logger_ptr: Option<*mut ::slog::Logger>,
     pub(crate) logger: ::slog::Logger,
+    debug_flags: DebugFlags,
     _not_send: *mut (),
 }
 
@@ -528,6 +530,7 @@ unsafe fn texture_program(gl: &ffi::Gles2, frag: &'static str) -> Result<Gles2Te
     let matrix = CStr::from_bytes_with_nul(b"matrix\0").expect("NULL terminated");
     let tex_matrix = CStr::from_bytes_with_nul(b"tex_matrix\0").expect("NULL terminated");
     let alpha = CStr::from_bytes_with_nul(b"alpha\0").expect("NULL terminated");
+    let tint = CStr::from_bytes_with_nul(b"tint\0").expect("NULL terminated");
 
     Ok(Gles2TexProgram {
         program,
@@ -535,6 +538,7 @@ unsafe fn texture_program(gl: &ffi::Gles2, frag: &'static str) -> Result<Gles2Te
         uniform_matrix: gl.GetUniformLocation(program, matrix.as_ptr() as *const ffi::types::GLchar),
         uniform_tex_matrix: gl.GetUniformLocation(program, tex_matrix.as_ptr() as *const ffi::types::GLchar),
         uniform_alpha: gl.GetUniformLocation(program, alpha.as_ptr() as *const ffi::types::GLchar),
+        uniform_tint: gl.GetUniformLocation(program, tint.as_ptr() as *const ffi::types::GLchar),
         attrib_vert: gl.GetAttribLocation(program, vert.as_ptr() as *const ffi::types::GLchar),
         attrib_vert_position: gl
             .GetAttribLocation(program, vert_position.as_ptr() as *const ffi::types::GLchar),
@@ -695,6 +699,7 @@ impl Gles2Renderer {
             supports_instancing,
             logger_ptr,
             logger: log,
+            debug_flags: DebugFlags::empty(),
             _not_send: std::ptr::null_mut(),
         };
         renderer.egl.unbind()?;
@@ -1927,6 +1932,14 @@ impl Renderer for Gles2Renderer {
             finished: AtomicBool::new(false),
         })
     }
+
+    fn set_debug_flags(&mut self, flags: DebugFlags) {
+        self.debug_flags = flags;
+    }
+
+    fn debug_flags(&self) -> DebugFlags {
+        self.debug_flags
+    }
 }
 
 /// Vertices for instanced rendering.
@@ -2300,6 +2313,12 @@ impl<'frame> Gles2Frame<'frame> {
                 self.renderer.tex_programs[tex.0.texture_kind].uniform_alpha,
                 alpha,
             );
+            let tint = if self.renderer.debug_flags.contains(DebugFlags::TINT) {
+                1.0f32
+            } else {
+                0.0f32
+            };
+            gl.Uniform1f(self.renderer.tex_programs[tex.0.texture_kind].uniform_tint, tint);
 
             gl.EnableVertexAttribArray(self.renderer.tex_programs[tex.0.texture_kind].attrib_vert as u32);
             gl.BindBuffer(ffi::ARRAY_BUFFER, self.renderer.vbos[0]);

--- a/src/backend/renderer/gles2/shaders.rs
+++ b/src/backend/renderer/gles2/shaders.rs
@@ -36,9 +36,17 @@ precision mediump float;
 uniform sampler2D tex;
 uniform float alpha;
 varying vec2 v_tex_coords;
+uniform float tint;
 
 void main() {
-    gl_FragColor = texture2D(tex, v_tex_coords) * alpha;
+    vec4 color;
+
+    color = texture2D(tex, v_tex_coords) * alpha;
+
+    if (tint == 1.0)
+        color = vec4(0.0, 0.3, 0.0, 0.2) + color * 0.8;
+
+    gl_FragColor = color;
 }
 "#;
 
@@ -49,9 +57,17 @@ precision mediump float;
 uniform sampler2D tex;
 uniform float alpha;
 varying vec2 v_tex_coords;
+uniform float tint;
 
 void main() {
-    gl_FragColor = vec4(texture2D(tex, v_tex_coords).rgb, 1.0) * alpha;
+    vec4 color;
+
+    color = vec4(texture2D(tex, v_tex_coords).rgb, 1.0) * alpha;
+
+    if (tint == 1.0)
+        color = vec4(0.0, 0.3, 0.0, 0.2) + color * 0.8;
+
+    gl_FragColor = color;
 }
 "#;
 
@@ -63,9 +79,17 @@ precision mediump float;
 uniform samplerExternalOES tex;
 uniform float alpha;
 varying vec2 v_tex_coords;
+uniform float tint;
 
 void main() {
-    gl_FragColor = texture2D(tex, v_tex_coords) * alpha;
+    vec4 color;
+
+    color = texture2D(tex, v_tex_coords) * alpha;
+
+    if (tint == 1.0)
+        color = vec4(0.0, 0.3, 0.0, 0.2) + color * 0.8;
+
+    gl_FragColor = color;
 }
 "#;
 

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -13,8 +13,8 @@ use crate::{
         allocator::{dmabuf::Dmabuf, Format},
         egl::EGLContext,
         renderer::{
-            gles2::*, Bind, Blit, ExportDma, ExportMem, ImportDma, ImportMem, Offscreen, Renderer,
-            TextureFilter, Unbind,
+            gles2::*, Bind, Blit, DebugFlags, ExportDma, ExportMem, ImportDma, ImportMem, Offscreen,
+            Renderer, TextureFilter, Unbind,
         },
     },
     utils::{Buffer as BufferCoord, Physical, Rectangle, Size, Transform},
@@ -175,6 +175,13 @@ impl Renderer for GlowRenderer {
     }
     fn upscale_filter(&mut self, filter: TextureFilter) -> Result<(), Self::Error> {
         self.gl.upscale_filter(filter)
+    }
+
+    fn set_debug_flags(&mut self, flags: DebugFlags) {
+        self.gl.set_debug_flags(flags)
+    }
+    fn debug_flags(&self) -> DebugFlags {
+        self.gl.debug_flags()
     }
 
     fn render(

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -207,6 +207,13 @@ pub trait Frame {
     fn finish(self) -> Result<(), Self::Error>;
 }
 
+bitflags::bitflags! {
+    /// Debug flags that can be enabled at runtime
+    pub struct DebugFlags: u32 {
+        /// Tint all rendered textures
+        const TINT = 0b00000001;
+    }
+}
 /// Abstraction of commonly used rendering operations for compositors.
 pub trait Renderer {
     /// Error type returned by the rendering operations of this renderer.
@@ -226,6 +233,11 @@ pub trait Renderer {
     fn downscale_filter(&mut self, filter: TextureFilter) -> Result<(), Self::Error>;
     /// Set the filter method to be used when rendering a texture into a larger area than its size
     fn upscale_filter(&mut self, filter: TextureFilter) -> Result<(), Self::Error>;
+
+    /// Set the enabled [`DebugFlags`]
+    fn set_debug_flags(&mut self, flags: DebugFlags);
+    /// Returns the current enabled [`DebugFlags`]
+    fn debug_flags(&self) -> DebugFlags;
 
     /// Initialize a rendering context on the current rendering target with given dimensions and transformation.
     ///

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -420,8 +420,9 @@ impl<A: GraphicsApi> GpuManager<A> {
                                 Vec::<Rectangle<i32, BufferCoords>>::new(),
                                 |damage, mut rect| {
                                     // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
-                                    let (overlapping, mut new_damage): (Vec<_>, Vec<_>) =
-                                        damage.into_iter().partition(|other| other.overlaps(rect));
+                                    let (overlapping, mut new_damage): (Vec<_>, Vec<_>) = damage
+                                        .into_iter()
+                                        .partition(|other| other.overlaps_or_touches(rect));
 
                                     for overlap in overlapping {
                                         rect = rect.merge(overlap);
@@ -538,8 +539,9 @@ impl<A: GraphicsApi> GpuManager<A> {
                                 })
                                 .fold(Vec::<Rectangle<i32, BufferCoords>>::new(), |damage, mut rect| {
                                     // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
-                                    let (overlapping, mut new_damage): (Vec<_>, Vec<_>) =
-                                        damage.into_iter().partition(|other| other.overlaps(rect));
+                                    let (overlapping, mut new_damage): (Vec<_>, Vec<_>) = damage
+                                        .into_iter()
+                                        .partition(|other| other.overlaps_or_touches(rect));
 
                                     for overlap in overlapping {
                                         rect = rect.merge(overlap);
@@ -1119,7 +1121,9 @@ where
 
                 // cpu copy
                 damage.dedup();
-                damage.retain(|rect| rect.overlaps(Rectangle::from_loc_and_size((0, 0), buffer_size)));
+                damage.retain(|rect| {
+                    rect.overlaps_or_touches(Rectangle::from_loc_and_size((0, 0), buffer_size))
+                });
                 damage.retain(|rect| rect.size.h > 0 && rect.size.w > 0);
 
                 let mut copy_rects = // merge overlapping rectangles
@@ -1127,7 +1131,7 @@ where
                         // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
                         let (overlapping, mut new_damage): (Vec<_>, Vec<_>) = new_damage
                             .into_iter()
-                            .partition(|other: &Rectangle<i32, BufferCoords>| other.overlaps(rect));
+                            .partition(|other: &Rectangle<i32, BufferCoords>| other.overlaps_or_touches(rect));
 
                         for overlap in overlapping {
                             rect = rect.merge(overlap);
@@ -1710,8 +1714,9 @@ where
                 .flat_map(|rect| rect.intersection(Rectangle::from_loc_and_size((0, 0), dmabuf.size())))
                 .fold(Vec::<Rectangle<i32, BufferCoords>>::new(), |damage, mut rect| {
                     // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
-                    let (overlapping, mut new_damage): (Vec<_>, Vec<_>) =
-                        damage.into_iter().partition(|other| other.overlaps(rect));
+                    let (overlapping, mut new_damage): (Vec<_>, Vec<_>) = damage
+                        .into_iter()
+                        .partition(|other| other.overlaps_or_touches(rect));
 
                     for overlap in overlapping {
                         rect = rect.merge(overlap);

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -909,6 +909,13 @@ where
             .map_err(Error::Render)
     }
 
+    fn set_debug_flags(&mut self, flags: DebugFlags) {
+        self.render.renderer_mut().set_debug_flags(flags)
+    }
+    fn debug_flags(&self) -> DebugFlags {
+        self.render.renderer().debug_flags()
+    }
+
     fn render<'frame>(
         &'frame mut self,
         size: Size<i32, Physical>,

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -216,7 +216,9 @@ impl<N: Coordinate, Kind> DamageTrackerSnapshot<N, Kind> {
         }
     }
 
-    fn add(&mut self, damage: &[Rectangle<N, Kind>]) {
+    fn add(&mut self, damage: impl IntoIterator<Item = Rectangle<N, Kind>>) {
+        let damage = damage.into_iter().collect::<Vec<_>>();
+
         if damage.is_empty() || damage.iter().all(|d| d.is_empty()) {
             // do not track empty damage
             return;
@@ -273,7 +275,7 @@ impl<N: Clone, Kind> DamageTracker<N, Kind> {
 
 impl<N: Coordinate, Kind> DamageTracker<N, Kind> {
     /// Add some damage to the tracker
-    pub fn add(&mut self, damage: &[Rectangle<N, Kind>]) {
+    pub fn add(&mut self, damage: impl IntoIterator<Item = Rectangle<N, Kind>>) {
         self.state.add(damage)
     }
 

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -178,7 +178,7 @@ impl RendererSurfaceState {
                                     RectangleKind::Add => {
                                         let added_regions = new_regions
                                             .iter()
-                                            .filter(|region| region.overlaps(rect))
+                                            .filter(|region| region.overlaps_or_touches(rect))
                                             .fold(vec![rect], |new_regions, existing_region| {
                                                 new_regions
                                                     .into_iter()
@@ -584,8 +584,9 @@ where
         .into_iter()
         .fold(Vec::new(), |new_damage, mut rect| {
             // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
-            let (overlapping, mut new_damage): (Vec<_>, Vec<_>) =
-                new_damage.into_iter().partition(|other| other.overlaps(rect));
+            let (overlapping, mut new_damage): (Vec<_>, Vec<_>) = new_damage
+                .into_iter()
+                .partition(|other| other.overlaps_or_touches(rect));
 
             for overlap in overlapping {
                 rect = rect.merge(overlap);

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -10,6 +10,7 @@ use crate::{
         viewporter,
     },
 };
+use std::sync::Arc;
 use std::{
     any::TypeId,
     cell::RefCell,
@@ -37,7 +38,7 @@ pub struct RendererSurfaceState {
     pub(crate) buffer_transform: Transform,
     pub(crate) buffer_delta: Option<Point<i32, Logical>>,
     pub(crate) buffer_has_alpha: Option<bool>,
-    pub(crate) buffer: Option<WlBuffer>,
+    pub(crate) buffer: Option<Buffer>,
     pub(crate) damage: DamageTracker<i32, BufferCoord>,
     pub(crate) renderer_seen: HashMap<(TypeId, usize), CommitCounter>,
     pub(crate) textures: HashMap<(TypeId, usize), Box<dyn std::any::Any>>,
@@ -45,6 +46,49 @@ pub struct RendererSurfaceState {
     pub(crate) opaque_regions: Vec<Rectangle<i32, Logical>>,
 
     accumulated_buffer_delta: Point<i32, Logical>,
+}
+
+#[derive(Debug)]
+struct InnerBuffer(WlBuffer);
+
+impl Drop for InnerBuffer {
+    fn drop(&mut self) {
+        self.0.release();
+    }
+}
+
+/// A wayland buffer
+#[derive(Debug, Clone)]
+pub struct Buffer {
+    inner: Arc<InnerBuffer>,
+}
+
+impl From<WlBuffer> for Buffer {
+    fn from(buffer: WlBuffer) -> Self {
+        Buffer {
+            inner: Arc::new(InnerBuffer(buffer)),
+        }
+    }
+}
+
+impl std::ops::Deref for Buffer {
+    type Target = WlBuffer;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.0
+    }
+}
+
+impl PartialEq<WlBuffer> for Buffer {
+    fn eq(&self, other: &WlBuffer) -> bool {
+        self.inner.0 == *other
+    }
+}
+
+impl PartialEq<WlBuffer> for &Buffer {
+    fn eq(&self, other: &WlBuffer) -> bool {
+        self.inner.0 == *other
+    }
 }
 
 impl RendererSurfaceState {
@@ -69,11 +113,10 @@ impl RendererSurfaceState {
                 self.buffer_scale = attrs.buffer_scale;
                 self.buffer_transform = attrs.buffer_transform.into();
 
-                if let Some(old_buffer) = std::mem::replace(&mut self.buffer, Some(buffer)) {
-                    if &old_buffer != self.buffer.as_ref().unwrap() {
-                        old_buffer.release();
-                    }
+                if !self.buffer.as_ref().map_or(false, |b| b == buffer) {
+                    self.buffer = Some(Buffer::from(buffer));
                 }
+
                 self.textures.clear();
 
                 let surface_size = self
@@ -162,9 +205,7 @@ impl RendererSurfaceState {
             Some(BufferAssignment::Removed) => {
                 // remove the contents
                 self.buffer_dimensions = None;
-                if let Some(buffer) = self.buffer.take() {
-                    buffer.release();
-                };
+                self.buffer = None;
                 self.textures.clear();
                 self.damage.reset();
                 self.surface_view = None;
@@ -218,7 +259,7 @@ impl RendererSurfaceState {
 
     /// Get the attached buffer.
     /// Can be used to check if surface is mapped
-    pub fn wl_buffer(&self) -> Option<&WlBuffer> {
+    pub fn buffer(&self) -> Option<&Buffer> {
         self.buffer.as_ref()
     }
 

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -145,7 +145,7 @@ impl RendererSurfaceState {
                     })
                     .collect::<Vec<Rectangle<i32, BufferCoord>>>();
                 buffer_damage.dedup();
-                self.damage.add(&buffer_damage);
+                self.damage.add(buffer_damage);
 
                 self.opaque_regions.clear();
                 if !self.buffer_has_alpha.unwrap_or(true) {

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -952,17 +952,6 @@ impl<N: Coordinate, Kind> SubAssign for Size<N, Kind> {
     }
 }
 
-impl<N: Coordinate, Kind> PartialOrd<Size<N, Kind>> for Size<N, Kind> {
-    #[inline]
-    fn partial_cmp(&self, other: &Size<N, Kind>) -> Option<std::cmp::Ordering> {
-        match self.w.partial_cmp(&other.w) {
-            Some(core::cmp::Ordering::Equal) => {}
-            ord => return ord,
-        }
-        self.h.partial_cmp(&other.h)
-    }
-}
-
 impl<N: Coordinate + Div<Output = N>, KindLhs, KindRhs> Div<Size<N, KindRhs>> for Size<N, KindLhs> {
     type Output = Scale<N>;
 

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -164,7 +164,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
             let _ = render_output(
                 &output,
                 &state.space,
-                &elements,
+                elements,
                 &mut renderer,
                 &mut damage_tracked_renderer,
                 0,

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -4,7 +4,7 @@ use smithay::{
     backend::{
         allocator::dmabuf::Dmabuf,
         renderer::{
-            Frame, ImportDma, ImportDmaWl, ImportEgl, ImportMem, ImportMemWl, Renderer, Texture,
+            DebugFlags, Frame, ImportDma, ImportDmaWl, ImportEgl, ImportMem, ImportMemWl, Renderer, Texture,
             TextureFilter,
         },
         SwapBuffersError,
@@ -45,6 +45,12 @@ impl Renderer for DummyRenderer {
 
     fn downscale_filter(&mut self, _filter: TextureFilter) -> Result<(), Self::Error> {
         Ok(())
+    }
+
+    fn set_debug_flags(&mut self, _flags: DebugFlags) {}
+
+    fn debug_flags(&self) -> DebugFlags {
+        DebugFlags::empty()
     }
 }
 


### PR DESCRIPTION
## Current limitations

- ~~no support for screen-capture~~ `DrmCompositor::render_frame` now returns a reference to everything needed to implement screencopy. Additional the returned struct implements functions for blitting the frame to a bound buffer.
- ~~cursor plane known to not work on nvidia (probably related to not using bo flags Cursor)~~ switched to gbm bo write and offscreen rendering -> works now
- ~~underlay/primary plane direct-scan out check could be relaxed~~ the primary plane can now be used for direct scan-out in more edge cases
## TODO

- [X] anvil: use `GbmBufferedSurface` as a fallback (or compile time feature)? -> The old behavior can be forced by setting the `ANVIL_DISABLE_DRM_COMPOSITOR` env variable