### PR TITLE
Fix partitions in space::space_render_elements.

### DIFF
--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -593,7 +593,7 @@ where
     let layer_map = layer_map_for_output(output);
     #[cfg(feature = "wayland_frontend")]
     let lower = {
-        let (upper, lower): (Vec<&LayerSurface>, Vec<&LayerSurface>) = layer_map
+        let (lower, upper): (Vec<&LayerSurface>, Vec<&LayerSurface>) = layer_map
             .layers()
             .rev()
             .partition(|s| matches!(s.layer(), Layer::Background | Layer::Bottom));


### PR DESCRIPTION
`Iterator::partition()` returns a pair, all of the elements for which it returned true, and all of the elements for which it returned false.