### PR TITLE
Truncate nul bytes from virtual keyboard string

### DIFF
--- a/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
+++ b/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
@@ -197,13 +197,18 @@ where
         debug!("Could not read keymap: {err}");
         return;
     }
-    let new_keymap = match String::from_utf8(keymap_buffer) {
+    let mut new_keymap = match String::from_utf8(keymap_buffer) {
         Ok(keymap) => keymap,
         Err(err) => {
             debug!("Invalid utf8 keymap: {err}");
             return;
         }
     };
+
+    // Ignore everything after the first nul byte.
+    if let Some(nul_index) = new_keymap.find('\0') {
+        new_keymap.truncate(nul_index);
+    }
 
     // Attempt to parse the new keymap.
     let new_keymap = xkb::Keymap::new_from_string(


### PR DESCRIPTION
This fixes a regression introduced in e16cee1, which caused the virtual keyboard protocol to break completely with a `NulError` in xkbcommon.

Since xkbcommon uses `CString::new`, which panics whenever encountering a nul byte, it is important to first strip any nul bytes from our String. Without this, the function is guaranteed to panic since there will always be at least on trailing nul byte.