### PR TITLE
Fix render output transforms

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1388,6 +1388,11 @@ where
         let current_size = self.output.current_mode().unwrap().size;
         let output_scale = self.output.current_scale().fractional_scale().into();
         let output_transform = self.output.current_transform();
+
+        // Output transform is specified in surface-rotation, so inversion gives us the
+        // render transform for the output itself.
+        let output_transform = output_transform.invert();
+
         // Geometry of the output derived from the output mode including the transform
         // This is used to calculate the intersection between elements and the output.
         // The renderer (and also the logic for direct scan-out) will take care of the

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -334,6 +334,11 @@ impl DamageTrackedRenderer {
         let log = crate::slog_or_fallback(log);
 
         let (output_size, output_scale, output_transform) = self.mode.clone().try_into()?;
+
+        // Output transform is specified in surface-rotation, so inversion gives us the
+        // render transform for the output itself.
+        let output_transform = output_transform.invert();
+
         // We have to apply to output transform to the output size so that the intersection
         // tests in damage_output_internal produces the correct results and do not crop
         // damage with the wrong size


### PR DESCRIPTION
The transform of an output is specified in the rotation that needs to be applied to a surface for rendering. This is the exact inverse of the transform that needs to be applied to the renderer itself.

This patch inverts the transform stored on the output's mode to ensure the rendering transform correctly specifies the inverse of the surface transform.

---

If there's any other renderer/compositors, please let me know and I'll add this line there too. This was tested on my phone and not a desktop monitor.