### PR TITLE
input: More introspection

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -508,4 +508,9 @@ impl<D: SeatHandler + 'static> Seat<D> {
             inner.send_all_caps();
         }
     }
+
+    /// Gets this seat's name
+    pub fn name(&self) -> &str {
+        &self.arc.name
+    }
 }


### PR DESCRIPTION
Supersedes #798 and adds some more functions to inspect the current state of a seat and the keyboard handle.

Changes `with_pressed_keysyms` to take an `FnOnce`, which will take a `Vec<KeysymHandle>` and passes on it's return value.