### PR TITLE
Fix CropRenderElement nesting

### DIFF
--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -154,13 +154,14 @@ impl<E: Element> CropRenderElement<E> {
             // Ok, for the src we need to know how much we cropped from the element geometry
             // and then bring that rectangle into buffer space. For this we have to first
             // apply the element transform and then scale it to buffer space.
-            let src = element_relative_intersection.to_f64().to_logical(1.0).to_buffer(
+            let mut src = element_relative_intersection.to_f64().to_logical(1.0).to_buffer(
                 physical_to_buffer_scale,
                 transform,
                 &element_geometry.size.to_f64().to_logical(1.0),
             );
 
             // Ensure cropping of the existing element is respected.
+            src.loc += element_src.loc;
             let src = match src.intersection(element_src) {
                 Some(src) => src,
                 None => return None,

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -162,10 +162,6 @@ impl<E: Element> CropRenderElement<E> {
 
             // Ensure cropping of the existing element is respected.
             src.loc += element_src.loc;
-            let src = match src.intersection(element_src) {
-                Some(src) => src,
-                None => return None,
-            };
 
             Some(CropRenderElement {
                 element,

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -160,6 +160,12 @@ impl<E: Element> CropRenderElement<E> {
                 &element_geometry.size.to_f64().to_logical(1.0),
             );
 
+            // Ensure cropping of the existing element is respected.
+            let src = match src.intersection(element_src) {
+                Some(src) => src,
+                None => return None,
+            };
+
             Some(CropRenderElement {
                 element,
                 src,


### PR DESCRIPTION
Previously the `CropRenderElement` would not take the existing element's cropping into account. This can create problems when nesting cropped render elements which can easily happen with viewporter for example.

The approach taken by this patch is to calculate the new cropped source rectangle and then only return the intersection to the original source rectangle. This allows `CropRenderElement` to crop stuff off without ever increasing the source rectangle and reverting existing cropping.

---

Just wanted to point out that this fix almost seems to simple to work just like this. So if someone can think of other potential edgecases that might break this, please let me know. This was only very briefly tested with viewporter (though it did work).