### PR TITLE
ci: Fix unnecessary mut for &mut references

### DIFF
--- a/src/backend/allocator/swapchain.rs
+++ b/src/backend/allocator/swapchain.rs
@@ -165,8 +165,7 @@ where
             .find(|s| !s.acquired.swap(true, Ordering::SeqCst))
         {
             if free_slot.buffer.is_none() {
-                let mut free_slot =
-                    Arc::get_mut(free_slot).expect("Acquired was false, but Arc is not unique?");
+                let free_slot = Arc::get_mut(free_slot).expect("Acquired was false, but Arc is not unique?");
                 match self
                     .allocator
                     .create_buffer(self.width, self.height, self.fourcc, &self.modifiers)

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -2455,7 +2455,7 @@ where
             trace!("repositioning cursor plane");
             let mut plane_state = previous_state.plane_state(plane_info.handle).unwrap().clone();
             plane_state.skip = false;
-            let mut config = plane_state.config.as_mut().unwrap();
+            let config = plane_state.config.as_mut().unwrap();
             config.dst.loc = cursor_plane_location;
             let res = frame_state.test_state(&self.surface, plane_info.handle, plane_state, false);
 

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -653,7 +653,7 @@ impl AxisFrame {
     /// the nature of the axis event. E.g. a scroll wheel might issue separate steps,
     /// while a touchpad may never issue this event as it has no steps.
     pub fn discrete(mut self, axis: Axis, steps: i32) -> Self {
-        let mut discrete = self.discrete.get_or_insert_with(Default::default);
+        let discrete = self.discrete.get_or_insert_with(Default::default);
         match axis {
             Axis::Horizontal => {
                 discrete.0 = steps;


### PR DESCRIPTION
New rust nightly detects this and causes CI to fail.