### PR TITLE
logging: Be less expensive with tracing

### DIFF
--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -11,7 +11,7 @@ bitflags = "1.2.1"
 fps_ticker = {version = "1.0.0", optional = true}
 image = {version = "0.24.0", default-features = false, optional = true}
 rand = "0.8"
-tracing = "0.1.37"
+tracing = { version = "0.1.37", features = ["max_level_trace", "release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 thiserror = "1"
 xcursor = {version = "0.3.3", optional = true}

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1363,7 +1363,7 @@ where
     }
 
     /// Render the next frame
-    #[instrument(parent = &self.span, skip_all)]
+    #[instrument(level = "trace", parent = &self.span, skip_all)]
     pub fn render_frame<'a, R, E, Target>(
         &'a mut self,
         renderer: &mut R,
@@ -2059,7 +2059,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     fn try_assign_element<'a, R, E, Target>(
         &mut self,
         renderer: &mut R,
@@ -2136,7 +2136,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     fn try_assign_cursor_plane<R, E, Target>(
         &mut self,
         renderer: &mut R,
@@ -2457,7 +2457,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     fn try_assign_overlay_plane<'a, R, E>(
         &self,
         renderer: &mut R,
@@ -2583,7 +2583,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     fn try_assign_primary_plane<R, E>(
         &self,
         renderer: &mut R,
@@ -2632,7 +2632,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "trace", skip_all)]
     fn try_assign_plane<R, E>(
         &self,
         element: &E,

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -21,7 +21,7 @@ use super::{error::Error, planes, Planes};
 use atomic::AtomicDrmDevice;
 use legacy::LegacyDrmDevice;
 
-use tracing::{error, info, info_span, instrument, trace};
+use tracing::{debug_span, error, info, instrument, trace};
 
 #[derive(Debug)]
 struct PlaneClaimInner {
@@ -182,7 +182,7 @@ impl DrmDevice {
     /// Returns an error if the file is no valid drm node or the device is not accessible.
     pub fn new(fd: DrmDeviceFd, disable_connectors: bool) -> Result<(Self, DrmDeviceNotifier), Error> {
         // setup parent span for internal device types
-        let span = info_span!(
+        let span = debug_span!(
             "drm_device",
             device = ?fd.dev_path()
         );

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -408,7 +408,7 @@ impl AtomicDrmSurface {
         Ok(())
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "debug", parent = &self.span, skip(self))]
     pub fn use_mode(&self, mode: Mode) -> Result<(), Error> {
         if !self.active.load(Ordering::SeqCst) {
             return Err(Error::DeviceInactive);
@@ -469,7 +469,7 @@ impl AtomicDrmSurface {
         *self.pending.read().unwrap() != *self.state.read().unwrap()
     }
 
-    #[instrument(parent = &self.span, skip(self, planes))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, planes))]
     pub fn test_state<'a>(
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,
@@ -500,7 +500,7 @@ impl AtomicDrmSurface {
         Ok(result)
     }
 
-    #[instrument(parent = &self.span, skip(self, planes))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, planes))]
     pub fn commit<'a>(
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,
@@ -612,7 +612,7 @@ impl AtomicDrmSurface {
         result
     }
 
-    #[instrument(parent = &self.span, skip(self, planes))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, planes))]
     pub fn page_flip<'a>(
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,

--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -179,7 +179,7 @@ impl LegacyDrmSurface {
         Ok(())
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "debug", parent = &self.span, skip(self))]
     pub fn use_mode(&self, mode: Mode) -> Result<(), Error> {
         if !self.active.load(Ordering::SeqCst) {
             return Err(Error::DeviceInactive);
@@ -213,7 +213,7 @@ impl LegacyDrmSurface {
         *self.pending.read().unwrap() != *self.state.read().unwrap()
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn commit(&self, framebuffer: framebuffer::Handle, event: bool) -> Result<(), Error> {
         if !self.active.load(Ordering::SeqCst) {
             return Err(Error::DeviceInactive);
@@ -304,7 +304,7 @@ impl LegacyDrmSurface {
         Ok(())
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn page_flip(&self, framebuffer: framebuffer::Handle, event: bool) -> Result<(), Error> {
         trace!("Queueing Page flip");
 
@@ -330,7 +330,7 @@ impl LegacyDrmSurface {
         })
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn test_buffer(&self, fb: framebuffer::Handle, mode: &Mode) -> Result<bool, Error> {
         if !self.active.load(Ordering::SeqCst) {
             return Err(Error::DeviceInactive);

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -23,7 +23,7 @@ use std::{
 
 use calloop::{EventSource, Interest, Mode, Poll, PostAction, Readiness, Token, TokenFactory};
 
-use tracing::{info, info_span, trace};
+use tracing::{debug_span, info, trace};
 
 mod tablet;
 
@@ -42,7 +42,7 @@ impl LibinputInputBackend {
     /// Initialize a new [`LibinputInputBackend`] from a given already initialized
     /// [libinput context](libinput::Libinput).
     pub fn new(context: libinput::Libinput) -> Self {
-        let span = info_span!("backend_libinput");
+        let span = debug_span!("backend_libinput");
         let _guard = span.enter();
 
         info!("Initializing a libinput backend");

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -319,7 +319,7 @@ impl DamageTrackedRenderer {
     }
 
     /// Render this output
-    #[instrument(parent = &self.span, skip(renderer, elements))]
+    #[instrument(level = "trace", parent = &self.span, skip(renderer, elements))]
     pub fn render_output<E, R>(
         &mut self,
         renderer: &mut R,
@@ -450,7 +450,7 @@ impl DamageTrackedRenderer {
     }
 
     /// Damage this output and return the damage without actually rendering the difference
-    #[instrument(parent = &self.span, skip(elements))]
+    #[instrument(level = "trace", parent = &self.span, skip(elements))]
     pub fn damage_output<E>(
         &mut self,
         age: usize,

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -288,7 +288,7 @@ impl MemoryRenderBufferInner {
         }
     }
 
-    #[instrument(skip(renderer))]
+    #[instrument(level = "trace", skip(renderer))]
     fn import_texture<R>(&mut self, renderer: &mut R) -> Result<(), <R as Renderer>::Error>
     where
         R: Renderer + ImportMem,
@@ -624,7 +624,7 @@ where
     R: Renderer + ImportMem,
     <R as Renderer>::TextureId: 'static,
 {
-    #[instrument(skip(self, frame))]
+    #[instrument(level = "trace", skip(self, frame))]
     fn draw<'a>(
         &self,
         frame: &mut <R as Renderer>::Frame<'a>,

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -211,7 +211,7 @@ use crate::{
 use super::{CommitCounter, Element, Id, RenderElement, UnderlyingStorage};
 
 /// Retrieve the [`WaylandSurfaceRenderElement`]s for a surface tree
-#[instrument(skip(renderer, location, scale))]
+#[instrument(level = "trace", skip(renderer, location, scale))]
 pub fn render_elements_from_surface_tree<R, E>(
     renderer: &mut R,
     surface: &wl_surface::WlSurface,
@@ -466,7 +466,7 @@ where
         })
     }
 
-    #[instrument(skip(frame))]
+    #[instrument(level = "trace", skip(frame))]
     fn draw<'a>(
         &self,
         frame: &mut <R as Renderer>::Frame<'a>,

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -811,7 +811,7 @@ where
     R: Renderer<TextureId = T>,
     T: Texture,
 {
-    #[instrument(skip(self, frame))]
+    #[instrument(level = "trace", skip(self, frame))]
     fn draw<'a>(
         &self,
         frame: &mut <R as Renderer>::Frame<'a>,

--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -774,7 +774,7 @@ impl Gles2Renderer {
 
 #[cfg(feature = "wayland_frontend")]
 impl ImportMemWl for Gles2Renderer {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn import_shm_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
@@ -917,7 +917,7 @@ impl ImportMemWl for Gles2Renderer {
 }
 
 impl ImportMem for Gles2Renderer {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn import_memory(
         &mut self,
         data: &[u8],
@@ -967,7 +967,7 @@ impl ImportMem for Gles2Renderer {
         Ok(texture)
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn update_memory(
         &mut self,
         texture: &<Self as Renderer>::TextureId,
@@ -1032,7 +1032,7 @@ impl ImportEgl for Gles2Renderer {
         self.egl_reader.as_ref()
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn import_egl_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
@@ -1085,7 +1085,7 @@ impl ImportEgl for Gles2Renderer {
 }
 
 impl ImportDma for Gles2Renderer {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn import_dmabuf(
         &mut self,
         buffer: &Dmabuf,
@@ -1182,7 +1182,7 @@ impl Gles2Renderer {
 impl ExportMem for Gles2Renderer {
     type TextureMapping = Gles2Mapping;
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn copy_framebuffer(
         &mut self,
         region: Rectangle<i32, BufferCoord>,
@@ -1216,7 +1216,7 @@ impl ExportMem for Gles2Renderer {
         })
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn copy_texture(
         &mut self,
         texture: &Self::TextureId,
@@ -1262,7 +1262,7 @@ impl ExportMem for Gles2Renderer {
         })
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn map_texture<'a>(
         &mut self,
         texture_mapping: &'a Self::TextureMapping,
@@ -1296,7 +1296,7 @@ impl ExportMem for Gles2Renderer {
 }
 
 impl ExportDma for Gles2Renderer {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn export_texture(&mut self, texture: &Gles2Texture) -> Result<Dmabuf, Gles2Error> {
         self.make_current()?;
 
@@ -1346,7 +1346,7 @@ impl ExportDma for Gles2Renderer {
         res
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn export_framebuffer(&mut self, size: Size<i32, BufferCoord>) -> Result<Dmabuf, Gles2Error> {
         self.make_current()?;
 
@@ -1449,7 +1449,7 @@ impl ExportDma for Gles2Renderer {
 }
 
 impl Bind<Rc<EGLSurface>> for Gles2Renderer {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn bind(&mut self, surface: Rc<EGLSurface>) -> Result<(), Gles2Error> {
         self.unbind()?;
         self.target = Some(Gles2Target::Surface(surface));
@@ -1459,7 +1459,7 @@ impl Bind<Rc<EGLSurface>> for Gles2Renderer {
 }
 
 impl Bind<Dmabuf> for Gles2Renderer {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn bind(&mut self, dmabuf: Dmabuf) -> Result<(), Gles2Error> {
         self.unbind()?;
         self.make_current()?;
@@ -1532,7 +1532,7 @@ impl Bind<Dmabuf> for Gles2Renderer {
 }
 
 impl Bind<Gles2Texture> for Gles2Renderer {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn bind(&mut self, texture: Gles2Texture) -> Result<(), Gles2Error> {
         self.unbind()?;
         self.make_current()?;
@@ -1569,7 +1569,7 @@ impl Bind<Gles2Texture> for Gles2Renderer {
 }
 
 impl Offscreen<Gles2Texture> for Gles2Renderer {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn create_buffer(&mut self, size: Size<i32, BufferCoord>) -> Result<Gles2Texture, Gles2Error> {
         self.make_current()?;
         let tex = unsafe {
@@ -1595,7 +1595,7 @@ impl Offscreen<Gles2Texture> for Gles2Renderer {
 }
 
 impl Bind<Gles2Renderbuffer> for Gles2Renderer {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn bind(&mut self, renderbuffer: Gles2Renderbuffer) -> Result<(), Gles2Error> {
         self.unbind()?;
         self.make_current()?;
@@ -1632,7 +1632,7 @@ impl Bind<Gles2Renderbuffer> for Gles2Renderer {
 }
 
 impl Offscreen<Gles2Renderbuffer> for Gles2Renderer {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn create_buffer(&mut self, size: Size<i32, BufferCoord>) -> Result<Gles2Renderbuffer, Gles2Error> {
         self.make_current()?;
         unsafe {
@@ -1655,7 +1655,7 @@ impl<Target> Blit<Target> for Gles2Renderer
 where
     Self: Bind<Target>,
 {
-    #[instrument(parent = &self.span, skip(self, to))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, to))]
     fn blit_to(
         &mut self,
         to: Target,
@@ -1676,7 +1676,7 @@ where
         result
     }
 
-    #[instrument(parent = &self.span, skip(self, from))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, from))]
     fn blit_from(
         &mut self,
         from: Target,
@@ -1848,7 +1848,7 @@ impl Gles2Renderer {
     /// or check the source code of the version of Smithay you are using to ensure
     /// your changes don't interfere with the renderer's behavior.
     /// Doing otherwise can lead to rendering errors while using other functions of this renderer.
-    #[instrument(parent = &self.span, skip_all)]
+    #[instrument(level = "trace", parent = &self.span, skip_all)]
     pub fn with_context<F, R>(&mut self, func: F) -> Result<R, Gles2Error>
     where
         F: FnOnce(&ffi::Gles2) -> R,
@@ -1867,7 +1867,7 @@ impl<'frame> Gles2Frame<'frame> {
     /// or check the source code of the version of Smithay you are using to ensure
     /// your changes don't interfere with the renderer's behavior.
     /// Doing otherwise can lead to rendering errors while using other functions of this renderer.
-    #[instrument(parent = &self.span, skip_all)]
+    #[instrument(level = "trace", parent = &self.span, skip_all)]
     pub fn with_context<F, R>(&mut self, func: F) -> Result<R, Gles2Error>
     where
         F: FnOnce(&ffi::Gles2) -> R,
@@ -1894,7 +1894,6 @@ impl Renderer for Gles2Renderer {
         Ok(())
     }
 
-    #[instrument(parent = &self.span, skip(self))]
     fn render(
         &mut self,
         mut output_size: Size<i32, Physical>,
@@ -1938,7 +1937,7 @@ impl Renderer for Gles2Renderer {
         let flip180 = Matrix3::new(1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0);
 
         let current_projection = flip180 * transform.matrix() * renderer;
-        let span = span!(Level::INFO, "renderer_gles2_frame", current_projection = ?current_projection, size = ?output_size, transform = ?transform).entered();
+        let span = span!(parent: &self.span, Level::DEBUG, "renderer_gles2_frame", current_projection = ?current_projection, size = ?output_size, transform = ?transform).entered();
 
         Ok(Gles2Frame {
             renderer: self,
@@ -2015,7 +2014,7 @@ impl<'frame> Frame for Gles2Frame<'frame> {
         self.renderer.id()
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Gles2Error> {
         if at.is_empty() {
             return Ok(());
@@ -2136,7 +2135,7 @@ impl<'frame> Frame for Gles2Frame<'frame> {
         Ok(())
     }
 
-    #[instrument(skip(self), parent = &self.span)]
+    #[instrument(level = "trace", skip(self), parent = &self.span)]
     fn render_texture_from_to(
         &mut self,
         texture: &Gles2Texture,
@@ -2273,7 +2272,7 @@ impl<'frame> Gles2Frame<'frame> {
     /// The given texture matrix is used to transform the instances into texture coordinates.
     /// In case the texture is rotated, flipped or y-inverted the matrix has to be set up accordingly.
     /// Additionally the matrix can be used to crop the texture.
-    #[instrument(skip(self), parent = &self.span)]
+    #[instrument(level = "trace", skip(self), parent = &self.span)]
     pub fn render_texture(
         &mut self,
         tex: &Gles2Texture,

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -185,7 +185,7 @@ impl<A: GraphicsApi> GpuManager<A> {
     ///
     /// This a convenience function to deal with the same types even, if you only need one device.
     /// Because no copies are necessary in these cases, all extra arguments can be omitted.
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn single_renderer<'api>(
         &'api mut self,
         device: &DrmNode,
@@ -222,7 +222,7 @@ impl<A: GraphicsApi> GpuManager<A> {
     /// - `copy_format` denotes the format buffers will be allocated in for offscreen rendering.
     ///
     /// It is valid to pass the same devices for both, but you *should* use [`GraphicsApi::single_renderer`] in those cases.
-    #[instrument(parent = &self.span, skip(self, allocator))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, allocator))]
     pub fn renderer<'api, 'alloc>(
         &'api mut self,
         render_device: &DrmNode,
@@ -291,7 +291,7 @@ impl<A: GraphicsApi> GpuManager<A> {
     ///     to do offscreen composition on. Dma copies will be used, if buffers returned by the allocator
     ///     also work on the `target_device`.
     /// - `copy_format` denotes the format buffers will be allocated in for offscreen rendering.
-    #[instrument(skip(render_api, target_api, allocator), follows_from = [&render_api.span, &target_api.span])]
+    #[instrument(level = "trace", skip(render_api, target_api, allocator), follows_from = [&render_api.span, &target_api.span])]
     pub fn cross_renderer<'render, 'target, 'alloc, B: GraphicsApi, Alloc: Allocator>(
         render_api: &'render mut Self,
         target_api: &'target mut GpuManager<B>,
@@ -390,7 +390,7 @@ impl<A: GraphicsApi> GpuManager<A> {
     /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
     /// to let smithay handle buffer management.
     #[cfg(feature = "wayland_frontend")]
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn early_import(
         &mut self,
         source: Option<DrmNode>,
@@ -803,7 +803,7 @@ where
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn unbind(&mut self) -> Result<(), <Self as Renderer>::Error> {
         if let Some(target) = self.target.as_mut() {
             target.device.renderer_mut().unbind().map_err(Error::Target)
@@ -833,7 +833,7 @@ where
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn create_buffer(&mut self, size: Size<i32, BufferCoords>) -> Result<Target, <Self as Renderer>::Error> {
         if let Some(target) = self.target.as_mut() {
             target
@@ -867,7 +867,7 @@ where
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    #[instrument(parent = &self.span, skip(self, bind))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, bind))]
     fn bind(&mut self, bind: Target) -> Result<(), <Self as Renderer>::Error> {
         if let Some(target) = self.target.as_mut() {
             target.device.renderer_mut().bind(bind).map_err(Error::Target)
@@ -926,7 +926,7 @@ where
         self.render.renderer().debug_flags()
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn render<'frame>(
         &'frame mut self,
         size: Size<i32, Physical>,
@@ -1079,7 +1079,7 @@ where
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn finish_internal(&mut self) -> Result<(), Error<R, T>> {
         if let Some(frame) = self.frame.take() {
             frame.finish().map_err(Error::Render)?;
@@ -1404,7 +1404,7 @@ where
         self.frame.as_ref().unwrap().id()
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Error<R, T>> {
         self.damage.extend(at);
         self.frame
@@ -1414,7 +1414,7 @@ where
             .map_err(Error::Render)
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn render_texture_from_to(
         &mut self,
         texture: &MultiTexture,
@@ -1468,7 +1468,7 @@ where
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn import_shm_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
@@ -1505,7 +1505,7 @@ where
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn import_memory(
         &mut self,
         data: &[u8],
@@ -1522,7 +1522,7 @@ where
         Ok(texture)
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn update_memory(
         &mut self,
         texture: &<Self as Renderer>::TextureId,
@@ -1556,7 +1556,7 @@ where
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn import_dma_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
@@ -1595,7 +1595,7 @@ where
         self.render.renderer().dmabuf_formats()
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn import_dmabuf(
         &mut self,
         dmabuf: &Dmabuf,
@@ -1990,7 +1990,7 @@ where
 {
     type TextureMapping = MultiTextureMapping<T, R>;
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn copy_framebuffer(
         &mut self,
         region: Rectangle<i32, BufferCoords>,
@@ -2011,7 +2011,7 @@ where
         }
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn copy_texture(
         &mut self,
         texture: &Self::TextureId,
@@ -2027,7 +2027,7 @@ where
             .map_err(Error::Render)
     }
 
-    #[instrument(parent = &self.span, skip(self, texture_mapping))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, texture_mapping))]
     fn map_texture<'c>(
         &mut self,
         texture_mapping: &'c Self::TextureMapping,
@@ -2063,7 +2063,7 @@ where
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn export_framebuffer(
         &mut self,
         size: Size<i32, BufferCoords>,
@@ -2082,7 +2082,7 @@ where
         }
     }
 
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     fn export_texture(
         &mut self,
         texture: &<Self as Renderer>::TextureId,
@@ -2111,7 +2111,7 @@ where
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
-    #[instrument(parent = &self.span, skip(self, to))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, to))]
     fn blit_to(
         &mut self,
         to: BlitTarget,
@@ -2133,7 +2133,7 @@ where
         }
     }
 
-    #[instrument(parent = &self.span, skip(self, from))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, from))]
     fn blit_from(
         &mut self,
         from: BlitTarget,

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -419,7 +419,7 @@ where
 /// Note: This will do nothing, if you are not using
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
-#[instrument(skip_all)]
+#[instrument(level = "trace", skip_all)]
 pub fn import_surface<R>(renderer: &mut R, states: &SurfaceData) -> Result<(), <R as Renderer>::Error>
 where
     R: Renderer + ImportAll,
@@ -461,7 +461,7 @@ where
 /// Note: This will do nothing, if you are not using
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
-#[instrument(skip_all)]
+#[instrument(level = "trace", skip_all)]
 pub fn import_surface_tree<R>(renderer: &mut R, surface: &WlSurface) -> Result<(), <R as Renderer>::Error>
 where
     R: Renderer + ImportAll,
@@ -515,7 +515,7 @@ where
 /// Note: This element will render nothing, if you are not using
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
-#[instrument(skip(frame, scale, elements))]
+#[instrument(level = "trace", skip(frame, scale, elements))]
 pub fn draw_render_elements<'a, R, S, E>(
     frame: &mut <R as Renderer>::Frame<'a>,
     scale: S,

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -49,7 +49,7 @@ use udev::{Enumerator, EventType, MonitorBuilder, MonitorSocket};
 
 use calloop::{EventSource, Interest, Mode, Poll, PostAction, Readiness, Token, TokenFactory};
 
-use tracing::{debug, info, info_span, warn};
+use tracing::{debug, debug_span, info, warn};
 
 /// Backend to monitor available drm devices.
 ///
@@ -87,7 +87,7 @@ impl UdevBackend {
     /// `seat`    - system seat which should be bound
     pub fn new<S: AsRef<str>>(seat: S) -> io::Result<UdevBackend> {
         let seat = seat.as_ref();
-        let span = info_span!("backend_udev", seat = seat.to_string());
+        let span = debug_span!("backend_udev", seat = seat.to_string());
         let _guard = span.enter();
 
         let devices = all_gpus(seat)?

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -485,7 +485,7 @@ impl PhysicalDevice {
     /// Returns the major and minor numbers of the primary node which corresponds to this physical device's DRM
     /// device.
     #[cfg(feature = "backend_drm")]
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "debug", parent = &self.span, skip(self))]
     pub fn primary_node(&self) -> Result<Option<DrmNode>, UnsupportedProperty> {
         let properties_drm = self.info.get_drm_properties()?;
         let node = Some(properties_drm)
@@ -503,7 +503,7 @@ impl PhysicalDevice {
     /// Note that not every device has a render node. If there is no render node (this function returns [`None`])
     /// then try to use the primary node.
     #[cfg(feature = "backend_drm")]
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "debug", parent = &self.span, skip(self))]
     pub fn render_node(&self) -> Result<Option<DrmNode>, UnsupportedProperty> {
         let properties_drm = self.info.get_drm_properties()?;
         let node = Some(properties_drm)
@@ -552,7 +552,7 @@ impl PhysicalDevice {
     /// Returns properties for each supported DRM modifier for the specified format.
     ///
     /// Returns [`Err`] if the `VK_EXT_image_drm_format_modifier` extension is not supported.
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "debug", parent = &self.span, skip(self))]
     pub fn get_format_modifier_properties(
         &self,
         format: vk::Format,

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -300,7 +300,7 @@ where
     }
 
     /// Bind the underlying window to the underlying renderer
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn bind(&mut self) -> Result<(), crate::backend::SwapBuffersError> {
         // apparently the nvidia-driver doesn't like `wl_egl_window_resize`, if the surface is not current.
         // So the order here is important.
@@ -330,7 +330,7 @@ where
     /// Otherwise and on error this function returns `None`.
     /// If you are using this value actively e.g. for damage-tracking you should
     /// likely interpret an error just as if "0" was returned.
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn buffer_age(&self) -> Option<usize> {
         if self.damage_tracking {
             self.egl.buffer_age().map(|x| x as usize)
@@ -340,7 +340,7 @@ where
     }
 
     /// Submits the back buffer to the window by swapping, requires the window to be previously bound (see [`WinitGraphicsBackend::bind`]).
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn submit(
         &mut self,
         damage: Option<&[Rectangle<i32, Physical>]>,
@@ -388,7 +388,7 @@ impl WinitEventLoop {
     ///
     /// The linked [`WinitGraphicsBackend`] will error with a lost context and should
     /// not be used anymore as well.
-    #[instrument(parent = &self.span, skip_all)]
+    #[instrument(level = "trace", parent = &self.span, skip_all)]
     pub fn dispatch_new_events<F>(&mut self, mut callback: F) -> Result<(), WinitError>
     where
         F: FnMut(WinitEvent),

--- a/src/backend/x11/mod.rs
+++ b/src/backend/x11/mod.rs
@@ -105,7 +105,7 @@ use std::{
         mpsc, Arc, Mutex, Weak,
     },
 };
-use tracing::{error, info, info_span, instrument, warn};
+use tracing::{debug_span, error, info, instrument, warn};
 use x11rb::{
     atom_manager,
     connection::Connection,
@@ -173,7 +173,7 @@ pub struct X11Backend {
 impl X11Backend {
     /// Initializes the X11 backend by connecting to the X server.
     pub fn new() -> Result<X11Backend, X11Error> {
-        let span = info_span!("backend_x11");
+        let span = debug_span!("backend_x11");
         let _guard = span.enter();
 
         info!("Connecting to the X server");

--- a/src/backend/x11/surface.rs
+++ b/src/backend/x11/surface.rs
@@ -68,7 +68,7 @@ impl X11Surface {
     /// You may bind this buffer to a renderer to render.
     /// This function will return the same buffer until [`submit`](Self::submit) is called
     /// or [`reset_buffers`](Self::reset_buffers) is used to reset the buffers.
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn buffer(&mut self) -> Result<(Dmabuf, u8), AllocateBuffersError> {
         if let Some(new_size) = self.resize.try_iter().last() {
             self.resize(new_size);
@@ -89,7 +89,7 @@ impl X11Surface {
     }
 
     /// Consume and submit the buffer to the window.
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn submit(&mut self) -> Result<(), X11Error> {
         if let Some(connection) = self.connection.upgrade() {
             // Get a new buffer
@@ -120,7 +120,7 @@ impl X11Surface {
     }
 
     /// Resets the internal buffers, e.g. to reset age values
-    #[instrument(parent = &self.span, skip(self))]
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn reset_buffers(&mut self) {
         self.swapchain.reset_buffers();
         self.buffer = None;

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     wayland::shell::wlr_layer::Layer,
 };
 use std::{collections::HashMap, fmt};
-use tracing::{debug, info_span, instrument};
+use tracing::{debug, debug_span, instrument};
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::protocol::wl_surface::WlSurface;
 
@@ -73,7 +73,7 @@ impl<E: SpaceElement> Drop for Space<E> {
 impl<E: SpaceElement> Default for Space<E> {
     fn default() -> Self {
         let id = next_space_id();
-        let span = info_span!("desktop_space", id);
+        let span = debug_span!("desktop_space", id);
 
         Self {
             id,
@@ -378,7 +378,7 @@ impl<E: SpaceElement + PartialEq> Space<E> {
     /// *Note:* Because this is not rendering a specific output,
     /// this will not contain layer surfaces.
     /// Use [`Space::render_elements_for_output`], if you care about this.
-    #[instrument(skip(self, renderer, scale), parent = &self.span)]
+    #[instrument(level = "trace", skip(self, renderer, scale), parent = &self.span)]
     pub fn render_elements_for_region<'a, R: Renderer, S: Into<Scale<f64>>>(
         &'a self,
         renderer: &mut R,
@@ -412,7 +412,7 @@ impl<E: SpaceElement + PartialEq> Space<E> {
     }
 
     /// Retrieve the render elements for an output
-    #[instrument(skip(self, renderer), parent = &self.span)]
+    #[instrument(level = "trace", skip(self, renderer), parent = &self.span)]
     pub fn render_elements_for_output<
         'a,
         #[cfg(feature = "wayland_frontend")] R: Renderer + ImportAll,
@@ -568,7 +568,7 @@ crate::backend::renderer::element::render_elements! {
 /// *Note*: If the `wayland_frontend`-feature is enabled
 /// this will include layer-shell surfaces added to this
 /// outputs [`LayerMap`].
-#[instrument(skip(spaces, renderer))]
+#[instrument(level = "trace", skip(spaces, renderer))]
 pub fn space_render_elements<
     'a,
     #[cfg(feature = "wayland_frontend")] R: Renderer + ImportAll,

--- a/src/desktop/space/wayland/mod.rs
+++ b/src/desktop/space/wayland/mod.rs
@@ -27,7 +27,7 @@ fn output_surfaces(o: &Output) -> RefMut<'_, HashSet<WlWeak<WlSurface>>> {
     surfaces
 }
 
-#[instrument]
+#[instrument(level = "debug", skip(output), fields(output = output.name()))]
 fn output_update(output: &Output, output_overlap: Rectangle<i32, Logical>, surface: &WlSurface) {
     let mut surface_list = output_surfaces(output);
 

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -18,7 +18,7 @@ use crate::{
     },
 };
 use indexmap::IndexSet;
-use tracing::{info_span, trace};
+use tracing::{debug_span, trace};
 use wayland_protocols::wp::presentation_time::server::wp_presentation_feedback;
 use wayland_server::{
     backend::ObjectId,
@@ -247,7 +247,7 @@ impl LayerMap {
     /// Note: Mapping or unmapping a layer surface will automatically cause a re-arrangement.
     pub fn arrange(&mut self) {
         if let Some(output) = self.output() {
-            let span = info_span!("layer_map", output = output.name());
+            let span = debug_span!("layer_map", output = output.name());
             let _guard = span.enter();
 
             let output_rect = Rectangle::from_loc_and_size(

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -479,7 +479,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     ///
     /// The module [`crate::wayland::seat::keysyms`] exposes definitions of all possible keysyms
     /// to be compared against. This includes non-character keysyms, such as XF86 special keys.
-    #[instrument(parent = &self.arc.span, skip(self, data, filter))]
+    #[instrument(level = "trace", parent = &self.arc.span, skip(self, data, filter))]
     pub fn input<T, F>(
         &self,
         data: &mut D,
@@ -532,7 +532,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     /// will be sent a [`wl_keyboard::Event::Leave`](wayland_server::protocol::wl_keyboard::Event::Leave)
     /// event, and if the new focus is not `None`,
     /// a [`wl_keyboard::Event::Enter`](wayland_server::protocol::wl_keyboard::Event::Enter) event will be sent.
-    #[instrument(parent = &self.arc.span, skip(self, data, focus), fields(focus = focus.is_some()))]
+    #[instrument(level = "debug", parent = &self.arc.span, skip(self, data, focus), fields(focus = focus.is_some()))]
     pub fn set_focus(&self, data: &mut D, focus: Option<<D as SeatHandler>::KeyboardFocus>, serial: Serial) {
         let mut guard = self.arc.internal.lock().unwrap();
         guard.pending_focus = focus.clone();

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -119,7 +119,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     /// If focus is set to [`Focus::Clear`] any currently focused surface will be unfocused.
     ///
     /// Overwrites any current grab.
-    #[instrument(parent = &self.span, skip(self, data, grab))]
+    #[instrument(level = "debug", parent = &self.span, skip(self, data, grab))]
     pub fn set_grab<G: PointerGrab<D> + 'static>(&self, data: &mut D, grab: G, serial: Serial, focus: Focus) {
         let seat = self.get_seat(data);
         self.inner
@@ -129,7 +129,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     }
 
     /// Remove any current grab on this pointer, resetting it to the default behavior
-    #[instrument(parent = &self.span, skip(self, data))]
+    #[instrument(level = "debug", parent = &self.span, skip(self, data))]
     pub fn unset_grab(&self, data: &mut D, serial: Serial, time: u32) {
         let seat = self.get_seat(data);
         self.inner.lock().unwrap().unset_grab(data, &seat, serial, time);
@@ -170,7 +170,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     ///
     /// This will internally take care of notifying the appropriate client objects
     /// of enter/motion/leave events.
-    #[instrument(parent = &self.span, skip(self, data, focus), fields(focus = ?focus.as_ref().map(|(_, loc)| ("...", loc))))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, data, focus), fields(focus = ?focus.as_ref().map(|(_, loc)| ("...", loc))))]
     pub fn motion(
         &self,
         data: &mut D,
@@ -190,7 +190,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     /// This will internally send the appropriate button event to the client
     /// objects matching with the currently focused surface, if the client uses
     /// the relative pointer protocol.
-    #[instrument(parent = &self.span, skip(self, data, focus), fields(focus = ?focus.as_ref().map(|(_, loc)| ("...", loc))))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, data, focus), fields(focus = ?focus.as_ref().map(|(_, loc)| ("...", loc))))]
     pub fn relative_motion(
         &self,
         data: &mut D,
@@ -209,7 +209,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     ///
     /// This will internally send the appropriate button event to the client
     /// objects matching with the currently focused surface.
-    #[instrument(parent = &self.span, skip(self, data))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn button(&self, data: &mut D, event: &ButtonEvent) {
         let mut inner = self.inner.lock().unwrap();
         match event.state {
@@ -229,7 +229,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     /// Start an axis frame
     ///
     /// A single frame will group multiple scroll events as if they happened in the same instance.
-    #[instrument(parent = &self.span, skip(self, data))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn axis(&self, data: &mut D, details: AxisFrame) {
         let seat = self.get_seat(data);
         self.inner.lock().unwrap().with_grab(&seat, |mut handle, grab| {

--- a/src/wayland/output/handlers.rs
+++ b/src/wayland/output/handlers.rs
@@ -1,4 +1,4 @@
-use tracing::{span, trace, warn, Level};
+use tracing::{trace, warn, warn_span};
 use wayland_protocols::xdg::xdg_output::zv1::server::{
     zxdg_output_manager_v1::{self, ZxdgOutputManagerV1},
     zxdg_output_v1::{self, ZxdgOutputV1},
@@ -37,7 +37,7 @@ where
 
         let mut inner = global_data.inner.0.lock().unwrap();
 
-        let span = span!(Level::WARN, "output_bind", name = inner.name);
+        let span = warn_span!("output_bind", name = inner.name);
         let _enter = span.enter();
 
         trace!("New WlOutput global instantiated");

--- a/src/wayland/shm/pool.rs
+++ b/src/wayland/shm/pool.rs
@@ -71,7 +71,7 @@ impl Pool {
         self.map.read().unwrap().size
     }
 
-    #[instrument(skip_all, name = "wayland_shm")]
+    #[instrument(level = "trace", skip_all, name = "wayland_shm")]
     pub fn with_data<T, F: FnOnce(*const u8, usize) -> T>(&self, f: F) -> Result<T, ()> {
         // Place the sigbus handler
         SIGBUS_INIT.call_once(|| unsafe {
@@ -107,7 +107,7 @@ impl Pool {
         })
     }
 
-    #[instrument(skip_all, name = "wayland_shm")]
+    #[instrument(level = "trace", skip_all, name = "wayland_shm")]
     pub fn with_data_mut<T, F: FnOnce(*mut u8, usize) -> T>(&self, f: F) -> Result<T, ()> {
         // Place the sigbus handler
         SIGBUS_INIT.call_once(|| unsafe {

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -72,7 +72,7 @@ use std::{
     os::unix::net::UnixStream,
     sync::Arc,
 };
-use tracing::{debug, error, info, info_span, trace, warn};
+use tracing::{debug, debug_span, error, info, trace, warn};
 use wayland_server::{protocol::wl_surface::WlSurface, Client, DisplayHandle, Resource};
 
 use x11rb::{
@@ -373,7 +373,7 @@ impl X11Wm {
         D: XwmHandler + 'static,
     {
         let id = XwmId(next_xwm_id());
-        let span = info_span!("xwayland_wm", id = id.0);
+        let span = debug_span!("xwayland_wm", id = id.0);
         let _guard = span.enter();
 
         // Create an X11 connection. XWayland only uses screen 0.


### PR DESCRIPTION
This downgrades the log-level of a bunch of spans, which annotate hot paths, many of which aren't even used for actual log messages.
Because entering and leaving spans generates internal events - even though we don't log them - this caused severe performance implications, observable using cargo-flamegraph before and after this commit.