### PR TITLE
space: Fixup multiple rendered layer_surfaces when using multiple spaces

### DIFF
--- a/src/desktop/space/element/mod.rs
+++ b/src/desktop/space/element/mod.rs
@@ -115,8 +115,6 @@ where
         match self {
             #[cfg(feature = "wayland_frontend")]
             SpaceElements::Layer { surface, .. } => {
-                use crate::wayland::shell::wlr_layer::Layer;
-
                 let layer = match surface.layer() {
                     Layer::Background => RenderZindex::Background,
                     Layer::Bottom => RenderZindex::Bottom,

--- a/src/wayland/shell/wlr_layer/types.rs
+++ b/src/wayland/shell/wlr_layer/types.rs
@@ -10,7 +10,7 @@ use wayland_server::WEnum;
 /// Traditional shell surfaces will typically be rendered between the bottom and top layers.
 /// Fullscreen shell surfaces are typically rendered at the top layer.
 /// Multiple surfaces can share a single layer, and ordering within a single layer is undefined.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Layer {
     /// The lowest layer, used usualy for wallpapers
     Background,


### PR DESCRIPTION
@cmeissl Ping.

Also added some more comments explaining the order of elements rendered for each of the different functions.