### PR TITLE
chore: fix wayland-protocols-* being not optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ thiserror = "1.0.25"
 udev = { version = "0.7", optional = true }
 wayland-egl = { version = "0.30.0", optional = true }
 wayland-protocols = { version = "0.30.0", features = ["unstable", "staging", "server"], optional = true }
-wayland-protocols-wlr = { version = "0.1.0", features = ["server"]}
-wayland-protocols-misc = { version = "0.1.0", features = ["server"]}
+wayland-protocols-wlr = { version = "0.1.0", features = ["server"], optional = true }
+wayland-protocols-misc = { version = "0.1.0", features = ["server"], optional = true }
 wayland-server = { version = "0.30.0", optional = true }
 wayland-sys = { version = "0.30.1", optional = true }
 wayland-backend = { version = "0.1.0", optional = true }
@@ -94,7 +94,7 @@ renderer_gl = ["gl_generator", "backend_egl"]
 renderer_glow = ["renderer_gl", "glow"]
 renderer_multi = ["backend_drm"]
 use_system_lib = ["wayland_frontend", "wayland-backend/server_system", "wayland-sys", "gbm?/import-wayland"]
-wayland_frontend = ["wayland-server", "wayland-protocols", "tempfile"]
+wayland_frontend = ["wayland-server", "wayland-protocols", "wayland-protocols-wlr", "wayland-protocols-misc", "tempfile"]
 x11rb_event_source = ["x11rb"]
 xwayland = ["encoding", "wayland_frontend", "x11rb/composite", "x11rb_event_source", "scopeguard"]
 test_all_features = ["default", "use_system_lib", "renderer_glow", "libinput_1_19"]


### PR DESCRIPTION
This won't pull wayland when there's no wayland feature enabled.