### PR TITLE
element: Allow errors to escape from  `RenderContext::draw`

### DIFF
--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -135,7 +135,7 @@
 //!             // Update the changed parts of the buffer
 //!
 //!             // Return the updated parts
-//!             vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))]
+//!             Result::<_, ()>::Ok(vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))])
 //!         });
 //!
 //!         last_update = now;

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -135,7 +135,7 @@
 //!     });
 //!
 //!     // Return the whole buffer as damage
-//!     vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))]
+//!     Result::<_, ()>::Ok(vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))])
 //! });
 //!
 //! // Optionally update the opaque regions
@@ -162,7 +162,7 @@
 //!             // Update the changed parts of the buffer
 //!
 //!             // Return the updated parts
-//!             vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))]
+//!             Result::<_, ()>::Ok(vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))])
 //!         });
 //!
 //!         last_update = now;
@@ -398,12 +398,13 @@ impl<'a> RenderContext<'a> {
     /// Draw to the buffer
     ///
     /// Provided closure has to return updated regions.
-    pub fn draw<F>(&mut self, f: F)
+    pub fn draw<F, E>(&mut self, f: F) -> Result<(), E>
     where
-        F: FnOnce(&mut [u8]) -> Vec<Rectangle<i32, Buffer>>,
+        F: FnOnce(&mut [u8]) -> Result<Vec<Rectangle<i32, Buffer>>, E>,
     {
-        let draw_damage = f(&mut self.buffer.mem);
+        let draw_damage = f(&mut self.buffer.mem)?;
         self.damage.extend(draw_damage);
+        Ok(())
     }
 
     /// Update the opaque regions

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -294,10 +294,10 @@
 //!     // Your draw code here...
 //!
 //!     // Return the damage areas
-//!     vec![Rectangle::from_loc_and_size(
+//!     Result::<_, ()>::Ok(vec![Rectangle::from_loc_and_size(
 //!         Point::default(),
 //!         Size::from((WIDTH, HEIGHT)),
-//!     )]
+//!     )])
 //! });
 //!
 //! // Optionally update the opaque regions
@@ -322,7 +322,7 @@
 //!             // Update the changed parts of the buffer
 //!
 //!             // Return the updated parts
-//!             vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))]
+//!             Result::<_, ()>::Ok(vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))])
 //!         });
 //!
 //!         last_update = now;
@@ -513,12 +513,13 @@ pub struct RenderContext<'a, T> {
 
 impl<'a, T> RenderContext<'a, T> {
     /// Draw to the buffer
-    pub fn draw<F>(&mut self, f: F)
+    pub fn draw<F, E>(&mut self, f: F) -> Result<(), E>
     where
-        F: FnOnce(&T) -> Vec<Rectangle<i32, Buffer>>,
+        F: FnOnce(&T) -> Result<Vec<Rectangle<i32, Buffer>>, E>,
     {
-        let draw_damage = f(&self.buffer.texture);
+        let draw_damage = f(&self.buffer.texture)?;
         self.damage.extend(draw_damage);
+        Ok(())
     }
 
     /// Update the opaque regions


### PR DESCRIPTION
cc @cmeissl 

Allows errors to propage from inside the `RenderContext::draw` call.