### PR TITLE
gles2: Always rebinding egl_images

### DIFF
--- a/src/backend/renderer/gles2/mod.rs
+++ b/src/backend/renderer/gles2/mod.rs
@@ -1346,14 +1346,12 @@ impl Gles2Renderer {
 
         if let Some(texture) = existing_texture {
             trace!("Re-using texture {:?} for {:?}", texture.0.texture, buffer);
-            if !texture.0.is_external {
-                if let Some(egl_images) = texture.0.egl_images.as_ref() {
-                    if egl_images[0] == ffi_egl::NO_IMAGE_KHR {
-                        return Ok(None);
-                    }
-                    let tex = Some(texture.0.texture);
-                    self.import_egl_image(egl_images[0], false, tex)?;
+            if let Some(egl_images) = texture.0.egl_images.as_ref() {
+                if egl_images[0] == ffi_egl::NO_IMAGE_KHR {
+                    return Ok(None);
                 }
+                let tex = Some(texture.0.texture);
+                self.import_egl_image(egl_images[0], texture.0.is_external, tex)?;
             }
             Ok(Some(texture))
         } else {


### PR DESCRIPTION
External images on nvidia gpus seem to suffer from synchronization issues without this change. OES_EGL_image_external also seems to suggest, that this is a good idea.