### PR TITLE
renderer: Add `Blit`-trait and implementations

### DIFF
--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1649,18 +1649,56 @@ where
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), <Self as Renderer>::Error> {
-        // glBlitFramebuffer is sadly only available for GLES 3.0 and higher
-        if self.gl_version < version::GLES_3_0 {
-            return Err(Gles2Error::GLVersionNotSupported(version::GLES_3_0));
-        }
-
+    ) -> Result<(), Gles2Error> {
         let src_target = self.target.take().ok_or(Gles2Error::BlitError)?;
         self.bind(to)?;
         let dst_target = self.target.take().unwrap();
         self.unbind()?;
 
-        match (&src_target, &dst_target) {
+        let result = self.blit(&src_target, &dst_target, src, dst, filter);
+
+        self.target = Some(src_target);
+        self.make_current()?;
+
+        result
+    }
+
+    fn blit_from(
+        &mut self,
+        from: Target,
+        src: Rectangle<i32, Physical>,
+        dst: Rectangle<i32, Physical>,
+        filter: TextureFilter,
+    ) -> Result<(), Gles2Error> {
+        let dst_target = self.target.take().ok_or(Gles2Error::BlitError)?;
+        self.bind(from)?;
+        let src_target = self.target.take().unwrap();
+        self.unbind()?;
+
+        let result = self.blit(&src_target, &dst_target, src, dst, filter);
+
+        self.target = Some(dst_target);
+        self.make_current()?;
+
+        result
+    }
+}
+
+impl Gles2Renderer {
+    fn blit(
+        &mut self,
+        src_target: &Gles2Target,
+        dst_target: &Gles2Target,
+        src: Rectangle<i32, Physical>,
+        dst: Rectangle<i32, Physical>,
+        filter: TextureFilter,
+    ) -> Result<(), Gles2Error> {
+        // glBlitFramebuffer is sadly only available for GLES 3.0 and higher
+        if self.gl_version < version::GLES_3_0 {
+            return Err(Gles2Error::GLVersionNotSupported(version::GLES_3_0));
+        }
+
+        match (src_target, dst_target) {
             (&Gles2Target::Surface(ref src), &Gles2Target::Surface(ref dst)) => unsafe {
                 self.egl
                     .make_current_with_draw_and_read_surface(Some(&**dst), Some(&**src))?;
@@ -1678,7 +1716,7 @@ where
             },
         }
 
-        match &src_target {
+        match src_target {
             Gles2Target::Image { ref buf, .. } => unsafe {
                 self.gl.BindFramebuffer(ffi::READ_FRAMEBUFFER, buf.fbo)
             },
@@ -1688,9 +1726,9 @@ where
             Gles2Target::Renderbuffer { ref fbo, .. } => unsafe {
                 self.gl.BindFramebuffer(ffi::READ_FRAMEBUFFER, *fbo)
             },
-            _ => {}
+            _ => {} // Note: The only target missing is `Surface` and handled above
         }
-        match &dst_target {
+        match dst_target {
             Gles2Target::Image { ref buf, .. } => unsafe {
                 self.gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, buf.fbo)
             },
@@ -1700,7 +1738,7 @@ where
             Gles2Target::Renderbuffer { ref fbo, .. } => unsafe {
                 self.gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, *fbo)
             },
-            _ => {}
+            _ => {} // Note: The only target missing is `Surface` and handled above
         }
 
         let status = unsafe { self.gl.CheckFramebufferStatus(ffi::FRAMEBUFFER) };
@@ -1728,10 +1766,6 @@ where
             );
             self.gl.GetError()
         };
-
-        self.unbind()?;
-        self.target = Some(src_target);
-        self.make_current()?;
 
         if errno == ffi::INVALID_OPERATION {
             Err(Gles2Error::BlitError)

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1710,7 +1710,7 @@ where
         }
 
         let errno = unsafe {
-            let _ = self.gl.GetError(); // clear flag before
+            while self.gl.GetError() != ffi::NO_ERROR {} // clear flag before
             self.gl.BlitFramebuffer(
                 src.loc.x,
                 src.loc.y,

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1677,6 +1677,7 @@ where
 
         let result = self.blit(&src_target, &dst_target, src, dst, filter);
 
+        self.unbind()?;
         self.target = Some(dst_target);
         self.make_current()?;
 

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1639,14 +1639,13 @@ impl Offscreen<Gles2Renderbuffer> for Gles2Renderer {
     }
 }
 
-impl<B1, B2> Blit<B1, B2> for Gles2Renderer
+impl<Target> Blit<Target> for Gles2Renderer
 where
-    Self: Bind<B1> + Bind<B2>,
+    Self: Bind<Target>,
 {
-    fn blit(
+    fn blit_to(
         &mut self,
-        from: B1,
-        to: B2,
+        to: Target,
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
@@ -1656,8 +1655,7 @@ where
             return Err(Gles2Error::GLVersionNotSupported(version::GLES_3_0));
         }
 
-        self.bind(from)?;
-        let src_target = self.target.take().unwrap();
+        let src_target = self.target.take().ok_or(Gles2Error::BlitError)?;
         self.bind(to)?;
         let dst_target = self.target.take().unwrap();
         self.unbind()?;
@@ -1732,6 +1730,8 @@ where
         };
 
         self.unbind()?;
+        self.target = Some(src_target);
+        self.make_current()?;
 
         if errno == ffi::INVALID_OPERATION {
             Err(Gles2Error::BlitError)

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1700,16 +1700,13 @@ impl Gles2Renderer {
 
         match (src_target, dst_target) {
             (&Gles2Target::Surface(ref src), &Gles2Target::Surface(ref dst)) => unsafe {
-                self.egl
-                    .make_current_with_draw_and_read_surface(Some(&**dst), Some(&**src))?;
+                self.egl.make_current_with_draw_and_read_surface(dst, src)?;
             },
             (&Gles2Target::Surface(ref src), _) => unsafe {
-                self.egl
-                    .make_current_with_draw_and_read_surface(None, Some(&**src))?;
+                self.egl.make_current_with_surface(src)?;
             },
             (_, &Gles2Target::Surface(ref dst)) => unsafe {
-                self.egl
-                    .make_current_with_draw_and_read_surface(Some(&**dst), None)?;
+                self.egl.make_current_with_surface(dst)?;
             },
             (_, _) => unsafe {
                 self.egl.make_current()?;

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -11,7 +11,7 @@ use crate::backend::{egl::display::EGLBufferReader, renderer::ImportEgl};
 use crate::{
     backend::{
         allocator::{dmabuf::Dmabuf, Format},
-        egl::{EGLContext, EGLSurface},
+        egl::EGLContext,
         renderer::{
             gles2::*, Bind, ExportDma, ExportMem, ImportDma, ImportMem, Offscreen, Renderer, TextureFilter,
             Unbind,
@@ -27,7 +27,6 @@ use glow::Context;
 use std::{
     borrow::{Borrow, BorrowMut},
     collections::HashSet,
-    rc::Rc,
     sync::Arc,
 };
 
@@ -366,50 +365,23 @@ impl ExportDma for GlowRenderer {
     }
 }
 
-impl Bind<Rc<EGLSurface>> for GlowRenderer {
-    fn bind(&mut self, surface: Rc<EGLSurface>) -> Result<(), Gles2Error> {
-        self.gl.bind(surface)
+impl<T> Bind<T> for GlowRenderer
+where
+    Gles2Renderer: Bind<T>,
+{
+    fn bind(&mut self, target: T) -> Result<(), Gles2Error> {
+        self.gl.bind(target)
     }
     fn supported_formats(&self) -> Option<HashSet<Format>> {
-        Bind::<Rc<EGLSurface>>::supported_formats(&self.gl)
+        self.gl.supported_formats()
     }
 }
 
-impl Bind<Dmabuf> for GlowRenderer {
-    fn bind(&mut self, dmabuf: Dmabuf) -> Result<(), Gles2Error> {
-        self.gl.bind(dmabuf)
-    }
-    fn supported_formats(&self) -> Option<HashSet<Format>> {
-        Bind::<Dmabuf>::supported_formats(&self.gl)
-    }
-}
-
-impl Bind<Gles2Texture> for GlowRenderer {
-    fn bind(&mut self, texture: Gles2Texture) -> Result<(), Gles2Error> {
-        self.gl.bind(texture)
-    }
-    fn supported_formats(&self) -> Option<HashSet<Format>> {
-        Bind::<Gles2Texture>::supported_formats(&self.gl)
-    }
-}
-
-impl Offscreen<Gles2Texture> for GlowRenderer {
-    fn create_buffer(&mut self, size: Size<i32, BufferCoord>) -> Result<Gles2Texture, Gles2Error> {
-        self.gl.create_buffer(size)
-    }
-}
-
-impl Bind<Gles2Renderbuffer> for GlowRenderer {
-    fn bind(&mut self, renderbuffer: Gles2Renderbuffer) -> Result<(), Gles2Error> {
-        self.gl.bind(renderbuffer)
-    }
-    fn supported_formats(&self) -> Option<HashSet<Format>> {
-        Bind::<Gles2Renderbuffer>::supported_formats(&self.gl)
-    }
-}
-
-impl Offscreen<Gles2Renderbuffer> for GlowRenderer {
-    fn create_buffer(&mut self, size: Size<i32, BufferCoord>) -> Result<Gles2Renderbuffer, Gles2Error> {
+impl<T> Offscreen<T> for GlowRenderer
+where
+    Gles2Renderer: Offscreen<T>,
+{
+    fn create_buffer(&mut self, size: Size<i32, BufferCoord>) -> Result<T, Gles2Error> {
         self.gl.create_buffer(size)
     }
 }

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -386,19 +386,18 @@ where
     }
 }
 
-impl<B1, B2> Blit<B1, B2> for GlowRenderer
+impl<Target> Blit<Target> for GlowRenderer
 where
-    Gles2Renderer: Blit<B1, B2>,
+    Gles2Renderer: Blit<Target>,
 {
-    fn blit(
+    fn blit_to(
         &mut self,
-        from: B1,
-        to: B2,
+        to: Target,
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
     ) -> Result<(), Gles2Error> {
-        self.gl.blit(from, to, src, dst, filter)
+        self.gl.blit_to(to, src, dst, filter)
     }
 }
 

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -399,6 +399,16 @@ where
     ) -> Result<(), Gles2Error> {
         self.gl.blit_to(to, src, dst, filter)
     }
+
+    fn blit_from(
+        &mut self,
+        from: Target,
+        src: Rectangle<i32, Physical>,
+        dst: Rectangle<i32, Physical>,
+        filter: TextureFilter,
+    ) -> Result<(), Gles2Error> {
+        self.gl.blit_from(from, src, dst, filter)
+    }
 }
 
 impl Unbind for GlowRenderer {

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -13,8 +13,8 @@ use crate::{
         allocator::{dmabuf::Dmabuf, Format},
         egl::EGLContext,
         renderer::{
-            gles2::*, Bind, ExportDma, ExportMem, ImportDma, ImportMem, Offscreen, Renderer, TextureFilter,
-            Unbind,
+            gles2::*, Bind, Blit, ExportDma, ExportMem, ImportDma, ImportMem, Offscreen, Renderer,
+            TextureFilter, Unbind,
         },
     },
     utils::{Buffer as BufferCoord, Physical, Rectangle, Size, Transform},
@@ -383,6 +383,22 @@ where
 {
     fn create_buffer(&mut self, size: Size<i32, BufferCoord>) -> Result<T, Gles2Error> {
         self.gl.create_buffer(size)
+    }
+}
+
+impl<B1, B2> Blit<B1, B2> for GlowRenderer
+where
+    Gles2Renderer: Blit<B1, B2>,
+{
+    fn blit(
+        &mut self,
+        from: B1,
+        to: B2,
+        src: Rectangle<i32, Physical>,
+        dst: Rectangle<i32, Physical>,
+        filter: TextureFilter,
+    ) -> Result<(), Gles2Error> {
+        self.gl.blit(from, to, src, dst, filter)
     }
 }
 

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -583,6 +583,36 @@ pub trait ExportDma: Renderer {
     ) -> Result<Dmabuf, <Self as Renderer>::Error>;
 }
 
+/// Trait for renderers supporting blitting contents from one framebuffer to another.
+pub trait Blit<B1, B2>
+where
+    Self: Renderer + Bind<B1> + Bind<B2>,
+{
+    /// Copies the contents of `src` in B1 to `dst` in B2, applying `filter` if necessary.
+    ///
+    /// This operation is non destructive, the contents of the source framebuffer
+    /// are kept intact as is any region not in `dst` for the target framebuffer.
+    ///
+    /// This operation needs no bound or default rendering target.
+    /// The currently bound target might get unbound during this operation and not restored.
+    ///
+    /// This function *may* fail, if (but not limited to):
+    /// - The source framebuffer is not readable
+    /// - The destination framebuffer is not writable
+    /// - `src` is out of bounds for the source framebuffer
+    /// - `dst` is out of bounds for the destination framebuffer
+    /// - `src` and `dst` sizes are different and interpolation id not supported by this renderer.
+    /// - source and target framebuffer are the same, and `src` and `dst` overlap
+    fn blit(
+        &mut self,
+        from: B1,
+        to: B2,
+        src: Rectangle<i32, Physical>,
+        dst: Rectangle<i32, Physical>,
+        filter: TextureFilter,
+    ) -> Result<(), <Self as Renderer>::Error>;
+}
+
 #[cfg(feature = "wayland_frontend")]
 #[non_exhaustive]
 /// Buffer type of a given wl_buffer, if managed by smithay

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -584,29 +584,29 @@ pub trait ExportDma: Renderer {
 }
 
 /// Trait for renderers supporting blitting contents from one framebuffer to another.
-pub trait Blit<B1, B2>
+pub trait Blit<Target>
 where
-    Self: Renderer + Bind<B1> + Bind<B2>,
+    Self: Renderer + Bind<Target>,
 {
-    /// Copies the contents of `src` in B1 to `dst` in B2, applying `filter` if necessary.
+    /// Copies the contents of `src` in the current bound framebuffer to `dst` in Target,
+    /// applying `filter` if necessary.
     ///
     /// This operation is non destructive, the contents of the source framebuffer
     /// are kept intact as is any region not in `dst` for the target framebuffer.
     ///
-    /// This operation needs no bound or default rendering target.
-    /// The currently bound target might get unbound during this operation and not restored.
+    /// This operation needs a bound or default rendering target.
+    /// The currently bound target is guaranteed to still be active after this operation.
     ///
     /// This function *may* fail, if (but not limited to):
-    /// - The source framebuffer is not readable
+    /// - The source framebuffer is not readable / unset
     /// - The destination framebuffer is not writable
     /// - `src` is out of bounds for the source framebuffer
     /// - `dst` is out of bounds for the destination framebuffer
     /// - `src` and `dst` sizes are different and interpolation id not supported by this renderer.
     /// - source and target framebuffer are the same, and `src` and `dst` overlap
-    fn blit(
+    fn blit_to(
         &mut self,
-        from: B1,
-        to: B2,
+        to: Target,
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -611,6 +611,30 @@ where
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
     ) -> Result<(), <Self as Renderer>::Error>;
+
+    /// Copies the contents of `src` in Target to `dst` of the current bound framebuffer,
+    /// applying `filter` if necessary.
+    ///
+    /// This operation is non destructive, the contents of the source framebuffer
+    /// are kept intact as is any region not in `dst` for the target framebuffer.
+    ///
+    /// This operation needs a bound or default rendering target.
+    /// The currently bound target is guaranteed to still be active after this operation.
+    ///
+    /// This function *may* fail, if (but not limited to):
+    /// - The source framebuffer is not readable
+    /// - The destination framebuffer is not writable / unset
+    /// - `src` is out of bounds for the source framebuffer
+    /// - `dst` is out of bounds for the destination framebuffer
+    /// - `src` and `dst` sizes are different and interpolation id not supported by this renderer.
+    /// - source and target framebuffer are the same, and `src` and `dst` overlap
+    fn blit_from(
+        &mut self,
+        from: Target,
+        src: Rectangle<i32, Physical>,
+        dst: Rectangle<i32, Physical>,
+        filter: TextureFilter,
+    ) -> Result<(), <Self as Renderer>::Error>;
 }
 
 #[cfg(feature = "wayland_frontend")]

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1961,17 +1961,11 @@ where
     }
 }
 
-impl<'a, 'b, R: GraphicsApi, T: GraphicsApi, Target, B1, B2> Blit<B1, B2>
+impl<'a, 'b, R: GraphicsApi, T: GraphicsApi, Target, BlitTarget> Blit<BlitTarget>
     for MultiRenderer<'a, 'b, R, T, Target>
 where
-    <R::Device as ApiDevice>::Renderer: Blit<B1, B2>,
-    <T::Device as ApiDevice>::Renderer: Blit<B1, B2>,
-    // We need these because the Bind-impl does and Bind requires Bind
-    <T::Device as ApiDevice>::Renderer: Bind<Target>,
-    <R::Device as ApiDevice>::Renderer: Bind<Target>,
-    // We need these because the Unbind-impl does and Blit requires Bind, which requires Unbind
-    <R::Device as ApiDevice>::Renderer: Unbind,
-    <T::Device as ApiDevice>::Renderer: Unbind,
+    <R::Device as ApiDevice>::Renderer: Blit<BlitTarget>,
+    <T::Device as ApiDevice>::Renderer: Blit<BlitTarget>,
     // We need this because the Renderer-impl does and Blit requires Renderer
     R: 'static,
     R::Error: 'static,
@@ -1981,10 +1975,9 @@ where
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    fn blit(
+    fn blit_to(
         &mut self,
-        from: B1,
-        to: B2,
+        to: BlitTarget,
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
@@ -1992,12 +1985,12 @@ where
         if let Some(target) = self.target.as_mut() {
             target
                 .renderer_mut()
-                .blit(from, to, src, dst, filter)
+                .blit_to(to, src, dst, filter)
                 .map_err(Error::Target)
         } else {
             self.render
                 .renderer_mut()
-                .blit(from, to, src, dst, filter)
+                .blit_to(to, src, dst, filter)
                 .map_err(Error::Render)
         }
     }

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1994,4 +1994,24 @@ where
                 .map_err(Error::Render)
         }
     }
+
+    fn blit_from(
+        &mut self,
+        from: BlitTarget,
+        src: Rectangle<i32, Physical>,
+        dst: Rectangle<i32, Physical>,
+        filter: TextureFilter,
+    ) -> Result<(), <Self as Renderer>::Error> {
+        if let Some(target) = self.target.as_mut() {
+            target
+                .renderer_mut()
+                .blit_from(from, src, dst, filter)
+                .map_err(Error::Target)
+        } else {
+            self.render
+                .renderer_mut()
+                .blit_from(from, src, dst, filter)
+                .map_err(Error::Render)
+        }
+    }
 }

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -318,6 +318,14 @@ where
         Ok(())
     }
 
+    /// Retrieve the underlying `EGLSurface` for advanced operations
+    ///
+    /// **Note:** Don't carelessly use this to manually bind the renderer to the surface,
+    /// `WinitGraphicsBackend::bind` transparently handles window resizes for you.
+    pub fn egl_surface(&self) -> Rc<EGLSurface> {
+        self.egl.clone()
+    }
+
     /// Retrieve the buffer age of the current backbuffer of the window.
     ///
     /// This will only return a meaningful value, if this `WinitGraphicsBackend`


### PR DESCRIPTION
Adds a new trait `Blit` that can be used to do copies between framebuffers.
These are usually more performant, than exporting the source framebuffer and rendering the resulting texture to the target framebuffer, if supported.

Best reviewed commit-by-commit.