### PR TITLE
anvil: Don't use Renderbuffer for offscreen cursor

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -37,7 +37,7 @@ use smithay::{
         renderer::{
             damage::{Error as OutputDamageTrackerError, OutputDamageTracker},
             element::{texture::TextureBuffer, AsRenderElements, RenderElement, RenderElementStates},
-            gles::{GlesRenderbuffer, GlesRenderer},
+            gles::{GlesRenderer, GlesTexture},
             multigpu::{gbm::GbmGlesBackend, GpuManager, MultiRenderer, MultiTexture},
             Bind, DebugFlags, ExportMem, ImportDma, ImportMemWl, Offscreen, Renderer,
         },
@@ -1494,7 +1494,7 @@ fn render_surface<'a, 'b>(
     let (rendered, states) =
         surface
             .compositor
-            .render_frame::<_, _, GlesRenderbuffer>(renderer, &elements, clear_color)?;
+            .render_frame::<_, _, GlesTexture>(renderer, &elements, clear_color)?;
 
     post_repaint(
         output,
@@ -1527,7 +1527,7 @@ fn initial_render(
 ) -> Result<(), SwapBuffersError> {
     surface
         .compositor
-        .render_frame::<_, CustomRenderElements<_>, GlesRenderbuffer>(renderer, &[], CLEAR_COLOR)?;
+        .render_frame::<_, CustomRenderElements<_>, GlesTexture>(renderer, &[], CLEAR_COLOR)?;
     surface.compositor.queue_frame(None)?;
     surface.compositor.reset_buffers();
 


### PR DESCRIPTION
With #991 being merged, we are now calling glRenderbufferStorage with GL_BGRA_EXT, if a renderbuffer is initialized with A/Xrgb8888 formats.

While this is technically correct, the docs of the EXT_texture_format_BGRA8888 [1] only mention:

> This extension provides an additional format and type combination
    for use when specifying **texture data**.

This is problematic, because we are currently using a Renderbuffer for offscreen cursor plane rendering in anvil for the `DrmCompositor`.

Furthermore glReadPixels is not guaranteed to support any read format besides `GL_RGBA` [2]. Fortunately it is pretty likely, that the driver will let us read the contents with GL_BGRA_EXT, if the internal storage is also GL_BGRA_EXT (though we should really check that with `GL_IMPLEMENTATION_COLOR_READ_FORMAT` and manually swizzle otherwise).

So lets use a texture as a framebuffer target instead of a renderbuffer, which will satisfy the extension and no longer spam the log with GL_INVALID_ENUM and hopefully will also let us read back the data in BGRA ordering.

[1] https://registry.khronos.org/OpenGL/extensions/EXT/EXT_texture_format_BGRA8888.txt
[2] https://docs.gl/es3/glReadPixels