### PR TITLE
desktop: Remove outdated doc comments about `z_index`

### DIFF
--- a/src/desktop/space/element/mod.rs
+++ b/src/desktop/space/element/mod.rs
@@ -51,7 +51,7 @@ pub trait SpaceElement: IsAlive {
     fn bbox(&self) -> Rectangle<i32, Logical>;
     /// Returns whenever a given point inside this element will be able to receive input
     fn is_in_input_region(&self, point: &Point<f64, Logical>) -> bool;
-    /// Gets the z-index of this element on the specified space
+    /// Gets the z-index of this element
     fn z_index(&self) -> u8 {
         RenderZindex::Overlay as u8
     }

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -92,11 +92,8 @@ impl<E: SpaceElement + PartialEq> Space<E> {
 
     /// Map a [`SpaceElement`] and move it to top of the stack
     ///
-    /// If a z_index is provided it will override the default
-    /// z_index of [`RenderZindex::Shell`] for the mapped window.
-    ///
     /// This can safely be called on an already mapped window
-    /// to update its location or z_index inside the space.
+    /// to update its location inside the space.
     ///
     /// If activate is true it will set the new windows state
     /// to be activate and removes that state from every


### PR DESCRIPTION
It seems since e8c977c9 `Space::map_element` doesn't take a `z_index` argument, and `SpaceElement::z_index` doesn't take a space. So these mentions are outdated.