### PR TITLE
Fix inaccurate renderer nameing

### DIFF
--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -1,6 +1,6 @@
 use smithay::{
     backend::renderer::{
-        damage::{DamageTrackedRenderer, DamageTrackedRendererError},
+        damage::{Error as OutputDamageTrackerError, OutputDamageTracker},
         element::{
             surface::WaylandSurfaceRenderElement,
             utils::{
@@ -194,15 +194,15 @@ pub fn render_output<'a, R>(
     space: &'a Space<WindowElement>,
     custom_elements: impl IntoIterator<Item = CustomRenderElements<R>>,
     renderer: &mut R,
-    damage_tracked_renderer: &mut DamageTrackedRenderer,
+    damage_tracker: &mut OutputDamageTracker,
     age: usize,
     show_window_preview: bool,
-) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), DamageTrackedRendererError<R>>
+) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), OutputDamageTrackerError<R>>
 where
     R: Renderer + ImportAll + ImportMem,
     R::TextureId: Clone + 'static,
 {
     let (elements, clear_color) =
         output_elements(output, space, custom_elements, renderer, show_window_preview);
-    damage_tracked_renderer.render_output(renderer, age, &elements, clear_color)
+    damage_tracker.render_output(renderer, age, &elements, clear_color)
 }

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -14,7 +14,7 @@ use smithay::{
         allocator::dmabuf::Dmabuf,
         egl::EGLDevice,
         renderer::{
-            damage::{DamageTrackedRenderer, DamageTrackedRendererError},
+            damage::{Error as OutputDamageTrackerError, OutputDamageTracker},
             element::AsRenderElements,
             gles2::{Gles2Renderer, Gles2Texture},
             ImportDma,
@@ -48,7 +48,7 @@ pub const OUTPUT_NAME: &str = "winit";
 
 pub struct WinitData {
     backend: WinitGraphicsBackend<Gles2Renderer>,
-    damage_tracked_renderer: DamageTrackedRenderer,
+    damage_tracker: OutputDamageTracker,
     dmabuf_state: (DmabufState, DmabufGlobal, Option<DmabufFeedback>),
     full_redraw: u8,
     #[cfg(feature = "debug")]
@@ -173,11 +173,11 @@ pub fn run_winit() {
     };
 
     let data = {
-        let damage_tracked_renderer = DamageTrackedRenderer::from_output(&output);
+        let damage_tracker = OutputDamageTracker::from_output(&output);
 
         WinitData {
             backend,
-            damage_tracked_renderer,
+            damage_tracker,
             dmabuf_state,
             full_redraw: 0,
             #[cfg(feature = "debug")]
@@ -254,7 +254,7 @@ pub fn run_winit() {
             let full_redraw = &mut state.backend_data.full_redraw;
             *full_redraw = full_redraw.saturating_sub(1);
             let space = &mut state.space;
-            let damage_tracked_renderer = &mut state.backend_data.damage_tracked_renderer;
+            let damage_tracker = &mut state.backend_data.damage_tracker;
             let show_window_preview = state.show_window_preview;
 
             let input_method = state.seat.input_method().unwrap();
@@ -325,12 +325,12 @@ pub fn run_winit() {
                     space,
                     elements,
                     renderer,
-                    damage_tracked_renderer,
+                    damage_tracker,
                     age,
                     show_window_preview,
                 )
                 .map_err(|err| match err {
-                    DamageTrackedRendererError::Rendering(err) => err.into(),
+                    OutputDamageTrackerError::Rendering(err) => err.into(),
                     _ => unreachable!(),
                 })
             });

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -23,7 +23,7 @@ use smithay::{
         },
         egl::{EGLContext, EGLDisplay},
         renderer::{
-            damage::DamageTrackedRenderer, element::AsRenderElements, gles2::Gles2Renderer, Bind, ImportDma,
+            damage::OutputDamageTracker, element::AsRenderElements, gles2::Gles2Renderer, Bind, ImportDma,
         },
         vulkan::{version::Version, Instance, PhysicalDevice},
         x11::{WindowBuilder, X11Backend, X11Event, X11Surface},
@@ -58,7 +58,7 @@ pub struct X11Data {
     // FIXME: If Gles2Renderer is dropped before X11Surface, then the MakeCurrent call inside Gles2Renderer will
     // fail because the X11Surface is keeping gbm alive.
     renderer: Gles2Renderer,
-    damage_tracked_renderer: DamageTrackedRenderer,
+    damage_tracker: OutputDamageTracker,
     surface: X11Surface,
     dmabuf_state: DmabufState,
     _dmabuf_global: DmabufGlobal,
@@ -227,14 +227,14 @@ pub fn run_x11() {
     output.change_current_state(Some(mode), None, None, Some((0, 0).into()));
     output.set_preferred(mode);
 
-    let damage_tracked_renderer = DamageTrackedRenderer::from_output(&output);
+    let damage_tracker = OutputDamageTracker::from_output(&output);
 
     let data = X11Data {
         render: true,
         mode,
         surface,
         renderer,
-        damage_tracked_renderer,
+        damage_tracker,
         dmabuf_state,
         _dmabuf_global: dmabuf_global,
         _dmabuf_default_feedback: dmabuf_default_feedback,
@@ -389,7 +389,7 @@ pub fn run_x11() {
                 &state.space,
                 elements,
                 &mut backend_data.renderer,
-                &mut backend_data.damage_tracked_renderer,
+                &mut backend_data.damage_tracker,
                 age.into(),
                 state.show_window_preview,
             );

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -3,8 +3,7 @@ use std::time::Duration;
 use smithay::{
     backend::{
         renderer::{
-            damage::DamageTrackedRenderer, element::surface::WaylandSurfaceRenderElement,
-            gles2::Gles2Renderer,
+            damage::OutputDamageTracker, element::surface::WaylandSurfaceRenderElement, gles2::Gles2Renderer,
         },
         winit::{self, WinitError, WinitEvent, WinitEventLoop, WinitGraphicsBackend},
     },
@@ -47,7 +46,7 @@ pub fn init_winit(
 
     state.space.map_output(&output, (0, 0));
 
-    let mut damage_tracked_renderer = DamageTrackedRenderer::from_output(&output);
+    let mut damage_tracker = OutputDamageTracker::from_output(&output);
 
     std::env::set_var("WAYLAND_DISPLAY", &state.socket_name);
 
@@ -60,7 +59,7 @@ pub fn init_winit(
             &mut winit,
             data,
             &output,
-            &mut damage_tracked_renderer,
+            &mut damage_tracker,
             &mut full_redraw,
         )
         .unwrap();
@@ -75,7 +74,7 @@ pub fn winit_dispatch(
     winit: &mut WinitEventLoop,
     data: &mut CalloopData,
     output: &Output,
-    damage_tracked_renderer: &mut DamageTrackedRenderer,
+    damage_tracker: &mut OutputDamageTracker,
     full_redraw: &mut u8,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let display = &mut data.display;
@@ -118,7 +117,7 @@ pub fn winit_dispatch(
         0,
         [&state.space],
         &[],
-        damage_tracked_renderer,
+        damage_tracker,
         [0.1, 0.1, 0.1, 1.0],
     )?;
     backend.submit(Some(&[damage]))?;

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1387,6 +1387,8 @@ where
     }
 
     /// Render the next frame
+    ///
+    /// - `elements` for this frame in front-to-back order
     #[instrument(level = "trace", parent = &self.span, skip_all)]
     pub fn render_frame<'a, R, E, Target>(
         &'a mut self,

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -139,12 +139,12 @@ use crate::{
         drm::{DrmError, PlaneDamageClips},
         renderer::{
             buffer_y_inverted,
-            damage::{DamageTrackedRenderer, DamageTrackedRendererError, OutputNoMode},
+            damage::{Error as OutputDamageTrackerError, OutputDamageTracker, OutputNoMode},
             element::{
                 Element, Id, RenderElement, RenderElementPresentationState, RenderElementState,
                 RenderElementStates, RenderingReason, UnderlyingStorage,
             },
-            utils::{CommitCounter, DamageTracker, DamageTrackerSnapshot},
+            utils::{CommitCounter, DamageBag, DamageSnapshot},
             Bind, Blit, DebugFlags, ExportMem, Frame as RendererFrame, Offscreen, Renderer, Texture,
         },
         SwapBuffersError,
@@ -646,7 +646,7 @@ pub enum PrimaryPlaneElement<'a, B: Buffer, E> {
         /// The transform applied during rendering
         transform: Transform,
         /// The damage on the primary plane
-        damage: DamageTrackerSnapshot<i32, BufferCoords>,
+        damage: DamageSnapshot<i32, BufferCoords>,
     },
     /// An element has been assigned for direct scan-out
     Element(&'a E),
@@ -692,7 +692,7 @@ struct SwapchainElement<'a, B: Buffer> {
     id: Id,
     slot: &'a Slot<B>,
     transform: Transform,
-    damage: &'a DamageTrackerSnapshot<i32, BufferCoords>,
+    damage: &'a DamageSnapshot<i32, BufferCoords>,
 }
 
 impl<'a, B: Buffer> Element for SwapchainElement<'a, B> {
@@ -828,7 +828,7 @@ where
     /// Get the damage of this frame for the specified dtr and age
     pub fn damage_from_age(
         &self,
-        dtr: &mut DamageTrackedRenderer,
+        damage_tracker: &mut OutputDamageTracker,
         age: usize,
         filter: impl IntoIterator<Item = Id>,
     ) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), OutputNoMode>
@@ -868,7 +868,7 @@ where
 
         elements.push(primary_render_element);
 
-        dtr.damage_output(age, &elements)
+        damage_tracker.damage_output(age, &elements)
     }
 }
 
@@ -1087,9 +1087,9 @@ where
     output: Output,
     surface: Arc<DrmSurface>,
     planes: Planes,
-    damage_tracked_renderer: DamageTrackedRenderer,
+    damage_tracker: OutputDamageTracker,
     primary_plane_element_id: Id,
-    primary_plane_damage_tracker: DamageTracker<i32, BufferCoords>,
+    primary_plane_damage_bag: DamageBag<i32, BufferCoords>,
 
     framebuffer_exporter: F,
 
@@ -1180,7 +1180,7 @@ where
             .sort_by_key(|p| std::cmp::Reverse(p.zpos.unwrap_or_default()));
 
         let cursor_size = Size::from((cursor_size.w as i32, cursor_size.h as i32));
-        let damage_tracked_renderer = DamageTrackedRenderer::from_output(output);
+        let damage_tracker = OutputDamageTracker::from_output(output);
 
         for format in SUPPORTED_FORMATS {
             debug!("Testing color format: {}", format);
@@ -1208,7 +1208,7 @@ where
 
                     let drm_renderer = DrmCompositor {
                         primary_plane_element_id: Id::new(),
-                        primary_plane_damage_tracker: DamageTracker::new(4),
+                        primary_plane_damage_bag: DamageBag::new(4),
                         current_frame,
                         pending_frame: None,
                         queued_frame: None,
@@ -1218,7 +1218,7 @@ where
                         cursor_size,
                         cursor_state,
                         surface,
-                        damage_tracked_renderer,
+                        damage_tracker,
                         output: output.clone(),
                         planes,
                         element_states: IndexMap::new(),
@@ -1750,7 +1750,7 @@ where
 
             renderer
                 .bind(dmabuf)
-                .map_err(DamageTrackedRendererError::Rendering)?;
+                .map_err(OutputDamageTrackerError::Rendering)?;
 
             // store the current renderer debug flags and replace them
             // with our own
@@ -1781,9 +1781,9 @@ where
                     .map(|e| DrmRenderElements::Other(*e)),
             );
 
-            let render_res =
-                self.damage_tracked_renderer
-                    .render_output(renderer, age, &elements, clear_color);
+            let render_res = self
+                .damage_tracker
+                .render_output(renderer, age, &elements, clear_color);
 
             // restore the renderer debug flags
             renderer.set_debug_flags(renderer_debug_flags);
@@ -1828,14 +1828,13 @@ where
                         if let Some(render_damage) = render_damage {
                             trace!("rendering damage: {:?}", render_damage);
 
-                            self.primary_plane_damage_tracker
-                                .add(render_damage.iter().map(|d| {
-                                    d.to_logical(1).to_buffer(
-                                        1,
-                                        Transform::Normal,
-                                        &output_geometry.size.to_logical(1),
-                                    )
-                                }));
+                            self.primary_plane_damage_bag.add(render_damage.iter().map(|d| {
+                                d.to_logical(1).to_buffer(
+                                    1,
+                                    Transform::Normal,
+                                    &output_geometry.size.to_logical(1),
+                                )
+                            }));
                             output_damage.extend(render_damage.clone());
                             config.damage_clips = PlaneDamageClips::from_damage(
                                 self.surface.device_fd(),
@@ -1859,7 +1858,7 @@ where
                             "clearing previous direct scan-out on primary plane, damaging complete output"
                         );
                         output_damage.push(output_geometry);
-                        self.primary_plane_damage_tracker
+                        self.primary_plane_damage_bag
                             .add([output_geometry.to_logical(1).to_buffer(
                                 1,
                                 Transform::Normal,
@@ -1895,7 +1894,7 @@ where
             PrimaryPlaneElement::Swapchain {
                 slot,
                 transform: output_transform,
-                damage: self.primary_plane_damage_tracker.snapshot(),
+                damage: self.primary_plane_damage_bag.snapshot(),
             }
         } else {
             PrimaryPlaneElement::Element(primary_plane_scanout_element.unwrap())
@@ -3059,7 +3058,7 @@ pub enum RenderFrameError<
     PrepareFrame(#[from] FrameError<A, B, F>),
     /// Rendering the frame encountered en error
     #[error(transparent)]
-    RenderFrame(#[from] DamageTrackedRendererError<R>),
+    RenderFrame(#[from] OutputDamageTrackerError<R>),
 }
 
 impl<A, B, F, R> std::fmt::Debug for RenderFrameError<A, B, F, R>

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -326,7 +326,9 @@ impl OutputDamageTracker {
         &self.mode
     }
 
-    /// Render this output
+    /// Render this output with the provided [`Renderer`]
+    ///
+    /// - `elements` for this output in front-to-back order
     #[instrument(level = "trace", parent = &self.span, skip(renderer, elements))]
     pub fn render_output<E, R>(
         &mut self,
@@ -458,6 +460,8 @@ impl OutputDamageTracker {
     }
 
     /// Damage this output and return the damage without actually rendering the difference
+    ///
+    /// - `elements` for this output in front-to-back order
     #[instrument(level = "trace", parent = &self.span, skip(elements))]
     pub fn damage_output<E>(
         &mut self,

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -1,16 +1,24 @@
-//! Helper for effective damage tracked rendering
+//! Helper for effective output damage tracking
 //!
 //! # Why use this implementation
 //!
-//! The [`DamageTrackedRenderer`] in combination with the [`RenderElement`] trait
+//! The [`OutputDamageTracker`] in combination with the [`RenderElement`] trait
 //! can help you to reduce resource consumption by tracking what elements have
 //! been damaged and only redraw the damaged parts on an output.
 //!
 //! It does so by keeping track of the last used [`CommitCounter`] for all provided
-//! [`RenderElement`]s and queries the element for new damage on each call to [`render_output`](DamageTrackedRenderer::render_output).
+//! [`RenderElement`]s and queries the element for new damage on each call to [`render_output`](OutputDamageTracker::render_output) or [`damage_output`](OutputDamageTracker::damage_output).
 //!
-//! You can initialize it with a static output by using [`DamageTrackedRenderer::new`] or
-//! allow it to track a specific [`Output`] with [`DamageTrackedRenderer::from_output`].
+//! Additionally the damage tracker will automatically generate damage in the following situations:
+//! - Current geometry for elements entering the output
+//! - Current and last known geometry for moved elements (includes z-index changes)
+//! - Last known geometry for elements no longer present
+//!
+//! Elements fully occluded by opaque regions as defined by elements higher in the stack are skipped.
+//! The actual action taken by the damage tracker can be inspected from the returned [`RenderElementStates`].
+//!
+//! You can initialize it with a static output by using [`OutputDamageTracker::new`] or
+//! allow it to track a specific [`Output`] with [`OutputDamageTracker::from_output`].
 //!
 //! See the [`renderer::element`](crate::backend::renderer::element) module for more information
 //! about how to use [`RenderElement`].
@@ -110,7 +118,7 @@
 //! # }
 //! use smithay::{
 //!     backend::renderer::{
-//!         damage::DamageTrackedRenderer,
+//!         damage::OutputDamageTracker,
 //!         element::memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement}
 //!     },
 //!     utils::{Point, Transform},
@@ -122,8 +130,8 @@
 //! # let mut renderer = FakeRenderer;
 //! # let buffer_age = 0;
 //!
-//! // Initialize a new damage tracked renderer
-//! let mut damage_tracked_renderer = DamageTrackedRenderer::new((800, 600), 1.0, Transform::Normal);
+//! // Initialize a new damage tracker for a static output
+//! let mut damage_tracker = OutputDamageTracker::new((800, 600), 1.0, Transform::Normal);
 //!
 //! // Initialize a buffer to render
 //! let mut memory_buffer = MemoryRenderBuffer::new((WIDTH, HEIGHT), 1, Transform::Normal, None);
@@ -152,7 +160,7 @@
 //!         .expect("Failed to upload memory to gpu");
 //!
 //!     // Render the output
-//!     damage_tracked_renderer
+//!     damage_tracker
 //!         .render_output(
 //!             &mut renderer,
 //!             buffer_age,
@@ -214,12 +222,12 @@ struct RendererState {
     old_damage: VecDeque<Vec<Rectangle<i32, Physical>>>,
 }
 
-/// Mode for the [`DamageTrackedRenderer`]
+/// Mode for the [`OutputDamageTracker`] output
 #[derive(Debug, Clone)]
-pub enum DamageTrackedRendererMode {
-    /// Automatic mode based on a output
+pub enum OutputDamageTrackerMode {
+    /// Automatic mode based on a [`Output`]
     Auto(Output),
-    /// Static mode
+    /// Static output mode
     Static {
         /// Size of the static output
         size: Size<i32, Physical>,
@@ -235,17 +243,17 @@ pub enum DamageTrackedRendererMode {
 #[error("Output has no active mode")]
 pub struct OutputNoMode;
 
-impl TryInto<(Size<i32, Physical>, Scale<f64>, Transform)> for DamageTrackedRendererMode {
+impl TryInto<(Size<i32, Physical>, Scale<f64>, Transform)> for OutputDamageTrackerMode {
     type Error = OutputNoMode;
 
     fn try_into(self) -> Result<(Size<i32, Physical>, Scale<f64>, Transform), Self::Error> {
         match self {
-            DamageTrackedRendererMode::Auto(output) => Ok((
+            OutputDamageTrackerMode::Auto(output) => Ok((
                 output.current_mode().ok_or(OutputNoMode)?.size,
                 output.current_scale().fractional_scale().into(),
                 output.current_transform(),
             )),
-            DamageTrackedRendererMode::Static {
+            OutputDamageTrackerMode::Static {
                 size,
                 scale,
                 transform,
@@ -254,17 +262,17 @@ impl TryInto<(Size<i32, Physical>, Scale<f64>, Transform)> for DamageTrackedRend
     }
 }
 
-/// Damage tracked renderer for a single output
+/// Damage tracker for a single output
 #[derive(Debug)]
-pub struct DamageTrackedRenderer {
-    mode: DamageTrackedRendererMode,
+pub struct OutputDamageTracker {
+    mode: OutputDamageTrackerMode,
     last_state: RendererState,
     span: tracing::Span,
 }
 
-/// Errors thrown by [`DamageTrackedRenderer::render_output`]
+/// Errors thrown by [`OutputDamageTracker::render_output`]
 #[derive(thiserror::Error)]
-pub enum DamageTrackedRendererError<R: Renderer> {
+pub enum Error<R: Renderer> {
     /// The provided [`Renderer`] returned an error
     #[error(transparent)]
     Rendering(R::Error),
@@ -273,24 +281,24 @@ pub enum DamageTrackedRendererError<R: Renderer> {
     OutputNoMode(#[from] OutputNoMode),
 }
 
-impl<R: Renderer> std::fmt::Debug for DamageTrackedRendererError<R> {
+impl<R: Renderer> std::fmt::Debug for Error<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DamageTrackedRendererError::Rendering(err) => std::fmt::Debug::fmt(err, f),
-            DamageTrackedRendererError::OutputNoMode(err) => std::fmt::Debug::fmt(err, f),
+            Error::Rendering(err) => std::fmt::Debug::fmt(err, f),
+            Error::OutputNoMode(err) => std::fmt::Debug::fmt(err, f),
         }
     }
 }
 
-impl DamageTrackedRenderer {
-    /// Initialize a static [`DamageTrackedRenderer`]
+impl OutputDamageTracker {
+    /// Initialize a static [`OutputDamageTracker`]
     pub fn new(
         size: impl Into<Size<i32, Physical>>,
         scale: impl Into<Scale<f64>>,
         transform: Transform,
     ) -> Self {
         Self {
-            mode: DamageTrackedRendererMode::Static {
+            mode: OutputDamageTrackerMode::Static {
                 size: size.into(),
                 scale: scale.into(),
                 transform,
@@ -300,21 +308,21 @@ impl DamageTrackedRenderer {
         }
     }
 
-    /// Initialize a new [`DamageTrackedRenderer`] from an [`Output`]
+    /// Initialize a new [`OutputDamageTracker`] from an [`Output`]
     ///
     /// The renderer will keep track of changes to the [`Output`]
     /// and handle size and scaling changes automatically on the
-    /// next call to [`render_output`](DamageTrackedRenderer::render_output)
+    /// next call to [`render_output`](OutputDamageTracker::render_output)
     pub fn from_output(output: &Output) -> Self {
         Self {
-            mode: DamageTrackedRendererMode::Auto(output.clone()),
+            mode: OutputDamageTrackerMode::Auto(output.clone()),
             last_state: Default::default(),
             span: info_span!("renderer_damage", output = output.name()),
         }
     }
 
-    /// Get the [`DamageTrackedRendererMode`] of the [`DamageTrackedRenderer`]
-    pub fn mode(&self) -> &DamageTrackedRendererMode {
+    /// Get the [`OutputDamageTrackerMode`] of the [`OutputDamageTracker`]
+    pub fn mode(&self) -> &OutputDamageTrackerMode {
         &self.mode
     }
 
@@ -326,7 +334,7 @@ impl DamageTrackedRenderer {
         age: usize,
         elements: &[E],
         clear_color: [f32; 4],
-    ) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), DamageTrackedRendererError<R>>
+    ) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), Error<R>>
     where
         E: RenderElement<R>,
         R: Renderer,
@@ -443,7 +451,7 @@ impl DamageTrackedRenderer {
             // if the rendering errors on us, we need to be prepared, that this whole buffer was partially updated and thus now unusable.
             // thus clean our old states before returning
             self.last_state = Default::default();
-            return Err(DamageTrackedRendererError::Rendering(err));
+            return Err(Error::Rendering(err));
         }
 
         Ok((Some(damage), states))

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -116,7 +116,7 @@
 //!
 //! use smithay::{
 //!     backend::renderer::{
-//!         damage::DamageTrackedRenderer,
+//!         damage::OutputDamageTracker,
 //!         element::memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
 //!     },
 //!     utils::{Point, Rectangle, Size, Transform},
@@ -150,8 +150,8 @@
 //! // We explicitly drop the context here to make the borrow checker happy
 //! std::mem::drop(render_context);
 //!
-//! // Initialize a static damage tracked renderer
-//! let mut damage_tracked_renderer = DamageTrackedRenderer::new((800, 600), 1.0, Transform::Normal);
+//! // Initialize a static damage tracker
+//! let mut damage_tracker = OutputDamageTracker::new((800, 600), 1.0, Transform::Normal);
 //! # let mut renderer = FakeRenderer;
 //!
 //! let mut last_update = Instant::now();
@@ -177,7 +177,7 @@
 //!         .expect("Failed to upload from memory to gpu");
 //!
 //!     // Render the element(s)
-//!     damage_tracked_renderer
+//!     damage_tracker
 //!         .render_output(&mut renderer, 0, &[&render_element], [0.8, 0.8, 0.9, 1.0])
 //!         .expect("failed to render output");
 //! }
@@ -194,7 +194,7 @@ use tracing::{instrument, trace, warn};
 
 use crate::{
     backend::renderer::{
-        utils::{CommitCounter, DamageTracker},
+        utils::{CommitCounter, DamageBag},
         Frame, ImportMem, Renderer,
     },
     utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
@@ -209,7 +209,7 @@ struct MemoryRenderBufferInner {
     scale: i32,
     transform: Transform,
     opaque_regions: Option<Vec<Rectangle<i32, Buffer>>>,
-    damage_tracker: DamageTracker<i32, Buffer>,
+    damage_bag: DamageBag<i32, Buffer>,
     textures: HashMap<(TypeId, usize), Box<dyn std::any::Any>>,
     renderer_seen: HashMap<(TypeId, usize), CommitCounter>,
 }
@@ -222,7 +222,7 @@ impl Default for MemoryRenderBufferInner {
             scale: 1,
             transform: Transform::Normal,
             opaque_regions: None,
-            damage_tracker: DamageTracker::default(),
+            damage_bag: DamageBag::default(),
             textures: HashMap::default(),
             renderer_seen: HashMap::default(),
         }
@@ -245,7 +245,7 @@ impl MemoryRenderBufferInner {
             scale,
             transform,
             opaque_regions,
-            damage_tracker: DamageTracker::default(),
+            damage_bag: DamageBag::default(),
             textures: HashMap::default(),
             renderer_seen: HashMap::default(),
         }
@@ -269,7 +269,7 @@ impl MemoryRenderBufferInner {
             scale,
             transform,
             opaque_regions,
-            damage_tracker: DamageTracker::default(),
+            damage_bag: DamageBag::default(),
             textures: HashMap::default(),
             renderer_seen: HashMap::default(),
         }
@@ -282,7 +282,7 @@ impl MemoryRenderBufferInner {
             self.mem.resize(mem_size, 0);
             self.renderer_seen.clear();
             self.textures.clear();
-            self.damage_tracker.reset();
+            self.damage_bag.reset();
             self.size = size;
             self.opaque_regions = None;
         }
@@ -295,10 +295,10 @@ impl MemoryRenderBufferInner {
         <R as Renderer>::TextureId: 'static,
     {
         let texture_id = (TypeId::of::<<R as Renderer>::TextureId>(), renderer.id());
-        let current_commit = self.damage_tracker.current_commit();
+        let current_commit = self.damage_bag.current_commit();
         let last_commit = self.renderer_seen.get(&texture_id).copied();
         let buffer_damage = self
-            .damage_tracker
+            .damage_bag
             .damage_since(last_commit)
             .map(|d| d.into_iter().reduce(|a, b| a.merge(b)).unwrap_or_default())
             .unwrap_or_else(|| Rectangle::from_loc_and_size(Point::default(), self.size));
@@ -390,7 +390,7 @@ impl MemoryRenderBuffer {
     }
 
     fn current_commit(&self) -> CommitCounter {
-        self.inner.lock().unwrap().damage_tracker.current_commit()
+        self.inner.lock().unwrap().damage_bag.current_commit()
     }
 
     fn size(&self) -> Size<i32, Logical> {
@@ -437,7 +437,7 @@ impl<'a> RenderContext<'a> {
 
 impl<'a> Drop for RenderContext<'a> {
     fn drop(&mut self) {
-        self.buffer.damage_tracker.add(std::mem::take(&mut self.damage));
+        self.buffer.damage_bag.add(std::mem::take(&mut self.damage));
         if let Some(opaque_regions) = self.opaque_regions.take() {
             self.buffer.opaque_regions = opaque_regions;
         }
@@ -509,7 +509,7 @@ impl<R: Renderer> MemoryRenderBufferRenderElement<R> {
         let guard = self.buffer.inner.lock().unwrap();
 
         guard
-            .damage_tracker
+            .damage_bag
             .damage_since(commit)
             .map(|damage| {
                 damage

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -170,7 +170,7 @@
 //! # impl ImportDmaWl for FakeRenderer {}
 //! use smithay::{
 //!     backend::renderer::{
-//!         damage::DamageTrackedRenderer,
+//!         damage::OutputDamageTracker,
 //!         element::surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
 //!     },
 //!     utils::{Point, Rectangle, Size, Transform},
@@ -181,7 +181,7 @@
 //! # let surface = WlSurface::from_id(&dh, ObjectId::null()).unwrap();
 //!
 //! // Initialize a static damage tracked renderer
-//! let mut damage_tracked_renderer = DamageTrackedRenderer::new((800, 600), 1.0, Transform::Normal);
+//! let mut damage_tracker = OutputDamageTracker::new((800, 600), 1.0, Transform::Normal);
 //! # let mut renderer = FakeRenderer;
 //!
 //! loop {
@@ -191,7 +191,7 @@
 //!         render_elements_from_surface_tree(&mut renderer, &surface, location, 1.0);
 //!
 //!     // Render the element(s)
-//!     damage_tracked_renderer
+//!     damage_tracker
 //!         .render_output(&mut renderer, 0, &*render_elements, [0.8, 0.8, 0.9, 1.0])
 //!         .expect("failed to render output");
 //! }

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -56,26 +56,26 @@ impl From<usize> for CommitCounter {
 /// and automatically caps the damage
 /// with the specified limit.
 ///
-/// See [`DamageTrackerSnapshot`] for more
+/// See [`DamageSnapshot`] for more
 /// information.
-pub struct DamageTracker<N, Kind> {
+pub struct DamageBag<N, Kind> {
     limit: usize,
-    state: DamageTrackerSnapshot<N, Kind>,
+    state: DamageSnapshot<N, Kind>,
 }
 
-/// A snapshot of the current state of a [`DamageTracker`]
+/// A snapshot of the current state of a [`DamageBag`]
 ///
 /// The snapshot can be used to get an immutable view
-/// into the current state of a [`DamageTracker`].
+/// into the current state of a [`DamageBag`].
 /// It provides an easy way to get the damage between two
 /// [`CommitCounter`]s.
-pub struct DamageTrackerSnapshot<N, Kind> {
+pub struct DamageSnapshot<N, Kind> {
     limit: usize,
     commit_counter: CommitCounter,
     damage: VecDeque<Vec<Rectangle<N, Kind>>>,
 }
 
-impl<N: Clone, Kind> Clone for DamageTrackerSnapshot<N, Kind> {
+impl<N: Clone, Kind> Clone for DamageSnapshot<N, Kind> {
     fn clone(&self) -> Self {
         Self {
             limit: self.limit,
@@ -85,54 +85,54 @@ impl<N: Clone, Kind> Clone for DamageTrackerSnapshot<N, Kind> {
     }
 }
 
-impl<N: fmt::Debug> fmt::Debug for DamageTracker<N, BufferCoord> {
+impl<N: fmt::Debug> fmt::Debug for DamageBag<N, BufferCoord> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DamageTracker")
+        f.debug_struct("DamageBag")
             .field("limit", &self.limit)
             .field("state", &self.state)
             .finish()
     }
 }
 
-impl<N: fmt::Debug> fmt::Debug for DamageTracker<N, Physical> {
+impl<N: fmt::Debug> fmt::Debug for DamageBag<N, Physical> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DamageTracker")
+        f.debug_struct("DamageBag")
             .field("limit", &self.limit)
             .field("state", &self.state)
             .finish()
     }
 }
 
-impl<N: fmt::Debug> fmt::Debug for DamageTracker<N, Logical> {
+impl<N: fmt::Debug> fmt::Debug for DamageBag<N, Logical> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DamageTracker")
+        f.debug_struct("DamageBag")
             .field("limit", &self.limit)
             .field("state", &self.state)
             .finish()
     }
 }
 
-impl<N: fmt::Debug> fmt::Debug for DamageTrackerSnapshot<N, BufferCoord> {
+impl<N: fmt::Debug> fmt::Debug for DamageSnapshot<N, BufferCoord> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DamageTrackerSnapshot")
+        f.debug_struct("DamageSnapshot")
             .field("commit_counter", &self.commit_counter)
             .field("damage", &self.damage)
             .finish()
     }
 }
 
-impl<N: fmt::Debug> fmt::Debug for DamageTrackerSnapshot<N, Physical> {
+impl<N: fmt::Debug> fmt::Debug for DamageSnapshot<N, Physical> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DamageTrackerSnapshot")
+        f.debug_struct("DamageSnapshot")
             .field("commit_counter", &self.commit_counter)
             .field("damage", &self.damage)
             .finish()
     }
 }
 
-impl<N: fmt::Debug> fmt::Debug for DamageTrackerSnapshot<N, Logical> {
+impl<N: fmt::Debug> fmt::Debug for DamageSnapshot<N, Logical> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DamageTrackerSnapshot")
+        f.debug_struct("DamageSnapshot")
             .field("commit_counter", &self.commit_counter)
             .field("damage", &self.damage)
             .finish()
@@ -141,15 +141,15 @@ impl<N: fmt::Debug> fmt::Debug for DamageTrackerSnapshot<N, Logical> {
 
 const MAX_DAMAGE: usize = 4;
 
-impl<N, Kind> Default for DamageTracker<N, Kind> {
+impl<N, Kind> Default for DamageBag<N, Kind> {
     fn default() -> Self {
-        DamageTracker::new(MAX_DAMAGE)
+        DamageBag::new(MAX_DAMAGE)
     }
 }
 
-impl<N, Kind> DamageTrackerSnapshot<N, Kind> {
+impl<N, Kind> DamageSnapshot<N, Kind> {
     fn new(limit: usize) -> Self {
-        DamageTrackerSnapshot {
+        DamageSnapshot {
             limit,
             commit_counter: CommitCounter::default(),
             damage: VecDeque::with_capacity(limit),
@@ -158,7 +158,7 @@ impl<N, Kind> DamageTrackerSnapshot<N, Kind> {
 
     /// Create an empty damage snapshot
     pub fn empty() -> Self {
-        DamageTrackerSnapshot {
+        DamageSnapshot {
             limit: 0,
             commit_counter: CommitCounter::default(),
             damage: VecDeque::default(),
@@ -168,8 +168,8 @@ impl<N, Kind> DamageTrackerSnapshot<N, Kind> {
     /// Gets the current [`CommitCounter`] of this snapshot
     ///
     /// The returned [`CommitCounter`] should be stored after
-    /// calling [`damage_since`](DamageTrackerSnapshot::damage_since)
-    /// and provided to the next call of [`damage_since`](DamageTrackerSnapshot::damage_since)
+    /// calling [`damage_since`](DamageSnapshot::damage_since)
+    /// and provided to the next call of [`damage_since`](DamageSnapshot::damage_since)
     /// to query the damage between these two [`CommitCounter`]s.
     pub fn current_commit(&self) -> CommitCounter {
         self.commit_counter
@@ -186,7 +186,7 @@ impl<N, Kind> DamageTrackerSnapshot<N, Kind> {
     }
 }
 
-impl<N: Coordinate, Kind> DamageTrackerSnapshot<N, Kind> {
+impl<N: Coordinate, Kind> DamageSnapshot<N, Kind> {
     /// Get the damage since the last commit
     ///
     /// Returns `None` in case the [`CommitCounter`] is too old
@@ -238,12 +238,12 @@ impl<N: Coordinate, Kind> DamageTrackerSnapshot<N, Kind> {
     }
 }
 
-impl<N, Kind> DamageTracker<N, Kind> {
-    /// Initialize a a new [`DamageTracker`]
+impl<N, Kind> DamageBag<N, Kind> {
+    /// Initialize a a new [`DamageBag`] with the specified limit
     pub fn new(limit: usize) -> Self {
-        DamageTracker {
+        DamageBag {
             limit,
-            state: DamageTrackerSnapshot::new(limit),
+            state: DamageSnapshot::new(limit),
         }
     }
 
@@ -266,14 +266,14 @@ impl<N, Kind> DamageTracker<N, Kind> {
     }
 }
 
-impl<N: Clone, Kind> DamageTracker<N, Kind> {
+impl<N: Clone, Kind> DamageBag<N, Kind> {
     /// Get a snapshot of the current damage
-    pub fn snapshot(&self) -> DamageTrackerSnapshot<N, Kind> {
+    pub fn snapshot(&self) -> DamageSnapshot<N, Kind> {
         self.state.clone()
     }
 }
 
-impl<N: Coordinate, Kind> DamageTracker<N, Kind> {
+impl<N: Coordinate, Kind> DamageBag<N, Kind> {
     /// Add some damage to the tracker
     pub fn add(&mut self, damage: impl IntoIterator<Item = Rectangle<N, Kind>>) {
         self.state.add(damage)

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -20,7 +20,7 @@ use tracing::{error, instrument, warn};
 
 use wayland_server::protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface};
 
-use super::{CommitCounter, DamageTracker, SurfaceView};
+use super::{CommitCounter, DamageBag, SurfaceView};
 
 /// Type stored in WlSurface states data_map
 ///
@@ -40,7 +40,7 @@ pub struct RendererSurfaceState {
     pub(crate) buffer_delta: Option<Point<i32, Logical>>,
     pub(crate) buffer_has_alpha: Option<bool>,
     pub(crate) buffer: Option<Buffer>,
-    pub(crate) damage: DamageTracker<i32, BufferCoord>,
+    pub(crate) damage: DamageBag<i32, BufferCoord>,
     pub(crate) renderer_seen: HashMap<(TypeId, usize), CommitCounter>,
     pub(crate) textures: HashMap<(TypeId, usize), Box<dyn std::any::Any>>,
     pub(crate) surface_view: Option<SurfaceView>,

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -4,7 +4,7 @@
 use crate::{
     backend::renderer::{
         damage::{
-            DamageTrackedRenderer, DamageTrackedRendererError, DamageTrackedRendererMode, OutputNoMode,
+            Error as OutputDamageTrackerError, OutputDamageTracker, OutputDamageTrackerMode, OutputNoMode,
         },
         element::{AsRenderElements, RenderElement, RenderElementStates, Wrap},
         Renderer, Texture,
@@ -664,16 +664,16 @@ pub fn render_output<
     age: usize,
     spaces: S,
     custom_elements: &'a [C],
-    damage_tracked_renderer: &mut DamageTrackedRenderer,
+    damage_tracker: &mut OutputDamageTracker,
     clear_color: [f32; 4],
-) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), DamageTrackedRendererError<R>>
+) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), OutputDamageTrackerError<R>>
 where
     <R as Renderer>::TextureId: Texture + 'static,
     <E as AsRenderElements<R>>::RenderElement: 'a,
     SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>:
         From<Wrap<<E as AsRenderElements<R>>::RenderElement>>,
 {
-    if let DamageTrackedRendererMode::Auto(renderer_output) = damage_tracked_renderer.mode() {
+    if let OutputDamageTrackerMode::Auto(renderer_output) = damage_tracker.mode() {
         assert!(renderer_output == output);
     }
 
@@ -685,5 +685,5 @@ where
     render_elements.extend(custom_elements.iter().map(OutputRenderElements::Custom));
     render_elements.extend(space_render_elements.into_iter().map(OutputRenderElements::Space));
 
-    damage_tracked_renderer.render_output(renderer, age, &render_elements, clear_color)
+    damage_tracker.render_output(renderer, age, &render_elements, clear_color)
 }

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -7,7 +7,7 @@ use std::{
 use smithay::{
     backend::{
         input::ButtonState,
-        renderer::{damage::DamageTrackedRenderer, element::AsRenderElements},
+        renderer::{damage::OutputDamageTracker, element::AsRenderElements},
     },
     input::pointer::{
         ButtonEvent, CursorImageAttributes, CursorImageStatus, MotionEvent, RelativeMotionEvent,
@@ -85,7 +85,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
     output.set_preferred(mode);
     state.space.map_output(&output, (0, 0));
 
-    let mut damage_tracked_renderer = DamageTrackedRenderer::from_output(&output);
+    let mut damage_tracker = OutputDamageTracker::from_output(&output);
     let mut pointer_element = PointerElement::default();
 
     while state.running.load(Ordering::SeqCst) {
@@ -157,7 +157,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
                 &state.space,
                 elements,
                 &mut renderer,
-                &mut damage_tracked_renderer,
+                &mut damage_tracker,
                 0,
                 false,
             );


### PR DESCRIPTION
The naming of `DamageTrackedRenderer` implies that it is a renderer, which it is not. Fix this inaccuracy by renaming:

- `DamageTrackedRenderer` -> `OutputDamageTracker`
- `DamageTracker` -> `DamageBag`
- `DamageTrackerSnapshot` -> `DamageSnapshot`

This also documents the expected z-order of elements.

fixes #895 