### PR TITLE
Restructure "Structure of the crate" doc section

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,17 @@
 //!
 //! ## Structure of the crate
 //!
-//! The provided helpers are split into two main modules. [`backend`] contains helpers for interacting with
-//! the operating system, such as session management, interactions with the graphic stack and input
-//! processing. On the other hand, [`wayland`] contains helpers for interacting with wayland clients
-//! according to the wayland protocol. In addition, the [`xwayland`] module contains helpers for managing
-//! an XWayland instance if you want to support it. See the documentation of these respective modules for
-//! information about their usage.
+//! The provided helpers are split into two main modules:
+//!
+//! - [`backend`] contains helpers for interacting with the operating
+//!     system, such as session management, interactions with the graphic stack
+//!     and input processing.
+//! - [`wayland`] contains helpers for interacting with wayland clients
+//!     according to the wayland protocol.
+//!
+//!     In addition, the [`xwayland`] module contains helpers for managing an
+//!     XWayland instance if you want to support it. See the documentation of
+//!     these respective modules for information about their usage.
 //!
 //! ## General principles for using Smithay
 //!


### PR DESCRIPTION
How it looks at the moment:

![image](https://user-images.githubusercontent.com/50843046/229351546-885ae371-695b-4e85-8fe7-90def6db29e5.png)

How it looks like with this PR:

![image](https://user-images.githubusercontent.com/50843046/229351578-ce299360-c9d7-4d55-9061-40c9ddcb2951.png)

Makes it easier to see which two modules you mean in my opinion.
