### PR TITLE
desktop/layer: Don't require dh for cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,7 @@ jobs:
         with:
           command: doc
           # TODO: Update nix when drm-rs is updated
-          args: --no-deps --features "test_all_features" -p smithay -p calloop:0.10.1 -p dbus -p drm -p gbm -p input -p nix:0.24.2 -p udev -p slog -p wayland-server:0.30.0-beta.11 -p wayland-backend -p wayland-protocols:0.30.0-beta.11 -p winit -p x11rb
+          args: --no-deps --features "test_all_features" -p smithay -p calloop:0.10.1 -p dbus -p drm -p gbm -p input -p nix:0.24.2 -p udev -p slog -p wayland-server:0.30.0-beta.12 -p wayland-backend -p wayland-protocols:0.30.0-beta.12 -p winit -p x11rb
 
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,7 @@ jobs:
         with:
           command: doc
           # TODO: Update nix when drm-rs is updated
-          args: --no-deps --features "test_all_features" -p smithay -p calloop:0.10.1 -p dbus -p drm -p gbm -p input -p nix:0.24.2 -p udev -p slog -p wayland-server:0.30.0-beta.10 -p wayland-backend -p wayland-protocols:0.30.0-beta.10 -p winit -p x11rb
+          args: --no-deps --features "test_all_features" -p smithay -p calloop:0.10.1 -p dbus -p drm -p gbm -p input -p nix:0.24.2 -p udev -p slog -p wayland-server:0.30.0-beta.11 -p wayland-backend -p wayland-protocols:0.30.0-beta.11 -p winit -p x11rb
 
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,13 @@ slog-stdlog = { version = "4", optional = true }
 tempfile = { version = "3.0", optional = true }
 thiserror = "1.0.25"
 udev = { version = "0.6", optional = true }
-wayland-egl = { version = "=0.30.0-beta.11", optional = true }
-wayland-protocols = { version = "=0.30.0-beta.11", features = ["unstable", "staging", "server"], optional = true }
-wayland-protocols-wlr = { version = "=0.1.0-beta.11", features = ["server"]}
-wayland-protocols-misc = { version = "=0.1.0-beta.11", features = ["server"]}
-wayland-server = { version = "=0.30.0-beta.11", optional = true }
-wayland-sys = { version = "=0.30.0-beta.11", optional = true }
-wayland-backend = { version = "=0.1.0-beta.11", optional = true }
+wayland-egl = { version = "=0.30.0-beta.12", optional = true }
+wayland-protocols = { version = "=0.30.0-beta.12", features = ["unstable", "staging", "server"], optional = true }
+wayland-protocols-wlr = { version = "=0.1.0-beta.12", features = ["server"]}
+wayland-protocols-misc = { version = "=0.1.0-beta.12", features = ["server"]}
+wayland-server = { version = "=0.30.0-beta.12", optional = true }
+wayland-sys = { version = "=0.30.0-beta.12", optional = true }
+wayland-backend = { version = "=0.1.0-beta.12", optional = true }
 winit = { version = "0.27.1", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
 x11rb = { version = "0.10.0", optional = true }
 xkbcommon = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,13 @@ slog-stdlog = { version = "4", optional = true }
 tempfile = { version = "3.0", optional = true }
 thiserror = "1.0.25"
 udev = { version = "0.6", optional = true }
-wayland-egl = { version = "=0.30.0-beta.10", optional = true }
-wayland-protocols = { version = "=0.30.0-beta.10", features = ["unstable", "staging", "server"], optional = true }
-wayland-protocols-wlr = { version = "=0.1.0-beta.10", features = ["server"]}
-wayland-protocols-misc = { version = "=0.1.0-beta.10", features = ["server"]}
-wayland-server = { version = "=0.30.0-beta.10", optional = true }
-wayland-sys = { version = "=0.30.0-beta.10", optional = true }
-wayland-backend = { version = "=0.1.0-beta.10", optional = true }
+wayland-egl = { version = "=0.30.0-beta.11", optional = true }
+wayland-protocols = { version = "=0.30.0-beta.11", features = ["unstable", "staging", "server"], optional = true }
+wayland-protocols-wlr = { version = "=0.1.0-beta.11", features = ["server"]}
+wayland-protocols-misc = { version = "=0.1.0-beta.11", features = ["server"]}
+wayland-server = { version = "=0.30.0-beta.11", optional = true }
+wayland-sys = { version = "=0.30.0-beta.11", optional = true }
+wayland-backend = { version = "=0.1.0-beta.11", optional = true }
 winit = { version = "0.27.1", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
 x11rb = { version = "0.10.0", optional = true }
 xkbcommon = "0.5.0"

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 use indexmap::IndexSet;
-use wayland_server::{backend::ObjectId, protocol::wl_surface::WlSurface, DisplayHandle, Resource};
+use wayland_server::{protocol::wl_surface::WlSurface, Resource, Weak};
 
 use std::{
     cell::{RefCell, RefMut},
@@ -36,7 +36,7 @@ pub struct LayerMap {
     output: WeakOutput,
     zone: Rectangle<i32, Logical>,
     // surfaces for tracking enter and leave events
-    surfaces: HashSet<ObjectId>,
+    surfaces: HashSet<Weak<WlSurface>>,
     logger: ::slog::Logger,
 }
 
@@ -113,9 +113,10 @@ impl LayerMap {
                 (),
                 |_, _, _| TraversalAction::DoChildren(()),
                 |wl_surface, _, _| {
-                    if self.surfaces.contains(&wl_surface.id()) {
+                    let weak = wl_surface.downgrade();
+                    if self.surfaces.contains(&weak) {
                         output.leave(wl_surface);
-                        self.surfaces.remove(&wl_surface.id());
+                        self.surfaces.remove(&weak);
                     }
                 },
                 |_, _, _| true,
@@ -127,9 +128,10 @@ impl LayerMap {
                     (),
                     |_, _, _| TraversalAction::DoChildren(()),
                     |wl_surface, _, _| {
-                        if self.surfaces.contains(&wl_surface.id()) {
+                        let weak = wl_surface.downgrade();
+                        if self.surfaces.contains(&weak) {
                             output.leave(wl_surface);
-                            self.surfaces.remove(&wl_surface.id());
+                            self.surfaces.remove(&weak);
                         }
                     },
                     |_, _, _| true,
@@ -264,9 +266,10 @@ impl LayerMap {
                     (),
                     |_, _, _| TraversalAction::DoChildren(()),
                     |wl_surface, _, _| {
-                        if !surfaces_ref.contains(&wl_surface.id()) {
+                        let weak = wl_surface.downgrade();
+                        if !surfaces_ref.contains(&weak) {
                             output.enter(wl_surface);
-                            surfaces_ref.insert(wl_surface.id());
+                            surfaces_ref.insert(weak);
                         }
                     },
                     |_, _, _| true,
@@ -278,9 +281,10 @@ impl LayerMap {
                         (),
                         |_, _, _| TraversalAction::DoChildren(()),
                         |wl_surface, _, _| {
-                            if !surfaces_ref.contains(&wl_surface.id()) {
+                            let weak = wl_surface.downgrade();
+                            if !surfaces_ref.contains(&weak) {
                                 output.enter(wl_surface);
-                                surfaces_ref.insert(wl_surface.id());
+                                surfaces_ref.insert(weak);
                             }
                         },
                         |_, _, _| true,
@@ -377,13 +381,12 @@ impl LayerMap {
     ///
     /// This function needs to be called periodically (though not necessarily frequently)
     /// to be able cleanup internally used resources.
-    pub fn cleanup(&mut self, dh: &DisplayHandle) {
+    pub fn cleanup(&mut self) {
         if self.layers.iter().any(|l| !l.alive()) {
             self.layers.retain(|layer| layer.alive());
             self.arrange();
         }
-        self.surfaces
-            .retain(|i| dh.backend_handle().object_info(i.clone()).is_ok());
+        self.surfaces.retain(|weak| weak.upgrade().is_ok());
     }
 
     /// Returns layers count

--- a/wlcs_anvil/Cargo.toml
+++ b/wlcs_anvil/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 smithay = { path = "..", default-features=false, features=["wayland_frontend", "backend_egl", "use_system_lib"] }
 anvil = { path = "../anvil", default-features=false }
-wayland-sys = { version = "=0.30.0-beta.11", features = ["client", "server"] }
+wayland-sys = { version = "=0.30.0-beta.12", features = ["client", "server"] }
 libc = "0.2"
 memoffset = "0.6"
 slog = "2.0"

--- a/wlcs_anvil/Cargo.toml
+++ b/wlcs_anvil/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 smithay = { path = "..", default-features=false, features=["wayland_frontend", "backend_egl", "use_system_lib"] }
 anvil = { path = "../anvil", default-features=false }
-wayland-sys = { version = "=0.30.0-beta.10", features = ["client", "server"] }
+wayland-sys = { version = "=0.30.0-beta.11", features = ["client", "server"] }
 libc = "0.2"
 memoffset = "0.6"
 slog = "2.0"


### PR DESCRIPTION
~~Draft because this requires a new wayland-server release to behave correctly. (`Weak::upgrade` may succeed for dead objects on 0.30-beta.10)~~

Also updates to ~~beta.11~~ beta.12