### PR TITLE
Ref counted FD

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -3,7 +3,7 @@ use std::{
     cell::RefCell,
     collections::hash_map::{Entry, HashMap},
     convert::TryInto,
-    os::unix::io::{AsRawFd, RawFd},
+    os::unix::io::FromRawFd,
     path::PathBuf,
     rc::Rc,
     sync::{atomic::Ordering, Mutex},
@@ -30,7 +30,10 @@ use smithay::{
 };
 use smithay::{
     backend::{
-        drm::{DrmDevice, DrmError, DrmEvent, DrmEventMetadata, DrmNode, GbmBufferedSurface, NodeType},
+        drm::{
+            DrmDevice, DrmDeviceFd, DrmError, DrmEvent, DrmEventMetadata, DrmNode, GbmBufferedSurface,
+            NodeType,
+        },
         egl::{EGLContext, EGLDevice, EGLDisplay},
         libinput::{LibinputInputBackend, LibinputSessionInterface},
         renderer::{
@@ -73,7 +76,7 @@ use smithay::{
     },
     utils::{
         signaling::{Linkable, SignalToken, Signaler},
-        Clock, IsAlive, Logical, Monotonic, Point, Rectangle, Scale, Transform,
+        Clock, DeviceFd, IsAlive, Logical, Monotonic, Point, Rectangle, Scale, Transform,
     },
     wayland::{
         compositor,
@@ -83,14 +86,6 @@ use smithay::{
 
 type UdevRenderer<'a> =
     MultiRenderer<'a, 'a, EglGlesBackend<Gles2Renderer>, EglGlesBackend<Gles2Renderer>, Gles2Renderbuffer>;
-
-#[derive(Copy, Clone)]
-pub struct SessionFd(RawFd);
-impl AsRawFd for SessionFd {
-    fn as_raw_fd(&self) -> RawFd {
-        self.0
-    }
-}
 
 #[derive(Debug, PartialEq)]
 struct UdevOutputId {
@@ -364,16 +359,16 @@ impl Drop for SurfaceData {
 struct BackendData {
     _restart_token: SignalToken,
     surfaces: Rc<RefCell<HashMap<crtc::Handle, Rc<RefCell<SurfaceData>>>>>,
-    gbm: Rc<RefCell<GbmDevice<SessionFd>>>,
+    gbm: Rc<RefCell<GbmDevice<DrmDeviceFd>>>,
     registration_token: RegistrationToken,
-    event_dispatcher: Dispatcher<'static, DrmDevice<SessionFd>, CalloopData<UdevData>>,
+    event_dispatcher: Dispatcher<'static, DrmDevice, CalloopData<UdevData>>,
 }
 
 #[allow(clippy::too_many_arguments)]
 fn scan_connectors(
     device_id: DrmNode,
-    device: &DrmDevice<SessionFd>,
-    gbm: &Rc<RefCell<GbmDevice<SessionFd>>>,
+    device: &DrmDevice,
+    gbm: &Rc<RefCell<GbmDevice<DrmDeviceFd>>>,
     display: &mut Display<AnvilState<UdevData>>,
     space: &mut Space<Window>,
     #[cfg(feature = "debug")] fps_texture: &MultiTexture,
@@ -530,8 +525,13 @@ impl AnvilState<UdevData> {
         let open_flags = OFlag::O_RDWR | OFlag::O_CLOEXEC | OFlag::O_NOCTTY | OFlag::O_NONBLOCK;
         let device_fd = self.backend_data.session.open(&path, open_flags).ok();
         let devices = device_fd
-            .map(SessionFd)
-            .map(|fd| (DrmDevice::new(fd, true, self.log.clone()), GbmDevice::new(fd)));
+            .map(|fd| DrmDeviceFd::new(unsafe { DeviceFd::from_raw_fd(fd) }, self.log.clone()))
+            .map(|fd| {
+                (
+                    DrmDevice::new(fd.clone(), true, self.log.clone()),
+                    GbmDevice::new(fd),
+                )
+            });
 
         // Report device open failures.
         let (mut device, gbm) = match devices {

--- a/src/backend/drm/device/fd.rs
+++ b/src/backend/drm/device/fd.rs
@@ -1,0 +1,86 @@
+use drm::{control::Device as ControlDevice, Device as BasicDevice};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
+
+use crate::utils::{DevPath, DeviceFd};
+
+/// Ref-counted file descriptor of an open drm device
+#[derive(Debug, Clone)]
+pub struct DrmDeviceFd {
+    fd: DeviceFd,
+    privileged: bool,
+    logger: slog::Logger,
+}
+
+impl AsFd for DrmDeviceFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
+    }
+}
+
+// TODO: drop impl once not needed anymore by smithay or dependencies
+impl AsRawFd for DrmDeviceFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd.as_raw_fd()
+    }
+}
+
+impl DrmDeviceFd {
+    /// Create a new `DrmDeviceFd`.
+    ///
+    /// This function will try to acquire the master lock for the underlying drm device
+    /// and release the lock on drop again.
+    /// For that reason you should never create multiple `DrmDeviceFd` out of the same
+    /// `DeviceFd`, but instead clone the `DrmDeviceFd`.
+    ///
+    /// Failing to do so might fail to acquire set lock and release it early,
+    /// which can cause some drm ioctls to fail later.
+    pub fn new(fd: DeviceFd, logger: impl Into<Option<slog::Logger>>) -> DrmDeviceFd {
+        let mut dev = DrmDeviceFd {
+            fd,
+            privileged: false,
+            logger: crate::slog_or_fallback(logger).new(slog::o!("smithay_module" => "backend_drm")),
+        };
+
+        // We want to modeset, so we better be the master, if we run via a tty session.
+        // This is only needed on older kernels. Newer kernels grant this permission,
+        // if no other process is already the *master*. So we skip over this error.
+        if dev.acquire_master_lock().is_err() {
+            slog::warn!(
+                dev.logger,
+                "Unable to become drm master, assuming unprivileged mode"
+            );
+        } else {
+            dev.privileged = true;
+        }
+
+        dev
+    }
+
+    pub(in crate::backend::drm) fn is_privileged(&self) -> bool {
+        self.privileged
+    }
+
+    /// Returns the underlying `DeviceFd`
+    pub fn device_fd(&self) -> DeviceFd {
+        self.fd.clone()
+    }
+
+    /// Returns the `dev_t` of the underlying device
+    pub fn dev_id(&self) -> Result<nix::libc::dev_t, nix::Error> {
+        Ok(nix::sys::stat::fstat(self.fd.as_raw_fd())?.st_rdev)
+    }
+}
+
+impl Drop for DrmDeviceFd {
+    fn drop(&mut self) {
+        slog::info!(self.logger, "Dropping device: {:?}", self.fd.dev_path());
+        if self.privileged {
+            if let Err(err) = self.release_master_lock() {
+                slog::error!(self.logger, "Failed to drop drm master state. Error: {}", err);
+            }
+        }
+    }
+}
+
+impl BasicDevice for DrmDeviceFd {}
+impl ControlDevice for DrmDeviceFd {}

--- a/src/backend/drm/device/fd.rs
+++ b/src/backend/drm/device/fd.rs
@@ -56,6 +56,7 @@ impl DrmDeviceFd {
         dev
     }
 
+    #[cfg(feature = "backend_session")]
     pub(in crate::backend::drm) fn is_privileged(&self) -> bool {
         self.privileged
     }

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -77,7 +77,8 @@ pub mod node;
 pub(self) mod session;
 pub(self) mod surface;
 
-pub use device::{DevPath, DrmDevice, DrmEvent, EventMetadata as DrmEventMetadata, Time as DrmEventTime};
+use crate::utils::DevPath;
+pub use device::{DrmDevice, DrmDeviceFd, DrmEvent, EventMetadata as DrmEventMetadata, Time as DrmEventTime};
 pub use error::Error as DrmError;
 pub use node::{CreateDrmNodeError, DrmNode, NodeType};
 #[cfg(feature = "backend_gbm")]
@@ -98,7 +99,7 @@ pub struct Planes {
 }
 
 fn planes(
-    dev: &impl ControlDevice,
+    dev: &(impl DevPath + ControlDevice),
     crtc: &crtc::Handle,
     has_universal_planes: bool,
 ) -> Result<Planes, DrmError> {
@@ -147,7 +148,7 @@ fn planes(
     })
 }
 
-fn plane_type(dev: &impl ControlDevice, plane: plane::Handle) -> Result<PlaneType, DrmError> {
+fn plane_type(dev: &(impl ControlDevice + DevPath), plane: plane::Handle) -> Result<PlaneType, DrmError> {
     let props = dev.get_properties(plane).map_err(|source| DrmError::Access {
         errmsg: "Failed to get properties of plane",
         dev: dev.dev_path(),

--- a/src/backend/egl/device.rs
+++ b/src/backend/egl/device.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::backend::drm::{DrmNode, NodeType};
 
 /// safe EGLDevice wrapper
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EGLDevice {
     pub(super) inner: EGLDeviceEXT,
     device_extensions: Vec<String>,

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -147,7 +147,7 @@ impl<A: AsRawFd + Send + 'static> EGLNativeDisplay for GbmDevice<A> {
 }
 
 #[cfg(feature = "backend_winit")]
-impl EGLNativeDisplay for WinitWindow {
+impl EGLNativeDisplay for Arc<WinitWindow> {
     fn supported_platforms(&self) -> Vec<EGLPlatform<'_>> {
         if let Some(display) = self.wayland_display() {
             vec![

--- a/src/backend/renderer/multigpu/egl.rs
+++ b/src/backend/renderer/multigpu/egl.rs
@@ -87,13 +87,12 @@ impl<R: From<Gles2Renderer> + Renderer<Error = Gles2Error>> GraphicsApi for EglG
             .filter(|(_, node)| !list.iter().any(|renderer| &renderer.node == node))
             .map(|(device, node)| {
                 slog::info!(log, "Trying to initialize {:?} from {}", device, node);
-                let display = unsafe { EGLDisplay::new(&device, None).map_err(Error::Egl)? };
+                let display = EGLDisplay::new(device, None).map_err(Error::Egl)?;
                 let context = EGLContext::new(&display, None).map_err(Error::Egl)?;
                 let renderer = unsafe { Gles2Renderer::new(context, None).map_err(Error::Gl)? }.into();
 
                 Ok(EglGlesDevice {
                     node,
-                    _device: device,
                     _display: display,
                     renderer,
                 })
@@ -131,7 +130,6 @@ pub struct EglGlesDevice<R> {
     node: DrmNode,
     renderer: R,
     _display: EGLDisplay,
-    _device: EGLDevice,
 }
 
 impl<R: Renderer> ApiDevice for EglGlesDevice<R> {

--- a/src/utils/fd.rs
+++ b/src/utils/fd.rs
@@ -1,0 +1,62 @@
+use std::{
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd},
+    path::PathBuf,
+    sync::Arc,
+};
+
+/// Ref-counted file descriptor of an open device node
+#[derive(Debug, Clone)]
+pub struct DeviceFd(Arc<OwnedFd>);
+
+impl PartialEq for DeviceFd {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_raw_fd() == other.0.as_raw_fd()
+    }
+}
+
+impl AsFd for DeviceFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
+    }
+}
+
+// TODO: drop impl once not needed anymore by smithay or dependencies
+impl AsRawFd for DeviceFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl FromRawFd for DeviceFd {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        DeviceFd(Arc::new(OwnedFd::from_raw_fd(fd)))
+    }
+}
+
+impl From<OwnedFd> for DeviceFd {
+    fn from(fd: OwnedFd) -> Self {
+        DeviceFd(Arc::new(fd))
+    }
+}
+
+impl TryInto<OwnedFd> for DeviceFd {
+    type Error = DeviceFd;
+
+    fn try_into(self) -> Result<OwnedFd, Self::Error> {
+        Arc::try_unwrap(self.0).map_err(DeviceFd)
+    }
+}
+
+/// Trait representing open devices that *may* return a `Path`
+pub trait DevPath {
+    /// Returns the path of the open device if possible
+    fn dev_path(&self) -> Option<PathBuf>;
+}
+
+impl<A: AsFd> DevPath for A {
+    fn dev_path(&self) -> Option<PathBuf> {
+        use std::fs;
+
+        fs::read_link(format!("/proc/self/fd/{:?}", self.as_fd().as_raw_fd())).ok()
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,6 +12,9 @@ pub mod user_data;
 pub(crate) mod alive_tracker;
 pub use self::alive_tracker::IsAlive;
 
+mod fd;
+pub use fd::*;
+
 #[cfg(feature = "wayland_frontend")]
 pub(crate) mod sealed_file;
 


### PR DESCRIPTION
This PR consists of two commits, that should be reviewed independently:

- 1a2c6b2 - Adds a new utility type `DeviceFd`, which is essentially a ref-counted `OwnedFd`. It also adds a `DrmDeviceFd` based on that and gets rid of most the generics in the `backend/drm`-module in the process.
- 5ae9412 - Tries to address the unsafety of the lifetime of `EGLDisplay`-objects, which are bound to their underlying object. The big issue here was the `GbmDevice`, which is only clonable, if they underlying file-type was clonable. And we didn't want to clone a raw file descriptor, but we can easily clone a ref-counted one. So now we can simply make the `EGLDisplay` take ownership of the native type.