### PR TITLE
Allow usage of KHR or EXT variants for eglSwapBuffersWithDamage

### DIFF
--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -217,11 +217,6 @@ pub fn run_winit(log: Logger) {
 
             let full_redraw = &mut state.backend_data.full_redraw;
             *full_redraw = full_redraw.saturating_sub(1);
-            let age = if *full_redraw > 0 {
-                0
-            } else {
-                backend.buffer_age().unwrap_or(0)
-            };
             let space = &mut state.space;
             let damage_tracked_renderer = &mut state.backend_data.damage_tracked_renderer;
 
@@ -246,6 +241,12 @@ pub fn run_winit(log: Logger) {
             let cursor_pos_scaled = cursor_pos.to_physical(scale).to_i32_round();
 
             let render_res = backend.bind().and_then(|_| {
+                let age = if *full_redraw > 0 {
+                    0
+                } else {
+                    backend.buffer_age().unwrap_or(0)
+                };
+
                 let renderer = backend.renderer();
 
                 let mut elements = Vec::<CustomRenderElements<Gles2Renderer>>::new();
@@ -297,7 +298,7 @@ pub fn run_winit(log: Logger) {
 
             match render_res {
                 Ok(Some(damage)) => {
-                    if let Err(err) = backend.submit(if age == 0 { None } else { Some(&*damage) }) {
+                    if let Err(err) = backend.submit(Some(&*damage)) {
                         warn!(log, "Failed to submit buffer: {}", err);
                     }
                     backend.window().set_cursor_visible(cursor_visible);

--- a/build.rs
+++ b/build.rs
@@ -40,6 +40,7 @@ fn gl_generate() {
                 "EGL_KHR_gl_image",
                 "EGL_EXT_buffer_age",
                 "EGL_EXT_swap_buffers_with_damage",
+                "EGL_KHR_swap_buffers_with_damage",
             ],
         )
         .write_bindings(gl_generator::GlobalGenerator, &mut file)

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -229,10 +229,7 @@ where
     let egl = Rc::new(surface);
     let renderer = unsafe { Gles2Renderer::new(context, log.clone())? };
     let resize_notification = Rc::new(Cell::new(None));
-    let damage_tracking = display.extensions().iter().any(|ext| ext == "EGL_EXT_buffer_age")
-        && display.extensions().iter().any(|ext| {
-            ext == "EGL_KHR_swap_buffers_with_damage" || ext == "EGL_EXT_swap_buffers_with_damage"
-        });
+    let damage_tracking = display.supports_damage();
 
     Ok((
         WinitGraphicsBackend {


### PR DESCRIPTION
The old implementation was arguably buggy (checking for either extension, but always calling EXT).
This might be a little too safe, but should work with every stupid driver out there.

Additionally this moves the buffer age query after `backend.bind()`. Otherwise the surface might not be current, resulting in another error and wrong age value.

(Fixes damage tracking issues with the winit-backend on nvidia's proprietary driver.)