### PR TITLE
gles: Fix BGRA usage out of spec

### DIFF
--- a/src/backend/renderer/gles/format.rs
+++ b/src/backend/renderer/gles/format.rs
@@ -7,7 +7,7 @@ use crate::backend::allocator::Fourcc;
 pub const fn fourcc_to_gl_formats(value: Fourcc) -> Option<(GLenum, GLenum, GLenum)> {
     match value {
         Fourcc::Abgr8888 => Some((ffi::RGBA8, ffi::RGBA, ffi::UNSIGNED_BYTE)),
-        Fourcc::Argb8888 => Some((ffi::RGBA8, ffi::BGRA_EXT, ffi::UNSIGNED_BYTE)),
+        Fourcc::Argb8888 => Some((ffi::BGRA_EXT, ffi::BGRA_EXT, ffi::UNSIGNED_BYTE)),
         Fourcc::Abgr2101010 => Some((ffi::RGB10_A2, ffi::RGBA, ffi::UNSIGNED_INT_2_10_10_10_REV)),
         Fourcc::Abgr16161616f => Some((ffi::RGBA16F, ffi::RGBA, ffi::HALF_FLOAT)),
         _ => None,

--- a/src/backend/renderer/gles/shaders/implicit/mod.rs
+++ b/src/backend/renderer/gles/shaders/implicit/mod.rs
@@ -45,7 +45,8 @@ impl GlesTexProgram {
         has_alpha: bool,
     ) -> &GlesTexProgramVariant {
         match format {
-            Some(ffi::RGBA8) | Some(ffi::RGB10_A2) | Some(ffi::RGBA16F) => {
+            Some(ffi::BGRA_EXT) | Some(ffi::RGBA) | Some(ffi::RGBA8) | Some(ffi::RGB10_A2)
+            | Some(ffi::RGBA16F) => {
                 if has_alpha {
                     &self.0.variants[0]
                 } else {


### PR DESCRIPTION
The nvidia-driver isn't very happy about us using `RGBA8` as an internal representation while reading the texture as `BGRA_EXT`. Mesa accepts that happily (probably converting internally), but nothing in the extension-spec says, that this is supposed to work.

Luckily storing the texture internally as BGRA, doesn't seem to have an effect on rendering. The colors are not inverted when accessing them in the shader, it just has an effect on reading back the texture with `ExportMem::copy_texture`, which shouldn't be a problem.
