### PR TITLE
Fix compiling glow renderer with use_system_lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ use_system_lib = ["wayland_frontend", "wayland-backend/server_system", "wayland-
 wayland_frontend = ["wayland-server", "wayland-protocols", "tempfile"]
 x11rb_event_source = ["x11rb"]
 xwayland = ["wayland_frontend"]
-test_all_features = ["default", "renderer_glow"]
+test_all_features = ["default", "use_system_lib", "renderer_glow"]
 
 [[example]]
 name = "minimal"

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -7,10 +7,7 @@ use crate::backend::renderer::{ImportDmaWl, ImportMemWl};
     feature = "backend_egl",
     feature = "use_system_lib"
 ))]
-use crate::backend::{
-    egl::display::{EGLBufferReader, Error as EglError},
-    renderer::ImportEgl,
-};
+use crate::backend::{egl::display::EGLBufferReader, renderer::ImportEgl};
 use crate::{
     backend::{
         allocator::{dmabuf::Dmabuf, Format},
@@ -262,7 +259,7 @@ impl ImportEgl for GlowRenderer {
     }
 
     fn egl_reader(&self) -> Option<&EGLBufferReader> {
-        self.gl.egl_render()
+        self.gl.egl_reader()
     }
 
     fn import_egl_buffer(


### PR DESCRIPTION
Little oversight writing the glow renderer. (Why was use_system_lib not added to test_all_features? :thinking: )