### PR TITLE
GAT Frame

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -51,7 +51,7 @@ impl<T: Texture> PointerElement<T> {
 render_elements! {
     pub PointerRenderElement<R> where
         R: ImportAll;
-    Surface=WaylandSurfaceRenderElement,
+    Surface=WaylandSurfaceRenderElement<R>,
     Texture=TextureRenderElement<<R as Renderer>::TextureId>,
 }
 
@@ -60,7 +60,12 @@ where
     R: Renderer<TextureId = T> + ImportAll,
 {
     type RenderElement = PointerRenderElement<R>;
-    fn render_elements<E>(&self, location: Point<i32, Physical>, scale: Scale<f64>) -> Vec<E>
+    fn render_elements<E>(
+        &self,
+        renderer: &mut R,
+        location: Point<i32, Physical>,
+        scale: Scale<f64>,
+    ) -> Vec<E>
     where
         E: From<PointerRenderElement<R>>,
     {
@@ -85,7 +90,7 @@ where
             CursorImageStatus::Surface(surface) => {
                 let elements: Vec<PointerRenderElement<R>> =
                     smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
-                        surface, location, scale,
+                        renderer, surface, location, scale, None,
                     );
                 elements.into_iter().map(E::from).collect()
             }
@@ -172,8 +177,7 @@ where
 {
     fn draw(
         &self,
-        _renderer: &mut R,
-        frame: &mut <R as Renderer>::Frame,
+        frame: &mut <R as Renderer>::Frame<'_>,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         damage: &[Rectangle<i32, Physical>],

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -20,7 +20,7 @@ smithay::backend::renderer::element::render_elements! {
     pub CustomRenderElements<R> where
         R: ImportAll;
     Pointer=PointerRenderElement<R>,
-    Surface=WaylandSurfaceRenderElement,
+    Surface=WaylandSurfaceRenderElement<R>,
     #[cfg(feature = "debug")]
     // Note: We would like to borrow this element instead, but that would introduce
     // a feature-dependent lifetime, which introduces a lot more feature bounds
@@ -53,7 +53,8 @@ where
         }
 
         let scale = output.current_scale().fractional_scale().into();
-        let window_render_elements = AsRenderElements::<R>::render_elements(&window, (0, 0).into(), scale);
+        let window_render_elements =
+            AsRenderElements::<R>::render_elements(&window, renderer, (0, 0).into(), scale);
 
         let render_elements = custom_elements
             .iter()

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -252,7 +252,7 @@ pub fn run_winit(log: Logger) {
 
                 let mut elements = Vec::<CustomRenderElements<Gles2Renderer>>::new();
 
-                elements.extend(pointer_element.render_elements(cursor_pos_scaled, scale));
+                elements.extend(pointer_element.render_elements(renderer, cursor_pos_scaled, scale));
 
                 // draw input method surface if any
                 let rectangle = input_method.coordinates();
@@ -263,6 +263,7 @@ pub fn run_winit(log: Logger) {
                 input_method.with_surface(|surface| {
                     elements.extend(AsRenderElements::<Gles2Renderer>::render_elements(
                         &smithay::desktop::space::SurfaceTree::from_surface(surface),
+                        renderer,
                         position.to_physical_precise_round(scale),
                         scale,
                     ));
@@ -273,6 +274,7 @@ pub fn run_winit(log: Logger) {
                     if surface.alive() {
                         elements.extend(AsRenderElements::<Gles2Renderer>::render_elements(
                             &smithay::desktop::space::SurfaceTree::from_surface(surface),
+                            renderer,
                             cursor_pos_scaled,
                             scale,
                         ));

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -280,7 +280,11 @@ pub fn run_x11(log: Logger) {
             let cursor_pos_scaled = cursor_pos.to_physical(scale).to_i32_round();
 
             pointer_element.set_status(cursor_guard.clone());
-            elements.extend(pointer_element.render_elements(cursor_pos_scaled, scale));
+            elements.extend(pointer_element.render_elements(
+                &mut backend_data.renderer,
+                cursor_pos_scaled,
+                scale,
+            ));
 
             // draw input method surface if any
             let input_method = state.seat.input_method().unwrap();
@@ -292,6 +296,7 @@ pub fn run_x11(log: Logger) {
             input_method.with_surface(|surface| {
                 elements.extend(AsRenderElements::<Gles2Renderer>::render_elements(
                     &smithay::desktop::space::SurfaceTree::from_surface(surface),
+                    &mut backend_data.renderer,
                     position.to_physical_precise_round(scale),
                     scale,
                 ));
@@ -302,6 +307,7 @@ pub fn run_x11(log: Logger) {
                 if surface.alive() {
                     elements.extend(AsRenderElements::<Gles2Renderer>::render_elements(
                         &smithay::desktop::space::SurfaceTree::from_surface(surface),
+                        &mut backend_data.renderer,
                         cursor_pos_scaled,
                         scale,
                     ));

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -118,7 +118,7 @@ pub fn winit_dispatch(
     let damage = Rectangle::from_loc_and_size((0, 0), size);
 
     backend.bind()?;
-    smithay::desktop::space::render_output::<_, WaylandSurfaceRenderElement, _, _, _>(
+    smithay::desktop::space::render_output::<_, WaylandSurfaceRenderElement<Gles2Renderer>, _, _, _>(
         output,
         backend.renderer(),
         0,

--- a/src/backend/renderer/element/tests.rs
+++ b/src/backend/renderer/element/tests.rs
@@ -143,10 +143,9 @@ impl<R> RenderElement<R> for ImportMemRenderElement
 where
     R: Renderer + ImportMem,
 {
-    fn draw(
+    fn draw<'a>(
         &self,
-        _renderer: &mut R,
-        _frame: &mut <R as Renderer>::Frame,
+        _frame: &mut <R as Renderer>::Frame<'a>,
         _location: Point<i32, Physical>,
         _scale: Scale<f64>,
         _damage: &[Rectangle<i32, Physical>],
@@ -182,10 +181,9 @@ impl<R> RenderElement<R> for Empty
 where
     R: Renderer,
 {
-    fn draw(
+    fn draw<'a>(
         &self,
-        _renderer: &mut R,
-        _frame: &mut <R as Renderer>::Frame,
+        _frame: &mut <R as Renderer>::Frame<'a>,
         _location: Point<i32, Physical>,
         _scale: Scale<f64>,
         _damage: &[Rectangle<i32, Physical>],
@@ -230,10 +228,9 @@ impl<R> RenderElement<R> for TestRenderElement2<R>
 where
     R: Renderer,
 {
-    fn draw(
+    fn draw<'a>(
         &self,
-        _renderer: &mut R,
-        _frame: &mut <R as Renderer>::Frame,
+        _frame: &mut <R as Renderer>::Frame<'a>,
         _location: Point<i32, Physical>,
         _scale: Scale<f64>,
         _damage: &[Rectangle<i32, Physical>],
@@ -277,10 +274,9 @@ impl<'a, R> RenderElement<R> for TestRenderElement<'a, R>
 where
     R: Renderer,
 {
-    fn draw(
+    fn draw<'b>(
         &self,
-        _renderer: &mut R,
-        _frame: &mut <R as Renderer>::Frame,
+        _frame: &mut <R as Renderer>::Frame<'b>,
         _location: Point<i32, Physical>,
         _scale: Scale<f64>,
         _damage: &[Rectangle<i32, Physical>],

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -64,6 +64,7 @@
 //! #     type Error = std::convert::Infallible;
 //! #     type TextureId = FakeTexture;
 //! #
+//! #     fn id(&self) -> usize { unimplemented!() }
 //! #     fn clear(&mut self, _: [f32; 4], _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }
@@ -81,6 +82,7 @@
 //! #     fn transformation(&self) -> Transform {
 //! #         unimplemented!()
 //! #     }
+//! #     fn finish(self) -> Result<(), Self::Error> { unimplemented!() }
 //! # }
 //! #
 //! # struct FakeRenderer;
@@ -88,7 +90,7 @@
 //! # impl Renderer for FakeRenderer {
 //! #     type Error = std::convert::Infallible;
 //! #     type TextureId = FakeTexture;
-//! #     type Frame = FakeFrame;
+//! #     type Frame<'a> = FakeFrame;
 //! #
 //! #     fn id(&self) -> usize {
 //! #         unimplemented!()
@@ -99,9 +101,7 @@
 //! #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }
-//! #     fn render<F, R>(&mut self, _: Size<i32, Physical>, _: Transform, _: F) -> Result<R, Self::Error>
-//! #     where
-//! #         F: FnOnce(&mut Self, &mut Self::Frame) -> R,
+//! #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>
 //! #     {
 //! #         unimplemented!()
 //! #     }
@@ -195,6 +195,7 @@
 //! #     type Error = std::convert::Infallible;
 //! #     type TextureId = FakeTexture;
 //! #
+//! #     fn id(&self) -> usize { unimplemented!() }
 //! #     fn clear(&mut self, _: [f32; 4], _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }
@@ -212,6 +213,7 @@
 //! #     fn transformation(&self) -> Transform {
 //! #         unimplemented!()
 //! #     }
+//! #     fn finish(self) -> Result<(), Self::Error> { unimplemented!() }
 //! # }
 //! #
 //! # struct FakeRenderer;
@@ -219,7 +221,7 @@
 //! # impl Renderer for FakeRenderer {
 //! #     type Error = std::convert::Infallible;
 //! #     type TextureId = FakeTexture;
-//! #     type Frame = FakeFrame;
+//! #     type Frame<'a> = FakeFrame;
 //! #
 //! #     fn id(&self) -> usize {
 //! #         unimplemented!()
@@ -230,9 +232,7 @@
 //! #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }
-//! #     fn render<F, R>(&mut self, _: Size<i32, Physical>, _: Transform, _: F) -> Result<R, Self::Error>
-//! #     where
-//! #         F: FnOnce(&mut Self, &mut Self::Frame) -> R,
+//! #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>
 //! #     {
 //! #         unimplemented!()
 //! #     }
@@ -801,16 +801,15 @@ where
     R: Renderer<TextureId = T>,
     T: Texture,
 {
-    fn draw(
+    fn draw<'a>(
         &self,
-        renderer: &mut R,
-        frame: &mut <R as Renderer>::Frame,
+        frame: &mut <R as Renderer>::Frame<'a>,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         damage: &[Rectangle<i32, Physical>],
         log: &slog::Logger,
     ) -> Result<(), <R as Renderer>::Error> {
-        if renderer.id() != self.renderer_id {
+        if frame.id() != self.renderer_id {
             warn!(log, "trying to render texture from different renderer");
             return Ok(());
         }

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -304,15 +304,15 @@ impl Drop for RendererId {
 /// which might cause glitches. Additionally parts of the GL state might not be reset correctly,
 /// causing unexpected results for later render commands.
 /// The internal GL context and framebuffer will remain valid, no re-creation will be necessary.
-pub struct Gles2Frame<'a> {
-    renderer: &'a mut Gles2Renderer,
+pub struct Gles2Frame<'frame> {
+    renderer: &'frame mut Gles2Renderer,
     current_projection: Matrix3<f32>,
     transform: Transform,
     size: Size<i32, Physical>,
     finished: AtomicBool,
 }
 
-impl<'a> fmt::Debug for Gles2Frame<'a> {
+impl<'frame> fmt::Debug for Gles2Frame<'frame> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Gles2Frame")
             .field("renderer", &self.renderer)
@@ -1682,7 +1682,7 @@ impl Gles2Renderer {
     }
 }
 
-impl<'a> Gles2Frame<'a> {
+impl<'frame> Gles2Frame<'frame> {
     /// Run custom code in the GL context owned by this renderer.
     ///
     /// The OpenGL state of the renderer is considered an implementation detail
@@ -1702,7 +1702,7 @@ impl<'a> Gles2Frame<'a> {
 impl Renderer for Gles2Renderer {
     type Error = Gles2Error;
     type TextureId = Gles2Texture;
-    type Frame<'a> = Gles2Frame<'a>;
+    type Frame<'frame> = Gles2Frame<'frame>;
 
     fn id(&self) -> usize {
         self.egl.user_data().get::<RendererId>().unwrap().0
@@ -1817,7 +1817,7 @@ const fn triangle_verts() -> [ffi::types::GLfloat; 12 * MAX_RECTS_PER_DRAW] {
     verts
 }
 
-impl<'a> Frame for Gles2Frame<'a> {
+impl<'frame> Frame for Gles2Frame<'frame> {
     type TextureId = Gles2Texture;
     type Error = Gles2Error;
 
@@ -2034,7 +2034,7 @@ impl<'a> Frame for Gles2Frame<'a> {
     }
 }
 
-impl<'a> Gles2Frame<'a> {
+impl<'frame> Gles2Frame<'frame> {
     fn finish_internal(&mut self) -> Result<(), Gles2Error> {
         if self.finished.swap(true, Ordering::SeqCst) {
             return Ok(());
@@ -2234,7 +2234,7 @@ impl<'a> Gles2Frame<'a> {
     }
 }
 
-impl<'a> Drop for Gles2Frame<'a> {
+impl<'frame> Drop for Gles2Frame<'frame> {
     fn drop(&mut self) {
         if let Err(err) = self.finish_internal() {
             slog::warn!(

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -2239,7 +2239,7 @@ impl<'a> Drop for Gles2Frame<'a> {
         if let Err(err) = self.finish_internal() {
             slog::warn!(
                 self.renderer.logger,
-                "Ignored error finishing MultiFrame on drop: {}",
+                "Ignored error finishing Gles2Frame on drop: {}",
                 err
             );
         }

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -298,7 +298,12 @@ impl Drop for RendererId {
     }
 }
 
-/// Handle to the currently rendered frame during [`Gles2Renderer::render`](Renderer::render)
+/// Handle to the currently rendered frame during [`Gles2Renderer::render`](Renderer::render).
+///
+/// Leaking this frame will prevent it from synchronizing the rendered framebuffer,
+/// which might cause glitches. Additionally parts of the GL state might not be reset correctly,
+/// causing unexpected results for later render commands.
+/// The internal GL context and framebuffer will remain valid, no re-creation will be necessary.
 pub struct Gles2Frame<'a> {
     renderer: &'a mut Gles2Renderer,
     current_projection: Matrix3<f32>,

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -27,53 +27,26 @@ use glow::Context;
 use std::{
     borrow::{Borrow, BorrowMut},
     collections::HashSet,
-    fmt,
-    ops::{Deref, DerefMut},
     rc::Rc,
     sync::Arc,
 };
 
+use super::Frame;
+
 #[derive(Debug)]
 /// A renderer utilizing OpenGL ES 2 and [`glow`] on top for easier custom rendering.
 pub struct GlowRenderer {
-    gl: Gles2Hack,
+    gl: Gles2Renderer,
     glow: Arc<Context>,
     logger: slog::Logger,
 }
 
-#[allow(clippy::large_enum_variant)]
-enum Gles2Hack {
-    Owned(Gles2Renderer),
-    Borrowed(*mut Gles2Renderer),
-}
-
-impl fmt::Debug for Gles2Hack {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            Gles2Hack::Owned(renderer) => renderer.fmt(f),
-            Gles2Hack::Borrowed(renderer) => unsafe { &**renderer }.fmt(f),
-        }
-    }
-}
-
-impl Deref for Gles2Hack {
-    type Target = Gles2Renderer;
-
-    fn deref(&self) -> &Gles2Renderer {
-        match self {
-            Gles2Hack::Owned(renderer) => renderer,
-            Gles2Hack::Borrowed(renderer) => unsafe { &**renderer },
-        }
-    }
-}
-
-impl DerefMut for Gles2Hack {
-    fn deref_mut(&mut self) -> &mut Gles2Renderer {
-        match self {
-            Gles2Hack::Owned(renderer) => renderer,
-            Gles2Hack::Borrowed(renderer) => unsafe { &mut **renderer },
-        }
-    }
+#[derive(Debug)]
+/// [`Frame`](super::Frame) implementation of a [`GlowRenderer`].
+pub struct GlowFrame<'a> {
+    frame: Option<Gles2Frame<'a>>,
+    glow: Arc<Context>,
+    log: slog::Logger,
 }
 
 impl GlowRenderer {
@@ -105,7 +78,7 @@ impl GlowRenderer {
         let gl = Gles2Renderer::new(context, log.clone())?;
 
         Ok(GlowRenderer {
-            gl: Gles2Hack::Owned(gl),
+            gl,
             glow: Arc::new(glow),
             logger: log,
         })
@@ -121,7 +94,9 @@ impl GlowRenderer {
     pub fn egl_context(&self) -> &EGLContext {
         self.gl.egl_context()
     }
+}
 
+impl<'a> GlowFrame<'a> {
     /// Run custom code in the GL context owned by this renderer.
     ///
     /// The OpenGL state of the renderer is considered an implementation detail
@@ -132,11 +107,9 @@ impl GlowRenderer {
     /// Doing otherwise can lead to rendering errors while using other functions of this renderer.
     pub fn with_context<F, R>(&mut self, func: F) -> Result<R, Gles2Error>
     where
-        F: FnOnce(&mut Self, &Arc<Context>) -> R,
+        F: FnOnce(&Arc<Context>) -> R,
     {
-        self.gl.make_current()?;
-        let glow = self.glow.clone();
-        Ok(func(self, &glow))
+        Ok(func(&self.glow))
     }
 }
 
@@ -152,7 +125,7 @@ impl From<Gles2Renderer> for GlowRenderer {
         };
 
         GlowRenderer {
-            gl: Gles2Hack::Owned(renderer),
+            gl: renderer,
             glow: Arc::new(glow),
             logger: log,
         }
@@ -174,7 +147,7 @@ impl BorrowMut<Gles2Renderer> for GlowRenderer {
 impl Renderer for GlowRenderer {
     type Error = Gles2Error;
     type TextureId = Gles2Texture;
-    type Frame = Gles2Frame;
+    type Frame<'a> = GlowFrame<'a>;
 
     fn id(&self) -> usize {
         self.gl.id()
@@ -187,25 +160,93 @@ impl Renderer for GlowRenderer {
         self.gl.upscale_filter(filter)
     }
 
-    fn render<F, R>(
+    fn render(
         &mut self,
         output_size: Size<i32, Physical>,
         transform: Transform,
-        rendering: F,
-    ) -> Result<R, Self::Error>
-    where
-        F: FnOnce(&mut Self, &mut Self::Frame) -> R,
-    {
-        self.gl.render(output_size, transform, |gl, frame| {
-            rendering(
-                &mut GlowRenderer {
-                    gl: Gles2Hack::Borrowed(gl as *mut _),
-                    glow: self.glow.clone(),
-                    logger: self.logger.clone(),
-                },
-                frame,
-            )
+    ) -> Result<GlowFrame<'_>, Self::Error> {
+        let glow = self.glow.clone();
+        let frame = self.gl.render(output_size, transform)?;
+        Ok(GlowFrame {
+            frame: Some(frame),
+            glow,
+            log: self.logger.clone(),
         })
+    }
+}
+
+impl<'a> Frame for GlowFrame<'a> {
+    type TextureId = Gles2Texture;
+    type Error = Gles2Error;
+
+    fn id(&self) -> usize {
+        self.frame.as_ref().unwrap().id()
+    }
+
+    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+        self.frame.as_mut().unwrap().clear(color, at)
+    }
+
+    fn render_texture_from_to(
+        &mut self,
+        texture: &Self::TextureId,
+        src: Rectangle<f64, BufferCoord>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        src_transform: Transform,
+        alpha: f32,
+    ) -> Result<(), Self::Error> {
+        self.frame
+            .as_mut()
+            .unwrap()
+            .render_texture_from_to(texture, src, dst, damage, src_transform, alpha)
+    }
+
+    fn transformation(&self) -> Transform {
+        self.frame.as_ref().unwrap().transformation()
+    }
+
+    fn render_texture_at(
+        &mut self,
+        texture: &Self::TextureId,
+        pos: crate::utils::Point<i32, Physical>,
+        texture_scale: i32,
+        output_scale: impl Into<crate::utils::Scale<f64>>,
+        src_transform: Transform,
+        damage: &[Rectangle<i32, Physical>],
+        alpha: f32,
+    ) -> Result<(), Self::Error> {
+        self.frame.as_mut().unwrap().render_texture_at(
+            texture,
+            pos,
+            texture_scale,
+            output_scale,
+            src_transform,
+            damage,
+            alpha,
+        )
+    }
+
+    fn finish(mut self) -> Result<(), Self::Error> {
+        self.finish_internal()
+    }
+}
+
+impl<'a> GlowFrame<'a> {
+    fn finish_internal(&mut self) -> Result<(), Gles2Error> {
+        if let Some(frame) = self.frame.take() {
+            frame.finish()
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<'a> Drop for GlowFrame<'a> {
+    fn drop(&mut self) {
+        if let Err(err) = self.finish_internal() {
+            slog::warn!(self.log, "Ignored error finishing MultiFrame on drop: {}", err);
+        }
     }
 }
 
@@ -328,7 +369,7 @@ impl Bind<Rc<EGLSurface>> for GlowRenderer {
         self.gl.bind(surface)
     }
     fn supported_formats(&self) -> Option<HashSet<Format>> {
-        Bind::<Rc<EGLSurface>>::supported_formats(&*self.gl)
+        Bind::<Rc<EGLSurface>>::supported_formats(&self.gl)
     }
 }
 
@@ -337,7 +378,7 @@ impl Bind<Dmabuf> for GlowRenderer {
         self.gl.bind(dmabuf)
     }
     fn supported_formats(&self) -> Option<HashSet<Format>> {
-        Bind::<Dmabuf>::supported_formats(&*self.gl)
+        Bind::<Dmabuf>::supported_formats(&self.gl)
     }
 }
 
@@ -346,7 +387,7 @@ impl Bind<Gles2Texture> for GlowRenderer {
         self.gl.bind(texture)
     }
     fn supported_formats(&self) -> Option<HashSet<Format>> {
-        Bind::<Gles2Texture>::supported_formats(&*self.gl)
+        Bind::<Gles2Texture>::supported_formats(&self.gl)
     }
 }
 
@@ -361,7 +402,7 @@ impl Bind<Gles2Renderbuffer> for GlowRenderer {
         self.gl.bind(renderbuffer)
     }
     fn supported_formats(&self) -> Option<HashSet<Format>> {
-        Bind::<Gles2Renderbuffer>::supported_formats(&*self.gl)
+        Bind::<Gles2Renderbuffer>::supported_formats(&self.gl)
     }
 }
 

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -247,7 +247,7 @@ impl<'a> GlowFrame<'a> {
 impl<'a> Drop for GlowFrame<'a> {
     fn drop(&mut self) {
         if let Err(err) = self.finish_internal() {
-            slog::warn!(self.log, "Ignored error finishing MultiFrame on drop: {}", err);
+            slog::warn!(self.log, "Ignored error finishing GlowFrame on drop: {}", err);
         }
     }
 }

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -43,6 +43,8 @@ pub struct GlowRenderer {
 
 #[derive(Debug)]
 /// [`Frame`](super::Frame) implementation of a [`GlowRenderer`].
+///
+/// Leaking the frame will cause the same problems as leaking a [`Gles2Frame`].
 pub struct GlowFrame<'a> {
     frame: Option<Gles2Frame<'a>>,
     glow: Arc<Context>,

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -98,7 +98,7 @@ impl GlowRenderer {
     }
 }
 
-impl<'a> GlowFrame<'a> {
+impl<'frame> GlowFrame<'frame> {
     /// Run custom code in the GL context owned by this renderer.
     ///
     /// The OpenGL state of the renderer is considered an implementation detail
@@ -149,7 +149,7 @@ impl BorrowMut<Gles2Renderer> for GlowRenderer {
 impl Renderer for GlowRenderer {
     type Error = Gles2Error;
     type TextureId = Gles2Texture;
-    type Frame<'a> = GlowFrame<'a>;
+    type Frame<'frame> = GlowFrame<'frame>;
 
     fn id(&self) -> usize {
         self.gl.id()
@@ -177,7 +177,7 @@ impl Renderer for GlowRenderer {
     }
 }
 
-impl<'a> Frame for GlowFrame<'a> {
+impl<'frame> Frame for GlowFrame<'frame> {
     type TextureId = Gles2Texture;
     type Error = Gles2Error;
 
@@ -234,7 +234,7 @@ impl<'a> Frame for GlowFrame<'a> {
     }
 }
 
-impl<'a> GlowFrame<'a> {
+impl<'frame> GlowFrame<'frame> {
     fn finish_internal(&mut self) -> Result<(), Gles2Error> {
         if let Some(frame) = self.frame.take() {
             frame.finish()
@@ -244,7 +244,7 @@ impl<'a> GlowFrame<'a> {
     }
 }
 
-impl<'a> Drop for GlowFrame<'a> {
+impl<'frame> Drop for GlowFrame<'frame> {
     fn drop(&mut self) {
         if let Err(err) = self.finish_internal() {
             slog::warn!(self.log, "Ignored error finishing GlowFrame on drop: {}", err);

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -214,9 +214,9 @@ pub trait Renderer {
     /// Texture Handle type used by this renderer.
     type TextureId: Texture;
     /// Type representing a currently in-progress frame during the [`Renderer::render`]-call
-    type Frame<'a>: Frame<Error = Self::Error, TextureId = Self::TextureId> + 'a
+    type Frame<'frame>: Frame<Error = Self::Error, TextureId = Self::TextureId> + 'frame
     where
-        Self: 'a;
+        Self: 'frame;
 
     /// Returns an id, that is unique to all renderers, that can use
     /// `TextureId`s originating from any of these renderers.

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -620,6 +620,11 @@ impl<'a, 'b, R: GraphicsApi, T: GraphicsApi, Target> AsMut<<R::Device as ApiDevi
 
 /// [`Frame`](super::Frame) implementation of a [`MultiRenderer`].
 pub struct MultiFrame<'a, 'b, 'c, R: GraphicsApi + 'c, T: GraphicsApi, Target>
+/// Leaking the frame will potentially keep it from doing necessary copies
+/// of the internal framebuffer for some multi-gpu configurations. The result would
+/// be no updated framebuffer contents.
+/// Additionally all problems related to the Frame-implementation of the underlying
+/// [`GraphicsApi`] will be present.
 where
     R: 'static,
     R::Error: 'static,

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -217,7 +217,7 @@ impl<A: GraphicsApi> GpuManager<A> {
 
             Ok(MultiRenderer {
                 dma_source: Some(&mut self.dma_source),
-                render: RenderDevice::Device(render.remove(0)),
+                render: render.remove(0),
                 target: Some(target.remove(0)),
                 other_renderers: others,
                 proxy_framebuffer: std::marker::PhantomData,
@@ -226,7 +226,7 @@ impl<A: GraphicsApi> GpuManager<A> {
         } else {
             Ok(MultiRenderer {
                 dma_source: Some(&mut self.dma_source),
-                render: RenderDevice::Device(render.remove(0)),
+                render: render.remove(0),
                 target: None,
                 other_renderers: others,
                 proxy_framebuffer: std::marker::PhantomData,
@@ -304,7 +304,7 @@ impl<A: GraphicsApi> GpuManager<A> {
 
             Ok(MultiRenderer {
                 dma_source: Some(&mut render_api.dma_source),
-                render: RenderDevice::Device(render.remove(0)),
+                render: render.remove(0),
                 target: Some(target),
                 other_renderers: others,
                 proxy_framebuffer: std::marker::PhantomData,
@@ -313,7 +313,7 @@ impl<A: GraphicsApi> GpuManager<A> {
         } else {
             Ok(MultiRenderer {
                 dma_source: Some(&mut render_api.dma_source),
-                render: RenderDevice::Device(render.remove(0)),
+                render: render.remove(0),
                 target: None,
                 other_renderers: others,
                 proxy_framebuffer: std::marker::PhantomData,
@@ -595,7 +595,7 @@ pub trait ApiDevice {
 #[derive(Debug)]
 pub struct MultiRenderer<'a, 'b, R: GraphicsApi, T: GraphicsApi, Target> {
     dma_source: Option<&'a mut HashMap<WeakDmabuf, DrmNode>>,
-    render: RenderDevice<'a, R>,
+    render: &'a mut R::Device,
     target: Option<&'b mut T::Device>,
     other_renderers: Vec<&'a mut R::Device>,
     proxy_framebuffer: std::marker::PhantomData<Target>,
@@ -618,74 +618,90 @@ impl<'a, 'b, R: GraphicsApi, T: GraphicsApi, Target> AsMut<<R::Device as ApiDevi
     }
 }
 
-// Hack for implementing Renderer::render..
-#[derive(Debug)]
-enum RenderDevice<'a, A: GraphicsApi> {
-    Device(&'a mut A::Device),
-    // Hack to avoid lifetime problems in Renderer::render
-    Renderer(*mut <A::Device as ApiDevice>::Renderer, DrmNode),
-}
-
-impl<'a, A: GraphicsApi> RenderDevice<'a, A> {
-    /*
-    fn unwrap_device(&mut self) -> &mut A::Device {
-        match self {
-            RenderDevice::Device(dev) => *dev,
-            RenderDevice::Renderer(_, _) => panic!("unwrap called on RenderDevice::Renderer"),
-        }
-    }
-    */
-
-    fn node(&self) -> &DrmNode {
-        match self {
-            RenderDevice::Device(dev) => dev.node(),
-            RenderDevice::Renderer(_, node) => node,
-        }
-    }
-
-    fn renderer(&self) -> &<A::Device as ApiDevice>::Renderer {
-        match self {
-            RenderDevice::Device(dev) => dev.renderer(),
-            RenderDevice::Renderer(renderer, _) => unsafe { &**renderer },
-        }
-    }
-
-    fn renderer_mut(&mut self) -> &mut <A::Device as ApiDevice>::Renderer {
-        match self {
-            RenderDevice::Device(dev) => dev.renderer_mut(),
-            RenderDevice::Renderer(renderer, _) => unsafe { &mut **renderer },
-        }
-    }
-}
-
 /// [`Frame`](super::Frame) implementation of a [`MultiRenderer`].
-#[derive(Debug)]
-pub struct MultiFrame<R: GraphicsApi, T: GraphicsApi> {
+pub struct MultiFrame<'a, 'b, 'c, R: GraphicsApi + 'c, T: GraphicsApi, Target>
+where
+    R: 'static,
+    R::Error: 'static,
+    T::Error: 'static,
+    <R::Device as ApiDevice>::Renderer: Offscreen<Target> + ExportDma + ExportMem + ImportDma + ImportMem,
+    <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+    <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+{
     node: DrmNode,
-    // FIXME: With GAT this would not need to be a raw-pointer
-    frame: *mut <<R::Device as ApiDevice>::Renderer as Renderer>::Frame,
+    frame: Option<<<R::Device as ApiDevice>::Renderer as Renderer>::Frame<'c>>,
+    render: *mut &'a mut R::Device,
+    target: &'c mut Option<&'b mut T::Device>,
+
+    dst_transform: Transform,
+    size: Size<i32, Physical>,
     damage: Vec<Rectangle<i32, Physical>>,
     // We need this for the associated Error type of the Frame implementation
-    _target: std::marker::PhantomData<T>,
+    _types: std::marker::PhantomData<(T, Target)>,
     log: ::slog::Logger,
+}
+
+impl<'a, 'b, 'c, R: GraphicsApi + 'c, T: GraphicsApi, Target> fmt::Debug
+    for MultiFrame<'a, 'b, 'c, R, T, Target>
+where
+    R: 'static,
+    R::Error: 'static,
+    T::Error: 'static,
+    <R::Device as ApiDevice>::Renderer: Offscreen<Target> + ExportDma + ExportMem + ImportDma + ImportMem,
+    <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+    <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+    R::Device: fmt::Debug,
+    T::Device: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MultiFrame")
+            .field("node", &self.node)
+            .field("render", unsafe { &*self.render })
+            .field("target", &self.target)
+            .field("dst_transform", &self.dst_transform)
+            .field("size", &self.size)
+            .field("damage", &self.damage)
+            .field("log", &self.log)
+            .finish()
+    }
 }
 
 // These casts are ok, because the frame cannot outlive the MultiFrame,
 // see MultiRenderer::render for how this hack works and why it is necessary.
 
-impl<R: GraphicsApi, T: GraphicsApi> AsRef<<<R::Device as ApiDevice>::Renderer as Renderer>::Frame>
-    for MultiFrame<R, T>
+impl<'a, 'b, 'c, R: GraphicsApi, T: GraphicsApi, Target>
+    AsRef<<<R::Device as ApiDevice>::Renderer as Renderer>::Frame<'c>>
+    for MultiFrame<'a, 'b, 'c, R, T, Target>
+where
+    R: 'static,
+    R::Error: 'static,
+    T::Error: 'static,
+    <R::Device as ApiDevice>::Renderer: Offscreen<Target> + ExportDma + ExportMem + ImportDma + ImportMem,
+    <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+    <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    fn as_ref(&self) -> &<<R::Device as ApiDevice>::Renderer as Renderer>::Frame {
-        unsafe { &*self.frame }
+    fn as_ref(&self) -> &<<R::Device as ApiDevice>::Renderer as Renderer>::Frame<'c> {
+        self.frame.as_ref().unwrap()
     }
 }
 
-impl<R: GraphicsApi, T: GraphicsApi> AsMut<<<R::Device as ApiDevice>::Renderer as Renderer>::Frame>
-    for MultiFrame<R, T>
+impl<'a, 'b, 'c, R: GraphicsApi, T: GraphicsApi, Target>
+    AsMut<<<R::Device as ApiDevice>::Renderer as Renderer>::Frame<'c>>
+    for MultiFrame<'a, 'b, 'c, R, T, Target>
+where
+    R: 'static,
+    R::Error: 'static,
+    T::Error: 'static,
+    <R::Device as ApiDevice>::Renderer: Offscreen<Target> + ExportDma + ExportMem + ImportDma + ImportMem,
+    <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+    <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    fn as_mut(&mut self) -> &mut <<R::Device as ApiDevice>::Renderer as Renderer>::Frame {
-        unsafe { &mut *self.frame }
+    fn as_mut(&mut self) -> &mut <<R::Device as ApiDevice>::Renderer as Renderer>::Frame<'c> {
+        self.frame.as_mut().unwrap()
     }
 }
 
@@ -791,7 +807,7 @@ where
 {
     type Error = Error<R, T>;
     type TextureId = MultiTexture;
-    type Frame = MultiFrame<R, T>;
+    type Frame<'c> = MultiFrame<'a, 'b, 'c, R, T, Target> where Self: 'c;
 
     fn id(&self) -> usize {
         self.render.renderer().id()
@@ -810,17 +826,13 @@ where
             .map_err(Error::Render)
     }
 
-    fn render<F, Res>(
-        &mut self,
+    fn render<'c>(
+        &'c mut self,
         size: Size<i32, Physical>,
         dst_transform: Transform,
-        rendering: F,
-    ) -> Result<Res, Self::Error>
-    where
-        F: FnOnce(&mut Self, &mut Self::Frame) -> Res,
-    {
-        let buffer_size = size.to_logical(1).to_buffer(1, dst_transform);
+    ) -> Result<MultiFrame<'a, 'b, 'c, R, T, Target>, Self::Error> {
         if self.target.is_some() {
+            let buffer_size = size.to_logical(1).to_buffer(1, dst_transform);
             let render_buffer = Offscreen::<Target>::create_buffer(self.render.renderer_mut(), buffer_size)
                 .map_err(Error::Render)?;
             self.render
@@ -831,188 +843,194 @@ where
 
         let node = *self.render.node();
 
-        // we need to move some stuff into the closure temporarily
-        let mut dma_source = self.dma_source.take();
-        let mut target = self.target.take();
-        let mut other_renderers = self.other_renderers.drain(..).collect::<Vec<_>>();
-        let dma_source_ref = &mut dma_source;
-        let target_ref = &mut target;
-        let other_renderers_ref = &mut other_renderers;
-
         let log = self.log.clone();
-        let res = self
+        let ptr = &mut self.render as *mut _;
+        let frame = self
             .render
             .renderer_mut()
-            .render(size, dst_transform, move |render, frame| {
-                let mut new_renderer = MultiRenderer {
-                    dma_source: dma_source_ref.take(),
-                    render: RenderDevice::Renderer(render, node),
-                    target: target_ref.take(),
-                    other_renderers: other_renderers_ref.drain(..).collect(),
-                    proxy_framebuffer: std::marker::PhantomData,
-                    log: log.clone(),
-                };
-                let mut frame = MultiFrame {
-                    node,
-                    frame, // we cheat here and use a raw-ptr, because otherwise your associated type would gain an uncostraint lifetime parameter
-                    damage: Vec::new(),
-                    _target: std::marker::PhantomData::<T>,
-                    log,
-                };
+            .render(size, dst_transform)
+            .map_err(Error::Render)?;
 
-                let res = rendering(&mut new_renderer, &mut frame);
+        Ok(MultiFrame {
+            node,
+            frame: Some(frame),
+            render: ptr, // this is fine, as long as we have the frame, this ptr is valid
+            target: &mut self.target,
+            dst_transform,
+            size,
+            damage: Vec::new(),
+            _types: std::marker::PhantomData::<(T, Target)>,
+            log,
+        })
+    }
+}
 
-                // don't return yet, but first reset the references, so we can restore self on error
-                *dma_source_ref = new_renderer.dma_source.take();
-                *target_ref = new_renderer.target.take();
-                *other_renderers_ref = new_renderer.other_renderers.drain(..).collect();
+impl<'a, 'b, 'c, R: GraphicsApi, T: GraphicsApi, Target> MultiFrame<'a, 'b, 'c, R, T, Target>
+where
+    R: 'static,
+    R::Error: 'static,
+    T::Error: 'static,
+    <R::Device as ApiDevice>::Renderer: Offscreen<Target> + ExportDma + ExportMem + ImportDma + ImportMem,
+    <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+    <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+{
+    fn finish_internal(&mut self) -> Result<(), Error<R, T>> {
+        if let Some(frame) = self.frame.take() {
+            frame.finish().map_err(Error::Render)?;
 
-                (res, frame.damage)
-            })
-            .map_err(Error::Render);
+            // now the frame is gone, lets use our unholy ptr till the end of this call:
+            let render = unsafe { &mut *self.render };
 
-        // restore self
-        self.dma_source = dma_source;
-        self.target = target;
-        self.other_renderers = other_renderers;
+            let mut damage = std::mem::take(&mut self.damage)
+                .into_iter()
+                .map(|rect| {
+                    rect.to_logical(1)
+                        .to_buffer(1, self.dst_transform, &self.size.to_logical(1))
+                })
+                .collect::<Vec<_>>();
 
-        // then possibly return the error
-        let (res, damage) = res?;
-        let mut damage = damage
-            .into_iter()
-            .map(|rect| {
-                rect.to_logical(1)
-                    .to_buffer(1, dst_transform, &size.to_logical(1))
-            })
-            .collect::<Vec<_>>();
-
-        if let Some(target) = self.target.as_mut() {
-            {
-                let mut can_import = CAN_IMPORT.lock().unwrap();
-                let dmabuf = self
-                    .render
-                    .renderer_mut()
-                    .export_framebuffer(buffer_size)
-                    .map_err(Error::Render)?;
-                let might_import = *can_import
-                    .get(&(*self.render.node(), *target.node(), dmabuf.format()))
-                    .unwrap_or(&true);
-                if might_import {
-                    // try gpu copy
-                    match target.renderer_mut().import_dmabuf(&dmabuf, Some(&damage)) {
-                        Ok(texture) => {
-                            // import successful
-                            let damage = damage
-                                .iter()
-                                .map(|rect| rect.to_logical(1, dst_transform, &buffer_size).to_physical(1))
-                                .collect::<Vec<_>>();
-                            target
-                                .renderer_mut()
-                                .render(size, dst_transform, |_renderer, frame| {
-                                    frame.render_texture_from_to(
+            let buffer_size = self.size.to_logical(1).to_buffer(1, self.dst_transform);
+            if let Some(target) = self.target.as_mut() {
+                {
+                    let mut can_import = CAN_IMPORT.lock().unwrap();
+                    let dmabuf = render
+                        .renderer_mut()
+                        .export_framebuffer(buffer_size)
+                        .map_err(Error::Render)?;
+                    let might_import = *can_import
+                        .get(&(*render.node(), *target.node(), dmabuf.format()))
+                        .unwrap_or(&true);
+                    if might_import {
+                        // try gpu copy
+                        match target.renderer_mut().import_dmabuf(&dmabuf, Some(&damage)) {
+                            Ok(texture) => {
+                                // import successful
+                                let damage = damage
+                                    .iter()
+                                    .map(|rect| {
+                                        rect.to_logical(1, self.dst_transform, &buffer_size)
+                                            .to_physical(1)
+                                    })
+                                    .collect::<Vec<_>>();
+                                let mut frame = target
+                                    .renderer_mut()
+                                    .render(self.size, self.dst_transform)
+                                    .map_err(Error::Target)?;
+                                frame
+                                    .render_texture_from_to(
                                         &texture,
                                         Rectangle::from_loc_and_size((0, 0), buffer_size).to_f64(),
-                                        Rectangle::from_loc_and_size((0, 0), size),
+                                        Rectangle::from_loc_and_size((0, 0), self.size),
                                         &damage,
-                                        dst_transform.invert(),
+                                        self.dst_transform.invert(),
                                         1.0,
                                     )
-                                })
-                                .and_then(std::convert::identity)
-                                .map_err(Error::Target)?;
+                                    .map_err(Error::Target)?;
+                                frame.finish().map_err(Error::Target)?;
 
-                            can_import.insert((*self.render.node(), *target.node(), dmabuf.format()), true);
-                            return Ok(res);
-                        }
-                        Err(err) => {
-                            let (source, target, format) =
-                                (*self.render.node(), *target.node(), dmabuf.format());
-                            slog::warn!(
-                                self.log,
-                                "Error importing dmabuf (format: {:?}) from {} to {}: {}",
-                                format,
-                                source,
-                                target,
-                                err
-                            );
-                            slog::info!(self.log, "Falling back to cpu-copy.");
-                            can_import.insert((source, target, format), false);
+                                can_import.insert((*render.node(), *target.node(), dmabuf.format()), true);
+                                return Ok(());
+                            }
+                            Err(err) => {
+                                let (source, target, format) =
+                                    (*render.node(), *target.node(), dmabuf.format());
+                                slog::warn!(
+                                    self.log,
+                                    "Error importing dmabuf (format: {:?}) from {} to {}: {}",
+                                    format,
+                                    source,
+                                    target,
+                                    err
+                                );
+                                slog::info!(self.log, "Falling back to cpu-copy.");
+                                can_import.insert((source, target, format), false);
+                            }
                         }
                     }
                 }
-            }
 
-            // cpu copy
-            if damage.len() > MAX_CPU_COPIES {
-                damage = Vec::from([Rectangle::from_loc_and_size((0, 0), buffer_size)]);
-            }
-            damage.dedup();
-            damage.retain(|rect| rect.overlaps(Rectangle::from_loc_and_size((0, 0), buffer_size)));
-            damage.retain(|rect| rect.size.h > 0 && rect.size.w > 0);
-            // merge overlapping rectangles
-            damage = damage.into_iter().fold(Vec::new(), |new_damage, mut rect| {
-                // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
-                let (overlapping, mut new_damage): (Vec<_>, Vec<_>) =
-                    new_damage.into_iter().partition(|other| other.overlaps(rect));
-
-                for overlap in overlapping {
-                    rect = rect.merge(overlap);
+                // cpu copy
+                if damage.len() > MAX_CPU_COPIES {
+                    damage = Vec::from([Rectangle::from_loc_and_size((0, 0), buffer_size)]);
                 }
-                new_damage.push(rect);
-                new_damage
-            });
+                damage.dedup();
+                damage.retain(|rect| rect.overlaps(Rectangle::from_loc_and_size((0, 0), buffer_size)));
+                damage.retain(|rect| rect.size.h > 0 && rect.size.w > 0);
+                // merge overlapping rectangles
+                damage = damage.into_iter().fold(Vec::new(), |new_damage, mut rect| {
+                    // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
+                    let (overlapping, mut new_damage): (Vec<_>, Vec<_>) =
+                        new_damage.into_iter().partition(|other| other.overlaps(rect));
 
-            let mut mappings = Vec::new();
-            for rect in damage {
-                let mapping = (
-                    self.render
-                        .renderer_mut()
-                        .copy_framebuffer(rect)
-                        .map_err(Error::Render)?,
-                    rect,
-                );
-                mappings.push(mapping);
-            }
-            mappings.sort_by(|map1, map2| {
-                let size1 = map1.1.size;
-                let size2 = map2.1.size;
-                (size1.w * size1.h).cmp(&(size2.w * size2.h))
-            });
-
-            let render = &mut self.render;
-            target
-                .renderer_mut()
-                .render(size, dst_transform, move |target, frame| {
-                    for mapping in mappings {
-                        let slice = render
-                            .renderer_mut()
-                            .map_texture(&mapping.0)
-                            .map_err(Error::Render::<R, T>)?;
-                        let texture = target
-                            .import_memory(slice, mapping.1.size, false)
-                            .map_err(Error::Target)?;
-                        let dst = mapping
-                            .1
-                            .to_logical(1, Transform::Normal, &buffer_size)
-                            .to_physical(1);
-                        frame
-                            .render_texture_from_to(
-                                &texture,
-                                Rectangle::from_loc_and_size((0, 0), mapping.1.size).to_f64(),
-                                dst,
-                                &[Rectangle::from_loc_and_size((0, 0), dst.size)],
-                                Transform::Normal,
-                                1.0,
-                            )
-                            .map_err(Error::Target)?;
+                    for overlap in overlapping {
+                        rect = rect.merge(overlap);
                     }
-                    Ok(())
-                })
-                .map_err(Error::Target)
-                .and_then(std::convert::identity)?;
+                    new_damage.push(rect);
+                    new_damage
+                });
+
+                let mut textures = Vec::new();
+                for rect in damage {
+                    let texture = (
+                        {
+                            let mapping = render
+                                .renderer_mut()
+                                .copy_framebuffer(rect)
+                                .map_err(Error::Render)?;
+                            let slice = render
+                                .renderer_mut()
+                                .map_texture(&mapping)
+                                .map_err(Error::Render::<R, T>)?;
+                            target
+                                .renderer_mut()
+                                .import_memory(slice, rect.size, false)
+                                .map_err(Error::Target)?
+                        },
+                        rect,
+                    );
+                    textures.push(texture);
+                }
+
+                let mut frame = target
+                    .renderer_mut()
+                    .render(self.size, self.dst_transform)
+                    .map_err(Error::Target)?;
+                for (texture, rect) in textures {
+                    let dst = rect.to_logical(1, Transform::Normal, &buffer_size).to_physical(1);
+                    frame
+                        .render_texture_from_to(
+                            &texture,
+                            Rectangle::from_loc_and_size((0, 0), rect.size).to_f64(),
+                            dst,
+                            &[Rectangle::from_loc_and_size((0, 0), dst.size)],
+                            Transform::Normal,
+                            1.0,
+                        )
+                        .map_err(Error::Target)?;
+                }
+                frame.finish().map_err(Error::Target)?;
+            }
         }
 
-        Ok(res)
+        Ok(())
+    }
+}
+
+impl<'a, 'b, 'c, R: GraphicsApi, T: GraphicsApi, Target> Drop for MultiFrame<'a, 'b, 'c, R, T, Target>
+where
+    R: 'static,
+    R::Error: 'static,
+    T::Error: 'static,
+    <R::Device as ApiDevice>::Renderer: Offscreen<Target> + ExportDma + ExportMem + ImportDma + ImportMem,
+    <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+    <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+{
+    fn drop(&mut self) {
+        if let Err(err) = self.finish_internal() {
+            slog::warn!(self.log, "Ignored error finishing MultiFrame on drop: {}", err);
+        }
     }
 }
 
@@ -1076,29 +1094,18 @@ impl MultiTexture {
         <<A::Device as ApiDevice>::Renderer as Renderer>::TextureId: 'static,
     {
         let tex = self.0.borrow();
-        // TODO: use Ref::filter_map when stabilized
-        if tex
-            .textures
-            .get(&TypeId::of::<A>())
-            .and_then(|textures| textures.get(render))
-            .and_then(|texture| texture.texture.as_ref())
-            .and_then(|texture| {
-                <dyn Any>::downcast_ref::<<<A::Device as ApiDevice>::Renderer as Renderer>::TextureId>(
-                    &**texture,
-                )
-            })
-            .is_some()
-        {
-            Some(Ref::map(tex, |tex| {
-                tex.textures.get(&TypeId::of::<A>())
-                        .and_then(|textures| textures.get(render))
-                        .and_then(|texture| texture.texture.as_ref())
-                        .and_then(|texture| <dyn Any>::downcast_ref::<<<A::Device as ApiDevice>::Renderer as Renderer>::TextureId>(&**texture))
-                        .unwrap()
-            }))
-        } else {
-            None
-        }
+        Ref::filter_map(tex, |tex| {
+            tex.textures
+                .get(&TypeId::of::<A>())
+                .and_then(|textures| textures.get(render))
+                .and_then(|texture| texture.texture.as_ref())
+                .and_then(|texture| {
+                    <dyn Any>::downcast_ref::<<<A::Device as ApiDevice>::Renderer as Renderer>::TextureId>(
+                        &**texture,
+                    )
+                })
+        })
+        .ok()
     }
 
     fn insert_texture<A: GraphicsApi + 'static>(
@@ -1194,33 +1201,41 @@ impl Texture for MultiTexture {
     }
 }
 
-impl<R: GraphicsApi, T: GraphicsApi> Frame for MultiFrame<R, T>
+impl<'a, 'b, 'c, R: GraphicsApi, T: GraphicsApi, Target> Frame for MultiFrame<'a, 'b, 'c, R, T, Target>
 where
     R: 'static,
     R::Error: 'static,
     T::Error: 'static,
+    <R::Device as ApiDevice>::Renderer: Offscreen<Target> + ExportDma + ExportMem + ImportDma + ImportMem,
+    <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    type Error = Error<R, T>;
     type TextureId = MultiTexture;
+    type Error = Error<R, T>;
 
-    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+    fn id(&self) -> usize {
+        self.frame.as_ref().unwrap().id()
+    }
+
+    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Error<R, T>> {
         self.damage.extend(at);
-        unsafe { &mut *self.frame }
+        self.frame
+            .as_mut()
+            .unwrap()
             .clear(color, at)
             .map_err(Error::Render)
     }
 
     fn render_texture_from_to(
         &mut self,
-        texture: &Self::TextureId,
+        texture: &MultiTexture,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         src_transform: Transform,
         alpha: f32,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error<R, T>> {
         if let Some(texture) = texture.get::<R>(&self.node) {
             self.damage.extend(damage.iter().map(|rect| {
                 let rect = rect.to_f64();
@@ -1235,7 +1250,9 @@ where
                 )
                 .to_i32_up()
             }));
-            unsafe { &mut *self.frame }
+            self.frame
+                .as_mut()
+                .unwrap()
                 .render_texture_from_to(&texture, src, dst, damage, src_transform, alpha)
                 .map_err(Error::Render)
         } else {
@@ -1251,7 +1268,11 @@ where
     }
 
     fn transformation(&self) -> Transform {
-        unsafe { &mut *self.frame }.transformation()
+        self.frame.as_ref().unwrap().transformation()
+    }
+
+    fn finish(mut self) -> Result<(), Self::Error> {
+        self.finish_internal()
     }
 }
 

--- a/src/desktop/mod.rs
+++ b/src/desktop/mod.rs
@@ -54,7 +54,7 @@ pub use self::space::Space;
 
 #[cfg(feature = "wayland_frontend")]
 pub use self::wayland::{
-    layer::{draw_layer_surface, layer_map_for_output, LayerMap, LayerSurface},
+    layer::{layer_map_for_output, LayerMap, LayerSurface},
     popup::*,
     utils,
     window::*,

--- a/src/desktop/space/element/mod.rs
+++ b/src/desktop/space/element/mod.rs
@@ -167,21 +167,22 @@ where
 
     fn render_elements<C: From<Self::RenderElement>>(
         &self,
+        renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
     ) -> Vec<C> {
         match &self {
             #[cfg(feature = "wayland_frontend")]
             SpaceElements::Layer { surface, .. } => AsRenderElements::<R>::render_elements::<
-                WaylandSurfaceRenderElement,
-            >(surface, location, scale)
+                WaylandSurfaceRenderElement<R>,
+            >(surface, renderer, location, scale)
             .into_iter()
             .map(SpaceRenderElements::Surface)
             .map(C::from)
             .collect(),
             SpaceElements::Element(element) => element
                 .element
-                .render_elements::<Wrap<<E as AsRenderElements<R>>::RenderElement>>(location, scale)
+                .render_elements::<Wrap<<E as AsRenderElements<R>>::RenderElement>>(renderer, location, scale)
                 .into_iter()
                 .map(SpaceRenderElements::Element)
                 .map(C::from)

--- a/src/desktop/space/element/wayland.rs
+++ b/src/desktop/space/element/wayland.rs
@@ -31,17 +31,20 @@ where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
 {
-    type RenderElement = WaylandSurfaceRenderElement;
+    type RenderElement = WaylandSurfaceRenderElement<R>;
 
-    fn render_elements<C: From<WaylandSurfaceRenderElement>>(
+    fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
         &self,
+        renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
     ) -> Vec<C> {
         crate::backend::renderer::element::surface::render_elements_from_surface_tree(
+            renderer,
             &self.surface,
             location,
             scale,
+            None,
         )
     }
 }

--- a/src/desktop/space/wayland/layer.rs
+++ b/src/desktop/space/wayland/layer.rs
@@ -15,10 +15,11 @@ where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
 {
-    type RenderElement = WaylandSurfaceRenderElement;
+    type RenderElement = WaylandSurfaceRenderElement<R>;
 
-    fn render_elements<C: From<WaylandSurfaceRenderElement>>(
+    fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
         &self,
+        renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
     ) -> Vec<C> {
@@ -32,12 +33,20 @@ where
                     .to_physical(scale)
                     .to_i32_round();
 
-                render_elements_from_surface_tree(popup.wl_surface(), location + offset, scale)
+                render_elements_from_surface_tree(
+                    renderer,
+                    popup.wl_surface(),
+                    location + offset,
+                    scale,
+                    None,
+                )
             });
 
         render_elements.extend(popup_render_elements);
 
-        render_elements.extend(render_elements_from_surface_tree(surface, location, scale));
+        render_elements.extend(render_elements_from_surface_tree(
+            renderer, surface, location, scale, None,
+        ));
 
         render_elements
     }

--- a/src/desktop/space/wayland/window.rs
+++ b/src/desktop/space/wayland/window.rs
@@ -235,10 +235,11 @@ where
     R: Renderer + ImportAll,
     <R as Renderer>::TextureId: 'static,
 {
-    type RenderElement = WaylandSurfaceRenderElement;
+    type RenderElement = WaylandSurfaceRenderElement<R>;
 
-    fn render_elements<C: From<WaylandSurfaceRenderElement>>(
+    fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
         &self,
+        renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
     ) -> Vec<C> {
@@ -250,12 +251,20 @@ where
                 let offset = (self.geometry().loc + popup_offset - popup.geometry().loc)
                     .to_physical_precise_round(scale);
 
-                render_elements_from_surface_tree(popup.wl_surface(), location + offset, scale)
+                render_elements_from_surface_tree(
+                    renderer,
+                    popup.wl_surface(),
+                    location + offset,
+                    scale,
+                    None,
+                )
             });
 
         render_elements.extend(popup_render_elements);
 
-        render_elements.extend(render_elements_from_surface_tree(surface, location, scale));
+        render_elements.extend(render_elements_from_surface_tree(
+            renderer, surface, location, scale, None,
+        ));
 
         render_elements
     }

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -1,12 +1,5 @@
 use crate::{
-    backend::{
-        input::KeyState,
-        renderer::{
-            element::{surface::WaylandSurfaceRenderElement, AsRenderElements},
-            utils::draw_render_elements,
-            ImportAll, Renderer,
-        },
-    },
+    backend::input::KeyState,
     desktop::{utils::*, PopupManager},
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
@@ -14,7 +7,7 @@ use crate::{
         Seat, SeatHandler,
     },
     output::{Output, WeakOutput},
-    utils::{user_data::UserDataMap, IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial},
+    utils::{user_data::UserDataMap, IsAlive, Logical, Point, Rectangle, Serial},
     wayland::{
         compositor::{with_states, with_surface_tree_downward, SurfaceData, TraversalAction},
         seat::WaylandFocus,
@@ -654,40 +647,6 @@ impl LayerSurface {
     pub fn user_data(&self) -> &UserDataMap {
         &self.0.userdata
     }
-}
-
-/// Renders a given [`LayerSurface`] using a provided renderer and frame.
-///
-/// - `scale` needs to be equivalent to the fractional scale the rendered result should have.
-/// - `location` is the position the layer surface should be drawn at.
-/// - `damage` is the set of regions of the layer surface that should be drawn.
-///
-/// Note: This function will render nothing, if you are not using
-/// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
-/// to let smithay handle buffer management.
-#[allow(clippy::too_many_arguments)]
-pub fn draw_layer_surface<R, P, S>(
-    renderer: &mut R,
-    frame: &mut <R as Renderer>::Frame,
-    layer: &LayerSurface,
-    scale: S,
-    location: P,
-    damage: &[Rectangle<i32, Physical>],
-    log: &slog::Logger,
-) -> Result<(), <R as Renderer>::Error>
-where
-    R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: 'static,
-    S: Into<Scale<f64>>,
-    P: Into<Point<i32, Physical>>,
-{
-    let location = location.into();
-    let scale = scale.into();
-    let elements =
-        AsRenderElements::<R>::render_elements::<WaylandSurfaceRenderElement>(layer, location, scale);
-
-    draw_render_elements(renderer, frame, scale, &elements, damage, log)?;
-    Ok(())
 }
 
 impl<D: SeatHandler + 'static> PointerTarget<D> for LayerSurface {

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -1,12 +1,5 @@
 use crate::{
-    backend::{
-        input::KeyState,
-        renderer::{
-            element::{surface::WaylandSurfaceRenderElement, AsRenderElements},
-            utils::draw_render_elements,
-            ImportAll, Renderer,
-        },
-    },
+    backend::input::KeyState,
     desktop::{space::RenderZindex, utils::*, PopupManager},
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
@@ -14,7 +7,7 @@ use crate::{
         Seat, SeatHandler,
     },
     output::Output,
-    utils::{user_data::UserDataMap, IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial},
+    utils::{user_data::UserDataMap, IsAlive, Logical, Point, Rectangle, Serial},
     wayland::{
         compositor::{with_states, SurfaceData},
         seat::WaylandFocus,
@@ -337,40 +330,6 @@ impl Window {
     pub fn user_data(&self) -> &UserDataMap {
         &self.0.user_data
     }
-}
-
-/// Renders a given [`Window`] using a provided renderer and frame.
-///
-/// - `scale` needs to be equivalent to the fractional scale the rendered result should have.
-/// - `location` is the position the window should be drawn at.
-/// - `damage` is the set of regions of the window that should be drawn.
-///
-/// Note: This function will render nothing, if you are not using
-/// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
-/// to let smithay handle buffer management.
-#[allow(clippy::too_many_arguments)]
-pub fn draw_window<R, P, S>(
-    renderer: &mut R,
-    frame: &mut <R as Renderer>::Frame,
-    window: &Window,
-    scale: S,
-    location: P,
-    damage: &[Rectangle<i32, Physical>],
-    log: &slog::Logger,
-) -> Result<(), <R as Renderer>::Error>
-where
-    R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: 'static,
-    S: Into<Scale<f64>>,
-    P: Into<Point<i32, Physical>>,
-{
-    let location = location.into();
-    let scale = scale.into();
-    let elements =
-        AsRenderElements::<R>::render_elements::<WaylandSurfaceRenderElement>(window, location, scale);
-
-    draw_render_elements(renderer, frame, scale, &elements, damage, log)?;
-    Ok(())
 }
 
 impl<D: SeatHandler + 'static> PointerTarget<D> for Window {

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -112,6 +112,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
             input_method.with_surface(|surface| {
                 elements.extend(AsRenderElements::<DummyRenderer>::render_elements(
                     &smithay::desktop::space::SurfaceTree::from_surface(surface),
+                    &mut renderer,
                     position.to_physical_precise_round(scale),
                     scale,
                 ));
@@ -144,13 +145,14 @@ pub fn run(channel: Channel<WlcsEvent>) {
             let cursor_pos_scaled = cursor_pos.to_physical(scale).to_i32_round();
 
             pointer_element.set_status(cursor_guard.clone());
-            elements.extend(pointer_element.render_elements(cursor_pos_scaled, scale));
+            elements.extend(pointer_element.render_elements(&mut renderer, cursor_pos_scaled, scale));
 
             // draw the dnd icon if any
             if let Some(surface) = state.dnd_icon.as_ref() {
                 if surface.alive() {
                     elements.extend(AsRenderElements::<DummyRenderer>::render_elements(
                         &smithay::desktop::space::SurfaceTree::from_surface(surface),
+                        &mut renderer,
                         cursor_pos_scaled,
                         scale,
                     ));

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -25,23 +25,18 @@ impl DummyRenderer {
 impl Renderer for DummyRenderer {
     type Error = SwapBuffersError;
     type TextureId = DummyTexture;
-    type Frame = DummyFrame;
+    type Frame<'a> = DummyFrame;
 
     fn id(&self) -> usize {
         0
     }
 
-    fn render<F, R>(
+    fn render(
         &mut self,
         _size: Size<i32, Physical>,
         _dst_transform: Transform,
-        rendering: F,
-    ) -> Result<R, Self::Error>
-    where
-        F: FnOnce(&mut Self, &mut Self::Frame) -> R,
-    {
-        let mut frame = DummyFrame {};
-        Ok(rendering(self, &mut frame))
+    ) -> Result<DummyFrame, Self::Error> {
+        Ok(DummyFrame {})
     }
 
     fn upscale_filter(&mut self, _filter: TextureFilter) -> Result<(), Self::Error> {
@@ -153,6 +148,10 @@ impl Frame for DummyFrame {
     type Error = SwapBuffersError;
     type TextureId = DummyTexture;
 
+    fn id(&self) -> usize {
+        0
+    }
+
     fn clear(&mut self, _color: [f32; 4], _damage: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -171,6 +170,10 @@ impl Frame for DummyFrame {
 
     fn transformation(&self) -> Transform {
         Transform::Normal
+    }
+
+    fn finish(self) -> Result<(), Self::Error> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This got a little out of hand... but this is what I initially imagined would have been the better API for `Renderer`/`Frame`. With GATs we finally can do it.

Notable changes:
- `Renderer::render` does not rely on a closure anymore, but returns a `Frame` instead.
- `Frame` does not implement the same traits as the renderers and blocks access to the renderer during it's lifetime. If that proves cumbersome, we can implement the traits without a problem, just a good pile of boilercode.
- This actually encourages a cleaner separation between resource management and actual rendering, which I personally see as a positiv (it is limiting however, as can be seen by the MultiRenderer, which needs both for cleaning up the Frame).
- Most hacks around wrapping `Renderer::render` calls are now gone (`GlowRenderer::render` and `MultiRenderer::render`, though `MultiRenderer` gained some new unsafe code).
- It gives downstream more options for passing a frame around and potentially even storing it.

Open for discussion.

~~Draft until tested.~~