### PR TITLE
wayland: Remove Arc<Mutex<Inner>> from xdg shell state

### DIFF
--- a/src/wayland/shell/xdg/handlers.rs
+++ b/src/wayland/shell/xdg/handlers.rs
@@ -1,7 +1,6 @@
 use super::{
-    InnerState, PopupConfigure, PositionerState, ShellClient, ShellClientData, SurfaceCachedState,
-    ToplevelConfigure, XdgPopupSurfaceRoleAttributes, XdgShellHandler, XdgShellState,
-    XdgToplevelSurfaceRoleAttributes,
+    PopupConfigure, PositionerState, ShellClient, ShellClientData, SurfaceCachedState, ToplevelConfigure,
+    XdgPopupSurfaceRoleAttributes, XdgShellHandler, XdgShellState, XdgToplevelSurfaceRoleAttributes,
 };
 
 mod wm_base;

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -24,7 +24,7 @@ use wayland_protocols::{
 use wayland_server::{protocol::wl_surface, DataInit, Dispatch, DisplayHandle, Resource, Weak};
 
 use super::{
-    InnerState, PopupConfigure, SurfaceCachedState, ToplevelConfigure, XdgPopupSurfaceRoleAttributes,
+    PopupConfigure, SurfaceCachedState, ToplevelConfigure, XdgPopupSurfaceRoleAttributes,
     XdgPositionerUserData, XdgShellHandler, XdgToplevelSurfaceRoleAttributes,
 };
 
@@ -112,7 +112,6 @@ where
                 let toplevel = data_init.init(
                     id,
                     XdgShellSurfaceUserData {
-                        shell_data: state.xdg_shell_state().inner.clone(),
                         wl_surface: data.wl_surface.clone(),
                         xdg_surface: xdg_surface.clone(),
                         wm_base: data.wm_base.clone(),
@@ -123,9 +122,6 @@ where
 
                 state
                     .xdg_shell_state()
-                    .inner
-                    .lock()
-                    .unwrap()
                     .known_toplevels
                     .push(make_toplevel_handle(&toplevel));
 
@@ -190,7 +186,6 @@ where
                 let popup = data_init.init(
                     id,
                     XdgShellSurfaceUserData {
-                        shell_data: state.xdg_shell_state().inner.clone(),
                         wl_surface: data.wl_surface.clone(),
                         xdg_surface: xdg_surface.clone(),
                         wm_base: data.wm_base.clone(),
@@ -201,9 +196,6 @@ where
 
                 state
                     .xdg_shell_state()
-                    .inner
-                    .lock()
-                    .unwrap()
                     .known_popups
                     .push(make_popup_handle(&popup));
 
@@ -316,7 +308,6 @@ where
 /// User data of xdg toplevel surface
 #[derive(Debug)]
 pub struct XdgShellSurfaceUserData {
-    pub(crate) shell_data: Arc<Mutex<InnerState>>,
     pub(crate) wl_surface: wl_surface::WlSurface,
     pub(crate) wm_base: xdg_wm_base::XdgWmBase,
     pub(crate) xdg_surface: xdg_surface::XdgSurface,

--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -71,14 +71,13 @@ where
         data.alive_tracker.destroy_notify();
 
         // remove this surface from the known ones (as well as any leftover dead surface)
-        let mut shell_data = data.shell_data.lock().unwrap();
-        if let Some(index) = shell_data
+        if let Some(index) = state
+            .xdg_shell_state()
             .known_popups
             .iter()
             .position(|pop| pop.shell_surface.id() == object_id)
         {
-            let popup = shell_data.known_popups.remove(index);
-            drop(shell_data);
+            let popup = state.xdg_shell_state().known_popups.remove(index);
             let surface = popup.wl_surface().clone();
             XdgShellHandler::popup_destroyed(state, popup);
             compositor::with_states(&surface, |states| {

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -126,14 +126,13 @@ where
         data.alive_tracker.destroy_notify();
         data.decoration.lock().unwrap().take();
 
-        let mut shell_data = data.shell_data.lock().unwrap();
-        if let Some(index) = shell_data
+        if let Some(index) = state
+            .xdg_shell_state()
             .known_toplevels
             .iter()
             .position(|top| top.shell_surface.id() == object_id)
         {
-            let toplevel = shell_data.known_toplevels.remove(index);
-            drop(shell_data);
+            let toplevel = state.xdg_shell_state().known_toplevels.remove(index);
             let surface = toplevel.wl_surface().clone();
             XdgShellHandler::toplevel_destroyed(state, toplevel);
             compositor::with_states(&surface, |states| {


### PR DESCRIPTION
This used to be needed because `destroyed` handler did not have access to compositor state, but that limitation is long gone.