### PR TITLE
Destruct hook state

### DIFF
--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -303,7 +303,7 @@ pub fn on_commit_buffer_handler(surface: &WlSurface) {
             |_, _, _| true,
         );
         for surf in &new_surfaces {
-            add_destruction_hook(surf, |data| {
+            add_destruction_hook(surf, |_, data| {
                 if let Some(buffer) = data
                     .data_map
                     .get::<RendererSurfaceStateUserData>()

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -294,13 +294,13 @@ where
     }
 
     fn destroyed(
-        _state: &mut D,
+        state: &mut D,
         _client_id: wayland_server::backend::ClientId,
         object_id: wayland_server::backend::ObjectId,
         data: &SurfaceUserData,
     ) {
         data.alive_tracker.destroy_notify();
-        PrivateSurfaceData::cleanup(data, object_id);
+        PrivateSurfaceData::cleanup::<D>(state, data, object_id);
     }
 }
 

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -105,6 +105,8 @@ mod handlers;
 mod transaction;
 mod tree;
 
+use std::any::Any;
+
 pub use self::cache::{Cacheable, MultiCache};
 pub use self::handlers::{RegionUserData, SubsurfaceCachedState, SubsurfaceUserData, SurfaceUserData};
 use self::tree::PrivateSurfaceData;
@@ -415,8 +417,9 @@ pub fn add_post_commit_hook(surface: &WlSurface, hook: fn(&DisplayHandle, &WlSur
 /// Register a destruction hook to be invoked on surface destruction
 ///
 /// It'll be invoked when the surface is destroyed (either explicitly by the client or on
-/// client disconnect).
-pub fn add_destruction_hook(surface: &WlSurface, hook: fn(&SurfaceData)) {
+/// client disconnect). The compositor state is passed back as `Any` and may be downcast as needed
+/// by the callee.
+pub fn add_destruction_hook(surface: &WlSurface, hook: fn(&mut dyn Any, &SurfaceData)) {
     PrivateSurfaceData::add_destruction_hook(surface, hook)
 }
 


### PR DESCRIPTION
This allows passing back the compositor state on the destruction hook. Such functionality may be useful for handling rendering operations after a surface is destroyed.