### PR TITLE
Remove `io-lifetimes` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ winit = { version = "0.27.1", default-features = false, features = ["wayland", "
 x11rb = { version = "0.10.0", optional = true }
 xkbcommon = { version = "0.5.0", features = ["wayland"]}
 scan_fmt = { version = "0.2.3", default-features = false }
-io-lifetimes = "=1.0.0-rc1"
 
 [dev-dependencies]
 slog-term = "2.3"

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -1,5 +1,5 @@
 use std::{
-    os::unix::prelude::AsRawFd,
+    os::unix::io::{AsRawFd, OwnedFd},
     sync::{atomic::AtomicBool, Arc, Mutex},
     time::Duration,
 };
@@ -22,7 +22,6 @@ use smithay::{
     output::Output,
     reexports::{
         calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
-        io_lifetimes::OwnedFd,
         wayland_protocols::xdg::decoration::{
             self as xdg_decoration, zv1::server::zxdg_toplevel_decoration_v1::Mode as DecorationMode,
         },

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{os::unix::io::OwnedFd, sync::Arc};
 
 use smithay::{
     backend::{
@@ -12,10 +12,7 @@ use smithay::{
     },
     delegate_compositor, delegate_data_device, delegate_seat, delegate_shm, delegate_xdg_shell,
     input::{keyboard::FilterResult, Seat, SeatHandler, SeatState},
-    reexports::{
-        io_lifetimes::OwnedFd,
-        wayland_server::{protocol::wl_seat, Display},
-    },
+    reexports::wayland_server::{protocol::wl_seat, Display},
     utils::{Rectangle, Serial, Transform},
     wayland::{
         buffer::BufferHandler,

--- a/smallvil/src/state.rs
+++ b/smallvil/src/state.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsString, os::unix::prelude::AsRawFd, sync::Arc};
+use std::{ffi::OsString, os::unix::io::AsRawFd, sync::Arc};
 
 use slog::Logger;
 use smithay::{

--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -12,8 +12,8 @@
 
 use super::{Buffer, Format, Fourcc, Modifier};
 use crate::utils::{Buffer as BufferCoords, Size};
-use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use std::hash::{Hash, Hasher};
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 use std::sync::{Arc, Weak};
 
 /// Maximum amount of planes this implementation supports

--- a/src/backend/allocator/gbm.rs
+++ b/src/backend/allocator/gbm.rs
@@ -10,8 +10,7 @@ use super::{
 };
 use crate::utils::{Buffer as BufferCoords, Size};
 pub use gbm::{BufferObject as GbmBuffer, BufferObjectFlags as GbmBufferFlags, Device as GbmDevice};
-use io_lifetimes::OwnedFd;
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd};
 
 impl<A: AsRawFd + 'static, T> Allocator<GbmBuffer<T>> for GbmDevice<A> {
     type Error = std::io::Error;

--- a/src/backend/allocator/vulkan/mod.rs
+++ b/src/backend/allocator/vulkan/mod.rs
@@ -23,7 +23,7 @@ pub mod format;
 use std::{
     ffi::CStr,
     fmt,
-    os::unix::io::FromRawFd,
+    os::unix::io::{FromRawFd, OwnedFd},
     sync::{mpsc, Arc, Weak},
 };
 
@@ -33,7 +33,6 @@ use ash::{
 };
 use bitflags::bitflags;
 use drm_fourcc::{DrmFormat, DrmFourcc, DrmModifier};
-use io_lifetimes::OwnedFd;
 
 use crate::{
     backend::{

--- a/src/backend/drm/node/mod.rs
+++ b/src/backend/drm/node/mod.rs
@@ -8,7 +8,7 @@ use libc::dev_t;
 use std::{
     fmt::{self, Display, Formatter},
     fs, io,
-    os::unix::prelude::{AsRawFd, RawFd},
+    os::unix::io::{AsRawFd, RawFd},
     path::{Path, PathBuf},
 };
 

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -8,10 +8,9 @@ use std::sync::Arc;
 use std::sync::{Mutex, Weak};
 use std::{
     collections::HashSet,
-    os::unix::prelude::{AsRawFd, FromRawFd},
+    os::unix::io::{AsRawFd, FromRawFd, OwnedFd},
 };
 
-use io_lifetimes::OwnedFd;
 use libc::c_void;
 use nix::libc::c_int;
 #[cfg(all(feature = "use_system_lib", feature = "wayland_frontend"))]

--- a/src/backend/x11/buffer.rs
+++ b/src/backend/x11/buffer.rs
@@ -27,7 +27,7 @@
 //! ensure you read the `presentproto.txt` file (link in the non-public comments of the
 //! x11 mod.rs).
 
-use std::{os::unix::prelude::AsRawFd, sync::atomic::Ordering};
+use std::{os::unix::io::AsRawFd, sync::atomic::Ordering};
 
 use super::{PresentError, Window, X11Error};
 use drm_fourcc::DrmFourcc;

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -3,7 +3,7 @@ use slog::error;
 use xkbcommon::xkb::{Keymap, KEYMAP_FORMAT_TEXT_V1};
 
 use std::ffi::CString;
-use std::os::unix::prelude::RawFd;
+use std::os::unix::io::RawFd;
 
 /// Wraps an XKB keymap into a sealed file or stores as just a string for sending to WlKeyboard over an fd
 #[derive(Debug)]
@@ -56,7 +56,7 @@ impl KeymapFile {
     where
         F: FnOnce(RawFd, usize),
     {
-        use std::{io::Write, os::unix::prelude::AsRawFd, path::PathBuf};
+        use std::{io::Write, os::unix::io::AsRawFd, path::PathBuf};
 
         if let Some(file) = supports_sealed.then_some(self.sealed.as_ref()).flatten() {
             cb(file.as_raw_fd(), file.size());

--- a/src/reexports.rs
+++ b/src/reexports.rs
@@ -11,7 +11,6 @@ pub use drm;
 pub use gbm;
 #[cfg(feature = "backend_libinput")]
 pub use input;
-pub use io_lifetimes;
 pub use nix;
 #[cfg(feature = "backend_udev")]
 pub use udev;

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -11,7 +11,7 @@ use std::{
     ffi::CString,
     fs::File,
     io::{Seek, Write},
-    os::unix::prelude::{AsRawFd, FromRawFd, RawFd},
+    os::unix::io::{AsRawFd, FromRawFd, RawFd},
 };
 
 #[derive(Debug)]

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -1,10 +1,9 @@
 use std::{
     cell::RefCell,
-    os::unix::prelude::AsRawFd,
+    os::unix::io::{AsRawFd, OwnedFd},
     sync::{Arc, Mutex},
 };
 
-use io_lifetimes::OwnedFd;
 use wayland_server::{
     backend::{protocol::Message, ClientId, Handle, ObjectData, ObjectId},
     protocol::{

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -64,9 +64,8 @@
 //! // You're now ready to go!
 //! ```
 
-use std::cell::RefCell;
+use std::{cell::RefCell, os::unix::io::OwnedFd};
 
-use io_lifetimes::OwnedFd;
 use wayland_server::{
     backend::GlobalId,
     protocol::{

--- a/src/wayland/data_device/seat_data.rs
+++ b/src/wayland/data_device/seat_data.rs
@@ -1,6 +1,8 @@
-use std::{os::unix::prelude::AsRawFd, sync::Arc};
+use std::{
+    os::unix::io::{AsRawFd, OwnedFd},
+    sync::Arc,
+};
 
-use io_lifetimes::OwnedFd;
 use slog::debug;
 use wayland_server::{
     backend::{protocol::Message, ClientId, Handle, ObjectData, ObjectId},

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -1,9 +1,9 @@
 use std::{
     cell::RefCell,
+    os::unix::io::OwnedFd,
     sync::{Arc, Mutex},
 };
 
-use io_lifetimes::OwnedFd;
 use wayland_server::{
     backend::{protocol::Message, ClientId, Handle, ObjectData, ObjectId},
     protocol::{

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -94,7 +94,7 @@ mod dispatch;
 use std::{
     collections::HashMap,
     convert::TryFrom,
-    os::unix::prelude::AsRawFd,
+    os::unix::io::AsRawFd,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,

--- a/src/wayland/primary_selection/mod.rs
+++ b/src/wayland/primary_selection/mod.rs
@@ -59,9 +59,8 @@
 //! // You're now ready to go!
 //! ```
 
-use std::cell::RefCell;
+use std::{cell::RefCell, os::unix::io::OwnedFd};
 
-use io_lifetimes::OwnedFd;
 use wayland_protocols::wp::primary_selection::zv1::server::{
     zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1 as PrimaryDeviceManager,
     zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1 as PrimarySource,

--- a/src/wayland/primary_selection/seat_data.rs
+++ b/src/wayland/primary_selection/seat_data.rs
@@ -1,6 +1,8 @@
-use std::{os::unix::prelude::AsRawFd, sync::Arc};
+use std::{
+    os::unix::io::{AsRawFd, OwnedFd},
+    sync::Arc,
+};
 
-use io_lifetimes::OwnedFd;
 use slog::debug;
 use wayland_protocols::wp::primary_selection::zv1::server::{
     zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1 as PrimaryDevice,

--- a/src/wayland/shm/handlers.rs
+++ b/src/wayland/shm/handlers.rs
@@ -5,7 +5,7 @@ use super::{
     BufferData, ShmHandler, ShmPoolUserData, ShmState,
 };
 
-use std::{os::unix::prelude::AsRawFd, sync::Arc};
+use std::{os::unix::io::AsRawFd, sync::Arc};
 use wayland_server::{
     protocol::{
         wl_buffer,

--- a/src/wayland/shm/pool.rs
+++ b/src/wayland/shm/pool.rs
@@ -1,11 +1,10 @@
 use std::{
     cell::Cell,
-    os::unix::{io::RawFd, prelude::AsRawFd},
+    os::unix::io::{AsRawFd, OwnedFd, RawFd},
     ptr,
     sync::{Once, RwLock},
 };
 
-use io_lifetimes::OwnedFd;
 use nix::{
     libc,
     sys::{

--- a/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
+++ b/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Debug,
-    os::unix::prelude::AsRawFd,
+    os::unix::io::AsRawFd,
     sync::{Arc, Mutex},
 };
 


### PR DESCRIPTION
Since Smithay now requires Rust 1.65.0, and io-lifetimes reexports these types from std on recent Rust versions, this dependency is redundant.