### PR TITLE
Fixes for building on FreeBSD

### DIFF
--- a/src/backend/drm/node/constants.rs
+++ b/src/backend/drm/node/constants.rs
@@ -23,17 +23,17 @@ pub const DRM_MAJOR: u64 = 226;
 #[cfg(not(target_os = "openbsd"))]
 pub const PRIMARY_NAME: &str = "card";
 
-#[cfg(target_os = "freebsd")]
+#[cfg(target_os = "openbsd")]
 pub const PRIMARY_NAME: &str = "drm";
 
 #[cfg(not(target_os = "openbsd"))]
 pub const CONTROL_NAME: &str = "controlD";
 
-#[cfg(target_os = "freebsd")]
+#[cfg(target_os = "openbsd")]
 pub const CONTROL_NAME: &str = "drmC";
 
 #[cfg(not(target_os = "openbsd"))]
 pub const RENDER_NAME: &str = "renderD";
 
-#[cfg(target_os = "freebsd")]
+#[cfg(target_os = "openbsd")]
 pub const RENDER_NAME: &str = "drmR";

--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -19,9 +19,17 @@ impl NonNegativeClockSource for Monotonic {}
 #[derive(Debug)]
 pub struct Boottime;
 
+#[cfg(target_os = "linux")]
 impl ClockSource for Boottime {
     fn id() -> libc::clockid_t {
         libc::CLOCK_BOOTTIME
+    }
+}
+
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+impl ClockSource for Boottime {
+    fn id() -> libc::clockid_t {
+        libc::CLOCK_UPTIME
     }
 }
 


### PR DESCRIPTION
With this I'm able to start Anvil, if I disable `xwayland`. (`UnixAddr::new_abstract` is Linux-specific.)

Handling drm device nodes is really a mess regardless of OS... and is also a mess in `libdrm`.