### PR TITLE
detect gbm_bo_get_fd_for_plane

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,13 +69,15 @@ slog-term = "2.3"
 [build-dependencies]
 gl_generator = { version = "0.14", optional = true }
 pkg-config = { version = "0.3.17", optional = true }
+cc = { version = "1.0", optional = true }
 
 [features]
 default = ["backend_drm", "backend_gbm", "backend_libinput", "backend_udev", "backend_session_logind", "backend_x11", "backend_winit", "desktop", "renderer_gl", "renderer_multi", "xwayland", "wayland_frontend", "slog-stdlog", "backend_vulkan"]
 backend_winit = ["winit", "backend_egl", "wayland-egl", "renderer_gl"]
 backend_x11 = ["x11rb", "x11rb/dri3", "x11rb/xfixes", "x11rb/present", "x11rb_event_source", "backend_gbm", "backend_drm", "backend_egl"]
 backend_drm = ["drm", "drm-ffi"]
-backend_gbm = ["gbm"]
+backend_gbm = ["gbm", "cc", "pkg-config"]
+backend_gbm_has_fd_for_plane = []
 backend_egl = ["gl_generator", "libloading"]
 backend_libinput = ["input"]
 backend_session = []

--- a/build.rs
+++ b/build.rs
@@ -97,10 +97,35 @@ fn find_logind() {
     }
 }
 
+#[cfg(all(feature = "backend_gbm", not(feature = "backend_gbm_has_fd_for_plane")))]
+fn test_gbm_bo_fd_for_plane() {
+    let gbm = match pkg_config::probe_library("gbm") {
+        Ok(lib) => lib,
+        Err(_) => {
+            println!("cargo:warning=failed to find gbm, assuming gbm_bo_get_fd_for_plane is unavailable");
+            return;
+        }
+    };
+
+    let has_gbm_bo_get_fd_for_plane = cc::Build::new()
+        .file("test_gbm_bo_get_fd_for_plane.c")
+        .includes(gbm.include_paths)
+        .warnings_into_errors(true)
+        .try_compile("test_gbm_bo_get_fd_for_plane")
+        .is_ok();
+
+    if has_gbm_bo_get_fd_for_plane {
+        println!("cargo:rustc-cfg=feature=\"backend_gbm_has_fd_for_plane\"");
+    }
+}
+
 fn main() {
     #[cfg(any(feature = "backend_egl", feature = "renderer_gl"))]
     gl_generate();
 
     #[cfg(feature = "backend_session_logind")]
     find_logind();
+
+    #[cfg(all(feature = "backend_gbm", not(feature = "backend_gbm_has_fd_for_plane")))]
+    test_gbm_bo_fd_for_plane();
 }

--- a/test_gbm_bo_get_fd_for_plane.c
+++ b/test_gbm_bo_get_fd_for_plane.c
@@ -1,0 +1,5 @@
+#include <gbm.h>
+
+void test() {
+    gbm_bo_get_fd_for_plane(NULL, 0);
+}


### PR DESCRIPTION
When available or forced with feature backend_gbm_has_fd_for_plane use fd_for_plane which allows the use of multi planar formats which expose multiple planes with different fds.