### PR TITLE
multigpu: Fix broken gpu-copy

### DIFF
--- a/src/backend/allocator/dumb.rs
+++ b/src/backend/allocator/dumb.rs
@@ -27,7 +27,8 @@ impl<A: AsRawFd + 'static> fmt::Debug for DumbBuffer<A> {
     }
 }
 
-impl<A: AsRawFd + 'static> Allocator<DumbBuffer<A>> for DrmDevice<A> {
+impl<A: AsRawFd + 'static> Allocator for DrmDevice<A> {
+    type Buffer = DumbBuffer<A>;
     type Error = drm::SystemError;
 
     fn create_buffer(

--- a/src/backend/allocator/gbm.rs
+++ b/src/backend/allocator/gbm.rs
@@ -12,7 +12,8 @@ use crate::utils::{Buffer as BufferCoords, Size};
 pub use gbm::{BufferObject as GbmBuffer, BufferObjectFlags as GbmBufferFlags, Device as GbmDevice};
 use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd};
 
-impl<A: AsRawFd + 'static, T> Allocator<GbmBuffer<T>> for GbmDevice<A> {
+impl<A: AsRawFd + 'static> Allocator for GbmDevice<A> {
+    type Buffer = GbmBuffer<()>;
     type Error = std::io::Error;
 
     fn create_buffer(
@@ -21,7 +22,7 @@ impl<A: AsRawFd + 'static, T> Allocator<GbmBuffer<T>> for GbmDevice<A> {
         height: u32,
         fourcc: Fourcc,
         modifiers: &[Modifier],
-    ) -> Result<GbmBuffer<T>, Self::Error> {
+    ) -> Result<GbmBuffer<()>, Self::Error> {
         match self.create_buffer_object_with_modifiers(width, height, fourcc, modifiers.iter().copied()) {
             Ok(bo) => Ok(bo),
             Err(err) => {

--- a/src/backend/allocator/vulkan/mod.rs
+++ b/src/backend/allocator/vulkan/mod.rs
@@ -335,7 +335,8 @@ impl VulkanAllocator {
     }
 }
 
-impl Allocator<VulkanImage> for VulkanAllocator {
+impl Allocator for VulkanAllocator {
+    type Buffer = VulkanImage;
     type Error = Error;
 
     fn create_buffer(

--- a/src/backend/renderer/multigpu/egl.rs
+++ b/src/backend/renderer/multigpu/egl.rs
@@ -161,6 +161,7 @@ where
         + ExportDma
         + ExportMem
         + 'static,
+    Target: Clone,
 {
     fn bind_wl_display(&mut self, display: &wayland_server::DisplayHandle) -> Result<(), EGLError> {
         self.render.renderer_mut().bind_wl_display(display)
@@ -179,8 +180,8 @@ where
         damage: &[Rectangle<i32, BufferCoords>],
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error> {
         if let Some(ref mut renderer) = self.target.as_mut() {
-            if let Ok(dmabuf) = Self::try_import_egl(renderer.renderer_mut(), buffer) {
-                let node = *renderer.node();
+            if let Ok(dmabuf) = Self::try_import_egl(renderer.device.renderer_mut(), buffer) {
+                let node = *renderer.device.node();
                 let texture = MultiTexture::from_surface(surface, dmabuf.size());
                 let texture_ref = texture.0.clone();
                 let res = self.import_dmabuf_internal(Some(node), &dmabuf, texture, Some(damage));

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -930,6 +930,9 @@ where
                                     .render(self.size, Transform::Normal)
                                     .map_err(Error::Target)?;
                                 frame
+                                    .clear([0.0, 0.0, 0.0, 0.0], &damage)
+                                    .map_err(Error::Target)?;
+                                frame
                                     .render_texture_from_to(
                                         &texture,
                                         Rectangle::from_loc_and_size((0, 0), buffer_size).to_f64(),
@@ -963,65 +966,66 @@ where
                 }
 
                 // cpu copy
-                if damage.len() > MAX_CPU_COPIES {
-                    damage = Vec::from([Rectangle::from_loc_and_size((0, 0), buffer_size)]);
-                }
                 damage.dedup();
                 damage.retain(|rect| rect.overlaps(Rectangle::from_loc_and_size((0, 0), buffer_size)));
                 damage.retain(|rect| rect.size.h > 0 && rect.size.w > 0);
-                // merge overlapping rectangles
-                damage = damage.into_iter().fold(Vec::new(), |new_damage, mut rect| {
-                    // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
-                    let (overlapping, mut new_damage): (Vec<_>, Vec<_>) =
-                        new_damage.into_iter().partition(|other| other.overlaps(rect));
 
-                    for overlap in overlapping {
-                        rect = rect.merge(overlap);
-                    }
-                    new_damage.push(rect);
-                    new_damage
-                });
+                let mut copy_rects = // merge overlapping rectangles
+                    damage.iter().cloned().fold(Vec::new(), |new_damage, mut rect| {
+                        // replace with drain_filter, when that becomes stable to reuse the original Vec's memory
+                        let (overlapping, mut new_damage): (Vec<_>, Vec<_>) = new_damage
+                            .into_iter()
+                            .partition(|other: &Rectangle<i32, BufferCoords>| other.overlaps(rect));
 
-                let mut textures = Vec::new();
-                for rect in damage {
-                    let texture = (
-                        {
-                            let mapping = render
-                                .renderer_mut()
-                                .copy_framebuffer(rect)
-                                .map_err(Error::Render)?;
-                            let slice = render
-                                .renderer_mut()
-                                .map_texture(&mapping)
-                                .map_err(Error::Render::<R, T>)?;
-                            target
-                                .renderer_mut()
-                                .import_memory(slice, rect.size, false)
-                                .map_err(Error::Target)?
-                        },
+                        for overlap in overlapping {
+                            rect = rect.merge(overlap);
+                        }
+                        new_damage.push(rect);
+                        new_damage
+                    });
+                if copy_rects.len() > MAX_CPU_COPIES {
+                    copy_rects = Vec::from([Rectangle::from_loc_and_size((0, 0), buffer_size)]);
+                }
+
+                let mut mappings = Vec::new();
+                for rect in copy_rects {
+                    let mapping = (
+                        render
+                            .renderer_mut()
+                            .copy_framebuffer(rect)
+                            .map_err(Error::Render)?,
                         rect,
                     );
-                    textures.push(texture);
+                    mappings.push(mapping);
                 }
 
-                let mut frame = target
-                    .renderer_mut()
-                    .render(self.size, Transform::Normal)
-                    .map_err(Error::Target)?;
-                for (texture, rect) in textures {
-                    let dst = rect.to_logical(1, Transform::Normal, &buffer_size).to_physical(1);
-                    frame
-                        .render_texture_from_to(
-                            &texture,
-                            Rectangle::from_loc_and_size((0, 0), rect.size).to_f64(),
-                            dst,
-                            &[Rectangle::from_loc_and_size((0, 0), dst.size)],
-                            Transform::Normal,
-                            1.0,
-                        )
+                for (mapping, rect) in mappings {
+                    let slice = render
+                        .renderer_mut()
+                        .map_texture(&mapping)
+                        .map_err(Error::Render::<R, T>)?;
+                    let texture = target
+                        .renderer_mut()
+                        .import_memory(slice, rect.size, false)
                         .map_err(Error::Target)?;
+                    let mut frame = target
+                        .renderer_mut()
+                        .render(self.size, Transform::Normal)
+                        .map_err(Error::Target)?;
+                    for damage_rect in damage.iter().filter_map(|dmg_rect| dmg_rect.intersection(rect)) {
+                        let dst = damage_rect
+                            .to_logical(1, Transform::Normal, &buffer_size)
+                            .to_physical(1);
+                        let src = Rectangle::from_loc_and_size(damage_rect.loc - rect.loc, damage_rect.size)
+                            .to_f64();
+                        let damage = &[Rectangle::from_loc_and_size((0, 0), dst.size)];
+                        frame.clear([0.0, 0.0, 0.0, 0.0], &[dst]).map_err(Error::Target)?;
+                        frame
+                            .render_texture_from_to(&texture, src, dst, damage, Transform::Normal, 1.0)
+                            .map_err(Error::Target)?;
+                    }
+                    frame.finish().map_err(Error::Target)?;
                 }
-                frame.finish().map_err(Error::Target)?;
             }
         }
 

--- a/src/backend/x11/mod.rs
+++ b/src/backend/x11/mod.rs
@@ -348,7 +348,7 @@ impl X11Handle {
     /// Creates a surface that allocates and presents buffers to the window.
     ///
     /// This will fail if the window has already been used to create a surface.
-    pub fn create_surface<A: Allocator<BufferObject<()>, Error = std::io::Error> + 'static>(
+    pub fn create_surface<A: Allocator<Buffer = BufferObject<()>, Error = std::io::Error> + 'static>(
         &self,
         window: &Window,
         allocator: A,
@@ -378,7 +378,8 @@ impl X11Handle {
         let format = window.0.format;
         let size = window.size();
         let swapchain = Swapchain::new(
-            Box::new(allocator) as Box<dyn Allocator<BufferObject<()>, Error = std::io::Error> + 'static>,
+            Box::new(allocator)
+                as Box<dyn Allocator<Buffer = BufferObject<()>, Error = std::io::Error> + 'static>,
             size.w as u32,
             size.h as u32,
             format,

--- a/src/backend/x11/surface.rs
+++ b/src/backend/x11/surface.rs
@@ -43,7 +43,7 @@ pub struct X11Surface {
     pub(crate) window: Weak<WindowInner>,
     pub(crate) resize: Receiver<Size<u16, Logical>>,
     pub(crate) swapchain:
-        Swapchain<Box<dyn Allocator<BufferObject<()>, Error = std::io::Error> + 'static>, BufferObject<()>>,
+        Swapchain<Box<dyn Allocator<Buffer = BufferObject<()>, Error = std::io::Error> + 'static>>,
     pub(crate) format: DrmFourcc,
     pub(crate) width: u16,
     pub(crate) height: u16,


### PR DESCRIPTION
Latest nvidia driver can somehow import the `Gles2Renderbuffer` on my system, which has an `Invalid`-modifier and is therefore garbage for the nvidia gpu as it is tiled.
So lets explicitly check for supported formats.

- Also includes commits from #841.
- Contains commit to move the generic buffer type of the `Allocator` trait into an associated generic type. Simplifies code all over the place.

Additionally prepares for more sensible gpu-copies in the future:
- Fixes missing cleanup of `GpuManager::dma_source`
- Caches offscreen-buffer
- Attempts to import the offscreen-buffer on the target gpu **on creation** (instead of after rendering, which is expected to fail in most cases)
- Caches resulting texture with the offscreen buffer

In the future we can hopefully do what #842 sets out to do and use a GBM `Allocator` instead of the `Offscreen`-trait, which allocates through the graphics-api.
Currently that crashes on nvidia-gpus, which are by far the most interesting use-case for this feature given most multi-gpu systems are likely nVidia Optimus laptops.
To fix that we need to either test and confirm, that the `VulkanAllocator` is working for this use-case or provide a `GlAllocator` as an alternative, that can only provide `Invalid`-buffers and can then replicate how the `MultiRenderer` works today.
(Also hopefully gbm buffers won't hard crash the nvidia driver in the future.)