### PR TITLE
xwm: replace LATE_SURFACE_ID

### DIFF
--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -28,6 +28,8 @@ use smithay::{
 };
 
 use crate::state::{AnvilState, Backend};
+#[cfg(feature = "xwayland")]
+use crate::CalloopData;
 
 mod element;
 mod grabs;
@@ -88,7 +90,7 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
     }
     fn commit(&mut self, surface: &WlSurface) {
         #[cfg(feature = "xwayland")]
-        X11Wm::commit_hook(surface);
+        X11Wm::commit_hook::<CalloopData<BackendData>>(surface);
 
         on_commit_buffer_handler(surface);
         self.backend_data.early_import(surface);

--- a/src/utils/x11rb.rs
+++ b/src/utils/x11rb.rs
@@ -36,8 +36,6 @@ use calloop::{
 pub struct X11Source {
     connection: Arc<RustConnection>,
     channel: Option<Channel<Event>>,
-    #[cfg(feature = "xwayland")]
-    pub(crate) sender: SyncSender<Event>,
     event_thread: Option<JoinHandle<()>>,
     close_window: Window,
     close_type: Atom,
@@ -60,16 +58,13 @@ impl X11Source {
         let (sender, channel) = sync_channel(5);
         let conn = Arc::clone(&connection);
         let log2 = log.clone();
-        let thread_sender = sender.clone();
         let event_thread = Some(spawn(move || {
-            run_event_thread(conn, thread_sender, log2);
+            run_event_thread(conn, sender, log2);
         }));
 
         Self {
             connection,
             channel: Some(channel),
-            #[cfg(feature = "xwayland")]
-            sender,
             event_thread,
             close_window,
             close_type,


### PR DESCRIPTION
The current mechanism by which x11 window ids and their corresponding wl_surfaces are matched, may inject a `LATE_SURFACE_ID` client message similar to the original `WL_SURFACE_ID` message.

The problem with injecting this message is, that to do that it utilizes the same `SyncSender`, that is internally used by the `X11Source`. Given that this sender is *sync* and limited to 5 in-flight messages, queuing up additional messages from the same thread, that runs the calloop event loop and receives these messages may cause a deadlock. This can often be encountered when multiple windows are spawned by a client at the same time.

Instead of making the channel unbound this PR avoids the problem by changing the mechanism all together. Instead of injecting a message, the xwm state is accessed by an idle callback, which isn't prone to cause a deadlock.