### PR TITLE
WIP IO Safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,16 +28,16 @@ appendlist = "1.4"
 # Intentionally pick a commit from "0.37-stable" branch since additions for 0.37.1 are used
 ash = { version = "0.37.1", optional = true }
 bitflags = "1"
-calloop = "0.10.1"
+calloop = { git = "https://github.com/ids1024/calloop", branch = "io-lifetimes" }
 cgmath = "0.18.0"
 dbus = { version = "0.9.4", optional = true }
 downcast-rs = "1.2.0"
 drm-fourcc = "^2.2.0"
-drm = { version = "0.7.0", optional = true }
+drm = { git = "https://github.com/smithay/drm-rs", optional = true }
 drm-ffi = { version = "0.3.0", optional = true }
-gbm = { version = "0.9.0", optional = true, default-features = false, features = ["drm-support"] }
+gbm = { git = "https://github.com/ids1024/gbm.rs", branch = "io-safety", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.11.2", optional = true }
-input = { version = "0.7", default-features = false, features=["libinput_1_14"], optional = true }
+input = { git = "https://github.com/ids1024/input.rs", branch = "as-fd", default-features = false, features=["libinput_1_14"], optional = true }
 indexmap = "1.7"
 lazy_static = "1"
 libc = "0.2.103"
@@ -51,7 +51,7 @@ slog = "2"
 slog-stdlog = { version = "4", optional = true }
 tempfile = { version = "3.0", optional = true }
 thiserror = "1.0.25"
-udev = { version = "0.6", optional = true }
+udev = { git = "https://github.com/Smithay/udev-rs", optional = true }
 wayland-egl = { version = "=0.30.0-beta.14", optional = true }
 wayland-protocols = { version = "=0.30.0-beta.14", features = ["unstable", "staging", "server"], optional = true }
 wayland-protocols-wlr = { version = "=0.1.0-beta.14", features = ["server"]}
@@ -74,6 +74,7 @@ cc = { version = "1.0", optional = true }
 
 [features]
 default = ["backend_drm", "backend_gbm", "backend_libinput", "backend_udev", "backend_session_logind", "backend_x11", "backend_winit", "desktop", "renderer_gl", "renderer_multi", "xwayland", "wayland_frontend", "slog-stdlog", "backend_vulkan"]
+#default = ["backend_drm", "backend_gbm", "backend_libinput", "backend_udev", "backend_x11", "backend_winit", "desktop", "renderer_gl", "renderer_multi", "xwayland", "wayland_frontend", "slog-stdlog", "backend_vulkan"]
 backend_winit = ["winit", "backend_egl", "wayland-egl", "renderer_gl"]
 backend_x11 = ["x11rb", "x11rb/dri3", "x11rb/xfixes", "x11rb/present", "x11rb_event_source", "backend_gbm", "backend_drm", "backend_egl"]
 backend_drm = ["drm", "drm-ffi"]
@@ -112,3 +113,6 @@ required-features = ["wayland_frontend"]
 [[example]]
 name = "vulkan"
 required-features = ["backend_vulkan"]
+
+[patch.crates-io]
+wayland-server = { git = "https://github.com/ids1024/wayland-rs", branch = "as-fd-beta14" }

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -1,5 +1,5 @@
 use std::{
-    os::unix::io::{AsRawFd, OwnedFd},
+    os::unix::io::OwnedFd,
     sync::{atomic::AtomicBool, Arc, Mutex},
     time::Duration,
 };
@@ -309,11 +309,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
         };
         handle
             .insert_source(
-                Generic::new(
-                    display.backend().poll_fd().as_raw_fd(),
-                    Interest::READ,
-                    Mode::Level,
-                ),
+                Generic::new(display.backend().poll_fd(), Interest::READ, Mode::Level),
                 |_, _, data| {
                     data.display.dispatch_clients(&mut data.state).unwrap();
                     Ok(PostAction::Continue)

--- a/src/backend/allocator/dumb.rs
+++ b/src/backend/allocator/dumb.rs
@@ -1,7 +1,7 @@
 //! Module for [DumbBuffer](https://01.org/linuxgraphics/gfx-docs/drm/gpu/drm-kms.html#dumb-buffer-objects) buffers
 
 use std::fmt;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::AsFd;
 use std::sync::Arc;
 
 use drm::buffer::Buffer as DrmBuffer;
@@ -12,13 +12,13 @@ use crate::backend::drm::device::{DrmDevice, DrmDeviceInternal, FdWrapper};
 use crate::utils::{Buffer as BufferCoords, Size};
 
 /// Wrapper around raw DumbBuffer handles.
-pub struct DumbBuffer<A: AsRawFd + 'static> {
+pub struct DumbBuffer<A: AsFd + 'static> {
     fd: Arc<FdWrapper<A>>,
     handle: Handle,
     format: Format,
 }
 
-impl<A: AsRawFd + 'static> fmt::Debug for DumbBuffer<A> {
+impl<A: AsFd + 'static> fmt::Debug for DumbBuffer<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DumbBuffer")
             .field("handle", &self.handle)
@@ -27,7 +27,7 @@ impl<A: AsRawFd + 'static> fmt::Debug for DumbBuffer<A> {
     }
 }
 
-impl<A: AsRawFd + 'static> Allocator<DumbBuffer<A>> for DrmDevice<A> {
+impl<A: AsFd + 'static> Allocator<DumbBuffer<A>> for DrmDevice<A> {
     type Error = drm::SystemError;
 
     fn create_buffer(
@@ -65,7 +65,7 @@ impl<A: AsRawFd + 'static> Allocator<DumbBuffer<A>> for DrmDevice<A> {
     }
 }
 
-impl<A: AsRawFd + 'static> Buffer for DumbBuffer<A> {
+impl<A: AsFd + 'static> Buffer for DumbBuffer<A> {
     fn size(&self) -> Size<i32, BufferCoords> {
         let (w, h) = self.handle.size();
         (w as i32, h as i32).into()
@@ -76,7 +76,7 @@ impl<A: AsRawFd + 'static> Buffer for DumbBuffer<A> {
     }
 }
 
-impl<A: AsRawFd + 'static> DumbBuffer<A> {
+impl<A: AsFd + 'static> DumbBuffer<A> {
     /// Raw handle to the underlying buffer.
     ///
     /// Note: This handle will become invalid, once the `DumbBuffer` wrapper is dropped
@@ -86,7 +86,7 @@ impl<A: AsRawFd + 'static> DumbBuffer<A> {
     }
 }
 
-impl<A: AsRawFd + 'static> Drop for DumbBuffer<A> {
+impl<A: AsFd + 'static> Drop for DumbBuffer<A> {
     fn drop(&mut self) {
         let _ = self.fd.destroy_dumb_buffer(self.handle);
     }

--- a/src/backend/drm/device/atomic.rs
+++ b/src/backend/drm/device/atomic.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::AsFd;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -29,7 +29,7 @@ pub type Mapping = (
     HashMap<plane::Handle, HashMap<String, property::Handle>>,
 );
 #[derive(Debug)]
-pub struct AtomicDrmDevice<A: AsRawFd + 'static> {
+pub struct AtomicDrmDevice<A: AsFd + 'static> {
     pub(crate) fd: Arc<FdWrapper<A>>,
     pub(crate) active: Arc<AtomicBool>,
     old_state: OldState,
@@ -37,7 +37,7 @@ pub struct AtomicDrmDevice<A: AsRawFd + 'static> {
     logger: ::slog::Logger,
 }
 
-impl<A: AsRawFd + 'static> AtomicDrmDevice<A> {
+impl<A: AsFd + 'static> AtomicDrmDevice<A> {
     pub fn new(
         fd: Arc<FdWrapper<A>>,
         active: Arc<AtomicBool>,
@@ -187,7 +187,7 @@ impl<A: AsRawFd + 'static> AtomicDrmDevice<A> {
     }
 }
 
-impl<A: AsRawFd + 'static> Drop for AtomicDrmDevice<A> {
+impl<A: AsFd + 'static> Drop for AtomicDrmDevice<A> {
     fn drop(&mut self) {
         if self.active.load(Ordering::SeqCst) {
             // Here we restore the card/tty's to it's previous state.

--- a/src/backend/drm/device/legacy.rs
+++ b/src/backend/drm/device/legacy.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::AsFd;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -13,14 +13,14 @@ use crate::backend::drm::error::Error;
 use slog::{error, info, o};
 
 #[derive(Debug)]
-pub struct LegacyDrmDevice<A: AsRawFd + 'static> {
+pub struct LegacyDrmDevice<A: AsFd + 'static> {
     pub(crate) fd: Arc<FdWrapper<A>>,
     pub(crate) active: Arc<AtomicBool>,
     old_state: HashMap<crtc::Handle, (crtc::Info, Vec<connector::Handle>)>,
     logger: ::slog::Logger,
 }
 
-impl<A: AsRawFd + 'static> LegacyDrmDevice<A> {
+impl<A: AsFd + 'static> LegacyDrmDevice<A> {
     pub fn new(
         fd: Arc<FdWrapper<A>>,
         active: Arc<AtomicBool>,
@@ -110,7 +110,7 @@ impl<A: AsRawFd + 'static> LegacyDrmDevice<A> {
     }
 }
 
-impl<A: AsRawFd + 'static> Drop for LegacyDrmDevice<A> {
+impl<A: AsFd + 'static> Drop for LegacyDrmDevice<A> {
     fn drop(&mut self) {
         info!(self.logger, "Dropping device: {:?}", self.fd.dev_path());
         if self.active.load(Ordering::SeqCst) {

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -413,27 +413,19 @@ where
     }
 
     fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
-        self.token = Some(factory.token());
-        poll.register(
-            self.as_fd(),
-            Interest::READ,
-            calloop::Mode::Level,
-            self.token.unwrap(),
-        )
+        let token = factory.token();
+        self.token = Some(token);
+        poll.register(self, Interest::READ, calloop::Mode::Level, token)
     }
 
     fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
-        self.token = Some(factory.token());
-        poll.reregister(
-            self.as_fd(),
-            Interest::READ,
-            calloop::Mode::Level,
-            self.token.unwrap(),
-        )
+        let token = factory.token();
+        self.token = Some(token);
+        poll.reregister(self, Interest::READ, calloop::Mode::Level, token)
     }
 
     fn unregister(&mut self, poll: &mut Poll) -> calloop::Result<()> {
         self.token = None;
-        poll.unregister(self.as_fd())
+        poll.unregister(self)
     }
 }

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -9,7 +9,7 @@ use crate::utils::{Physical, Rectangle};
 use std::os::raw::c_int;
 use std::os::raw::c_void;
 #[cfg(feature = "backend_gbm")]
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::AsFd;
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 #[cfg(feature = "backend_winit")]
@@ -135,7 +135,7 @@ pub trait EGLNativeDisplay: Send {
 }
 
 #[cfg(feature = "backend_gbm")]
-impl<A: AsRawFd + Send + 'static> EGLNativeDisplay for GbmDevice<A> {
+impl<A: AsFd + Send + 'static> EGLNativeDisplay for GbmDevice<A> {
     fn supported_platforms(&self) -> Vec<EGLPlatform<'_>> {
         vec![
             // see: https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_platform_gbm.txt

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -589,13 +589,15 @@ impl EventSource for LibinputInputBackend {
     }
 
     fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
-        self.token = Some(factory.token());
-        poll.register(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap())
+        let token = factory.token();
+        self.token = Some(token);
+        poll.register(self, Interest::READ, Mode::Level, token)
     }
 
     fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
-        self.token = Some(factory.token());
-        poll.reregister(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap())
+        let token = factory.token();
+        self.token = Some(token);
+        poll.reregister(self, Interest::READ, Mode::Level, token)
     }
 
     fn unregister(&mut self, poll: &mut Poll) -> calloop::Result<()> {

--- a/src/backend/session/auto.rs
+++ b/src/backend/session/auto.rs
@@ -41,7 +41,7 @@ use super::{
 };
 use crate::utils::signaling::Signaler;
 use nix::fcntl::OFlag;
-use std::{cell::RefCell, os::unix::io::RawFd, path::Path, rc::Rc};
+use std::{cell::RefCell, os::unix::io::OwnedFd, path::Path, rc::Rc};
 
 use calloop::{EventSource, Poll, PostAction, Readiness, Token, TokenFactory};
 
@@ -136,7 +136,7 @@ impl AutoSession {
 impl Session for AutoSession {
     type Error = Error;
 
-    fn open(&mut self, path: &Path, flags: OFlag) -> Result<RawFd, Error> {
+    fn open(&mut self, path: &Path, flags: OFlag) -> Result<OwnedFd, Error> {
         match *self {
             #[cfg(feature = "backend_session_logind")]
             AutoSession::Logind(ref mut logind) => logind.open(path, flags).map_err(|e| e.into()),
@@ -145,7 +145,7 @@ impl Session for AutoSession {
             AutoSession::LibSeat(ref mut logind) => logind.open(path, flags).map_err(|e| e.into()),
         }
     }
-    fn close(&mut self, fd: RawFd) -> Result<(), Error> {
+    fn close(&mut self, fd: OwnedFd) -> Result<(), Error> {
         match *self {
             #[cfg(feature = "backend_session_logind")]
             AutoSession::Logind(ref mut logind) => logind.close(fd).map_err(|e| e.into()),

--- a/src/backend/session/libseat.rs
+++ b/src/backend/session/libseat.rs
@@ -7,7 +7,7 @@ use libseat::{Seat, SeatEvent};
 use std::{
     cell::RefCell,
     collections::HashMap,
-    os::unix::io::RawFd,
+    os::unix::io::{FromRawFd, IntoRawFd, OwnedFd, RawFd},
     path::Path,
     rc::{Rc, Weak},
     sync::{
@@ -125,7 +125,7 @@ impl LibSeatSession {
 impl Session for LibSeatSession {
     type Error = Error;
 
-    fn open(&mut self, path: &Path, _flags: OFlag) -> Result<RawFd, Self::Error> {
+    fn open(&mut self, path: &Path, _flags: OFlag) -> Result<OwnedFd, Self::Error> {
         if let Some(session) = self.internal.upgrade() {
             debug!(session.logger, "Opening device: {:?}", path);
 
@@ -143,7 +143,7 @@ impl Session for LibSeatSession {
         }
     }
 
-    fn close(&mut self, fd: RawFd) -> Result<(), Self::Error> {
+    fn close(&mut self, fd: OwnedFd) -> Result<(), Self::Error> {
         if let Some(session) = self.internal.upgrade() {
             debug!(session.logger, "Closing device: {:?}", fd);
 
@@ -159,7 +159,7 @@ impl Session for LibSeatSession {
                 Ok(())
             };
 
-            close(fd).unwrap();
+            close(fd.into_raw_fd()).unwrap();
 
             out
         } else {

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -191,18 +191,20 @@ impl EventSource for UdevBackend {
     }
 
     fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
-        self.token = Some(factory.token());
-        poll.register(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap())
+        let token = factory.token();
+        self.token = Some(token);
+        poll.register(self, Interest::READ, Mode::Level, token)
     }
 
     fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
-        self.token = Some(factory.token());
-        poll.reregister(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap())
+        let token = factory.token();
+        self.token = Some(token);
+        poll.reregister(self, Interest::READ, Mode::Level, token)
     }
 
     fn unregister(&mut self, poll: &mut Poll) -> calloop::Result<()> {
         self.token = None;
-        poll.unregister(self.as_fd())
+        poll.unregister(self)
     }
 }
 


### PR DESCRIPTION
Requires https://github.com/Smithay/input.rs/pull/41, https://github.com/Smithay/wayland-rs/pull/589, https://github.com/Smithay/calloop/pull/119, and https://github.com/Smithay/gbm.rs/pull/18. And releases of those, udev-rs, and drm-rs.

Anvil doesn't currently build here. `display.backend().poll_fd()` gives a `BorrowedFd`, while we want something with a `'static` lifetime. Not sure how to handle this?