### PR TITLE
Set MSRV in Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 homepage = "https://smithay.github.io/"
 keywords = ["wayland", "compositor", "graphics", "server"]
 categories = ["gui"]
+rust-version = "1.65.0"
 
 [package.metadata.docs.rs]
 features = ["test_all_features"]


### PR DESCRIPTION
This sets the minimum supported Rust version to 1.65.0 in Smithay's manifest, which helps with troubleshooting downstream when attempting to build Smithay with an outdated compiler.

Especially since the MSRV is far above the introduction of the `rust-version` field anyway, it should not come with any significant drawbacks besides the potential maintenance overhead.