### PR TITLE
Fix xdg_output's logical size with transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 - `wl_shm` properly validates parameters when creating a `wl_buffer`.
 - `ServerDnDGrab` and `DnDGrab` now correctly send data device `leave` event on button release
 - Client are now allowed to reassign the same role to a surface
+- `xdg_output` now applies the output transforms to the reported logical size
 
 #### Backends
 

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -192,7 +192,7 @@ impl Output {
         // XdgOutput has to be updated before WlOutput
         // Because WlOutput::done() has to allways be called last
         if let Some(xdg_output) = inner.xdg_output.as_ref() {
-            xdg_output.change_current_state(new_mode, new_scale, new_location);
+            xdg_output.change_current_state(new_mode, new_scale, new_location, new_transform);
         }
 
         let mut flags = WMode::Current;


### PR DESCRIPTION
This fixes an issue where the reported logical size of the xdg_output implementation would incorrectly report the untransformed logical size.

Closes #857.