### PR TITLE
xwm: Only set _NET_WM_STATE if it has changed 

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -871,8 +871,6 @@ fn handle_event<D: XwmHandler>(state: &mut D, xwmid: XwmId, event: Event) -> Res
         }
         Event::MapRequest(r) => {
             if let Some(surface) = xwm.windows.iter().find(|x| x.window_id() == r.window).cloned() {
-                surface.update_properties(Some(xwm.atoms._NET_WM_STATE))?;
-
                 // we reparent windows, because a lot of stuff expects, that we do
                 let geo = conn.get_geometry(r.window)?.reply()?;
                 let win = r.window;

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -727,7 +727,7 @@ impl X11Surface {
         };
 
         let mut state = self.state.lock().unwrap();
-        state.net_state = atoms
+        state.window_type = atoms
             .and_then(|atoms| Some(atoms.value32()?.collect::<Vec<_>>()))
             .unwrap_or_default();
         Ok(())


### PR DESCRIPTION
EWMH says a client MUST use a client message to change this, so this should be managed by the compositor and it is not necessary to read the value from X. Assuming the `X11Surface` exists for the lifetime of the X window, and the compositor only sets this via `change_net_state`.

Fixes https://github.com/pop-os/cosmic-comp/issues/90. This should also generally perform better since it removes a `get_property` call which has to wait on the X server, and it doesn't allocate a `HashSet`. For what difference that makes.

This also fixes what appears to be a mistake in `update_net_window_type`.