### PR TITLE
replacing `dev_id: dev_t` with DrmNode

### DIFF
--- a/src/backend/drm/error.rs
+++ b/src/backend/drm/error.rs
@@ -2,6 +2,8 @@ use crate::backend::SwapBuffersError;
 use drm::control::{connector, crtc, plane, Mode, RawResourceHandle};
 use std::path::PathBuf;
 
+use super::CreateDrmNodeError;
+
 /// Errors thrown by the [`DrmDevice`](crate::backend::drm::DrmDevice)
 /// and the [`DrmSurface`](crate::backend::drm::DrmSurface).
 #[derive(thiserror::Error, Debug)]
@@ -68,6 +70,10 @@ pub enum Error {
     /// Atomic Test failed for new properties
     #[error("Atomic Test failed for new properties on crtc ({0:?})")]
     TestFailed(crtc::Handle),
+
+    /// Creating a DrmNode failed.
+    #[error(transparent)]
+    CreateDrmNodeError(#[from] CreateDrmNodeError),
 }
 
 impl From<Error> for SwapBuffersError {

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -6,12 +6,11 @@ use std::sync::Arc;
 use drm::control::{connector, crtc, framebuffer, plane, property, Device as ControlDevice, Mode};
 use drm::{Device as BasicDevice, DriverCapability};
 
-use nix::libc::dev_t;
-
 pub(super) mod atomic;
 #[cfg(feature = "backend_gbm")]
 pub(super) mod gbm;
 pub(super) mod legacy;
+use super::DrmNode;
 use super::{
     device::PlaneClaimStorage, error::Error, plane_type, planes, DrmDeviceFd, PlaneClaim, PlaneType, Planes,
 };
@@ -30,7 +29,7 @@ use tracing::trace;
 pub struct DrmSurface {
     // This field is only read when 'backend_session' is enabled
     #[allow(dead_code)]
-    pub(super) dev_id: dev_t,
+    pub(super) dev_id: DrmNode,
     pub(super) crtc: crtc::Handle,
     pub(super) primary: plane::Handle,
     pub(super) internal: Arc<DrmSurfaceInternal>,


### PR DESCRIPTION
Since the `DrmNode` basically acts as a `dev_id`, why not using it instead of the `dev_t` type?

There are some breaking changes sadly (like return-type of a function differs), so I'm not sure if it's really "worth it".
What do you guys think?