### PR TITLE
Fix wp_presentation documentation

### DIFF
--- a/src/wayland/presentation/mod.rs
+++ b/src/wayland/presentation/mod.rs
@@ -13,13 +13,13 @@
 //!
 //! # struct State;
 //! # let mut display = wayland_server::Display::<State>::new().unwrap();
-//! // Create the viewporter state:
-//! let viewporter_state = PresentationState::new::<State>(
+//! // Create the presentation state:
+//! let presentation_state = PresentationState::new::<State>(
 //!     &display.handle(), // the display
 //!     1 // the id of the clock
 //! );
 //!
-//! // implement Dispatch for the Viewporter types
+//! // implement Dispatch for the Presentation types
 //! delegate_presentation!(State);
 //!
 //! // You're now ready to go!


### PR DESCRIPTION
The `wp_presentation` documentation still contained some documentation mentioning viewporter, however the two are unrelated. This was likely a copy-paste mistake.