### PR TITLE
WIP API to correctly handle modifiers in X/Wayland backends

### DIFF
--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -100,6 +100,8 @@ pub trait KeyboardKeyEvent<B: InputBackend>: Event<B> {
 
     /// Total number of keys pressed on all devices on the associated [`Seat`](crate::input::Seat)
     fn count(&self) -> u32;
+
+    fn update_state(&self) -> bool;
 }
 
 impl<B: InputBackend> KeyboardKeyEvent<B> for UnusedEvent {
@@ -112,6 +114,10 @@ impl<B: InputBackend> KeyboardKeyEvent<B> for UnusedEvent {
     }
 
     fn count(&self) -> u32 {
+        match *self {}
+    }
+
+    fn update_state(&self) -> bool {
         match *self {}
     }
 }

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -151,6 +151,10 @@ impl backend::KeyboardKeyEvent<LibinputInputBackend> for event::keyboard::Keyboa
     fn count(&self) -> u32 {
         self.seat_key_count()
     }
+
+    fn update_state(&self) -> bool {
+        true
+    }
 }
 
 impl backend::Event<LibinputInputBackend> for event::pointer::PointerAxisEvent {

--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -78,6 +78,10 @@ impl KeyboardKeyEvent<WinitInput> for WinitKeyboardInputEvent {
     fn count(&self) -> u32 {
         self.count
     }
+
+    fn update_state(&self) -> bool {
+        true
+    }
 }
 
 /// Winit-Backend internal event wrapping `winit`'s types into a [`PointerMotionAbsoluteEvent`]

--- a/src/backend/x11/input.rs
+++ b/src/backend/x11/input.rs
@@ -85,6 +85,10 @@ impl KeyboardKeyEvent<X11Input> for X11KeyboardInputEvent {
     fn count(&self) -> u32 {
         self.count
     }
+
+    fn update_state(&self) -> bool {
+        true
+    }
 }
 
 /// X11-Backend internal event wrapping `X11`'s types into a [`PointerAxisEvent`]

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -123,7 +123,7 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
     }
 
     // return true if modifier state has changed
-    fn key_input(&mut self, keycode: u32, state: KeyState) -> bool {
+    fn key_input(&mut self, keycode: u32, state: KeyState, update_state: bool) -> bool {
         // track pressed keys as xkbcommon does not seem to expose it :(
         let direction = match state {
             KeyState::Pressed => {
@@ -136,11 +136,26 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
             }
         };
 
-        // update state
-        // Offset the keycode by 8, as the evdev XKB rules reflect X's
-        // broken keycode system, which starts at 8.
-        let state_components = self.state.update_key(keycode + 8, direction);
+        if update_state {
+            // Offset the keycode by 8, as the evdev XKB rules reflect X's
+            // broken keycode system, which starts at 8.
+            let state_components = self.state.update_key(keycode + 8, direction);
 
+            if state_components != 0 {
+                self.mods_state.update_with(&self.state);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    fn modifiers(&mut self, mods_depressed: u32, mods_latched: u32, mods_locked: u32, group: u32) -> bool {
+        let state_components = self
+            .state
+            .update_mask(mods_depressed, mods_latched, mods_locked, group, 0, 0);
         if state_components != 0 {
             self.mods_state.update_with(&self.state);
             true
@@ -494,6 +509,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         state: KeyState,
         serial: Serial,
         time: u32,
+        update_state: bool,
         filter: F,
     ) -> Option<T>
     where
@@ -501,7 +517,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     {
         trace!(self.arc.logger, "Handling keystroke"; "keycode" => keycode, "state" => format_args!("{:?}", state));
         let mut guard = self.arc.internal.lock().unwrap();
-        let mods_changed = guard.key_input(keycode, state);
+        let mods_changed = guard.key_input(keycode, state, update_state);
         let key_handle = KeysymHandle {
             // Offset the keycode by 8, as the evdev XKB rules reflect X's
             // broken keycode system, which starts at 8.
@@ -537,6 +553,18 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         }
 
         None
+    }
+
+    pub fn modifiers(
+        &self,
+        serial: Serial,
+        mods_depressed: u32,
+        mods_latched: u32,
+        mods_locked: u32,
+        group: u32,
+    ) {
+        let mut guard = self.arc.internal.lock().unwrap();
+        let mods_changed = guard.modifiers(mods_depressed, mods_latched, mods_locked, group);
     }
 
     /// Set the current focus of this keyboard


### PR DESCRIPTION
A start on trying to implement https://github.com/Smithay/smithay/issues/751. Some improvement here will be needed to make both the X and Wayland backends behave properly.

As seen in https://github.com/Smithay/smithay/issues/646, the current way `xkb::State` is updated can lead to problems in the X backend since

Reading libxkbcommon's documentation, I've concluded `KeyboardHandle::input` should take a bool determining whether or not `xkb::State::update_key` is called, and another method that calls `xkb::State::update_mask`. It turns out this is quite similar to how it's done in wlroots.

In `struct wlr_keyboard_key_event`, there's a `bool update_state` member. Does it make sense to add this `KeyboardKeyEvent` and have another `KeyboardModifiersEvent`? Or is there another way this could be represented in the events from the backend?

Wlroots' X backend seems to call `update_mask` then `update_key` in response to every press or release, since the X events have a modifier mask but it represents the modifiers before the current press/release event. Not sure how that compares to other possible implementations.

I'm not sure how the `KeyboardGrab::input` API should be impacted by this.