### PR TITLE
Adding link to calloop crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@
 //! ### Logging
 //!
 //! TODO: docs about tracing
+//!
+//! [`calloop`]: https://crates.io/crates/calloop
 
 pub mod backend;
 #[cfg(feature = "desktop")]


### PR DESCRIPTION
The [docs] about [`calloop`] arent' correctly linked a the moment.


[docs]: https://smithay.github.io/smithay/smithay/index.html#the-event-loop-and-state-handling
[`calloop`]: https://crates.io/crates/calloop