### PR TITLE
input: store known seats as Weak<WlSeat>

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -188,7 +188,7 @@ pub(crate) struct Inner<D: SeatHandler> {
     #[cfg(feature = "wayland_frontend")]
     pub(crate) global: Option<wayland_server::backend::GlobalId>,
     #[cfg(feature = "wayland_frontend")]
-    pub(crate) known_seats: Vec<wayland_server::protocol::wl_seat::WlSeat>,
+    pub(crate) known_seats: Vec<wayland_server::Weak<wayland_server::protocol::wl_seat::WlSeat>>,
 }
 
 #[cfg(not(feature = "wayland_frontend"))]


### PR DESCRIPTION
This fixes a reference cycle that prevented the resources associated with `Seat` to not be dropped (notably the memfd of the keymap).

Also needs https://github.com/Smithay/wayland-rs/pull/602 for a complete fix the of leak.