### PR TITLE
Use pointer and length to refer to shm memory, instead of slice

### DIFF
--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -787,7 +787,7 @@ impl ImportMemWl for Gles2Renderer {
         // this is guaranteed a non-public internal type, so we are good.
         type CacheMap = HashMap<usize, Rc<Gles2TextureInternal>>;
 
-        with_buffer_contents(buffer, |slice, data| {
+        with_buffer_contents(buffer, |ptr, len, data| {
             self.make_current()?;
 
             let offset = data.offset as i32;
@@ -800,7 +800,7 @@ impl ImportMemWl for Gles2Renderer {
             let pixelsize = 4i32;
 
             // ensure consistency, the SHM handler of smithay should ensure this
-            assert!((offset + (height - 1) * stride + width * pixelsize) as usize <= slice.len());
+            assert!((offset + (height - 1) * stride + width * pixelsize) as usize <= len);
 
             let (gl_format, shader_idx) = match data.format {
                 wl_shm::Format::Abgr8888 => (ffi::RGBA, 0),
@@ -874,7 +874,7 @@ impl ImportMemWl for Gles2Renderer {
                         0,
                         gl_format,
                         ffi::UNSIGNED_BYTE as u32,
-                        slice.as_ptr().offset(offset as isize) as *const _,
+                        ptr.offset(offset as isize) as *const _,
                     );
                 } else {
                     for region in damage.iter() {
@@ -890,7 +890,7 @@ impl ImportMemWl for Gles2Renderer {
                             region.size.h,
                             gl_format,
                             ffi::UNSIGNED_BYTE as u32,
-                            slice.as_ptr().offset(offset as isize) as *const _,
+                            ptr.offset(offset as isize) as *const _,
                         );
                         self.gl.PixelStorei(ffi::UNPACK_SKIP_PIXELS, 0);
                         self.gl.PixelStorei(ffi::UNPACK_SKIP_ROWS, 0);

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -676,7 +676,7 @@ pub fn buffer_type(buffer: &wl_buffer::WlBuffer) -> Option<BufferType> {
     }
 
     if !matches!(
-        crate::wayland::shm::with_buffer_contents(buffer, |_, _| ()),
+        crate::wayland::shm::with_buffer_contents(buffer, |_, _, _| ()),
         Err(BufferAccessError::NotManaged)
     ) {
         return Some(BufferType::Shm);
@@ -711,7 +711,7 @@ pub fn buffer_has_alpha(buffer: &wl_buffer::WlBuffer) -> Option<bool> {
         return Some(crate::backend::allocator::format::has_alpha(dmabuf.0.format));
     }
 
-    if let Ok(has_alpha) = crate::wayland::shm::with_buffer_contents(buffer, |_, data| {
+    if let Ok(has_alpha) = crate::wayland::shm::with_buffer_contents(buffer, |_, _, data| {
         crate::wayland::shm::has_alpha(data.format)
     }) {
         return Some(has_alpha);
@@ -747,7 +747,7 @@ pub fn buffer_dimensions(buffer: &wl_buffer::WlBuffer) -> Option<Size<i32, Buffe
         return Some((buf.width() as i32, buf.height() as i32).into());
     }
 
-    match shm::with_buffer_contents(buffer, |_, data| (data.width, data.height).into()) {
+    match shm::with_buffer_contents(buffer, |_, _, data| (data.width, data.height).into()) {
         Ok(data) => Some(data),
 
         Err(BufferAccessError::NotManaged) => {

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1480,7 +1480,7 @@ where
             .renderer_mut()
             .import_shm_buffer(buffer, surface, damage)
             .expect("import_shm_buffer without checking buffer type?");
-        let dimensions = shm::with_buffer_contents(buffer, |_, data| (data.width, data.height).into())
+        let dimensions = shm::with_buffer_contents(buffer, |_, _, data| (data.width, data.height).into())
             .map_err(|_| Error::ImportFailed)?;
         let mut texture = MultiTexture::from_surface(surface, dimensions);
         texture.insert_texture::<R>(*self.render.node(), shm_texture);

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -82,7 +82,8 @@ impl ImportMemWl for DummyRenderer {
         _damage: &[Rectangle<i32, Buffer>],
     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error> {
         use smithay::wayland::shm::with_buffer_contents;
-        let ret = with_buffer_contents(buffer, |slice, data| {
+        use std::ptr;
+        let ret = with_buffer_contents(buffer, |ptr, len, data| {
             let offset = data.offset as u32;
             let width = data.width as u32;
             let height = data.height as u32;
@@ -91,7 +92,9 @@ impl ImportMemWl for DummyRenderer {
             let mut x = 0;
             for h in 0..height {
                 for w in 0..width {
-                    x |= slice[(offset + w + h * stride) as usize];
+                    let idx = (offset + w + h * stride) as usize;
+                    assert!(idx < len);
+                    x |= unsafe { ptr::read(ptr.offset(idx as isize)) };
                 }
             }
 


### PR DESCRIPTION
Creating a slice into shared memory is problematic, since this is considered undefined behavior if the client mutates the memory. This is especially a problem since it was creating a slice for the whole pool, as even a correctly behaving client may mutate another buffer in the same pool.

We don't want to trust clients not to mutate buffers for soundness, even if it's not obvious what bugs or exploits this could result in. It's also quite unnecessary if all we do is convert the slice back to a pointer and pass it to OpenGL.

Memory access that could result in `SIGBUS` is probably also problematic in access from safe Rust code that expects all memory accesses to succeed.

This simply replaces the slice with a pointer and length, which for the most part (with the current renderer implementation) means we're not converting to a slice just to convert it back to a pointer again.