### PR TITLE
enable doc_auto_cfg when generating docs for master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
       - name: Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly # We need nightly to enable doc_auto_cfg
           override: true
 
       - name: System dependencies
@@ -517,6 +517,7 @@ jobs:
           command: doc
           # TODO: Update nix when drm-rs is updated
           args: --no-deps --features "test_all_features" -p smithay -p calloop:0.10.1 -p dbus -p drm -p gbm -p input -p nix:0.24.2 -p udev -p slog -p wayland-server:0.30.0-beta.12 -p wayland-backend -p wayland-protocols:0.30.0-beta.12 -p winit -p x11rb
+          env: RUSTDOCFLAGS=--cfg="docsrs"
 
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html


### PR DESCRIPTION
At the moment the feature labels are only generated when publishing to crates.io