### PR TITLE
Adding dependency-checker in `build.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,12 +63,22 @@ xkbcommon = { version = "0.5.0", features = ["wayland"]}
 scan_fmt = { version = "0.2.3", default-features = false }
 encoding = { version = "0.2.33", optional = true }
 
+# external system dependencies
+[package.metadata.system-deps]
+libudev = "1.7.6"
+xkbcommon = "0.0.0"
+libinput = "1.22.0"
+gbm = "1.0.0"
+
+libseat = { version = "0.1.7", feature = "libseat" }
+
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
 image = "0.24"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
 [build-dependencies]
+system-deps = "6.0.3"
 gl_generator = { version = "0.14", optional = true }
 pkg-config = { version = "0.3.17", optional = true }
 cc = { version = "1.0.79", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ encoding = { version = "0.2.33", optional = true }
 
 # external system dependencies
 [package.metadata.system-deps]
-libudev = "1.7.6"
+libudev = { version = "1.7.6", feature = "backend_udev" }
 xkbcommon = "0.0.0"
 libinput = "1.22.0"
 gbm = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ encoding = { version = "0.2.33", optional = true }
 libudev = { version = "1.7.6", feature = "backend_udev" }
 xkbcommon = "0.0.0"
 libinput = "1.22.0"
-gbm = "1.0.0"
+gbm = { version = "1.0.0", feature = "backend_gbm" }
 
 libseat = { version = "0.1.7", feature = "libseat" }
 

--- a/build.rs
+++ b/build.rs
@@ -119,6 +119,8 @@ fn test_gbm_bo_create_with_modifiers2() {
 }
 
 fn main() {
+    check_dependencies();
+
     #[cfg(any(feature = "backend_egl", feature = "renderer_gl"))]
     gl_generate();
 
@@ -129,4 +131,8 @@ fn main() {
         not(feature = "backend_gbm_has_create_with_modifiers2")
     ))]
     test_gbm_bo_create_with_modifiers2();
+}
+
+fn check_dependencies() {
+    system_deps::Config::new().probe().unwrap();
 }


### PR DESCRIPTION
This PR should help to automatically detect the system dependencies and report an appropriate error message if they're not there.