### PR TITLE
Fix drm rotation

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -2127,6 +2127,7 @@ where
                 scale,
                 frame_state,
                 output_damage,
+                output_transform,
                 output_geometry,
             )? {
                 Ok(plane) => {
@@ -2634,6 +2635,7 @@ where
         scale: Scale<f64>,
         frame_state: &mut Frame<A, F>,
         output_damage: &mut Vec<Rectangle<i32, Physical>>,
+        output_transform: Transform,
         output_geometry: Rectangle<i32, Physical>,
     ) -> Result<Result<PlaneInfo, Option<RenderingReason>>, ExportBufferError>
     where
@@ -2664,7 +2666,7 @@ where
             scale,
             frame_state,
             output_damage,
-            Transform::Normal,
+            output_transform,
             output_geometry,
         )
     }

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1627,7 +1627,7 @@ where
                     .planes
                     .overlay
                     .iter()
-                    .filter(|p| p.zpos.unwrap_or_default() <= self.planes.primary.zpos.unwrap_or_default())
+                    .filter(|p| p.zpos.unwrap_or_default() < self.planes.primary.zpos.unwrap_or_default())
                     .any(|p| next_frame_state.overlaps(p.handle, element_geometry));
                 !overlaps_with_underlay
                     && (crtc_background_matches_clear_color

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -787,6 +787,15 @@ impl AtomicDrmSurface {
                         prop,
                         property::Value::Bitmask(DrmRotation::from(config.transform).bits() as u64),
                     );
+                } else if config.transform != Transform::Normal {
+                    // if we are missing the rotation property we can no rely on
+                    // the driver to report a non working configuration and can
+                    // only guarantee that Transform::Normal (no rotation) will
+                    // work
+                    return Err(Error::UnknownProperty {
+                        handle: (*handle).into(),
+                        name: "rotation",
+                    });
                 }
                 if let Ok(prop) = plane_prop_handle(&prop_mapping, *handle, "FB_DAMAGE_CLIPS") {
                     if let Some(damage) = config.damage_clips.as_ref() {


### PR DESCRIPTION
There were multiple issues regarding rotation with drm planes:

- The output `Transform` was not used for direct scan-out on the primary plane (fixed by 1e9726dea3c0cbc73746913fe6e5ea0839a20059)
- The surface did not report an issue when a plane does not expose a rotation property but a `Transform` was requested (fixed by 1cdfe14305d84ae8c06d37614aa3724fc1f79c53)

cc @chrisduerr 