### PR TITLE
Implement `Default` for `RenderElementStates`

### DIFF
--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -289,7 +289,7 @@ pub fn default_primary_scanout_output_compare<'a>(
 }
 
 /// Holds the states for a set of [`RenderElement`]s
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct RenderElementStates {
     /// Holds the render states of the elements
     pub states: HashMap<Id, RenderElementState>,


### PR DESCRIPTION
This change makes it easier for consumers to just `mem::take` the states from the frame result, which is useful since it has a lifetime attached to the original input data.

This patch now derives all important common traits that are directly derivable, following Rust's official API guidelines: https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits