### PR TITLE
Fix IME not closing on application exit

### DIFF
--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -162,6 +162,12 @@ where
     }
 
     fn destroyed(_state: &mut D, _client: ClientId, ti: ObjectId, data: &TextInputUserData) {
+        // Ensure IME is deactivated when text input dies.
+        data.input_method_handle.with_instance(|input_method| {
+            input_method.deactivate();
+            input_method.done();
+        });
+
         data.handle
             .inner
             .lock()


### PR DESCRIPTION
This fixes an issue with the text_input/input_method protocols where the application requesting IME wouldn't notify the IME client about its death, keeping the IME client open after the application was closed.

With this patch whenever the `text_input` object is destroyed, the `deactivate` event is automatically emitted and committed ensuring the IME client is properly updated.

Closes #835.