### PR TITLE
Adding rust toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.65.0"


### PR DESCRIPTION
In my opinion it wouldn't be bad, if smithay would include the
rust-toolchain.toml file because then it's likely guaranteed that all devs are
using the same rust-tools.
