### PR TITLE
wayland: Return serial on configure

### DIFF
--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -316,7 +316,11 @@ impl LayerSurface {
     ///
     /// You can manipulate the state that will be sent to the client with the [`with_pending_state`](#method.with_pending_state)
     /// method.
-    pub fn send_configure(&self) {
+    ///
+    /// If changes have occured a configure event will be send to the clients and the serial will be returned
+    /// (for tracking the configure in [`LayerShellHandler::ack_configure`] if desired).
+    /// If no changes occured no event will be send and `None` will be returned.
+    pub fn send_configure(&self) -> Option<Serial> {
         let configure = compositor::with_states(&self.wl_surface, |states| {
             let mut attributes = states
                 .data_map
@@ -345,6 +349,9 @@ impl LayerSurface {
             let serial = configure.serial;
             self.shell_surface
                 .configure(serial.into(), width as u32, height as u32);
+            Some(configure.serial)
+        } else {
+            None
         }
     }
 


### PR DESCRIPTION
Downstream might want to track configures send and check if they have already been acked. This is quite difficult with the current api, because downstream has to compare the changes it made to the configure struct passed to `LayerShellHandler::ack_configure` and `XdgShellHandler::ack_configure` respectively.

This PR changes `send_configure` calls to return the serial used for the configure, so downstream can simply compare the serial in `ack_configure` to be sure state was acknoledged.