### PR TITLE
Add ext-session-lock protocol support

### DIFF
--- a/src/wayland/idle_inhibit/mod.rs
+++ b/src/wayland/idle_inhibit/mod.rs
@@ -137,16 +137,16 @@ pub trait IdleInhibitHandler {
 #[macro_export]
 macro_rules! delegate_idle_inhibit {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            smithay::reexports::wayland_protocols::wp::idle_inhibit::zv1::server::zwp_idle_inhibit_manager_v1::ZwpIdleInhibitManagerV1: ()
+        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::idle_inhibit::zv1::server::zwp_idle_inhibit_manager_v1::ZwpIdleInhibitManagerV1: ()
         ] => $crate::wayland::idle_inhibit::IdleInhibitManagerState);
 
-        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            smithay::reexports::wayland_protocols::wp::idle_inhibit::zv1::server::zwp_idle_inhibit_manager_v1::ZwpIdleInhibitManagerV1: ()
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::idle_inhibit::zv1::server::zwp_idle_inhibit_manager_v1::ZwpIdleInhibitManagerV1: ()
         ] => $crate::wayland::idle_inhibit::IdleInhibitManagerState);
 
-        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            smithay::reexports::wayland_protocols::wp::idle_inhibit::zv1::server::zwp_idle_inhibitor_v1::ZwpIdleInhibitorV1: $crate::wayland::idle_inhibit::inhibitor::IdleInhibitorState
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::idle_inhibit::zv1::server::zwp_idle_inhibitor_v1::ZwpIdleInhibitorV1: $crate::wayland::idle_inhibit::inhibitor::IdleInhibitorState
         ] => $crate::wayland::idle_inhibit::IdleInhibitManagerState);
     };
 }

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -59,6 +59,7 @@ pub mod presentation;
 pub mod primary_selection;
 pub mod relative_pointer;
 pub mod seat;
+pub mod session_lock;
 pub mod shell;
 pub mod shm;
 pub mod socket;

--- a/src/wayland/session_lock/lock.rs
+++ b/src/wayland/session_lock/lock.rs
@@ -49,7 +49,9 @@ where
         match request {
             Request::GetLockSurface { id, surface, output } => {
                 // Assign surface a role and ensure it never had one before.
-                if compositor::give_role(&surface, LOCK_SURFACE_ROLE).is_err() {
+                if compositor::get_role(&surface).is_some()
+                    || compositor::give_role(&surface, LOCK_SURFACE_ROLE).is_err()
+                {
                     lock.post_error(Error::Role, "Surface already has a role.");
                     return;
                 }

--- a/src/wayland/session_lock/lock.rs
+++ b/src/wayland/session_lock/lock.rs
@@ -1,0 +1,124 @@
+//! ext-session-lock lock.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::wayland::compositor;
+use crate::wayland::compositor::SurfaceAttributes;
+use _session_lock::ext_session_lock_surface_v1::ExtSessionLockSurfaceV1;
+use _session_lock::ext_session_lock_v1::{Error, ExtSessionLockV1, Request};
+use wayland_protocols::ext::session_lock::v1::server as _session_lock;
+use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, Resource};
+
+use crate::wayland::session_lock::surface::{ExtLockSurfaceUserData, LockSurface, LockSurfaceAttributes};
+use crate::wayland::session_lock::{SessionLockHandler, SessionLockManagerState};
+
+/// Surface role for ext-session-lock surfaces.
+const LOCK_SURFACE_ROLE: &str = "ext_session_lock_surface_v1";
+
+/// [`ExtSessionLockV1`] state.
+#[derive(Debug)]
+pub struct SessionLockState {
+    pub(crate) lock_status: Arc<AtomicBool>,
+}
+
+impl SessionLockState {
+    pub(crate) fn new() -> Self {
+        Self {
+            lock_status: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl<D> Dispatch<ExtSessionLockV1, SessionLockState, D> for SessionLockManagerState
+where
+    D: Dispatch<ExtSessionLockV1, SessionLockState>,
+    D: Dispatch<ExtSessionLockSurfaceV1, ExtLockSurfaceUserData>,
+    D: SessionLockHandler,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        lock: &ExtSessionLockV1,
+        request: Request,
+        data: &SessionLockState,
+        _display: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            Request::GetLockSurface { id, surface, output } => {
+                // Assign surface a role and ensure it never had one before.
+                if compositor::give_role(&surface, LOCK_SURFACE_ROLE).is_err() {
+                    lock.post_error(Error::Role, "Surface already has a role.");
+                    return;
+                }
+
+                // Ensure output is not already locked.
+                let lock_state = state.lock_state();
+                if lock_state.locked_outputs.contains(&output) {
+                    lock.post_error(Error::DuplicateOutput, "Output is already locked.");
+                    return;
+                }
+                lock_state.locked_outputs.push(output.clone());
+
+                // Ensure surface has no existing buffers attached.
+                let has_buffer = compositor::with_states(&surface, |states| {
+                    let attributes = states.cached_state.current::<SurfaceAttributes>();
+                    attributes.buffer.is_some()
+                });
+                if has_buffer {
+                    lock.post_error(Error::AlreadyConstructed, "Surface has a buffer attached.");
+                    return;
+                }
+
+                let data = ExtLockSurfaceUserData {
+                    surface: surface.clone(),
+                };
+                let shell_surface = data_init.init(id, data);
+
+                // Initialize surface data.
+                compositor::with_states(&surface, |states| {
+                    states
+                        .data_map
+                        .insert_if_missing_threadsafe(|| Mutex::new(LockSurfaceAttributes::default()))
+                });
+
+                // Add pre-commit hook for updating surface state.
+                compositor::add_pre_commit_hook(&surface, |_dh, surface| {
+                    compositor::with_states(surface, |states| {
+                        let attributes = states.data_map.get::<Mutex<LockSurfaceAttributes>>();
+                        let mut attributes = attributes.unwrap().lock().unwrap();
+
+                        if let Some(state) = attributes.last_acked {
+                            attributes.current = state;
+                        }
+                    });
+                });
+
+                // Call compositor handler.
+                let lock_surface = LockSurface::new(surface, shell_surface);
+                state.new_surface(lock_surface.clone(), output);
+
+                // Send initial configure when the interface is bound.
+                lock_surface.send_configure();
+            }
+            Request::UnlockAndDestroy => {
+                // Ensure session is locked.
+                if !data.lock_status.load(Ordering::Relaxed) {
+                    lock.post_error(Error::InvalidUnlock, "Session is not locked.");
+                }
+
+                state.lock_state().locked_outputs.clear();
+                state.unlock();
+            }
+            Request::Destroy => {
+                // Ensure session is not locked.
+                if data.lock_status.load(Ordering::Relaxed) {
+                    lock.post_error(Error::InvalidDestroy, "Cannot destroy session lock while locked.");
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/wayland/session_lock/lock.rs
+++ b/src/wayland/session_lock/lock.rs
@@ -64,8 +64,9 @@ where
 
                 // Ensure surface has no existing buffers attached.
                 let has_buffer = compositor::with_states(&surface, |states| {
-                    let attributes = states.cached_state.current::<SurfaceAttributes>();
-                    attributes.buffer.is_some()
+                    let pending = states.cached_state.pending::<SurfaceAttributes>();
+                    let current = states.cached_state.current::<SurfaceAttributes>();
+                    current.buffer.is_some() || pending.buffer.is_some()
                 });
                 if has_buffer {
                     lock.post_error(Error::AlreadyConstructed, "Surface has a buffer attached.");

--- a/src/wayland/session_lock/lock.rs
+++ b/src/wayland/session_lock/lock.rs
@@ -78,7 +78,7 @@ where
                 let data = ExtLockSurfaceUserData {
                     surface: surface.clone(),
                 };
-                let shell_surface = data_init.init(id, data);
+                let lock_surface = data_init.init(id, data);
 
                 // Initialize surface data.
                 compositor::with_states(&surface, |states| {
@@ -100,7 +100,7 @@ where
                 });
 
                 // Call compositor handler.
-                let lock_surface = LockSurface::new(surface, shell_surface);
+                let lock_surface = LockSurface::new(surface, lock_surface);
                 state.new_surface(lock_surface.clone(), output);
 
                 // Send initial configure when the interface is bound.

--- a/src/wayland/session_lock/mod.rs
+++ b/src/wayland/session_lock/mod.rs
@@ -1,0 +1,220 @@
+//! Utilities for handling the `ext-session-lock` protocol
+//!
+//! ## How to use it
+//!
+//! ### Initialization
+//!
+//! To initialize this implementation create the [`SessionLockManagerState`] and
+//! implement the [`SessionLockHandler`], as shown in this example:
+//!
+//! ```
+//! use smithay::delegate_session_lock;
+//! use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
+//! use smithay::wayland::session_lock::{SessionLockManagerState, SessionLockHandler, SessionLocker};
+//! use smithay::wayland::session_lock::surface::LockSurface;
+//!
+//! # struct State { session_lock_state: SessionLockManagerState }
+//! # let mut display = wayland_server::Display::<State>::new().unwrap();
+//! // Create the compositor state
+//! let session_lock_state = SessionLockManagerState::new::<State>(&display.handle());
+//!
+//! // Insert the SessionLockManagerState into your state.
+//!
+//! // Implement the necessary trait.
+//! impl SessionLockHandler for State {
+//!     fn lock_state(&mut self) -> &mut SessionLockManagerState {
+//!         &mut self.session_lock_state
+//!     }
+//!
+//!     fn lock(&mut self, _confirmation: SessionLocker) {
+//!         // Lock and clear the screen.
+//!
+//!         // Call `SessionLocker::lock` after the cleared frame was presented.
+//!     }
+//!
+//!     fn unlock(&mut self) {
+//!         // Remove session lock.
+//!     }
+//!
+//!     fn new_surface(&mut self, _surface: LockSurface, _output: WlOutput) {
+//!         // Display `LockSurface` on `WlOutput`.
+//!     }
+//! }
+//! delegate_session_lock!(State);
+//!
+//! // You're now ready to go!
+//! ```
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use _session_lock::ext_session_lock_manager_v1::{ExtSessionLockManagerV1, Request};
+use _session_lock::ext_session_lock_v1::ExtSessionLockV1;
+use wayland_protocols::ext::session_lock::v1::server as _session_lock;
+use wayland_server::protocol::wl_output::WlOutput;
+use wayland_server::protocol::wl_surface::WlSurface;
+use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New};
+
+use crate::wayland::session_lock::lock::SessionLockState;
+use crate::wayland::session_lock::surface::{LockSurface, LockSurfaceConfigure};
+
+pub mod lock;
+pub mod surface;
+
+const MANAGER_VERSION: u32 = 1;
+
+/// State of the [`ExtSessionLockManagerV1`] Global.
+#[derive(Debug)]
+pub struct SessionLockManagerState {
+    pub(crate) locked_outputs: Vec<WlOutput>,
+}
+
+impl SessionLockManagerState {
+    /// Create new [`ExtSessionLockManagerV1`] global.
+    pub fn new<D>(display: &DisplayHandle) -> Self
+    where
+        D: GlobalDispatch<ExtSessionLockManagerV1, ()>,
+        D: Dispatch<ExtSessionLockManagerV1, ()>,
+        D: Dispatch<ExtSessionLockV1, SessionLockState>,
+        D: SessionLockHandler,
+        D: 'static,
+    {
+        display.create_global::<D, ExtSessionLockManagerV1, _>(MANAGER_VERSION, ());
+
+        Self {
+            locked_outputs: Vec::new(),
+        }
+    }
+}
+
+impl<D> GlobalDispatch<ExtSessionLockManagerV1, (), D> for SessionLockManagerState
+where
+    D: GlobalDispatch<ExtSessionLockManagerV1, ()>,
+    D: Dispatch<ExtSessionLockManagerV1, ()>,
+    D: Dispatch<ExtSessionLockV1, SessionLockState>,
+    D: SessionLockHandler,
+    D: 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _display: &DisplayHandle,
+        _client: &Client,
+        manager: New<ExtSessionLockManagerV1>,
+        _manager_state: &(),
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(manager, ());
+    }
+}
+
+impl<D> Dispatch<ExtSessionLockManagerV1, (), D> for SessionLockManagerState
+where
+    D: GlobalDispatch<ExtSessionLockManagerV1, ()>,
+    D: Dispatch<ExtSessionLockManagerV1, ()>,
+    D: Dispatch<ExtSessionLockV1, SessionLockState>,
+    D: SessionLockHandler,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        _manager: &ExtSessionLockManagerV1,
+        request: Request,
+        _data: &(),
+        _display: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            Request::Lock { id } => {
+                let lock_state = SessionLockState::new();
+                let lock_status = lock_state.lock_status.clone();
+                let lock = data_init.init(id, lock_state);
+                state.lock(SessionLocker::new(lock, lock_status));
+            }
+            Request::Destroy => (),
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Handler trait for ext-session-lock.
+pub trait SessionLockHandler {
+    /// Session lock state.
+    fn lock_state(&mut self) -> &mut SessionLockManagerState;
+
+    /// Handle compositor locking requests.
+    ///
+    /// The [`SessionLocker`] parameter is used to confirm once the session was
+    /// locked and no more client data is accessible using the
+    /// [`SessionLocker::lock`] method.
+    ///
+    /// If locking was not possible, dropping the [`SessionLocker`] will
+    /// automatically notify the requesting client about the failure.
+    fn lock(&mut self, confirmation: SessionLocker);
+
+    /// Handle compositor lock removal.
+    fn unlock(&mut self);
+
+    /// Add a new lock surface for an output.
+    fn new_surface(&mut self, surface: LockSurface, output: WlOutput);
+
+    /// A surface has acknowledged a configure serial.
+    fn ack_configure(&mut self, _surface: WlSurface, _configure: LockSurfaceConfigure) {}
+}
+
+/// Manage session locking.
+///
+/// See [`SessionLockHandler::lock`] for more detail.
+#[derive(Debug)]
+pub struct SessionLocker {
+    lock: Option<ExtSessionLockV1>,
+    lock_status: Arc<AtomicBool>,
+}
+
+impl Drop for SessionLocker {
+    fn drop(&mut self) {
+        // If the session wasn't locked, we notify clients about the failure.
+        if let Some(lock) = self.lock.take() {
+            lock.finished();
+        }
+    }
+}
+
+impl SessionLocker {
+    fn new(lock: ExtSessionLockV1, lock_status: Arc<AtomicBool>) -> Self {
+        Self {
+            lock: Some(lock),
+            lock_status,
+        }
+    }
+
+    /// Notify the client that the session lock was successful.
+    pub fn lock(mut self) {
+        if let Some(lock) = self.lock.take() {
+            self.lock_status.store(true, Ordering::Relaxed);
+            lock.locked();
+        }
+    }
+}
+
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! delegate_session_lock {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::ext::session_lock::v1::server::ext_session_lock_manager_v1::ExtSessionLockManagerV1: ()
+        ] => $crate::wayland::session_lock::SessionLockManagerState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::ext::session_lock::v1::server::ext_session_lock_manager_v1::ExtSessionLockManagerV1: ()
+        ] => $crate::wayland::session_lock::SessionLockManagerState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::ext::session_lock::v1::server::ext_session_lock_v1::ExtSessionLockV1: $crate::wayland::session_lock::lock::SessionLockState
+        ] => $crate::wayland::session_lock::SessionLockManagerState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::ext::session_lock::v1::server::ext_session_lock_surface_v1::ExtSessionLockSurfaceV1: $crate::wayland::session_lock::surface::ExtLockSurfaceUserData
+        ] => $crate::wayland::session_lock::SessionLockManagerState);
+    };
+}

--- a/src/wayland/session_lock/surface.rs
+++ b/src/wayland/session_lock/surface.rs
@@ -1,0 +1,232 @@
+//! ext-session-lock surface.
+
+use std::sync::Mutex;
+
+use crate::utils::{IsAlive, Logical, Serial, Size, SERIAL_COUNTER};
+use crate::wayland::compositor;
+use _session_lock::ext_session_lock_surface_v1::{Error, ExtSessionLockSurfaceV1, Request};
+use wayland_protocols::ext::session_lock::v1::server as _session_lock;
+use wayland_server::protocol::wl_surface::WlSurface;
+use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, Resource};
+
+use crate::wayland::session_lock::{SessionLockHandler, SessionLockManagerState};
+
+/// User data for ext-session-lock surfaces.
+#[derive(Debug)]
+pub struct ExtLockSurfaceUserData {
+    pub(crate) surface: WlSurface,
+}
+
+impl<D> Dispatch<ExtSessionLockSurfaceV1, ExtLockSurfaceUserData, D> for SessionLockManagerState
+where
+    D: Dispatch<ExtSessionLockSurfaceV1, ExtLockSurfaceUserData>,
+    D: SessionLockHandler,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        lock_surface: &ExtSessionLockSurfaceV1,
+        request: Request,
+        data: &ExtLockSurfaceUserData,
+        _display: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            Request::AckConfigure { serial } => {
+                // Find configure for this serial.
+                let serial = Serial::from(serial);
+                let configure = compositor::with_states(&data.surface, |states| {
+                    let surface_data = states.data_map.get::<Mutex<LockSurfaceAttributes>>();
+                    surface_data.unwrap().lock().unwrap().ack_configure(serial)
+                });
+
+                match configure {
+                    Some(configure) => state.ack_configure(data.surface.clone(), configure),
+                    None => lock_surface.post_error(
+                        Error::InvalidSerial,
+                        format!("wrong configure serial: {}", <u32>::from(serial)),
+                    ),
+                }
+            }
+            Request::Destroy => (),
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Attributes for ext-session-lock surfaces.
+#[derive(Default, Debug)]
+pub struct LockSurfaceAttributes {
+    /// The serial of the last acked configure
+    pub configure_serial: Option<Serial>,
+
+    /// Holds the pending state as set by the server.
+    pub server_pending: Option<LockSurfaceState>,
+
+    /// Holds the configures the server has sent out to the client waiting to be
+    /// acknowledged by the client. All pending configures that are older than
+    /// the acknowledged one will be discarded during processing
+    /// layer_surface.ack_configure.
+    pub pending_configures: Vec<LockSurfaceConfigure>,
+
+    /// Holds the last server_pending state that has been acknowledged by the
+    /// client. This state should be cloned to the current during a commit.
+    pub last_acked: Option<LockSurfaceState>,
+
+    /// Holds the current state of the layer after a successful commit.
+    pub current: LockSurfaceState,
+}
+
+impl LockSurfaceAttributes {
+    fn ack_configure(&mut self, serial: Serial) -> Option<LockSurfaceConfigure> {
+        let configure = self
+            .pending_configures
+            .iter()
+            .find(|configure| configure.serial == serial)
+            .cloned()?;
+
+        self.pending_configures
+            .retain(|configure| configure.serial > serial);
+        self.last_acked = Some(configure.state);
+        self.configure_serial = Some(serial);
+
+        Some(configure)
+    }
+}
+
+/// Handle for a ext-session-lock surface.
+#[derive(Clone, Debug)]
+pub struct LockSurface {
+    shell_surface: ExtSessionLockSurfaceV1,
+    surface: WlSurface,
+}
+
+impl PartialEq for LockSurface {
+    fn eq(&self, other: &Self) -> bool {
+        self.surface == other.surface
+    }
+}
+
+impl LockSurface {
+    pub(crate) fn new(surface: WlSurface, shell_surface: ExtSessionLockSurfaceV1) -> Self {
+        Self {
+            surface,
+            shell_surface,
+        }
+    }
+
+    /// Check if the surface is still alive.
+    pub fn alive(&self) -> bool {
+        self.surface.alive()
+    }
+
+    /// Get the current pending configure state.
+    pub fn get_pending_state(&self, attributes: &mut LockSurfaceAttributes) -> Option<LockSurfaceState> {
+        let server_pending = match attributes.server_pending.take() {
+            Some(state) => state,
+            None => return None,
+        };
+
+        // Get the last pending state.
+        let pending = attributes.pending_configures.last();
+        let last_state = pending.map(|c| &c.state).or(attributes.last_acked.as_ref());
+
+        // Check if last state matches pending state.
+        match last_state {
+            Some(state) if state == &server_pending => None,
+            _ => Some(server_pending),
+        }
+    }
+
+    /// Send a configure to the surface.
+    ///
+    /// You can manipulate the client's state using
+    /// [`LockSurface::with_pending_state`].
+    pub fn send_configure(&self) {
+        compositor::with_states(&self.surface, |states| {
+            // Get surface attributes.
+            let attributes = states.data_map.get::<Mutex<LockSurfaceAttributes>>();
+            let mut attributes = attributes.unwrap().lock().unwrap();
+
+            // Create our new configure event.
+            let pending = match self.get_pending_state(&mut attributes) {
+                Some(pending) => pending,
+                None => return,
+            };
+            let configure = LockSurfaceConfigure::new(pending);
+
+            // Extract client configure state.
+            let (width, height) = configure.state.size.unwrap_or_default().into();
+            let serial = configure.serial;
+
+            // Update pending state.
+            attributes.pending_configures.push(configure);
+
+            // Send configure to the client.
+            self.shell_surface.configure(serial.into(), width, height);
+        })
+    }
+
+    /// Access the underlying [`WlSurface`].
+    pub fn wl_surface(&self) -> &WlSurface {
+        &self.surface
+    }
+
+    /// Manipulate this surface's pending state.
+    pub fn with_pending_state<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&mut LockSurfaceState) -> T,
+    {
+        compositor::with_states(&self.surface, |states| {
+            let attributes = states.data_map.get::<Mutex<LockSurfaceAttributes>>();
+            let mut attributes = attributes.unwrap().lock().unwrap();
+
+            // Ensure pending state is initialized.
+            let current = attributes.current;
+            let server_pending = attributes.server_pending.get_or_insert(current);
+
+            f(server_pending)
+        })
+    }
+
+    /// Get the current pending state.
+    #[allow(unused)]
+    pub fn current_state(&self) -> LockSurfaceState {
+        compositor::with_states(&self.surface, |states| {
+            states
+                .data_map
+                .get::<Mutex<LockSurfaceAttributes>>()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .current
+        })
+    }
+}
+
+/// State of an ext-session-lock surface.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct LockSurfaceState {
+    /// The suggested size of the surface.
+    pub size: Option<Size<u32, Logical>>,
+}
+
+/// A configure message for ext-session-lock surfaces.
+#[derive(Debug, Copy, Clone)]
+pub struct LockSurfaceConfigure {
+    /// The state associated with this configure.
+    pub state: LockSurfaceState,
+
+    /// A serial number to track acknowledgment from the client.
+    pub serial: Serial,
+}
+
+impl LockSurfaceConfigure {
+    fn new(state: LockSurfaceState) -> Self {
+        Self {
+            serial: SERIAL_COUNTER.next_serial(),
+            state,
+        }
+    }
+}


### PR DESCRIPTION
This adds support for the ext-session-lock protocol, which allows
clients to lock the Wayland session and present surfaces of their choice
as lockscreens.

---

This PR does not include an Anvil implementation yet. At this point it's basically just a 1:1 copy of what I required to make this protocol work in my compositor, so before trying to implement this for Anvil I'd like some feedback on the approach taken here. I think it should serve well as a general-purpose implementation, but I'm open to suggestions.