### PR TITLE
renderer: allow BGRA_EXT in gles 2.0

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -780,6 +780,7 @@ impl ImportMemWl for GlesRenderer {
             if self.gl_version.major == 2 {
                 // es 2.0 doesn't define sized variants
                 internal_format = match internal_format {
+                    ffi::BGRA_EXT => ffi::BGRA_EXT,
                     ffi::RGBA8 => ffi::RGBA,
                     ffi::RGB8 => ffi::RGB,
                     _ => unreachable!(),


### PR DESCRIPTION
we always map Argb8888 to BGRA_EXT, so we also have to handle that in the gles 2.0 code path

fixes broken shm clients when run with opengl es 2.0 (either on real hardware or forcing with `MESA_GLES_VERSION_OVERRIDE="2.0"`)