### PR TITLE
Make `DmabufBuilder::add_plane()` take an `OwnedFd`

### DIFF
--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -94,7 +94,7 @@ mod dispatch;
 use std::{
     collections::HashMap,
     convert::TryFrom,
-    os::unix::{io::IntoRawFd, prelude::AsRawFd},
+    os::unix::prelude::AsRawFd,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -472,7 +472,7 @@ impl DmabufParamsData {
             let offset = plane.offset;
             let stride = plane.stride;
             let modi = plane.modifier;
-            buf.add_plane(plane.into_raw_fd(), i as u32, offset, stride, modi);
+            buf.add_plane(plane.into(), i as u32, offset, stride, modi);
         }
 
         let dmabuf = match buf.build() {


### PR DESCRIPTION
Converting an arbitrary `RawFd` to an `OwnedFd` in a safe function is unsound. This provides a more correct API.