### PR TITLE
Fix overlay zpos check during rendering

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1728,7 +1728,7 @@ where
                 .iter()
                 .map(|(p, element)| {
                     let is_underlay = overlay_plane_lookup.get(p).unwrap().zpos.unwrap_or_default()
-                        <= self.planes.primary.zpos.unwrap_or_default();
+                        < self.planes.primary.zpos.unwrap_or_default();
                     if is_underlay {
                         HolepunchRenderElement::from_render_element(element, output_scale).into()
                     } else {


### PR DESCRIPTION
This fixes an issue where Overlay planes were assumed to be below the primary plane when they both had a zpos of 0. However some devices do not report a zpos for the overlay plane which should still put it above the primary one.

To fix this, overlay planes are now assumed to be above the primary plane when their zpos is equal to that of the primary plane. This is consistent with the other `is_underlay` check in
`try_assign_overlay_plane`.