### PR TITLE
gbm: export fd per plane

### DIFF
--- a/src/backend/allocator/gbm.rs
+++ b/src/backend/allocator/gbm.rs
@@ -124,15 +124,13 @@ impl<T> AsDmabuf for GbmBuffer<T> {
             // check all planes have the same handle. We can't use
             // drmPrimeHandleToFD because that messes up handle ref'counting in
             // the user-space driver.
-            return Err(GbmConvertError::UnsupportedBuffer); //TODO
+            return Err(GbmConvertError::UnsupportedBuffer);
         }
-
-        // Make sure to only call fd once as each call will create
-        // a new file descriptor which has to be closed
-        let fd = self.fd()?;
 
         let mut builder = Dmabuf::builder_from_buffer(self, DmabufFlags::empty());
         for idx in 0..planes {
+            let fd = self.fd()?;
+
             builder.add_plane(
                 // SAFETY: `gbm_bo_get_fd` returns a new fd owned by the caller.
                 fd,


### PR DESCRIPTION
the recent IO safety work revealed a bug
in GbmBuffer::export when the system does
not support gbm_bo_get_fd_for_plane.
Before the IO safety work the same fd was
used for multiple planes (this is problematic
because each plane takes ownership of the fd).
Practically this should not have happened as
the legacy version only supports bo with a single
plane.

The latests gbm release made this kind of
error impossible by directly returning an OwnedFd, but we missed it in smithay because of conditional compilation.

fixes #854 