### PR TITLE
drm: workaround zpos range type boolean

### DIFF
--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -216,6 +216,9 @@ fn plane_zpos(dev: &(impl ControlDevice + DevPath), plane: plane::Handle) -> Res
             let plane_zpos = match info.value_type().convert_value(val) {
                 drm::control::property::Value::UnsignedRange(u) => Some(u as i32),
                 drm::control::property::Value::SignedRange(i) => Some(i as i32),
+                // A range from [0,1] will be interpreted as Boolean in drm-rs
+                // TODO: Once that has been changed we can remove this special handling here
+                drm::control::property::Value::Boolean(b) => Some(b.into()),
                 _ => None,
             };
             return Ok(plane_zpos);


### PR DESCRIPTION
drm-rs interprets a range with [0,1] as Boolean, but in case of zpos we want to know the actual value. Until sorted out in rm-rs we just reverse the transform back to receive the zpos value.