### PR TITLE
input: Add a way to retrieve current focus

### DIFF
--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -586,6 +586,23 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     }
 }
 
+impl<D> KeyboardHandle<D>
+where
+    D: SeatHandler,
+    <D as SeatHandler>::KeyboardFocus: Clone,
+{
+    /// Retrieve the current keyboard focus
+    pub fn current_focus(&self) -> Option<<D as SeatHandler>::KeyboardFocus> {
+        self.arc
+            .internal
+            .lock()
+            .unwrap()
+            .focus
+            .clone()
+            .map(|(focus, _)| focus)
+    }
+}
+
 /// This inner handle is accessed from inside a keyboard grab logic, and directly
 /// sends event to the client
 pub struct KeyboardInnerHandle<'a, D: SeatHandler> {

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -215,6 +215,17 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     }
 }
 
+impl<D> PointerHandle<D>
+where
+    D: SeatHandler,
+    <D as SeatHandler>::PointerFocus: Clone,
+{
+    /// Retrieve the current pointer focus
+    pub fn current_focus(&self) -> Option<<D as SeatHandler>::PointerFocus> {
+        self.inner.lock().unwrap().focus.clone().map(|(focus, _)| focus)
+    }
+}
+
 /// This inner handle is accessed from inside a pointer grab logic, and directly
 /// sends event to the client
 pub struct PointerInnerHandle<'a, D: SeatHandler> {


### PR DESCRIPTION
Now that the `Seat` is generic over focused elements, we have lost the option to easily receive the currently focused element.
We cannot return a reference, as both fields are behind `Mutex`. When this was still just a `WlSurface`, we could just clone it.
So lets re-introduce this option with a little trait bound.