### PR TITLE
egl: Add support for surfaceless

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,7 @@ fn gl_generate() {
                 "EGL_EXT_platform_wayland",
                 "EGL_KHR_platform_gbm",
                 "EGL_MESA_platform_gbm",
+                "EGL_MESA_platform_surfaceless",
                 "EGL_EXT_platform_device",
                 "EGL_WL_bind_wayland_display",
                 "EGL_KHR_image_base",

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -201,6 +201,23 @@ impl EGLNativeDisplay for EGLDevice {
     }
 }
 
+/// Shallow type for the EGL_PLATFORM_SURFACELESS with default EGL display
+#[derive(Debug)]
+pub struct EGLSurfacelessDisplay;
+
+impl EGLNativeDisplay for EGLSurfacelessDisplay {
+    fn supported_platforms(&self) -> Vec<EGLPlatform<'_>> {
+        vec![
+            // see: https://www.khronos.org/registry/EGL/extensions/MESA/EGL_MESA_platform_surfaceless.txt
+            egl_platform!(
+                PLATFORM_SURFACELESS_MESA,
+                ffi::egl::DEFAULT_DISPLAY,
+                &["EGL_MESA_platform_surfaceless"]
+            ),
+        ]
+    }
+}
+
 /// Trait for types returning valid surface pointers for initializing egl.
 ///
 /// ## Safety


### PR DESCRIPTION
ChromeOS uses [minigbm](https://chromium.googlesource.com/chromiumos/platform/minigbm/) instead of GBM. As part of this, the EGL_MESA_platform_gbm is unavailable. To allow Smithay to work on ChromeOS, enable a minigbm flag.