### PR TITLE
renderer: fix wayland surface opaque region scale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,7 @@ jobs:
         with:
           command: doc
           # TODO: Update nix when drm-rs is updated
-          args: --no-deps --features "test_all_features" -p smithay -p calloop:0.10.3 -p dbus -p drm -p gbm -p input -p nix:0.24.2 -p udev -p slog -p wayland-server:0.30.0-beta.13 -p wayland-backend -p wayland-protocols:0.30.0-beta.13 -p winit -p x11rb
+          args: --no-deps --features "test_all_features" -p smithay -p calloop:0.10.3 -p dbus -p drm -p gbm -p input -p nix:0.24.3 -p udev -p slog -p wayland-server:0.30.0-beta.13 -p wayland-backend -p wayland-protocols:0.30.0-beta.13 -p winit -p x11rb
           env: RUSTDOCFLAGS=--cfg="docsrs"
 
       - name: Setup index

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -441,7 +441,14 @@ impl<R: Renderer + ImportAll> Element for WaylandSurfaceRenderElement<R> {
                 data.opaque_regions()
                     .map(|r| {
                         r.iter()
-                            .map(|r| r.to_physical_precise_up(scale))
+                            .map(|r| {
+                                let loc = r.loc.to_physical_precise_round(scale);
+                                let size = ((r.size.to_f64().to_physical(scale).to_point() + self.location)
+                                    .to_i32_round()
+                                    - self.location.to_i32_round())
+                                .to_size();
+                                Rectangle::from_loc_and_size(loc, size)
+                            })
                             .collect::<Vec<_>>()
                     })
                     .unwrap_or_default()


### PR DESCRIPTION
the scaling for opaque regions has to follow the same rules as the geometry or otherwise we end up with
a mismatch which could result in rendering artifacts