### PR TITLE
backend: Gesture events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - `ImportMem` and `ImportDma` were split and do now have accompanying traits `ImportMemWl` and `ImportDmaWl` to import wayland buffers.
 - Added `EGLSurface::get_size`
 - `EGLDisplay::get_extensions` was renamed to `extensions` and now returns a `&[String]`.
+- Added gesture input events, which are supported with the libinput backend.
 
 ### Additions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ drm = { version = "0.8.0", optional = true }
 drm-ffi = { version = "0.4.0", optional = true }
 gbm = { version = "0.11.0", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.11.2", optional = true }
-input = { version = "0.8.1", default-features = false, features=["libinput_1_14"], optional = true }
+input = { version = "0.8.2", default-features = false, features=["libinput_1_14"], optional = true }
 indexmap = "1.7"
 lazy_static = "1"
 libc = "0.2.103"
@@ -86,6 +86,7 @@ backend_udev = ["udev", "input/udev"]
 backend_vulkan = ["ash", "scopeguard"]
 backend_session_libseat = ["backend_session", "libseat"]
 desktop = []
+libinput_1_19 = ["input/libinput_1_19"]
 renderer_gl = ["gl_generator", "backend_egl"]
 renderer_glow = ["renderer_gl", "glow"]
 renderer_multi = ["backend_drm"]
@@ -93,7 +94,7 @@ use_system_lib = ["wayland_frontend", "wayland-backend/server_system", "wayland-
 wayland_frontend = ["wayland-server", "wayland-protocols", "tempfile"]
 x11rb_event_source = ["x11rb"]
 xwayland = ["encoding", "wayland_frontend", "x11rb/composite", "x11rb_event_source", "scopeguard"]
-test_all_features = ["default", "use_system_lib", "renderer_glow"]
+test_all_features = ["default", "use_system_lib", "renderer_glow", "libinput_1_19"]
 
 [[example]]
 name = "minimal"

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -185,6 +185,111 @@ impl<B: InputBackend> PointerButtonEvent<B> for UnusedEvent {
         match *self {}
     }
 }
+/// Trait for gesture begin events.
+pub trait GestureBeginEvent<B: InputBackend>: Event<B> {
+    /// Number of fingers.
+    fn fingers(&self) -> u32;
+}
+
+impl<B: InputBackend> GestureBeginEvent<B> for UnusedEvent {
+    fn fingers(&self) -> u32 {
+        match *self {}
+    }
+}
+
+/// Trait for gesture end events.
+pub trait GestureEndEvent<B: InputBackend>: Event<B> {
+    /// True if event was cancelled.
+    fn cancelled(&self) -> bool;
+}
+
+impl<B: InputBackend> GestureEndEvent<B> for UnusedEvent {
+    fn cancelled(&self) -> bool {
+        match *self {}
+    }
+}
+
+/// Trait for gesture swipe begin event.
+pub trait GestureSwipeBeginEvent<B: InputBackend>: GestureBeginEvent<B> {}
+
+impl<B: InputBackend> GestureSwipeBeginEvent<B> for UnusedEvent {}
+
+/// Trait for gesture swipe update event.
+pub trait GestureSwipeUpdateEvent<B: InputBackend>: Event<B> {
+    /// Delta of center on the x axis from last begin/update.
+    fn delta_x(&self) -> f64;
+
+    /// Delta of center on the y axis from last begin/update.
+    fn delta_y(&self) -> f64;
+}
+
+impl<B: InputBackend> GestureSwipeUpdateEvent<B> for UnusedEvent {
+    fn delta_x(&self) -> f64 {
+        match *self {}
+    }
+
+    fn delta_y(&self) -> f64 {
+        match *self {}
+    }
+}
+
+/// Trait for gesture swipe end event.
+pub trait GestureSwipeEndEvent<B: InputBackend>: GestureEndEvent<B> {}
+
+impl<B: InputBackend> GestureSwipeEndEvent<B> for UnusedEvent {}
+
+/// Trait for gesture pinch begin event.
+pub trait GesturePinchBeginEvent<B: InputBackend>: GestureBeginEvent<B> {}
+
+impl<B: InputBackend> GesturePinchBeginEvent<B> for UnusedEvent {}
+
+/// Trait for gesture pinch update event.
+pub trait GesturePinchUpdateEvent<B: InputBackend>: Event<B> {
+    /// Delta of center on the x axis from last begin/update.
+    fn delta_x(&self) -> f64;
+
+    /// Delta of center on the y axis from last begin/update.
+    fn delta_y(&self) -> f64;
+
+    /// Absolute scale compared to begin event.
+    fn scale(&self) -> f64;
+
+    /// Relative angle in degrees from last begin/update.
+    fn rotation(&self) -> f64;
+}
+
+impl<B: InputBackend> GesturePinchUpdateEvent<B> for UnusedEvent {
+    fn delta_x(&self) -> f64 {
+        match *self {}
+    }
+
+    fn delta_y(&self) -> f64 {
+        match *self {}
+    }
+
+    fn scale(&self) -> f64 {
+        match *self {}
+    }
+
+    fn rotation(&self) -> f64 {
+        match *self {}
+    }
+}
+
+/// Trait for gesture pinch end event.
+pub trait GesturePinchEndEvent<B: InputBackend>: GestureEndEvent<B> {}
+
+impl<B: InputBackend> GesturePinchEndEvent<B> for UnusedEvent {}
+
+/// Trait for gesture hold begin event.
+pub trait GestureHoldBeginEvent<B: InputBackend>: GestureBeginEvent<B> {}
+
+impl<B: InputBackend> GestureHoldBeginEvent<B> for UnusedEvent {}
+
+/// Trait for gesture hold end event.
+pub trait GestureHoldEndEvent<B: InputBackend>: GestureEndEvent<B> {}
+
+impl<B: InputBackend> GestureHoldEndEvent<B> for UnusedEvent {}
 
 /// Axis when scrolling
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -432,6 +537,22 @@ pub trait InputBackend: Sized {
     type PointerMotionEvent: PointerMotionEvent<Self>;
     /// Type representing motion events of pointer devices
     type PointerMotionAbsoluteEvent: PointerMotionAbsoluteEvent<Self>;
+    /// Type representing swipe begin events of pointer devices
+    type GestureSwipeBeginEvent: GestureSwipeBeginEvent<Self>;
+    /// Type representing swipe update events of pointer devices
+    type GestureSwipeUpdateEvent: GestureSwipeUpdateEvent<Self>;
+    /// Type representing swipe end events of pointer devices
+    type GestureSwipeEndEvent: GestureSwipeEndEvent<Self>;
+    /// Type representing pinch begin events of pointer devices
+    type GesturePinchBeginEvent: GesturePinchBeginEvent<Self>;
+    /// Type representing pinch update events of pointer devices
+    type GesturePinchUpdateEvent: GesturePinchUpdateEvent<Self>;
+    /// Type representing pinch end events of pointer devices
+    type GesturePinchEndEvent: GesturePinchEndEvent<Self>;
+    /// Type representing hold begin events of pointer devices
+    type GestureHoldBeginEvent: GestureHoldBeginEvent<Self>;
+    /// Type representing hold end events of pointer devices
+    type GestureHoldEndEvent: GestureHoldEndEvent<Self>;
     /// Type representing touch events starting
     type TouchDownEvent: TouchDownEvent<Self>;
     /// Type representing touch events ending
@@ -492,6 +613,46 @@ pub enum InputEvent<B: InputBackend> {
     PointerAxis {
         /// The pointer axis event
         event: B::PointerAxisEvent,
+    },
+    /// A pointer swipe gesture began
+    GestureSwipeBegin {
+        /// The gesture event
+        event: B::GestureSwipeBeginEvent,
+    },
+    /// A pointer swipe gesture updated
+    GestureSwipeUpdate {
+        /// The gesture event
+        event: B::GestureSwipeUpdateEvent,
+    },
+    /// A pointer swipe gesture ended
+    GestureSwipeEnd {
+        /// The gesture event
+        event: B::GestureSwipeEndEvent,
+    },
+    /// A pointer pinch gesture began
+    GesturePinchBegin {
+        /// The gesture event
+        event: B::GesturePinchBeginEvent,
+    },
+    /// A pointer pinch gesture updated
+    GesturePinchUpdate {
+        /// The gesture event
+        event: B::GesturePinchUpdateEvent,
+    },
+    /// A pointer pinch gesture ended
+    GesturePinchEnd {
+        /// The gesture event
+        event: B::GesturePinchEndEvent,
+    },
+    /// A pointer hold gesture began
+    GestureHoldBegin {
+        /// The gesture event
+        event: B::GestureHoldBeginEvent,
+    },
+    /// A pointer hold gesture ended
+    GestureHoldEnd {
+        /// The gesture event
+        event: B::GestureHoldEndEvent,
     },
     /// A new touchpoint appeared
     TouchDown {

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -1,3 +1,7 @@
+// TODO: Update to use new `Scroll*` events instead of now deprecated
+// `PointerAxis*`.
+#![cfg_attr(feature = "libinput_1_19", allow(deprecated))]
+
 //! Implementation of input backend trait for types provided by `libinput`
 
 use crate::backend::input::{self as backend, Axis, InputBackend, InputEvent};
@@ -240,6 +244,148 @@ impl backend::AbsolutePositionEvent<LibinputInputBackend> for event::pointer::Po
     }
 }
 
+impl<T> backend::GestureBeginEvent<LibinputInputBackend> for T
+where
+    T: event::gesture::GestureEventTrait + backend::Event<LibinputInputBackend>,
+{
+    fn fingers(&self) -> u32 {
+        self.finger_count() as u32
+    }
+}
+
+impl<T> backend::GestureEndEvent<LibinputInputBackend> for T
+where
+    T: event::gesture::GestureEndEvent + backend::Event<LibinputInputBackend>,
+{
+    fn cancelled(&self) -> bool {
+        self.cancelled()
+    }
+}
+
+impl backend::Event<LibinputInputBackend> for event::gesture::GestureSwipeBeginEvent {
+    fn time(&self) -> u64 {
+        event::gesture::GestureEventTrait::time_usec(self)
+    }
+
+    fn device(&self) -> libinput::Device {
+        event::EventTrait::device(self)
+    }
+}
+
+impl backend::GestureSwipeBeginEvent<LibinputInputBackend> for event::gesture::GestureSwipeBeginEvent {}
+
+impl backend::Event<LibinputInputBackend> for event::gesture::GestureSwipeUpdateEvent {
+    fn time(&self) -> u64 {
+        event::gesture::GestureEventTrait::time_usec(self)
+    }
+
+    fn device(&self) -> libinput::Device {
+        event::EventTrait::device(self)
+    }
+}
+
+impl backend::GestureSwipeUpdateEvent<LibinputInputBackend> for event::gesture::GestureSwipeUpdateEvent {
+    fn delta_x(&self) -> f64 {
+        event::gesture::GestureEventCoordinates::dx(self)
+    }
+
+    fn delta_y(&self) -> f64 {
+        event::gesture::GestureEventCoordinates::dy(self)
+    }
+}
+
+impl backend::Event<LibinputInputBackend> for event::gesture::GestureSwipeEndEvent {
+    fn time(&self) -> u64 {
+        event::gesture::GestureEventTrait::time_usec(self)
+    }
+
+    fn device(&self) -> libinput::Device {
+        event::EventTrait::device(self)
+    }
+}
+
+impl backend::GestureSwipeEndEvent<LibinputInputBackend> for event::gesture::GestureSwipeEndEvent {}
+
+impl backend::Event<LibinputInputBackend> for event::gesture::GesturePinchBeginEvent {
+    fn time(&self) -> u64 {
+        event::gesture::GestureEventTrait::time_usec(self)
+    }
+
+    fn device(&self) -> libinput::Device {
+        event::EventTrait::device(self)
+    }
+}
+
+impl backend::GesturePinchBeginEvent<LibinputInputBackend> for event::gesture::GesturePinchBeginEvent {}
+
+impl backend::Event<LibinputInputBackend> for event::gesture::GesturePinchUpdateEvent {
+    fn time(&self) -> u64 {
+        event::gesture::GestureEventTrait::time_usec(self)
+    }
+
+    fn device(&self) -> libinput::Device {
+        event::EventTrait::device(self)
+    }
+}
+
+impl backend::GesturePinchUpdateEvent<LibinputInputBackend> for event::gesture::GesturePinchUpdateEvent {
+    fn delta_x(&self) -> f64 {
+        event::gesture::GestureEventCoordinates::dx(self)
+    }
+
+    fn delta_y(&self) -> f64 {
+        event::gesture::GestureEventCoordinates::dy(self)
+    }
+
+    fn scale(&self) -> f64 {
+        event::gesture::GesturePinchEventTrait::scale(self)
+    }
+
+    fn rotation(&self) -> f64 {
+        self.angle_delta()
+    }
+}
+
+impl backend::Event<LibinputInputBackend> for event::gesture::GesturePinchEndEvent {
+    fn time(&self) -> u64 {
+        event::gesture::GestureEventTrait::time_usec(self)
+    }
+
+    fn device(&self) -> libinput::Device {
+        event::EventTrait::device(self)
+    }
+}
+
+impl backend::GesturePinchEndEvent<LibinputInputBackend> for event::gesture::GesturePinchEndEvent {}
+
+#[cfg(feature = "libinput_1_19")]
+impl backend::Event<LibinputInputBackend> for event::gesture::GestureHoldBeginEvent {
+    fn time(&self) -> u64 {
+        event::gesture::GestureEventTrait::time_usec(self)
+    }
+
+    fn device(&self) -> libinput::Device {
+        event::EventTrait::device(self)
+    }
+}
+
+#[cfg(feature = "libinput_1_19")]
+impl backend::GestureHoldBeginEvent<LibinputInputBackend> for event::gesture::GestureHoldBeginEvent {}
+
+#[cfg(feature = "libinput_1_19")]
+impl backend::Event<LibinputInputBackend> for event::gesture::GestureHoldEndEvent {
+    fn time(&self) -> u64 {
+        event::gesture::GestureEventTrait::time_usec(self)
+    }
+
+    fn device(&self) -> libinput::Device {
+        event::EventTrait::device(self)
+    }
+}
+
+#[cfg(feature = "libinput_1_19")]
+impl backend::GestureHoldEndEvent<LibinputInputBackend> for event::gesture::GestureHoldEndEvent {}
+
 impl backend::Event<LibinputInputBackend> for event::touch::TouchDownEvent {
     fn time(&self) -> u64 {
         event::touch::TouchEventTrait::time_usec(self)
@@ -367,6 +513,22 @@ impl InputBackend for LibinputInputBackend {
     type PointerButtonEvent = event::pointer::PointerButtonEvent;
     type PointerMotionEvent = event::pointer::PointerMotionEvent;
     type PointerMotionAbsoluteEvent = event::pointer::PointerMotionAbsoluteEvent;
+
+    type GestureSwipeBeginEvent = event::gesture::GestureSwipeBeginEvent;
+    type GestureSwipeUpdateEvent = event::gesture::GestureSwipeUpdateEvent;
+    type GestureSwipeEndEvent = event::gesture::GestureSwipeEndEvent;
+    type GesturePinchBeginEvent = event::gesture::GesturePinchBeginEvent;
+    type GesturePinchUpdateEvent = event::gesture::GesturePinchUpdateEvent;
+    type GesturePinchEndEvent = event::gesture::GesturePinchEndEvent;
+    #[cfg(not(feature = "libinput_1_19"))]
+    type GestureHoldBeginEvent = backend::UnusedEvent;
+    #[cfg(not(feature = "libinput_1_19"))]
+    type GestureHoldEndEvent = backend::UnusedEvent;
+    #[cfg(feature = "libinput_1_19")]
+    type GestureHoldBeginEvent = event::gesture::GestureHoldBeginEvent;
+    #[cfg(feature = "libinput_1_19")]
+    type GestureHoldEndEvent = event::gesture::GestureHoldEndEvent;
+
     type TouchDownEvent = event::touch::TouchDownEvent;
     type TouchUpEvent = event::touch::TouchUpEvent;
     type TouchMotionEvent = event::touch::TouchMotionEvent;
@@ -544,6 +706,37 @@ impl EventSource for LibinputInputBackend {
                         }
                         _ => {
                             trace!(self.logger, "Unknown libinput pointer event");
+                        }
+                    },
+                    libinput::Event::Gesture(gesture_event) => match gesture_event {
+                        event::GestureEvent::Swipe(event::gesture::GestureSwipeEvent::Begin(event)) => {
+                            callback(InputEvent::GestureSwipeBegin { event }, &mut ());
+                        }
+                        event::GestureEvent::Swipe(event::gesture::GestureSwipeEvent::Update(event)) => {
+                            callback(InputEvent::GestureSwipeUpdate { event }, &mut ());
+                        }
+                        event::GestureEvent::Swipe(event::gesture::GestureSwipeEvent::End(event)) => {
+                            callback(InputEvent::GestureSwipeEnd { event }, &mut ());
+                        }
+                        event::GestureEvent::Pinch(event::gesture::GesturePinchEvent::Begin(event)) => {
+                            callback(InputEvent::GesturePinchBegin { event }, &mut ());
+                        }
+                        event::GestureEvent::Pinch(event::gesture::GesturePinchEvent::Update(event)) => {
+                            callback(InputEvent::GesturePinchUpdate { event }, &mut ());
+                        }
+                        event::GestureEvent::Pinch(event::gesture::GesturePinchEvent::End(event)) => {
+                            callback(InputEvent::GesturePinchEnd { event }, &mut ());
+                        }
+                        #[cfg(feature = "libinput_1_19")]
+                        event::GestureEvent::Hold(event::gesture::GestureHoldEvent::Begin(event)) => {
+                            callback(InputEvent::GestureHoldBegin { event }, &mut ());
+                        }
+                        #[cfg(feature = "libinput_1_19")]
+                        event::GestureEvent::Hold(event::gesture::GestureHoldEvent::End(event)) => {
+                            callback(InputEvent::GestureHoldEnd { event }, &mut ());
+                        }
+                        _ => {
+                            trace!(self.logger, "Unknown libinput gesture event");
                         }
                     },
                     libinput::Event::Tablet(tablet_event) => match tablet_event {

--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -383,6 +383,16 @@ impl InputBackend for WinitInput {
     type PointerButtonEvent = WinitMouseInputEvent;
     type PointerMotionEvent = UnusedEvent;
     type PointerMotionAbsoluteEvent = WinitMouseMovedEvent;
+
+    type GestureSwipeBeginEvent = UnusedEvent;
+    type GestureSwipeUpdateEvent = UnusedEvent;
+    type GestureSwipeEndEvent = UnusedEvent;
+    type GesturePinchBeginEvent = UnusedEvent;
+    type GesturePinchUpdateEvent = UnusedEvent;
+    type GesturePinchEndEvent = UnusedEvent;
+    type GestureHoldBeginEvent = UnusedEvent;
+    type GestureHoldEndEvent = UnusedEvent;
+
     type TouchDownEvent = WinitTouchStartedEvent;
     type TouchUpEvent = WinitTouchEndedEvent;
     type TouchMotionEvent = WinitTouchMovedEvent;

--- a/src/backend/x11/input.rs
+++ b/src/backend/x11/input.rs
@@ -230,6 +230,15 @@ impl InputBackend for X11Input {
 
     type PointerMotionAbsoluteEvent = X11MouseMovedEvent;
 
+    type GestureSwipeBeginEvent = UnusedEvent;
+    type GestureSwipeUpdateEvent = UnusedEvent;
+    type GestureSwipeEndEvent = UnusedEvent;
+    type GesturePinchBeginEvent = UnusedEvent;
+    type GesturePinchUpdateEvent = UnusedEvent;
+    type GesturePinchEndEvent = UnusedEvent;
+    type GestureHoldBeginEvent = UnusedEvent;
+    type GestureHoldEndEvent = UnusedEvent;
+
     type TouchDownEvent = UnusedEvent;
     type TouchUpEvent = UnusedEvent;
     type TouchMotionEvent = UnusedEvent;


### PR DESCRIPTION
This just defines the traits and associated types. It still needs an implementation for libinput (which is straightforward). And then to be useful an implementation of the `zwp_pointer_gestures_v1` protocol is also needed.

This seems to be consistent with how other event types are handled, but seems a little verbose. Would it be better to not have 10 new traits and 8 new associated types?

The `begin` events are all the same, as are the `end` events. `update` exists only for swipe and pinch, and has additional fields for pinch. Would it be sensible to reduce the 6 begin/end associated types to 2?