### PR TITLE
desktop: Fix handling for output_enter/leave events

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -861,7 +861,7 @@ fn render_surface<'a>(
     ));
     input_method.with_surface(|surface| {
         elements.extend(AsRenderElements::<UdevRenderer<'a>>::render_elements(
-            &SurfaceTree::from_surface(surface, position),
+            &SurfaceTree::from_surface(surface),
             position.to_physical_precise_round(scale),
             scale,
         ));
@@ -908,7 +908,7 @@ fn render_surface<'a>(
             if let Some(wl_surface) = dnd_icon.as_ref() {
                 if wl_surface.alive() {
                     elements.extend(AsRenderElements::<UdevRenderer<'a>>::render_elements(
-                        &SurfaceTree::from_surface(wl_surface, cursor_pos.to_i32_round()),
+                        &SurfaceTree::from_surface(wl_surface),
                         cursor_pos_scaled,
                         scale,
                     ));

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -266,7 +266,7 @@ pub fn run_winit(log: Logger) {
                 ));
                 input_method.with_surface(|surface| {
                     elements.extend(AsRenderElements::<Gles2Renderer>::render_elements(
-                        &smithay::desktop::space::SurfaceTree::from_surface(surface, position),
+                        &smithay::desktop::space::SurfaceTree::from_surface(surface),
                         position.to_physical_precise_round(scale),
                         scale,
                     ));
@@ -276,10 +276,7 @@ pub fn run_winit(log: Logger) {
                 if let Some(surface) = dnd_icon {
                     if surface.alive() {
                         elements.extend(AsRenderElements::<Gles2Renderer>::render_elements(
-                            &smithay::desktop::space::SurfaceTree::from_surface(
-                                surface,
-                                cursor_pos.to_i32_round(),
-                            ),
+                            &smithay::desktop::space::SurfaceTree::from_surface(surface),
                             cursor_pos_scaled,
                             scale,
                         ));

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -296,7 +296,7 @@ pub fn run_x11(log: Logger) {
             ));
             input_method.with_surface(|surface| {
                 elements.extend(AsRenderElements::<Gles2Renderer>::render_elements(
-                    &smithay::desktop::space::SurfaceTree::from_surface(surface, position),
+                    &smithay::desktop::space::SurfaceTree::from_surface(surface),
                     position.to_physical_precise_round(scale),
                     scale,
                 ));
@@ -306,10 +306,7 @@ pub fn run_x11(log: Logger) {
             if let Some(surface) = state.dnd_icon.as_ref() {
                 if surface.alive() {
                     elements.extend(AsRenderElements::<Gles2Renderer>::render_elements(
-                        &smithay::desktop::space::SurfaceTree::from_surface(
-                            surface,
-                            cursor_pos.to_i32_round(),
-                        ),
+                        &smithay::desktop::space::SurfaceTree::from_surface(surface),
                         cursor_pos_scaled,
                         scale,
                     ));

--- a/src/desktop/space/element/wayland.rs
+++ b/src/desktop/space/element/wayland.rs
@@ -1,26 +1,20 @@
 use crate::{
     backend::renderer::Renderer,
     desktop::space::*,
-    output::Output,
-    utils::{Logical, Physical, Point, Rectangle, Scale},
+    utils::{Physical, Point, Scale},
 };
-use crate::{
-    desktop::utils as desktop_utils,
-    wayland::compositor::{with_surface_tree_downward, TraversalAction},
-};
+use wayland_server::protocol::wl_surface::WlSurface;
 
 /// A custom surface tree
 #[derive(Debug)]
 pub struct SurfaceTree {
-    location: Point<i32, Logical>,
     surface: WlSurface,
 }
 
 impl SurfaceTree {
     /// Create a surface tree from a surface
-    pub fn from_surface(surface: &WlSurface, location: impl Into<Point<i32, Logical>>) -> Self {
+    pub fn from_surface(surface: &WlSurface) -> Self {
         SurfaceTree {
-            location: location.into(),
             surface: surface.clone(),
         }
     }
@@ -29,45 +23,6 @@ impl SurfaceTree {
 impl IsAlive for SurfaceTree {
     fn alive(&self) -> bool {
         self.surface.alive()
-    }
-}
-
-impl SpaceElement for SurfaceTree {
-    fn geometry(&self) -> Rectangle<i32, Logical> {
-        self.bbox()
-    }
-
-    fn bbox(&self) -> Rectangle<i32, Logical> {
-        desktop_utils::bbox_from_surface_tree(&self.surface, self.location)
-    }
-
-    fn is_in_input_region(&self, point: &Point<f64, Logical>) -> bool {
-        desktop_utils::under_from_surface_tree(&self.surface, *point, (0, 0), WindowSurfaceType::ALL)
-            .is_some()
-    }
-
-    fn set_activate(&self, _activated: bool) {}
-    fn output_enter(&self, output: &Output) {
-        with_surface_tree_downward(
-            &self.surface,
-            (),
-            |_, _, _| TraversalAction::DoChildren(()),
-            |wl_surface, _, _| {
-                output.enter(wl_surface);
-            },
-            |_, _, _| true,
-        );
-    }
-    fn output_leave(&self, output: &Output) {
-        with_surface_tree_downward(
-            &self.surface,
-            (),
-            |_, _, _| TraversalAction::DoChildren(()),
-            |wl_surface, _, _| {
-                output.leave(wl_surface);
-            },
-            |_, _, _| true,
-        );
     }
 }
 

--- a/src/desktop/space/wayland/layer.rs
+++ b/src/desktop/space/wayland/layer.rs
@@ -6,45 +6,9 @@ use crate::{
         },
         ImportAll, Renderer,
     },
-    desktop::{
-        space::{RenderZindex, SpaceElement},
-        LayerSurface, PopupManager, WindowSurfaceType,
-    },
-    output::Output,
-    utils::{Logical, Physical, Point, Rectangle, Scale},
-    wayland::shell::wlr_layer::Layer,
+    desktop::{LayerSurface, PopupManager},
+    utils::{Physical, Point, Scale},
 };
-
-impl SpaceElement for LayerSurface {
-    fn geometry(&self) -> Rectangle<i32, Logical> {
-        self.bbox_with_popups()
-    }
-    fn bbox(&self) -> Rectangle<i32, Logical> {
-        self.bbox_with_popups()
-    }
-    fn is_in_input_region(&self, point: &Point<f64, Logical>) -> bool {
-        self.surface_under(*point, WindowSurfaceType::ALL).is_some()
-    }
-    /// Gets the z-index of this element on the specified space
-    fn z_index(&self) -> u8 {
-        let layer = self.layer();
-        let z_index = match layer {
-            Layer::Background => RenderZindex::Background,
-            Layer::Bottom => RenderZindex::Bottom,
-            Layer::Top => RenderZindex::Top,
-            Layer::Overlay => RenderZindex::Overlay,
-        };
-        z_index as u8
-    }
-
-    fn set_activate(&self, _activated: bool) {}
-    fn output_enter(&self, output: &Output) {
-        output.enter(self.wl_surface())
-    }
-    fn output_leave(&self, output: &Output) {
-        output.leave(self.wl_surface())
-    }
-}
 
 impl<R> AsRenderElements<R> for LayerSurface
 where

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -111,7 +111,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
             ));
             input_method.with_surface(|surface| {
                 elements.extend(AsRenderElements::<DummyRenderer>::render_elements(
-                    &smithay::desktop::space::SurfaceTree::from_surface(surface, position),
+                    &smithay::desktop::space::SurfaceTree::from_surface(surface),
                     position.to_physical_precise_round(scale),
                     scale,
                 ));
@@ -150,10 +150,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
             if let Some(surface) = state.dnd_icon.as_ref() {
                 if surface.alive() {
                     elements.extend(AsRenderElements::<DummyRenderer>::render_elements(
-                        &smithay::desktop::space::SurfaceTree::from_surface(
-                            surface,
-                            cursor_pos.to_i32_round(),
-                        ),
+                        &smithay::desktop::space::SurfaceTree::from_surface(surface),
                         cursor_pos_scaled,
                         scale,
                     ));


### PR DESCRIPTION
@cmeissl This is an attempt to handle all edge-cases around output_enter/leave events with the new generic space.

- `SurfaceTree` is not really mapped by anything, remove `SpaceElement`-impl and just provide `AsRenderElements` (TODO: Implement it directly for `WlSurface`?)
- `LayerSurface` is not mapped, but belongs to an `Output`, so also remove its `SpaceElement`-implementation
- `Window`s consist of multiple surfaces and can be on multiple outputs simultaniously. This means some surfaces might not be inside one outputs bounds, we thus need to provide `output_enter` and `refresh` with positioning information to allow for multiplexing this call correctly
- Additionally surfaces can be destroyed and created at any point, so `refresh` needs to recalculate outputs.

Note: The code for output-tracking for windows is pretty gross. Especially where it creates a `WeakOutput` to avoid any possible reference-cycles. This is the only piece of code requiring such a handle for now, so we might just leave that as is??
But I would clean this up significantly with a proper `WeakOutput` type. Or is that over-engineering?

Do you have some suggestions on the various approaches? And more importantly, do you see any edge-cases, where a sub-surface/popup might not receive the correct enter/leave events?