### PR TITLE
Rename FractionScaleHandler to FractionalScaleHandler

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -43,7 +43,7 @@ use smithay::{
             ServerDndGrabHandler,
         },
         dmabuf::DmabufFeedback,
-        fractional_scale::{with_fractional_scale, FractionScaleHandler, FractionalScaleManagerState},
+        fractional_scale::{with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState},
         input_method::{InputMethodManagerState, InputMethodSeat},
         keyboard_shortcuts_inhibit::{
             KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
@@ -347,7 +347,7 @@ delegate_xdg_shell!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 delegate_layer_shell!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 delegate_presentation!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
-impl<BackendData: Backend> FractionScaleHandler for AnvilState<BackendData> {
+impl<BackendData: Backend> FractionalScaleHandler for AnvilState<BackendData> {
     fn new_fractional_scale(
         &mut self,
         surface: smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,

--- a/src/wayland/fractional_scale/mod.rs
+++ b/src/wayland/fractional_scale/mod.rs
@@ -5,7 +5,7 @@
 //! ### Initialization
 //!
 //! To initialize this implementation create the [`FractionalScaleManagerState`], store it inside your `State` struct
-//! and implement the [`FractionScaleHandler`], as shown in this example:
+//! and implement the [`FractionalScaleHandler`], as shown in this example:
 //!
 //! ```
 //! use smithay::delegate_fractional_scale;
@@ -14,7 +14,7 @@
 //! use smithay::wayland::fractional_scale::{
 //!     self,
 //!     FractionalScaleManagerState,
-//!     FractionScaleHandler,
+//!     FractionalScaleHandler,
 //! };
 //!
 //! # struct State { fractional_scale_manager_state: FractionalScaleManagerState }
@@ -28,7 +28,7 @@
 //! // ..
 //!
 //! // implement the necessary traits
-//! impl FractionScaleHandler for State {
+//! impl FractionalScaleHandler for State {
 //!    fn new_fractional_scale(&mut self, surface: wl_surface::WlSurface) {
 //!        compositor::with_states(&surface, |states| {
 //!            fractional_scale::with_fractional_scale(states, |fractional_scale| {
@@ -89,7 +89,7 @@ impl FractionalScaleManagerState {
             + Dispatch<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1, ()>
             + Dispatch<wp_fractional_scale_v1::WpFractionalScaleV1, Weak<wl_surface::WlSurface>>
             + 'static,
-        D: FractionScaleHandler,
+        D: FractionalScaleHandler,
     {
         FractionalScaleManagerState {
             global: display
@@ -109,7 +109,7 @@ where
     D: GlobalDispatch<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1, ()>
         + Dispatch<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1, ()>
         + Dispatch<wp_fractional_scale_v1::WpFractionalScaleV1, Weak<wl_surface::WlSurface>>,
-    D: FractionScaleHandler,
+    D: FractionalScaleHandler,
 {
     fn bind(
         _state: &mut D,
@@ -129,7 +129,7 @@ where
     D: GlobalDispatch<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1, ()>
         + Dispatch<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1, ()>
         + Dispatch<wp_fractional_scale_v1::WpFractionalScaleV1, Weak<wl_surface::WlSurface>>,
-    D: FractionScaleHandler,
+    D: FractionalScaleHandler,
 {
     fn request(
         state: &mut D,
@@ -195,7 +195,7 @@ where
     D: GlobalDispatch<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1, ()>
         + Dispatch<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1, ()>
         + Dispatch<wp_fractional_scale_v1::WpFractionalScaleV1, Weak<wl_surface::WlSurface>>,
-    D: FractionScaleHandler,
+    D: FractionalScaleHandler,
 {
     fn request(
         _state: &mut D,
@@ -223,7 +223,7 @@ where
 }
 
 /// Fractional scale handler type
-pub trait FractionScaleHandler {
+pub trait FractionalScaleHandler {
     /// A new fractional scale was instantiated
     fn new_fractional_scale(&mut self, surface: wl_surface::WlSurface);
 }


### PR DESCRIPTION
Both the protocol and the existing `FractionalScaleManagerState` name this feature "fracitonal scale". During implementation I just quickly typed out the code and had to fix it after realizing that Smithay's handler has inconsistent naming.

While this is a somewhat unnecessary breakage, I think in the long run it's going to be beneficial to have consistent naming that doesn't get in the way and this feature is still relatively new.