### PR TITLE
SubsurfaceUserData: Add an accessor for the parent surface

### DIFF
--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -423,6 +423,13 @@ where
 pub struct SubsurfaceUserData {
     surface: WlSurface,
 }
+
+impl SubsurfaceUserData {
+    /// Returns the surface for this subsurface (not to be confused with the parent surface).
+    pub fn surface(&self) -> &WlSurface {
+        &self.surface
+    }
+}
 /// The cached state associated with a subsurface
 #[derive(Debug)]
 pub struct SubsurfaceCachedState {


### PR DESCRIPTION
Wayland defines subsurfaces in terms of a surface with a role. Smithay also treats it as such and this is problematic for protocol that is designed to work with wl_subsurface objects directly. Without a mechanism to obtain the underlying protocol implementations external to Smithay are unable to perform any operations.

Here is an example of usage using Chrome specific protocol (whose actually usefulness is out of scope).

```
augmented_sub_surface::Request::SetPosition { x, y } => {
    if x.trunc() != x || y.trunc() != y {
        info!("Unsupported float offset x:{x} y:{y}");
    }
    with_states(
        data.wl_subsurface
            .upgrade()
            .unwrap()
            .data::<SubsurfaceUserData>()
            .unwrap()
            .surface(),
        |states| {
            states
                .cached_state
                .pending::<SubsurfaceCachedState>()
                .location = (x as i32, y as i32).into()
        },
    );
}
```