### PR TITLE
xwm: More fixes

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -991,13 +991,15 @@ fn handle_event<D: XwmHandler>(state: &mut D, xwmid: XwmId, event: Event) -> Res
                 );
             } else if let Some(surface) = xwm.windows.iter().find(|x| x.window_id() == n.window).cloned() {
                 if surface.is_override_redirect() {
+                    let geometry = Rectangle::from_loc_and_size(
+                        (n.x as i32, n.y as i32),
+                        (n.width as i32, n.height as i32),
+                    );
+                    surface.state.lock().unwrap().geometry = geometry;
                     state.configure_notify(
                         id,
                         surface,
-                        Rectangle::from_loc_and_size(
-                            (n.x as i32, n.y as i32),
-                            (n.width as i32, n.height as i32),
-                        ),
+                        geometry,
                         if n.above_sibling == x11rb::NONE {
                             None
                         } else {

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -760,19 +760,21 @@ impl X11Wm {
             render_format,
             &CreatePictureAux::new(),
         )?;
-        let gc = GcontextWrapper::create_gc(&*self.conn, picture.picture(), &CreateGCAux::new())?;
-        self.conn.put_image(
-            ImageFormat::Z_PIXMAP,
-            picture.picture(),
-            gc.gcontext(),
-            size.w,
-            size.h,
-            0,
-            0,
-            0,
-            32,
-            pixels,
-        )?;
+        {
+            let gc = GcontextWrapper::create_gc(&*self.conn, pixmap.pixmap(), &CreateGCAux::new())?;
+            self.conn.put_image(
+                ImageFormat::Z_PIXMAP,
+                pixmap.pixmap(),
+                gc.gcontext(),
+                size.w,
+                size.h,
+                0,
+                0,
+                0,
+                32,
+                pixels,
+            )?;
+        }
         let cursor = self.conn.generate_id()?;
         self.conn
             .render_create_cursor(cursor, picture.picture(), hotspot.x, hotspot.y)?;

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -586,6 +586,7 @@ impl X11Wm {
 
         let mut last_pos = None;
         self.conn.grab_server()?;
+        let mut changed = false;
         for relatable in order {
             let pos = self
                 .client_list_stacking
@@ -604,6 +605,7 @@ impl X11Wm {
                             .stack_mode(StackMode::BELOW),
                     )?;
                     self.client_list_stacking.insert(last_pos, elem);
+                    changed = true;
                     continue;
                 }
             }
@@ -611,13 +613,15 @@ impl X11Wm {
                 last_pos = pos;
             }
         }
-        self.conn.change_property32(
-            PropMode::REPLACE,
-            self.screen.root,
-            self.atoms._NET_CLIENT_LIST_STACKING,
-            AtomEnum::WINDOW,
-            &self.client_list_stacking,
-        )?;
+        if changed {
+            self.conn.change_property32(
+                PropMode::REPLACE,
+                self.screen.root,
+                self.atoms._NET_CLIENT_LIST_STACKING,
+                AtomEnum::WINDOW,
+                &self.client_list_stacking,
+            )?;
+        }
         Ok(())
     }
 
@@ -654,6 +658,7 @@ impl X11Wm {
             let _ = self.conn.flush();
         });
         self.conn.grab_server()?;
+        let mut changed = false;
         for relatable in order {
             let pos = self
                 .client_list_stacking
@@ -672,6 +677,7 @@ impl X11Wm {
                             .stack_mode(StackMode::ABOVE),
                     )?;
                     self.client_list_stacking.insert(last_pos, elem);
+                    changed = true;
                     continue;
                 }
             }
@@ -679,13 +685,15 @@ impl X11Wm {
                 last_pos = pos;
             }
         }
-        self.conn.change_property32(
-            PropMode::REPLACE,
-            self.screen.root,
-            self.atoms._NET_CLIENT_LIST_STACKING,
-            AtomEnum::WINDOW,
-            &self.client_list_stacking,
-        )?;
+        if changed {
+            self.conn.change_property32(
+                PropMode::REPLACE,
+                self.screen.root,
+                self.atoms._NET_CLIENT_LIST_STACKING,
+                AtomEnum::WINDOW,
+                &self.client_list_stacking,
+            )?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
- Make sure new geometry of an override redirect window is represented in its internal state.
- Don't spam clients with new stacking lists, if nothing actually changed