### PR TITLE
dev: make space render_output more ergonomic

### DIFF
--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -62,7 +62,7 @@ where
             output,
             renderer,
             age,
-            &[space],
+            [space],
             custom_elements,
             damage_tracked_renderer,
             CLEAR_COLOR,

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -115,11 +115,11 @@ pub fn winit_dispatch(
     let damage = Rectangle::from_loc_and_size((0, 0), size);
 
     backend.bind().ok().and_then(|_| {
-        smithay::desktop::space::render_output::<_, WaylandSurfaceRenderElement, _, _>(
+        smithay::desktop::space::render_output::<_, WaylandSurfaceRenderElement, _, _, _>(
             output,
             backend.renderer(),
             0,
-            &[&state.space],
+            [&state.space],
             &[],
             damage_tracked_renderer,
             [0.1, 0.1, 0.1, 1.0],

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -513,9 +513,10 @@ pub fn space_render_elements<
     'a,
     #[cfg(feature = "wayland_frontend")] R: Renderer + ImportAll,
     #[cfg(not(feature = "wayland_frontend"))] R: Renderer,
-    E: SpaceElement + PartialEq + AsRenderElements<R>,
+    E: SpaceElement + PartialEq + AsRenderElements<R> + 'a,
+    S: IntoIterator<Item = &'a Space<E>>,
 >(
-    spaces: &[&'a Space<E>],
+    spaces: S,
     output: &Output,
 ) -> Result<Vec<SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>>, OutputNoMode>
 where
@@ -544,13 +545,14 @@ pub fn render_output<
     #[cfg(feature = "wayland_frontend")] R: Renderer + ImportAll,
     #[cfg(not(feature = "wayland_frontend"))] R: Renderer,
     C: RenderElement<R>,
-    E: SpaceElement + PartialEq + AsRenderElements<R>,
+    E: SpaceElement + PartialEq + AsRenderElements<R> + 'a,
     L: Into<Option<slog::Logger>>,
+    S: IntoIterator<Item = &'a Space<E>>,
 >(
     output: &Output,
     renderer: &mut R,
     age: usize,
-    spaces: &[&'a Space<E>],
+    spaces: S,
     custom_elements: &'a [C],
     damage_tracked_renderer: &mut DamageTrackedRenderer,
     clear_color: [f32; 4],


### PR DESCRIPTION
We can use IntoIterator instead of requiring a slice for render_output and space_render_elements