### PR TITLE
wayland: Surface Transactions

### DIFF
--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -97,10 +97,7 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
     }
     fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState {
         if let Some(state) = client.get_data::<XWaylandClientData>() {
-            state
-                .user_data()
-                .insert_if_missing(CompositorClientState::default);
-            return state.user_data().get::<CompositorClientState>().unwrap();
+            return &state.compositor_state;
         }
         if let Some(state) = client.get_data::<ClientState>() {
             return &state.compositor_state;

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -37,7 +37,7 @@ use smithay::{
     },
     utils::{Clock, Logical, Monotonic, Point},
     wayland::{
-        compositor::{get_parent, with_states, CompositorState},
+        compositor::{get_parent, with_states, CompositorClientState, CompositorState},
         data_device::{
             set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
             ServerDndGrabHandler,
@@ -87,7 +87,9 @@ pub struct CalloopData<BackendData: Backend + 'static> {
 }
 
 #[derive(Debug, Default)]
-pub struct ClientState;
+pub struct ClientState {
+    pub compositor_state: CompositorClientState,
+}
 impl ClientData for ClientState {
     /// Notification that a client was initialized
     fn initialized(&self, _client_id: ClientId) {}
@@ -395,7 +397,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                     if let Err(err) = data
                         .display
                         .handle()
-                        .insert_client(client_stream, Arc::new(ClientState))
+                        .insert_client(client_stream, Arc::new(ClientState::default()))
                     {
                         warn!("Error adding wayland client: {}", err);
                     };

--- a/examples/compositor.rs
+++ b/examples/compositor.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use smithay::delegate_compositor;
 use smithay::reexports::wayland_server::Display;
 
-use smithay::wayland::compositor::{CompositorHandler, CompositorState};
+use smithay::wayland::compositor::{CompositorClientState, CompositorHandler, CompositorState};
 
 use wayland_server::backend::{ClientData, ClientId, DisconnectReason};
 use wayland_server::protocol::wl_surface::WlSurface;
-use wayland_server::ListeningSocket;
+use wayland_server::{Client, ListeningSocket};
 
 struct App {
     compositor_state: CompositorState,
@@ -16,6 +16,10 @@ struct App {
 impl CompositorHandler for App {
     fn compositor_state(&mut self) -> &mut CompositorState {
         &mut self.compositor_state
+    }
+
+    fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState {
+        &client.get_data::<ClientState>().unwrap().compositor_state
     }
 
     fn commit(&mut self, surface: &WlSurface) {
@@ -41,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let client = display
                 .handle()
-                .insert_client(stream, Arc::new(ClientState))
+                .insert_client(stream, Arc::new(ClientState::default()))
                 .unwrap();
             clients.push(client);
         }
@@ -51,7 +55,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-struct ClientState;
+#[derive(Default)]
+struct ClientState {
+    compositor_state: CompositorClientState,
+}
 impl ClientData for ClientState {
     fn initialized(&self, _client_id: ClientId) {
         println!("initialized");

--- a/smallvil/src/handlers/compositor.rs
+++ b/smallvil/src/handlers/compositor.rs
@@ -1,11 +1,16 @@
-use crate::{grabs::resize_grab, Smallvil};
+use crate::{grabs::resize_grab, state::ClientState, Smallvil};
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
     delegate_compositor, delegate_shm,
-    reexports::wayland_server::protocol::{wl_buffer, wl_surface::WlSurface},
+    reexports::wayland_server::{
+        protocol::{wl_buffer, wl_surface::WlSurface},
+        Client,
+    },
     wayland::{
         buffer::BufferHandler,
-        compositor::{get_parent, is_sync_subsurface, CompositorHandler, CompositorState},
+        compositor::{
+            get_parent, is_sync_subsurface, CompositorClientState, CompositorHandler, CompositorState,
+        },
         shm::{ShmHandler, ShmState},
     },
 };
@@ -15,6 +20,10 @@ use super::xdg_shell;
 impl CompositorHandler for Smallvil {
     fn compositor_state(&mut self) -> &mut CompositorState {
         &mut self.compositor_state
+    }
+
+    fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState {
+        &client.get_data::<ClientState>().unwrap().compositor_state
     }
 
     fn commit(&mut self, surface: &WlSurface) {

--- a/smallvil/src/state.rs
+++ b/smallvil/src/state.rs
@@ -13,8 +13,12 @@ use smithay::{
     },
     utils::{Logical, Point},
     wayland::{
-        compositor::CompositorState, data_device::DataDeviceState, output::OutputManagerState,
-        shell::xdg::XdgShellState, shm::ShmState, socket::ListeningSocketSource,
+        compositor::{CompositorClientState, CompositorState},
+        data_device::DataDeviceState,
+        output::OutputManagerState,
+        shell::xdg::XdgShellState,
+        shm::ShmState,
+        socket::ListeningSocketSource,
     },
 };
 
@@ -113,7 +117,7 @@ impl Smallvil {
                 state
                     .display
                     .handle()
-                    .insert_client(client_stream, Arc::new(ClientState))
+                    .insert_client(client_stream, Arc::new(ClientState::default()))
                     .unwrap();
             })
             .expect("Failed to init the wayland event source.");
@@ -149,7 +153,11 @@ impl Smallvil {
     }
 }
 
-pub struct ClientState;
+#[derive(Default)]
+pub struct ClientState {
+    pub compositor_state: CompositorClientState,
+}
+
 impl ClientData for ClientState {
     fn initialized(&self, _client_id: ClientId) {}
     fn disconnected(&self, _client_id: ClientId, _reason: DisconnectReason) {}

--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -10,10 +10,17 @@
 //! This can be especially useful in resources where other parts of the stack should decide upon
 //! the lifetime of the buffer. E.g. when you are only caching associated resources for a dmabuf.
 
+use calloop::generic::Generic;
+use calloop::{EventSource, Interest, Mode, PostAction};
+use nix::poll;
+
 use super::{Allocator, Buffer, Format, Fourcc, Modifier};
 use crate::utils::{Buffer as BufferCoords, Size};
+#[cfg(feature = "wayland_frontend")]
+use crate::wayland::compositor::{Blocker, BlockerState};
 use std::hash::{Hash, Hasher};
-use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 use std::{error, fmt};
 
@@ -217,6 +224,19 @@ impl Dmabuf {
     pub fn weak(&self) -> WeakDmabuf {
         WeakDmabuf(Arc::downgrade(&self.0))
     }
+
+    /// Create an [`calloop::EventSource`] and [`crate::wayland::compositor::Blocker`] for this [`Dmabuf`].
+    ///
+    /// Usually used to block applying surface state on the readiness of an attached dmabuf.
+    #[cfg(feature = "wayland_frontend")]
+    pub fn generate_blocker(
+        &self,
+        interest: Interest,
+    ) -> Result<(DmabufBlocker, DmabufSource), AlreadyReady> {
+        let source = DmabufSource::new(self.clone(), interest)?;
+        let blocker = DmabufBlocker(source.signal.clone());
+        Ok((blocker, source))
+    }
 }
 
 impl WeakDmabuf {
@@ -297,5 +317,197 @@ where
             .create_buffer(width, height, fourcc, modifiers)
             .map_err(|err| AnyError(err.into()))
             .and_then(|b| AsDmabuf::export(&b).map_err(|err| AnyError(err.into())))
+    }
+}
+
+/// [`crate::wayland::compositor::Blocker`] implementation for an accompaning [`DmabufSource`]
+#[cfg(feature = "wayland_frontend")]
+#[derive(Debug)]
+pub struct DmabufBlocker(Arc<AtomicBool>);
+
+#[cfg(feature = "wayland_frontend")]
+impl Blocker for DmabufBlocker {
+    fn state(&self) -> BlockerState {
+        if self.0.load(Ordering::SeqCst) {
+            BlockerState::Released
+        } else {
+            BlockerState::Pending
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Subsource {
+    Active(Generic<RawFd, std::io::Error>),
+    Done(Generic<RawFd, std::io::Error>),
+    Empty,
+}
+
+impl Subsource {
+    fn done(&mut self) {
+        let mut this = Subsource::Empty;
+        std::mem::swap(self, &mut this);
+        match this {
+            Subsource::Done(source) | Subsource::Active(source) => {
+                *self = Subsource::Done(source);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// [`Dmabuf`]-based event source. Can be used to monitor implicit fences of a dmabuf.
+#[derive(Debug)]
+pub struct DmabufSource {
+    dmabuf: Dmabuf,
+    signal: Arc<AtomicBool>,
+    sources: [Subsource; 4],
+}
+
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[error("Dmabuf is already ready for the given interest")]
+/// Dmabuf is already ready for the given interest
+pub struct AlreadyReady;
+
+impl DmabufSource {
+    /// Creates a new [`DmabufSource`] from a [`Dmabuf`] and interest.
+    ///
+    /// This event source will monitor the implicit fences of the given dmabuf.
+    /// Monitoring for READ-access will monitor the state of the most recent write or exclusive fence.
+    /// Monitoring for WRITE-access, will monitor state of all attached fences, shared and exclusive ones.
+    ///
+    /// The event source is a one shot event source and will remove itself from the event loop after being triggered once.
+    /// To monitor for new fences added at a later time a new DmabufSource needs to be created.
+    ///
+    /// Returns `AlreadyReady` if all corresponding fences are already signalled or if `interest` is empty.
+    pub fn new(dmabuf: Dmabuf, interest: Interest) -> Result<Self, AlreadyReady> {
+        if !interest.readable && !interest.writable {
+            return Err(AlreadyReady);
+        }
+
+        let mut sources = [
+            Subsource::Empty,
+            Subsource::Empty,
+            Subsource::Empty,
+            Subsource::Empty,
+        ];
+        for (idx, handle) in dmabuf.handles().enumerate() {
+            // SAFETY: This is stored together with the Dmabuf holding the owned file descriptors
+            let fd = handle.as_raw_fd();
+            if matches!(
+                poll::poll(
+                    &mut [poll::PollFd::new(
+                        fd,
+                        if interest.writable {
+                            poll::PollFlags::POLLOUT
+                        } else {
+                            poll::PollFlags::POLLIN
+                        },
+                    )],
+                    0
+                ),
+                Ok(1)
+            ) {
+                continue;
+            }
+            sources[idx] = Subsource::Active(Generic::new(fd, interest, Mode::OneShot));
+        }
+        if sources
+            .iter()
+            .all(|x| matches!(x, Subsource::Done(_) | Subsource::Empty))
+        {
+            Err(AlreadyReady)
+        } else {
+            Ok(DmabufSource {
+                dmabuf,
+                sources,
+                signal: Arc::new(AtomicBool::new(false)),
+            })
+        }
+    }
+}
+
+impl EventSource for DmabufSource {
+    type Event = ();
+    type Metadata = Dmabuf;
+    type Ret = Result<(), std::io::Error>;
+
+    type Error = std::io::Error;
+
+    fn process_events<F>(
+        &mut self,
+        readiness: calloop::Readiness,
+        token: calloop::Token,
+        mut callback: F,
+    ) -> Result<PostAction, Self::Error>
+    where
+        F: FnMut(Self::Event, &mut Self::Metadata) -> Self::Ret,
+    {
+        for i in 0..4 {
+            if let Ok(PostAction::Remove) = if let Subsource::Active(ref mut source) = &mut self.sources[i] {
+                // luckily Generic skips events for other tokens
+                source.process_events(readiness, token, |_, _| Ok(PostAction::Remove))
+            } else {
+                Ok(PostAction::Continue)
+            } {
+                self.sources[i].done();
+            }
+        }
+
+        if self
+            .sources
+            .iter()
+            .all(|x| matches!(x, Subsource::Done(_) | Subsource::Empty))
+        {
+            self.signal.store(true, Ordering::SeqCst);
+            callback((), &mut self.dmabuf)?;
+            Ok(PostAction::Remove)
+        } else {
+            Ok(PostAction::Reregister)
+        }
+    }
+
+    fn register(
+        &mut self,
+        poll: &mut calloop::Poll,
+        token_factory: &mut calloop::TokenFactory,
+    ) -> calloop::Result<()> {
+        for source in self.sources.iter_mut().filter_map(|source| match source {
+            Subsource::Active(ref mut source) => Some(source),
+            _ => None,
+        }) {
+            source.register(poll, token_factory)?;
+        }
+        Ok(())
+    }
+
+    fn reregister(
+        &mut self,
+        poll: &mut calloop::Poll,
+        token_factory: &mut calloop::TokenFactory,
+    ) -> calloop::Result<()> {
+        for source in self.sources.iter_mut() {
+            match source {
+                Subsource::Active(ref mut source) => source.reregister(poll, token_factory)?,
+                Subsource::Done(ref mut source) => {
+                    let _ = source.unregister(poll);
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn unregister(&mut self, poll: &mut calloop::Poll) -> calloop::Result<()> {
+        for source in self.sources.iter_mut() {
+            match source {
+                Subsource::Active(ref mut source) => source.unregister(poll)?,
+                Subsource::Done(ref mut source) => {
+                    let _ = source.unregister(poll);
+                }
+                _ => {}
+            }
+        }
+        Ok(())
     }
 }

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -244,7 +244,7 @@ where
             wl_surface::Request::Commit => {
                 PrivateSurfaceData::invoke_pre_commit_hooks(state, handle, surface);
 
-                PrivateSurfaceData::commit(surface, handle);
+                PrivateSurfaceData::commit(surface, handle, state);
 
                 PrivateSurfaceData::invoke_post_commit_hooks(state, handle, surface);
 

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -245,12 +245,6 @@ where
                 PrivateSurfaceData::invoke_pre_commit_hooks(state, handle, surface);
 
                 PrivateSurfaceData::commit(surface, handle, state);
-
-                PrivateSurfaceData::invoke_post_commit_hooks(state, handle, surface);
-
-                trace!("Calling user implementation for wl_surface.commit");
-
-                state.commit(surface);
             }
             wl_surface::Request::SetBufferTransform { transform } => {
                 if let WEnum::Value(transform) = transform {

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -63,7 +63,7 @@ where
     D: 'static,
 {
     fn request(
-        _state: &mut D,
+        state: &mut D,
         _client: &wayland_server::Client,
         _resource: &WlCompositor,
         request: wl_compositor::Request,
@@ -84,6 +84,7 @@ where
                     },
                 );
                 PrivateSurfaceData::init(&surface);
+                state.new_surface(&surface);
             }
             wl_compositor::Request::CreateRegion { id } => {
                 trace!(id = ?id, "Creating a new wl_region");

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -530,14 +530,14 @@ impl CompositorClientState {
     /// To be called, when a previously added blocker (via [`add_blocker`])
     /// got `Released` or `Cancelled` from being `Pending` previously for any
     /// surface belonging to this client.
-    pub fn blocker_cleared<D: CompositorHandler>(
+    pub fn blocker_cleared<D: CompositorHandler + 'static>(
         &self,
         surface: &WlSurface,
         state: &mut D,
         dh: &DisplayHandle,
     ) {
         if let Some(queue) = self.queue.lock().unwrap().as_mut() {
-            if queue.apply_ready(dh) {
+            if queue.apply_ready(dh, state) {
                 CompositorHandler::commit(state, surface)
             }
         }

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -509,6 +509,14 @@ pub trait CompositorHandler {
     /// to ensure automatic cleanup of the state, when the client disconnects.
     fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState;
 
+    /// New surface handler.
+    ///
+    /// This handler can be used to setup hooks (see [`add_pre_commit_hook`]/[`add_post_commit_hook`]/[`add_destruction_hook`]),
+    /// but not much else. The surface has no role or attached data at this point and cannot be rendered.
+    fn new_surface(&mut self, surface: &WlSurface) {
+        let _ = surface;
+    }
+
     /// Surface commit handler
     ///
     /// This is called when any changed state from a commit actually becomes visible.

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -510,6 +510,13 @@ pub trait CompositorHandler {
     fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState;
 
     /// Surface commit handler
+    ///
+    /// This is called when any changed state from a commit actually becomes visible.
+    /// That might be some time after the actual commit has taken place, if the
+    /// state changes are delayed by an added blocker (see [`add_blocker`]).
+    ///
+    /// If you need to handle a commit as soon as it occurs, you might want to consider
+    /// using a pre-commit hook (see [`add_pre_commit_hook`]).
     fn commit(&mut self, surface: &WlSurface);
 }
 

--- a/src/wayland/compositor/transaction.rs
+++ b/src/wayland/compositor/transaction.rs
@@ -237,8 +237,8 @@ impl TransactionQueue {
         self.transactions.push(t);
     }
 
-    pub(crate) fn apply_ready<C: CompositorHandler>(&mut self, dh: &DisplayHandle, state: &mut C) -> bool {
-        let mut applied = false;
+    pub(crate) fn take_ready(&mut self) -> Vec<Transaction> {
+        let mut ready_transactions = Vec::new();
         // this is a very non-optimized implementation
         // we just iterate over the queue of transactions, keeping track of which
         // surface we have seen as they encode transaction dependencies
@@ -288,10 +288,10 @@ impl TransactionQueue {
                 i += 1;
             } else {
                 // this transaction is to be applied, yay!
-                self.transactions.remove(i).apply(dh, state);
-                applied = true;
+                ready_transactions.push(self.transactions.remove(i));
             }
         }
-        applied
+
+        ready_transactions
     }
 }

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -3,7 +3,7 @@ use crate::{utils::Serial, wayland::compositor::SUBSURFACE_ROLE};
 use super::{
     cache::MultiCache,
     handlers::{is_effectively_sync, SurfaceUserData},
-    transaction::{PendingTransaction, TransactionQueue},
+    transaction::{Blocker, PendingTransaction, TransactionQueue},
     BufferAssignment, CompositorHandler, SurfaceAttributes, SurfaceData,
 };
 use std::{
@@ -179,6 +179,12 @@ impl PrivateSurfaceData {
         let my_data_mutex = &surface.data::<SurfaceUserData>().unwrap().inner;
         let my_data = my_data_mutex.lock().unwrap();
         f(&my_data.public_data)
+    }
+
+    pub fn add_blocker(surface: &WlSurface, blocker: impl Blocker + Send + 'static) {
+        let my_data_mutex = &surface.data::<SurfaceUserData>().unwrap().inner;
+        let my_data = my_data_mutex.lock().unwrap();
+        my_data.pending_transaction.add_blocker(blocker)
     }
 
     pub fn add_pre_commit_hook(

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -238,7 +238,7 @@ impl PrivateSurfaceData {
         }
     }
 
-    pub fn commit<C: CompositorHandler>(surface: &WlSurface, dh: &DisplayHandle, state: &mut C) {
+    pub fn commit<C: CompositorHandler + 'static>(surface: &WlSurface, dh: &DisplayHandle, state: &mut C) {
         let is_sync = is_effectively_sync(surface);
         let children = PrivateSurfaceData::get_children(surface);
         let my_data_mutex = &surface.data::<SurfaceUserData>().unwrap().inner;
@@ -279,7 +279,7 @@ impl PrivateSurfaceData {
             // release the mutex, as applying the transaction will try to lock it
             std::mem::drop(my_data);
             // trigger the queue
-            queue.apply_ready(dh);
+            queue.apply_ready(dh, state);
         }
     }
 

--- a/src/wayland/content_type/mod.rs
+++ b/src/wayland/content_type/mod.rs
@@ -8,13 +8,15 @@
 //! use wayland_server::{protocol::wl_surface::WlSurface, DisplayHandle};
 //! use smithay::{
 //!     delegate_content_type, delegate_compositor,
-//!     wayland::compositor::{self, CompositorState, CompositorHandler},
+//!     wayland::compositor::{self, CompositorState, CompositorClientState, CompositorHandler},
 //!     wayland::content_type::{ContentTypeSurfaceCachedState, ContentTypeState},
 //! };
 //!
 //! pub struct State {
 //!     compositor_state: CompositorState,
 //! };
+//! struct ClientState { compositor_state: CompositorClientState }
+//! impl wayland_server::backend::ClientData for ClientState {}
 //!
 //! delegate_content_type!(State);
 //! delegate_compositor!(State);
@@ -22,6 +24,10 @@
 //! impl CompositorHandler for State {
 //!    fn compositor_state(&mut self) -> &mut CompositorState {
 //!        &mut self.compositor_state
+//!    }
+//!
+//!    fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState {
+//!        &client.get_data::<ClientState>().unwrap().compositor_state    
 //!    }
 //!
 //!    fn commit(&mut self, surface: &WlSurface) {

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -65,6 +65,8 @@ use tracing::{error, info, instrument};
 
 use super::x11_sockets::{prepare_x11_sockets, X11Lock};
 use crate::utils::user_data::UserDataMap;
+#[cfg(feature = "wayland_frontend")]
+use crate::wayland::compositor::CompositorClientState;
 
 /// The XWayland handle
 #[derive(Debug)]
@@ -208,6 +210,9 @@ struct Inner {
 #[derive(Debug)]
 pub struct XWaylandClientData {
     inner: Arc<Mutex<Inner>>,
+    /// client state of the [`wayland::compsitor`] module
+    #[cfg(feature = "wayland_frontend")]
+    pub compositor_state: CompositorClientState,
     data_map: UserDataMap,
 }
 
@@ -292,6 +297,8 @@ where
         wl_me,
         Arc::new(XWaylandClientData {
             inner: inner.clone(),
+            #[cfg(feature = "wayland_frontend")]
+            compositor_state: CompositorClientState::default(),
             data_map,
         }),
     )?;


### PR DESCRIPTION
Best reviewed commit-by-commit:

**[compositor: Use the TransactionQueue](https://github.com/Smithay/smithay/commit/71f145b59fbc71598cd8c18375eb2c5da7b0e5ee)**

Changes the internal handling of the compositor module to use the TransactionQueue. Should result in identical behavior, doesn't expose anything new to downstream.

**[compositor: Make it possible to add Blockers](https://github.com/Smithay/smithay/commit/6946f4b5e29f5e181eab73a80b215d673877b23c)**

Adds new public api to the compositor module to allow downstream to add Blockers to a surface, which will be considered on the next commit.

Couple of open questions for this commit:
- [x] ~~The `CompositorClientState::blocker_cleared`-method takes a lot of really generic arguments. It works for the upcoming dmabuf-commit, but might be problematic for other use-cases. Could we require less? Should we possibly move the responsibility to re-run the commit-handler to downstream and just take a DisplayHandle?~~ Necessary to call commit and less of an issue with the changes below.
- [x] ~~If we keep the `commit`-callback here, do we maybe want to skip the original commit-callback in the first place? We can easily bubble up the return value of `apply_ready` to conditionally skip the call.~~ `commit` call has been moved into `Transaction::apply`
- [x] ~~If there are pending blockers, post-commit-hooks will not observe any changed state. Luckily smithay doesn't use them for anything, does any compositor? Do we consider this expected behaviour? Do we want to run them once the transaction is done instead? Can we maybe just drop them?~~ `post_commit`-hooks as well

**[buffer: Add buffer_attached callback](https://github.com/Smithay/smithay/commit/91ffd61aa41ac69b2764b38ef4e381e1ead3c77e)**

Adds a new `buffer_attached`-callback to the `BufferHandler`. Prerequisite for the next commit

**[WIP: anvil: Wait for dmabufs to become ready](https://github.com/Smithay/smithay/commit/b50e3a3fcedd7d63a859ce610595a792717d0a28)**

Very rudimentary test of the above functionality.

Possible todos:
- [x] The code should be moved into a different module
- [x] Maybe we can add some implementations/abstractions in smithay to make this easier, specifically for the dmabuf case?
- [x] We should `poll` new buffers before adding a blocker for them. We can skip a complete event loop cycle, if the buffers are already ready, which is not unlikely.