### PR TITLE
xwayland: More versatile xwayland launching

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -64,7 +64,21 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             KeyAction::Run(cmd) => {
                 info!(self.log, "Starting program"; "cmd" => cmd.clone());
 
-                if let Err(e) = Command::new(&cmd).spawn() {
+                if let Err(e) = Command::new(&cmd)
+                    .envs(
+                        self.socket_name
+                            .clone()
+                            .map(|v| ("WAYLAND_DISPLAY", v))
+                            .into_iter()
+                            .chain(
+                                #[cfg(feature = "xwayland")]
+                                self.xdisplay.map(|v| ("DISPLAY", format!(":{}", v))),
+                                #[cfg(not(feature = "xwayland"))]
+                                None,
+                            ),
+                    )
+                    .spawn()
+                {
                     error!(self.log,
                         "Failed to start program";
                         "cmd" => cmd,

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -132,6 +132,8 @@ pub struct AnvilState<BackendData: Backend + 'static> {
     pub xwayland: XWayland,
     #[cfg(feature = "xwayland")]
     pub xwm: Option<X11Wm>,
+    #[cfg(feature = "xwayland")]
+    pub xdisplay: Option<u32>,
 
     #[cfg(feature = "debug")]
     pub renderdoc: Option<renderdoc::RenderDoc<renderdoc::V141>>,
@@ -412,7 +414,6 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                 })
                 .expect("Failed to init wayland socket source");
             info!(log, "Listening on wayland socket"; "name" => socket_name.clone());
-            ::std::env::set_var("WAYLAND_DISPLAY", &socket_name);
             Some(socket_name)
         } else {
             None
@@ -479,7 +480,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                     connection,
                     client,
                     client_fd: _,
-                    display: _,
+                    display,
                 } => {
                     let mut wm = X11Wm::start_wm(
                         data.state.handle.clone(),
@@ -498,6 +499,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                     )
                     .expect("Failed to set xwayland default cursor");
                     data.state.xwm = Some(wm);
+                    data.state.xdisplay = Some(display);
                 }
                 XWaylandEvent::Exited => {
                     let _ = data.state.xwm.take();
@@ -546,6 +548,8 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
             xwayland,
             #[cfg(feature = "xwayland")]
             xwm: None,
+            #[cfg(feature = "xwayland")]
+            xdisplay: None,
             #[cfg(feature = "debug")]
             renderdoc: renderdoc::RenderDoc::new().ok(),
             show_window_preview: false,

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "xwayland")]
+use std::ffi::OsString;
 use std::{
     borrow::Cow,
     cell::RefCell,
@@ -334,7 +336,12 @@ pub fn run_udev(log: Logger) {
      * Start XWayland if supported
      */
     #[cfg(feature = "xwayland")]
-    if let Err(e) = state.xwayland.start(state.handle.clone()) {
+    if let Err(e) = state.xwayland.start(
+        state.handle.clone(),
+        None,
+        std::iter::empty::<(OsString, OsString)>(),
+        |_| {},
+    ) {
         error!(log, "Failed to start XWayland: {}", e);
     }
 

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "xwayland")]
+use std::ffi::OsString;
 use std::{
     sync::{atomic::Ordering, Mutex},
     time::Duration,
@@ -160,7 +162,12 @@ pub fn run_winit(log: Logger) {
     state.space.map_output(&output, (0, 0));
 
     #[cfg(feature = "xwayland")]
-    if let Err(e) = state.xwayland.start(state.handle.clone()) {
+    if let Err(e) = state.xwayland.start(
+        state.handle.clone(),
+        None,
+        std::iter::empty::<(OsString, OsString)>(),
+        |_| {},
+    ) {
         error!(log, "Failed to start XWayland: {}", e);
     }
 

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "xwayland")]
+use std::ffi::OsString;
 use std::{
     sync::{atomic::Ordering, Mutex},
     time::Duration,
@@ -224,7 +226,12 @@ pub fn run_x11(log: Logger) {
         .expect("Failed to insert X11 Backend into event loop");
 
     #[cfg(feature = "xwayland")]
-    if let Err(e) = state.xwayland.start(state.handle.clone()) {
+    if let Err(e) = state.xwayland.start(
+        state.handle.clone(),
+        None,
+        std::iter::empty::<(OsString, OsString)>(),
+        |_| {},
+    ) {
         error!(log, "Failed to start XWayland: {}", e);
     }
     info!(log, "Initialization completed, starting the main loop.");

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -351,11 +351,8 @@ impl Inner {
 
             // send error occurs if the user dropped the channel... We cannot do much except ignore.
             let _ = self.sender.send(XWaylandEvent::Exited);
-
             // All connections and lockfiles are cleaned by their destructors
 
-            // Remove DISPLAY from the env
-            ::std::env::remove_var("DISPLAY");
             // We do like wlroots:
             // > We do not kill the XWayland process, it dies to broken pipe
             // > after we close our side of the wm/wl fds. This is more reliable
@@ -385,9 +382,6 @@ fn xwayland_ready(inner: &Arc<Mutex<Inner>>) {
     };
 
     if success {
-        // setup the environment
-        ::std::env::set_var("DISPLAY", format!(":{}", instance.display_lock.display()));
-
         // signal the WM
         info!(
             guard.log,

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -130,6 +130,19 @@ impl XWayland {
 
     /// Attempt to start the XWayland instance
     ///
+    /// ## Arguments
+    ///
+    /// - `display` - if provided only the given display number will be tested.
+    ///     If you wish smithay to choose a display for you, pass `None`.
+    /// - `envs` - Allows additionally environment variables for the xwayland executable to be set
+    /// - `user_data` - Allows mutating the `XWaylandClientData::user_data`-map before the client
+    ///    is added to the wayland display. Useful for initializing state for global filters.
+    ///
+    /// ## Return value
+    ///
+    /// Returns the display value, that was choosen to start the Xserver.
+    /// This function does **not** set the `DISPLAY` environment variable.
+    ///
     /// If it succeeds, you'll eventually receive an `XWaylandEvent::Ready`
     /// through the source provided by `XWayland::new()` containing an
     /// `UnixStream` representing your WM connection to XWayland, and the

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -383,7 +383,13 @@ fn xwayland_ready(inner: &Arc<Mutex<Inner>>) {
     let guard = &mut *guard;
     info!(guard.log, "XWayland ready");
     // instance should never be None at this point
-    let instance = guard.instance.as_mut().unwrap();
+    let Some(instance) = guard.instance.as_mut() else {
+        error!(
+            guard.log,
+            "XWayland crashed at startup, will not try to restart it."
+        );
+        return;
+    };
     // neither the child_stdout
     let child_stdout = &mut instance.child_stdout;
 

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -139,6 +139,7 @@ impl XWayland {
     pub fn start<D, K, V, I, F>(
         &self,
         loop_handle: LoopHandle<'_, D>,
+        display: impl Into<Option<u32>>,
         envs: I,
         user_data: F,
     ) -> io::Result<()>
@@ -149,7 +150,7 @@ impl XWayland {
         F: FnOnce(&UserDataMap),
     {
         let dh = self.inner.lock().unwrap().dh.clone();
-        launch(&self.inner, loop_handle, dh, envs, user_data)
+        launch(&self.inner, loop_handle, dh, display.into(), envs, user_data)
     }
 
     /// Shutdown XWayland
@@ -218,6 +219,7 @@ fn launch<D, K, V, I, F>(
     inner: &Arc<Mutex<Inner>>,
     loop_handle: LoopHandle<'_, D>,
     mut dh: DisplayHandle,
+    display: Option<u32>,
     envs: I,
     user_data: F,
 ) -> io::Result<()>
@@ -237,7 +239,7 @@ where
     let (x_wm_x11, x_wm_me) = UnixStream::pair()?;
     let (wl_x11, wl_me) = UnixStream::pair()?;
 
-    let (lock, x_fds) = prepare_x11_sockets(guard.log.clone())?;
+    let (lock, x_fds) = prepare_x11_sockets(guard.log.clone(), display)?;
 
     // we have now created all the required sockets
 


### PR DESCRIPTION
Modifies the `XWayland::start` function in various ways, best reviewed commit-by-commit.

- [xserver: Allow user provided env vars](https://github.com/Smithay/smithay/commit/4ea4e0277f361ea8bd78bab4e5a96484322b4111) - Self-explanatory
- [xserver: Allow initialization of user_data for XWaylandClient](https://github.com/Smithay/smithay/commit/a100db722c7e073fc966dba78b2b9b62b907a450)  - This is necessary to base any global filters for Xwayland on a specific Xwayland instance.
- [xserver: Don't mutate environment](https://github.com/Smithay/smithay/commit/15a3598e0e497a4bfbd3a354963738c092937970) - Mutating the environment in multi-threaded programs is unsafe in some unix systems. Additionally this doesn't work, if downstream is spawning multiple Xwayland instances. So let downstream set the display instead.
- [xserver: Allow explicit selection of X display](https://github.com/Smithay/smithay/commit/2cba6e49b0d6bb967623443f9cd0d4c06d7bd4e7) - Self-explanatory
- [xserver: start documentation](https://github.com/Smithay/smithay/commit/45287eac802491fd7c6aab96e98a084ffe1a7f66) - Documentation for all of the above.
- [anvil: Update Xwayland start](https://github.com/Smithay/smithay/commit/c955130882f638f906c010c2e81525027fea33e0) - Updates anvil for all these changes.
- [anvil: Explicitly set client env](https://github.com/Smithay/smithay/pull/871/commits/cf24adbd829146b9a33e88d9370a1d1162acad1e) - Removes `set_var` from anvil as well and explicitly sets the `WAYLAND_DISPLAY` and `DISPLAY` for launched clients.