### PR TITLE
input/wayland: Return owned surface from WaylandFocus

### DIFF
--- a/anvil/src/focus.rs
+++ b/anvil/src/focus.rs
@@ -32,7 +32,7 @@ impl IsAlive for FocusTarget {
 
 impl From<FocusTarget> for WlSurface {
     fn from(target: FocusTarget) -> Self {
-        target.wl_surface().unwrap().clone()
+        target.wl_surface().unwrap()
     }
 }
 
@@ -138,11 +138,11 @@ impl<Backend> KeyboardTarget<AnvilState<Backend>> for FocusTarget {
 }
 
 impl WaylandFocus for FocusTarget {
-    fn wl_surface(&self) -> Option<&WlSurface> {
+    fn wl_surface(&self) -> Option<WlSurface> {
         Some(match self {
-            FocusTarget::Window(w) => w.toplevel().wl_surface(),
-            FocusTarget::LayerSurface(l) => l.wl_surface(),
-            FocusTarget::Popup(p) => p.wl_surface(),
+            FocusTarget::Window(w) => w.toplevel().wl_surface().clone(),
+            FocusTarget::LayerSurface(l) => l.wl_surface().clone(),
+            FocusTarget::Popup(p) => p.wl_surface().clone(),
         })
     }
     fn same_client_as(&self, object_id: &ObjectId) -> bool {

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -677,7 +677,7 @@ impl AnvilState<UdevData> {
 
                 tool.motion(
                     self.pointer_location,
-                    under.and_then(|(f, loc)| f.wl_surface().map(|s| (s.clone(), loc))),
+                    under.and_then(|(f, loc)| f.wl_surface().map(|s| (s, loc))),
                     &tablet,
                     SCOUNTER.next_serial(),
                     evt.time(),
@@ -710,7 +710,7 @@ impl AnvilState<UdevData> {
             let tool = tablet_seat.get_tool(&tool);
 
             if let (Some(under), Some(tablet), Some(tool)) = (
-                under.and_then(|(f, loc)| f.wl_surface().map(|s| (s.clone(), loc))),
+                under.and_then(|(f, loc)| f.wl_surface().map(|s| (s, loc))),
                 tablet,
                 tool,
             ) {

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -350,7 +350,7 @@ where
     /// Returns the new topmost popup in case of nested popups
     /// or if the grab has ended the root surface
     pub fn ungrab(&mut self, strategy: PopupUngrabStrategy) -> Option<WlSurface> {
-        let root_surface = self.root.wl_surface()?.clone();
+        let root_surface = self.root.wl_surface()?;
         self.toplevel_grab
             .ungrab(&root_surface, strategy)
             .or(Some(root_surface))

--- a/src/desktop/wayland/popup/manager.rs
+++ b/src/desktop/wayland/popup/manager.rs
@@ -78,7 +78,7 @@ impl PopupManager {
         <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
     {
         let surface = popup.wl_surface();
-        assert_eq!(root.wl_surface().cloned(), Some(find_popup_root_surface(&popup)?));
+        assert_eq!(root.wl_surface(), Some(find_popup_root_surface(&popup)?));
 
         match popup {
             PopupKind::Xdg(ref xdg) => {
@@ -118,7 +118,7 @@ impl PopupManager {
             Err(err) => {
                 match err {
                     PopupGrabError::ParentDismissed => {
-                        let _ = PopupManager::dismiss_popup(root.wl_surface().unwrap(), &popup);
+                        let _ = PopupManager::dismiss_popup(&root.wl_surface().unwrap(), &popup);
                     }
                     PopupGrabError::NotTheTopmostPopup => {
                         surface.post_error(

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -374,8 +374,8 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for Window {
 }
 
 impl WaylandFocus for Window {
-    fn wl_surface(&self) -> Option<&wl_surface::WlSurface> {
-        Some(self.toplevel().wl_surface())
+    fn wl_surface(&self) -> Option<wl_surface::WlSurface> {
+        Some(self.toplevel().wl_surface().clone())
     }
 
     fn same_client_as(&self, object_id: &ObjectId) -> bool {

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -88,7 +88,7 @@ where
             .get::<RefCell<SeatData>>()
             .unwrap()
             .borrow_mut();
-        if focus.as_ref().and_then(|&(ref s, _)| s.wl_surface()) != self.current_focus.as_ref() {
+        if focus.as_ref().and_then(|&(ref s, _)| s.wl_surface()) != self.current_focus.clone() {
             // focus changed, we need to make a leave if appropriate
             if let Some(surface) = self.current_focus.take() {
                 // only leave if there is a data source or we are on the original client
@@ -155,7 +155,7 @@ where
                             offer.source_actions(meta.dnd_action);
                         })
                         .unwrap();
-                        device.enter(event.serial.into(), surface, x, y, Some(&offer));
+                        device.enter(event.serial.into(), &surface, x, y, Some(&offer));
                         self.pending_offers.push(offer);
                     }
                     self.offer_data = Some(offer_data);
@@ -164,12 +164,12 @@ where
                     if self.origin.id().same_client_as(&surface.id()) {
                         for device in seat_data.known_devices() {
                             if device.id().same_client_as(&surface.id()) {
-                                device.enter(event.serial.into(), surface, x, y, None);
+                                device.enter(event.serial.into(), &surface, x, y, None);
                             }
                         }
                     }
                 }
-                self.current_focus = Some(surface.clone());
+                self.current_focus = Some(surface);
             } else {
                 // make a move
                 if self.data_source.is_some() || self.origin.id().same_client_as(&surface.id()) {

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -82,7 +82,7 @@ where
             .get::<RefCell<SeatData>>()
             .unwrap()
             .borrow_mut();
-        if focus.as_ref().and_then(|&(ref s, _)| s.wl_surface()) != self.current_focus.as_ref() {
+        if focus.as_ref().and_then(|&(ref s, _)| s.wl_surface()) != self.current_focus.clone() {
             // focus changed, we need to make a leave if appropriate
             if let Some(surface) = self.current_focus.take() {
                 for device in seat_data.known_devices() {
@@ -141,11 +141,11 @@ where
                         offer.offer(mime_type);
                     }
                     offer.source_actions(self.metadata.dnd_action);
-                    device.enter(serial.into(), surface, x, y, Some(&offer));
+                    device.enter(serial.into(), &surface, x, y, Some(&offer));
                     self.pending_offers.push(offer);
                 }
                 self.offer_data = Some(offer_data);
-                self.current_focus = Some(surface.clone());
+                self.current_focus = Some(surface);
             } else {
                 // make a move
                 for device in seat_data.known_devices() {

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -77,12 +77,11 @@ where
         serial: crate::utils::Serial,
     ) {
         let inner = self.inner.lock().unwrap();
-        inner
-            .text_input_handle
-            .set_focus(focus.as_ref().and_then(|f| f.wl_surface()), || {
-                let mut popup = inner.popup_handle.inner.lock().unwrap();
-                popup.surface_role = None;
-            });
+        let surface = focus.as_ref().and_then(|f| f.wl_surface());
+        inner.text_input_handle.set_focus(surface.as_ref(), || {
+            let mut popup = inner.popup_handle.inner.lock().unwrap();
+            popup.surface_role = None;
+        });
         handle.set_focus(data, focus, serial)
     }
 

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -65,7 +65,7 @@ where
             if focused.same_client_as(&kbd.id()) {
                 let serialized = guard.mods_state.serialized;
                 let keys = serialize_pressed_keys(guard.pressed_keys.iter().cloned().collect());
-                kbd.enter((*serial).into(), focused.wl_surface().unwrap(), keys);
+                kbd.enter((*serial).into(), &focused.wl_surface().unwrap(), keys);
                 // Modifiers must be send after enter event.
                 kbd.modifiers(
                     (*serial).into(),

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -90,7 +90,7 @@ pub trait WaylandFocus {
     ///
     /// *Note*: This has to return `Some`, if `same_client_as` can return true
     /// for any provided `ObjectId`
-    fn wl_surface(&self) -> Option<&wl_surface::WlSurface>;
+    fn wl_surface(&self) -> Option<wl_surface::WlSurface>;
     /// Returns true, if the underlying wayland object originates from
     /// the same client connection as the provided `ObjectId`.
     ///
@@ -103,8 +103,8 @@ pub trait WaylandFocus {
 }
 
 impl WaylandFocus for wl_surface::WlSurface {
-    fn wl_surface(&self) -> Option<&wl_surface::WlSurface> {
-        Some(self)
+    fn wl_surface(&self) -> Option<wl_surface::WlSurface> {
+        Some(self.clone())
     }
 }
 


### PR DESCRIPTION
Drop the reference from `WaylandFocus::wl_surface`.

Forcing a reference here, makes it impossible to wrap the underlying object in a `Rc<RefCell<_>>` or `Arc<Mutex<_>>` internally, as you cannot return references of the elements contained.

This is particularly desirable, when storing multiple `Window`s in a collection, e.g. to implement a stacked window layout. Anything resembling a window is usually clonable and internally refcounted. If you wanted to ref-count such a collection type, you would end up in the situation laid out above.

`WlSurface`s are cheap handles, so lets get around that, by just cloning them.