### PR TITLE
Replace Vec for tracking of pressed keys with HashSet

### DIFF
--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -3,6 +3,7 @@
 use crate::backend::input::KeyState;
 use crate::utils::{IsAlive, Serial};
 use slog::{debug, error, info, o, trace};
+use std::collections::HashSet;
 use std::{
     default::Default,
     ffi::CString,
@@ -57,7 +58,7 @@ enum GrabStatus<D> {
 pub(crate) struct KbdInternal<D: SeatHandler> {
     pub(crate) focus: Option<(<D as SeatHandler>::KeyboardFocus, Serial)>,
     pending_focus: Option<<D as SeatHandler>::KeyboardFocus>,
-    pub(crate) pressed_keys: Vec<u32>,
+    pub(crate) pressed_keys: HashSet<u32>,
     pub(crate) mods_state: ModifiersState,
     keymap: xkb::Keymap,
     pub(crate) state: xkb::State,
@@ -112,7 +113,7 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
         Ok(KbdInternal {
             focus: None,
             pending_focus: None,
-            pressed_keys: Vec::new(),
+            pressed_keys: HashSet::new(),
             mods_state: ModifiersState::default(),
             keymap,
             state,
@@ -127,11 +128,11 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
         // track pressed keys as xkbcommon does not seem to expose it :(
         let direction = match state {
             KeyState::Pressed => {
-                self.pressed_keys.push(keycode);
+                self.pressed_keys.insert(keycode);
                 xkb::KeyDirection::Down
             }
             KeyState::Released => {
-                self.pressed_keys.retain(|&k| k != keycode);
+                self.pressed_keys.remove(&keycode);
                 xkb::KeyDirection::Up
             }
         };

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -64,7 +64,7 @@ where
         if let Some((focused, serial)) = guard.focus.as_ref() {
             if focused.same_client_as(&kbd.id()) {
                 let serialized = guard.mods_state.serialized;
-                let keys = serialize_pressed_keys(guard.pressed_keys.clone());
+                let keys = serialize_pressed_keys(guard.pressed_keys.iter().cloned().collect());
                 kbd.enter((*serial).into(), focused.wl_surface().unwrap(), keys);
                 // Modifiers must be send after enter event.
                 kbd.modifiers(


### PR DESCRIPTION
In the previous implementation, pressed keys were stored in a list. This meant that each element in the list was not guaranteed to be unique, and if you received several key press events, the list would quickly expand in size. If the list became longer than 1024 elements (4096 bytes), sending the key map to any client would result in an error and the connection to the client being severed.

Switching to a set has the advantage of solving this issue as well as potentially speeding up the processing of any key release events, since the whole vec no longer has to be traversed.