### PR TITLE
output: Add WeakOutput type

### DIFF
--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
     desktop::{utils::*, PopupManager, Space},
-    output::{Inner as OutputInner, Output},
+    output::{Output, WeakOutput},
     utils::{user_data::UserDataMap, IsAlive, Logical, Physical, Point, Rectangle, Scale},
     wayland::{
         compositor::{with_states, with_surface_tree_downward, TraversalAction},
@@ -18,7 +18,7 @@ use std::{
     cell::{RefCell, RefMut},
     collections::HashSet,
     hash::{Hash, Hasher},
-    sync::{Arc, Mutex, Weak},
+    sync::Arc,
 };
 
 use super::WindowSurfaceType;
@@ -29,7 +29,7 @@ crate::utils::ids::id_gen!(next_layer_id, LAYER_ID, LAYER_IDS);
 #[derive(Debug)]
 pub struct LayerMap {
     layers: IndexSet<LayerSurface>,
-    output: Weak<(Mutex<OutputInner>, UserDataMap)>,
+    output: WeakOutput,
     zone: Rectangle<i32, Logical>,
     // surfaces for tracking enter and leave events
     surfaces: HashSet<ObjectId>,
@@ -47,11 +47,10 @@ pub struct LayerMap {
 /// of the same output using this function *will* result in a panic.
 pub fn layer_map_for_output(o: &Output) -> RefMut<'_, LayerMap> {
     let userdata = o.user_data();
-    let weak_output = Arc::downgrade(&o.inner);
     userdata.insert_if_missing(|| {
         RefCell::new(LayerMap {
             layers: IndexSet::new(),
-            output: weak_output,
+            output: o.downgrade(),
             zone: Rectangle::from_loc_and_size(
                 (0, 0),
                 o.current_mode()
@@ -356,7 +355,7 @@ impl LayerMap {
     }
 
     fn output(&self) -> Option<Output> {
-        self.output.upgrade().map(|inner| Output { inner })
+        self.output.upgrade()
     }
 
     /// Cleanup some internally used resources.

--- a/src/desktop/layer.rs
+++ b/src/desktop/layer.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::renderer::{utils::draw_surface_tree, ImportAll, Renderer},
     desktop::{utils::*, PopupManager, Space},
-    output::{Inner as OutputInner, Output, OutputData},
+    output::{Inner as OutputInner, Output},
     utils::{user_data::UserDataMap, IsAlive, Logical, Physical, Point, Rectangle, Scale},
     wayland::{
         compositor::{with_states, with_surface_tree_downward, TraversalAction},
@@ -47,7 +47,7 @@ pub struct LayerMap {
 /// of the same output using this function *will* result in a panic.
 pub fn layer_map_for_output(o: &Output) -> RefMut<'_, LayerMap> {
     let userdata = o.user_data();
-    let weak_output = Arc::downgrade(&o.data.inner);
+    let weak_output = Arc::downgrade(&o.inner);
     userdata.insert_if_missing(|| {
         RefCell::new(LayerMap {
             layers: IndexSet::new(),
@@ -64,7 +64,7 @@ pub fn layer_map_for_output(o: &Output) -> RefMut<'_, LayerMap> {
                     .unwrap_or_else(|| (0, 0).into()),
             ),
             surfaces: HashSet::new(),
-            logger: (*o.data.inner.0.lock().unwrap())
+            logger: (*o.inner.0.lock().unwrap())
                 .log
                 .new(slog::o!("smithay_module" => "layer_map")),
         })
@@ -356,9 +356,7 @@ impl LayerMap {
     }
 
     fn output(&self) -> Option<Output> {
-        self.output.upgrade().map(|inner| Output {
-            data: OutputData { inner },
-        })
+        self.output.upgrade().map(|inner| Output { inner })
     }
 
     /// Cleanup some internally used resources.

--- a/src/desktop/space/element.rs
+++ b/src/desktop/space/element.rs
@@ -302,7 +302,7 @@ pub struct SpaceOutputTuple<'a, 'b>(pub &'a Space, pub &'b Output);
 impl<'a, 'b> Hash for SpaceOutputTuple<'a, 'b> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.id.hash(state);
-        (std::sync::Arc::as_ptr(&self.1.data.inner) as *const () as usize).hash(state);
+        (std::sync::Arc::as_ptr(&self.1.inner) as *const () as usize).hash(state);
     }
 }
 
@@ -311,7 +311,7 @@ impl<'a, 'b> SpaceOutputTuple<'a, 'b> {
     pub fn owned_hash(&self) -> SpaceOutputHash {
         SpaceOutputHash(
             self.0.id,
-            std::sync::Arc::as_ptr(&self.1.data.inner) as *const () as usize,
+            std::sync::Arc::as_ptr(&self.1.inner) as *const () as usize,
         )
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -158,9 +158,8 @@ impl Scale {
     }
 }
 
-/// Inner output data
 #[derive(Debug)]
-pub struct Inner {
+pub(crate) struct Inner {
     pub(crate) name: String,
     pub(crate) description: String,
     #[cfg(feature = "wayland_frontend")]
@@ -198,7 +197,7 @@ pub struct WeakOutput {
 }
 
 /// Data of an Output
-pub type OutputData = Arc<(Mutex<Inner>, UserDataMap)>;
+pub(crate) type OutputData = Arc<(Mutex<Inner>, UserDataMap)>;
 
 impl Output {
     /// Create a new output with given name and physical properties.

--- a/src/wayland/output/handlers.rs
+++ b/src/wayland/output/handlers.rs
@@ -35,7 +35,7 @@ where
             },
         );
 
-        let mut inner = global_data.inner.0.lock().unwrap();
+        let mut inner = global_data.0.lock().unwrap();
 
         trace!(inner.log, "New WlOutput global instantiated."; "name" => &inner.name);
 
@@ -98,7 +98,6 @@ where
         data: &OutputUserData,
     ) {
         data.global_data
-            .inner
             .0
             .lock()
             .unwrap()
@@ -151,7 +150,7 @@ where
                 output: wl_output,
             } => {
                 let output = Output::from_resource(&wl_output).unwrap();
-                let mut inner = output.data.inner.0.lock().unwrap();
+                let mut inner = output.inner.0.lock().unwrap();
 
                 let xdg_output = XdgOutput::new(&inner, inner.log.clone());
 

--- a/src/wayland/output/handlers.rs
+++ b/src/wayland/output/handlers.rs
@@ -8,15 +8,15 @@ use wayland_server::{
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
 
-use super::{xdg::XdgOutput, Output, OutputData, OutputManagerState, OutputUserData};
+use super::{xdg::XdgOutput, Output, OutputManagerState, OutputUserData, WlOutputData};
 
 /*
  * Wl Output
  */
 
-impl<D> GlobalDispatch<WlOutput, OutputData, D> for OutputManagerState
+impl<D> GlobalDispatch<WlOutput, WlOutputData, D> for OutputManagerState
 where
-    D: GlobalDispatch<WlOutput, OutputData>,
+    D: GlobalDispatch<WlOutput, WlOutputData>,
     D: Dispatch<WlOutput, OutputUserData>,
     D: 'static,
 {
@@ -25,17 +25,17 @@ where
         _dh: &DisplayHandle,
         _client: &Client,
         resource: New<WlOutput>,
-        global_data: &OutputData,
+        global_data: &WlOutputData,
         data_init: &mut DataInit<'_, D>,
     ) {
         let output = data_init.init(
             resource,
             OutputUserData {
-                global_data: global_data.clone(),
+                global_data: global_data.inner.clone(),
             },
         );
 
-        let mut inner = global_data.0.lock().unwrap();
+        let mut inner = global_data.inner.0.lock().unwrap();
 
         trace!(inner.log, "New WlOutput global instantiated."; "name" => &inner.name);
 

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -159,13 +159,13 @@ impl Output {
         D: GlobalDispatch<WlOutput, OutputData>,
         D: 'static,
     {
-        display.create_global::<D, WlOutput, _>(4, self.data.clone())
+        display.create_global::<D, WlOutput, _>(4, self.inner.clone())
     }
 
     /// Attempt to retrieve a [`Output`] from an existing resource
     pub fn from_resource(output: &WlOutput) -> Option<Output> {
         output.data::<OutputUserData>().map(|ud| Output {
-            data: ud.global_data.clone(),
+            inner: ud.global_data.clone(),
         })
     }
 
@@ -176,7 +176,7 @@ impl Output {
         new_scale: Option<Scale>,
         new_location: Option<Point<i32, Logical>>,
     ) {
-        let inner = self.data.inner.0.lock().unwrap();
+        let inner = self.inner.0.lock().unwrap();
         // XdgOutput has to be updated before WlOutput
         // Because WlOutput::done() has to allways be called last
         if let Some(xdg_output) = inner.xdg_output.as_ref() {
@@ -208,8 +208,7 @@ impl Output {
 
     /// Check is given [`wl_output`](WlOutput) instance is managed by this [`Output`].
     pub fn owns(&self, output: &WlOutput) -> bool {
-        self.data
-            .inner
+        self.inner
             .0
             .lock()
             .unwrap()
@@ -225,7 +224,6 @@ impl Output {
         F: FnMut(&DisplayHandle, &WlOutput),
     {
         let list: Vec<_> = self
-            .data
             .inner
             .0
             .lock()


### PR DESCRIPTION
We have a couple of hack surrounding the internal use of `Output` inside smithay to make sure resources are getting cleaned up properly.
One of those is creating *weak output references*, as seen in the [`LayerMap`] and additionally (with a very hack hash-implementation) in #727.

Additionally I have found a bunch of use-cases for using `HashMap<Output, _>` in cosmic-comp, which would also be better served by a `WeakOutput` type.
So lets add that.