### PR TITLE
smallvil: fix bad handling of the active window state

### DIFF
--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -71,8 +71,9 @@ impl Smallvil {
                     {
                         self.space.raise_element(&window, true);
                         keyboard.set_focus(self, Some(window.toplevel().wl_surface().clone()), serial);
-                        window.set_activated(true);
-                        window.configure();
+                        self.space.elements().for_each(|window| {
+                            window.configure();
+                        });
                     } else {
                         self.space.elements().for_each(|window| {
                             window.set_activated(false);


### PR DESCRIPTION
In Smallvil windows only get deactivated when pressing on the background and not when pressing on a different window. This PR fixes this by first removing the redundant `window.set_activated(true);` and looping through every window to run `.configure` so the necessary windows get deactivated/activated.  