### PR TITLE
renderer: fix export_texture

### DIFF
--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1303,7 +1303,11 @@ impl ExportDma for Gles2Renderer {
             egl_images[0]
         } else {
             unsafe {
-                let attributes = [ffi_egl::IMAGE_PRESERVED, ffi_egl::TRUE, ffi_egl::NONE];
+                let attributes: [ffi_egl::types::EGLAttrib; 3] = [
+                    ffi_egl::IMAGE_PRESERVED as ffi_egl::types::EGLAttrib,
+                    ffi_egl::TRUE as ffi_egl::types::EGLAttrib,
+                    ffi_egl::NONE as ffi_egl::types::EGLAttrib,
+                ];
                 let img = ffi_egl::CreateImage(
                     **self.egl.display().get_display_handle(),
                     self.egl.get_context_handle(),


### PR DESCRIPTION
eglCreateImage expects the attributes to be of type EGLAttrib which is platform dependent using EGLEnum types will 
 populate an array with the wrong type which causes a segfault when calculating the attrib list len in the mesa egl code