### PR TITLE
input: Expose `AxisFrame` values

### DIFF
--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -115,11 +115,13 @@ where
                     ptr.axis_source(source);
                 }
                 // axis discrete
-                if details.discrete.0 != 0 {
-                    ptr.axis_discrete(WlAxis::HorizontalScroll, details.discrete.0);
-                }
-                if details.discrete.1 != 0 {
-                    ptr.axis_discrete(WlAxis::VerticalScroll, details.discrete.1);
+                if let Some((x, y)) = details.discrete {
+                    if x != 0 {
+                        ptr.axis_discrete(WlAxis::HorizontalScroll, x);
+                    }
+                    if y != 0 {
+                        ptr.axis_discrete(WlAxis::VerticalScroll, y);
+                    }
                 }
                 // stop
                 if details.stop.0 {


### PR DESCRIPTION
Currently all values of `AxisFrame` are private, making it completely useless if passed for [`PointerTarget::axis`](https://smithay.github.io/smithay/smithay/input/pointer/trait.PointerTarget.html#tymethod.axis), when implementing a new target out of tree.

This PR fixes that. (And also includes a small bugfix to properly accumulate multiple value calls, as the docs say.)