### PR TITLE
layer: Limit `size` to `source.size`

### DIFF
--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -324,6 +324,8 @@ impl LayerMap {
                 }
 
                 let mut size = data.size;
+                size.w = size.w.min(source.size.w);
+                size.h = size.h.min(source.size.h);
                 if size.w == 0 {
                     size.w = source.size.w / 2;
                 }


### PR DESCRIPTION
A shell surface shouldn't receive `configure` with a larger size than the space available to it. Also, the positioning logic here behaves in an unexpected way if `(source.size.h / 2) - (size.h / 2)` is negative.