### PR TITLE
Feature/renderer element state

### DIFF
--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -1,7 +1,7 @@
 use smithay::{
     backend::renderer::{
         damage::{DamageTrackedRenderer, DamageTrackedRendererError, DamageTrackedRendererMode},
-        element::{surface::WaylandSurfaceRenderElement, AsRenderElements},
+        element::{surface::WaylandSurfaceRenderElement, AsRenderElements, RenderElementStates},
         ImportAll, Renderer,
     },
     desktop::{self, space::Space, Window},
@@ -38,7 +38,7 @@ pub fn render_output<'a, R>(
     damage_tracked_renderer: &mut DamageTrackedRenderer,
     age: usize,
     log: &slog::Logger,
-) -> Result<Option<Vec<Rectangle<i32, Physical>>>, DamageTrackedRendererError<R>>
+) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), DamageTrackedRendererError<R>>
 where
     R: Renderer + ImportAll,
     R::TextureId: Clone + 'static,

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -820,13 +820,15 @@ impl AnvilState<UdevData> {
                     .expect("failed to schedule frame timer");
             }
 
-            outputs.push(output.clone());
+            if let Ok((_, states)) = result {
+                outputs.push((output.clone(), states));
+            }
         }
 
         std::mem::drop(surfaces);
-        for output in outputs {
+        for (output, states) in outputs {
             // Send frame events so that client start drawing their next frame
-            self.send_frames(&output);
+            self.send_frames(&output, &states);
         }
     }
 }

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -297,13 +297,14 @@ pub fn run_winit(log: Logger) {
             });
 
             match render_res {
-                Ok(Some(damage)) => {
-                    if let Err(err) = backend.submit(Some(&*damage)) {
-                        warn!(log, "Failed to submit buffer: {}", err);
+                Ok((damage, _)) => {
+                    if let Some(damage) = damage {
+                        if let Err(err) = backend.submit(Some(&*damage)) {
+                            warn!(log, "Failed to submit buffer: {}", err);
+                        }
                     }
                     backend.window().set_cursor_visible(cursor_visible);
                 }
-                Ok(None) => backend.window().set_cursor_visible(cursor_visible),
                 Err(SwapBuffersError::ContextLost(err)) => {
                     error!(log, "Critical Rendering Error: {}", err);
                     state.running.store(false, Ordering::SeqCst);

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -333,7 +333,7 @@ pub fn run_x11(log: Logger) {
             );
 
             match render_res {
-                Ok(_) => {
+                Ok((_, states)) => {
                     trace!(log, "Finished rendering");
                     if let Err(err) = backend_data.surface.submit() {
                         backend_data.surface.reset_buffers();
@@ -341,6 +341,9 @@ pub fn run_x11(log: Logger) {
                     } else {
                         state.backend_data.render = false;
                     };
+
+                    // Send frame events so that client start drawing their next frame
+                    state.send_frames(&output, &states);
                 }
                 Err(err) => {
                     backend_data.surface.reset_buffers();
@@ -353,9 +356,6 @@ pub fn run_x11(log: Logger) {
             state.backend_data.fps.tick();
             window.set_cursor_visible(cursor_visible);
         }
-
-        // Send frame events so that client start drawing their next frame
-        state.send_frames(&output);
 
         let mut calloop_data = CalloopData { state, display };
         let result = event_loop.dispatch(Some(Duration::from_millis(16)), &mut calloop_data);

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -114,21 +114,18 @@ pub fn winit_dispatch(
     let size = backend.window_size().physical_size;
     let damage = Rectangle::from_loc_and_size((0, 0), size);
 
-    backend.bind().ok().and_then(|_| {
-        smithay::desktop::space::render_output::<_, WaylandSurfaceRenderElement, _, _, _>(
-            output,
-            backend.renderer(),
-            0,
-            [&state.space],
-            &[],
-            damage_tracked_renderer,
-            [0.1, 0.1, 0.1, 1.0],
-            log.clone(),
-        )
-        .unwrap()
-    });
-
-    backend.submit(Some(&[damage])).unwrap();
+    backend.bind()?;
+    smithay::desktop::space::render_output::<_, WaylandSurfaceRenderElement, _, _, _>(
+        output,
+        backend.renderer(),
+        0,
+        [&state.space],
+        &[],
+        damage_tracked_renderer,
+        [0.1, 0.1, 0.1, 1.0],
+        log.clone(),
+    )?;
+    backend.submit(Some(&[damage]))?;
 
     state
         .space

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -127,10 +127,14 @@ pub fn winit_dispatch(
     )?;
     backend.submit(Some(&[damage]))?;
 
-    state
-        .space
-        .elements()
-        .for_each(|window| window.send_frame(state.start_time.elapsed().as_millis() as u32));
+    state.space.elements().for_each(|window| {
+        window.send_frame(
+            output,
+            state.start_time.elapsed(),
+            Some(Duration::ZERO),
+            |_, _| Some(output.clone()),
+        )
+    });
 
     state.space.refresh();
     display.flush_clients()?;

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -6,7 +6,7 @@ use crate::{
         damage::{
             DamageTrackedRenderer, DamageTrackedRendererError, DamageTrackedRendererMode, OutputNoMode,
         },
-        element::{AsRenderElements, RenderElement, Wrap},
+        element::{AsRenderElements, RenderElement, RenderElementStates, Wrap},
         Renderer, Texture,
     },
     output::Output,
@@ -647,7 +647,7 @@ pub fn render_output<
     damage_tracked_renderer: &mut DamageTrackedRenderer,
     clear_color: [f32; 4],
     log: L,
-) -> Result<Option<Vec<Rectangle<i32, Physical>>>, DamageTrackedRendererError<R>>
+) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), DamageTrackedRendererError<R>>
 where
     <R as Renderer>::TextureId: Texture + 'static,
     <E as AsRenderElements<R>>::RenderElement: 'a,

--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -1,12 +1,16 @@
 //! Helper functions to ease dealing with surface trees
 
 use crate::{
-    backend::renderer::utils::RendererSurfaceState,
+    backend::renderer::{
+        element::{PrimaryScanoutOutput, RenderElementState, RenderElementStates},
+        utils::RendererSurfaceState,
+    },
     desktop::WindowSurfaceType,
+    output::Output,
     utils::{Logical, Point, Rectangle},
-    wayland::compositor::{with_surface_tree_downward, SurfaceAttributes, TraversalAction},
+    wayland::compositor::{with_surface_tree_downward, SurfaceAttributes, SurfaceData, TraversalAction},
 };
-use std::cell::RefCell;
+use std::{cell::RefCell, sync::Mutex, time::Duration};
 use wayland_server::protocol::wl_surface;
 
 impl RendererSurfaceState {
@@ -133,24 +137,140 @@ where
     found.into_inner()
 }
 
+type SurfacePrimaryScanoutOutput = Mutex<PrimaryScanoutOutput>;
+
+/// Run a closure on all surfaces of a surface tree
+pub fn with_surfaces_surface_tree<F>(surface: &wl_surface::WlSurface, mut processor: F)
+where
+    F: FnMut(&wl_surface::WlSurface, &SurfaceData),
+{
+    with_surface_tree_downward(
+        surface,
+        (),
+        |_, _, _| TraversalAction::DoChildren(()),
+        |surface, states, _| processor(surface, states),
+        |_, _, _| true,
+    )
+}
+
+/// Retrieve a previously stored primary scan-out output from a surface
+///
+/// This will always return `None` if [`update_surface_primary_scanout_output`] is not used.
+pub fn surface_primary_scanout_output(
+    _surface: &wl_surface::WlSurface,
+    states: &SurfaceData,
+) -> Option<Output> {
+    states
+        .data_map
+        .insert_if_missing_threadsafe(SurfacePrimaryScanoutOutput::default);
+    let surface_primary_scanout_output = states.data_map.get::<SurfacePrimaryScanoutOutput>().unwrap();
+    surface_primary_scanout_output.lock().unwrap().current_output()
+}
+
+/// Update the surface primary scan-out output from a output render report
+///
+/// The compare function can be used to alter the behavior for selecting the primary scan-out
+/// output. See [`update_from_render_element_states`](crate::backend::renderer::element::PrimaryScanoutOutput::update_from_render_element_states) for more information about primary scan-out
+/// output selection.
+pub fn update_surface_primary_scanout_output<F>(
+    surface: &wl_surface::WlSurface,
+    output: &Output,
+    surface_data: &SurfaceData,
+    states: &RenderElementStates,
+    compare: F,
+) where
+    F: for<'a> Fn(&'a Output, &'a RenderElementState, &'a Output, &'a RenderElementState) -> &'a Output,
+{
+    surface_data
+        .data_map
+        .insert_if_missing_threadsafe(SurfacePrimaryScanoutOutput::default);
+    let surface_primary_scanout_output = surface_data
+        .data_map
+        .get::<SurfacePrimaryScanoutOutput>()
+        .unwrap();
+    surface_primary_scanout_output
+        .lock()
+        .unwrap()
+        .update_from_render_element_states(surface, output, states, compare);
+}
+
 /// Sends frame callbacks for a surface and its subsurfaces with the given `time`.
-pub fn send_frames_surface_tree(surface: &wl_surface::WlSurface, time: u32) {
+///
+/// The frame callbacks for a [`WlSurface`](wl_surface::WlSurface) will only be sent if the
+/// primary scan-out output equals the provided output or if the surface has no primary
+/// scan-out output and the frame callback is overdue. A frame callback is considered
+/// overdue if the last time a frame callback has been sent is greater than the provided
+/// throttle threshold. If the threshold is `None` this will never send frame callbacks
+/// for a surface that is not visible. Specifying [`Duration::ZERO`] as the throttle threshold
+/// will always send frame callbacks for non visible surfaces.
+#[allow(clippy::too_many_arguments)]
+pub fn send_frames_surface_tree<T, F>(
+    surface: &wl_surface::WlSurface,
+    output: &Output,
+    time: T,
+    throttle: Option<Duration>,
+    mut primary_scan_out_output: F,
+) where
+    T: Into<Duration>,
+    F: FnMut(&wl_surface::WlSurface, &SurfaceData) -> Option<Output>,
+{
+    let time = time.into();
+
     with_surface_tree_downward(
         surface,
         (),
         |_, _, &()| TraversalAction::DoChildren(()),
-        |_surf, states, &()| {
-            // the surface may not have any user_data if it is a subsurface and has not
-            // yet been commited
-            for callback in states
-                .cached_state
-                .current::<SurfaceAttributes>()
-                .frame_callbacks
-                .drain(..)
-            {
-                callback.done(time);
+        |surface, states, &()| {
+            states
+                .data_map
+                .insert_if_missing_threadsafe(SurfaceFrameThrottlingState::default);
+            let surface_frame_throttling_state =
+                states.data_map.get::<SurfaceFrameThrottlingState>().unwrap();
+
+            let on_primary_scanout_output = primary_scan_out_output(surface, states)
+                .map(|preferred_output| preferred_output == *output)
+                .unwrap_or(false);
+
+            let frame_overdue = surface_frame_throttling_state.update(time, throttle);
+
+            // We only want to send frame callbacks on the primary scan-out output
+            // or if we have no output and the frame is overdue, this can only
+            // happen if the surface is completely occluded on all outputs
+            let send_frame_callback = on_primary_scanout_output || frame_overdue;
+
+            if send_frame_callback {
+                // the surface may not have any user_data if it is a subsurface and has not
+                // yet been commited
+                for callback in states
+                    .cached_state
+                    .current::<SurfaceAttributes>()
+                    .frame_callbacks
+                    .drain(..)
+                {
+                    callback.done(time.as_millis() as u32);
+                }
             }
         },
         |_, _, &()| true,
     );
+}
+
+#[derive(Debug, Default)]
+struct SurfaceFrameThrottlingState(Mutex<Option<Duration>>);
+
+impl SurfaceFrameThrottlingState {
+    pub fn update(&self, time: Duration, throttle: Option<Duration>) -> bool {
+        if let Some(throttle) = throttle {
+            let mut guard = self.0.lock().unwrap();
+            let send_throttled_frame = guard
+                .map(|last| time.saturating_sub(last) > throttle)
+                .unwrap_or(true);
+            if send_throttled_frame {
+                *guard = Some(time);
+            }
+            send_throttled_frame
+        } else {
+            false
+        }
+    }
 }

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -169,10 +169,14 @@ pub fn run(channel: Channel<WlcsEvent>) {
         }
 
         // Send frame events so that client start drawing their next frame
-        state
-            .space
-            .elements()
-            .for_each(|window| window.send_frame(state.start_time.elapsed().as_millis() as u32));
+        state.space.elements().for_each(|window| {
+            window.send_frame(
+                &output,
+                state.start_time.elapsed(),
+                Some(Duration::ZERO),
+                |_, _| Some(output.clone()),
+            )
+        });
 
         let mut calloop_data = CalloopData { state, display };
         let result = event_loop.dispatch(Some(Duration::from_millis(16)), &mut calloop_data);


### PR DESCRIPTION
This PR adds a `OutputRenderReport` that holds the state for each `RenderElement`. The report can be used the query the `RenderElementState` for each element provided to the `render_output` function. The state is usefull to test if an element was skipped or directly scanned out.

The `send_frame` functions in desktop now allow to gate sending the frame callbacks by a provided function.
`desktop` now also offers a function to query the primary output for a window surface.

Anvil has been updated to use the report in combination with the send frame gate function to implement a simple
frame callback throttling for surfaces that have been skipped.
Additionally this also filters the frame callbacks to that they are not driven by the surface primary output.

same goal as #789 but with `wp_presentation_feedback` in mind
~~based on #793~~ merged and rebased

Todo:
- [ ] enhance docs
- [ ] review comments
- [ ] cleanup the mess in `PrimaryScanoutOutput::update_from_output_render_report`
- [ ] better `default_primary_scanout_output_compare` implementation based on refresh rate and visible portion