### PR TITLE
Fix toplevel death not calling XDG handler

### DIFF
--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -126,13 +126,6 @@ where
         data.alive_tracker.destroy_notify();
         data.decoration.lock().unwrap().take();
 
-        // remove this surface from the known ones (as well as any leftover dead surface)
-        data.shell_data
-            .lock()
-            .unwrap()
-            .known_toplevels
-            .retain(|other| other.shell_surface.id() != object_id);
-
         let mut shell_data = data.shell_data.lock().unwrap();
         if let Some(index) = shell_data
             .known_toplevels


### PR DESCRIPTION
This fixes an issue with the `XdgShellHandler::toplevel_destroyed` method where it wouldn't get fired when a toplevel surface is destroyed.

This was caused by the destroyed toplevel surface getting removed from the tracked toplevel surfaces before looking it up to dispatch the handler.