### PR TITLE
deps: Update glow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ drm = { version = "0.9.0", optional = true }
 drm-ffi = { version = "0.5.0", optional = true }
 
 gbm = { version = "0.12.0", optional = true, default-features = false, features = ["drm-support"] }
-glow = { version = "0.11.2", optional = true }
+glow = { version = "0.12", optional = true }
 input = { version = "0.8.2", default-features = false, features=["libinput_1_14"], optional = true }
 indexmap = "1.9"
 lazy_static = "1"


### PR DESCRIPTION
This is necessary to use egui 0.21 in smithay-egui.