### PR TITLE
desktop/layer: Don't calculate geometry including popups

### DIFF
--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -142,7 +142,7 @@ impl LayerMap {
         if !self.layers.contains(layer) {
             return None;
         }
-        let mut bbox = layer.bbox_with_popups();
+        let mut bbox = layer.bbox();
         let state = layer_state(layer);
         bbox.loc += state.location;
         Some(bbox)
@@ -156,8 +156,13 @@ impl LayerMap {
     ) -> Option<&LayerSurface> {
         let point = point.into();
         self.layers_on(layer).rev().find(|l| {
-            let bbox = self.layer_geometry(l).unwrap();
-            bbox.to_f64().contains(point)
+            let bbox_with_popups = {
+                let mut bbox = l.bbox_with_popups();
+                let state = layer_state(l);
+                bbox.loc += state.location;
+                bbox
+            };
+            bbox_with_popups.to_f64().contains(point)
         })
     }
 


### PR DESCRIPTION
When calculating `layer_geometry` the user expects to get geometry relative to the origin of the layer_surface.
Popups extending negatively from the surface might shift that, if the calculation happens based on `bbox_with_popups()` (e.g. for Bottom anchored layer_shell surfaces).
This can e.g. break input in interesting ways as it is not easily possible to calculate surface-relative coordinates this way.

Additionally change layer_under to still use the bbox_with_popups to catch cursors over layer_surface popups correctly.

We have not previously observed this issue with anvil, because anvil does not constrain xdg_popups correctly.
This PR fixes the buggy behaviour in cosmic-comp without breaking any existing functionality in anvil, but it does not make the bug reproducable or testable in anvil.