### PR TITLE
input: Add `KeyboardHandle::set_xkb_config` method

### DIFF
--- a/src/input/keyboard/xkb_config.rs
+++ b/src/input/keyboard/xkb_config.rs
@@ -1,3 +1,5 @@
+pub use xkbcommon::xkb;
+
 /// Configuration for xkbcommon.
 ///
 /// For the fields that are not set ("" or None, as set in the `Default` impl), xkbcommon will use
@@ -25,4 +27,19 @@ pub struct XkbConfig<'a> {
     /// preferences, like which key combinations are used for switching layouts, or which key is the
     /// Compose key.
     pub options: Option<String>,
+}
+
+impl<'a> XkbConfig<'a> {
+    pub(crate) fn compile_keymap(&self, context: &xkb::Context) -> Result<xkb::Keymap, ()> {
+        xkb::Keymap::new_from_names(
+            context,
+            self.rules,
+            self.model,
+            self.layout,
+            self.variant,
+            self.options.clone(),
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        )
+        .ok_or(())
+    }
 }


### PR DESCRIPTION
This allows changing the keymap used the keyboard without removing and re-adding the `wl_keyboard`. This seems to be the best way to do dynamic xkb configuration, so settings can be changed without restarting the compositor.

Like `wlr_keyboard_set_keymap`, this creates a new `xkb_state`, updates it with pressed keys, and sends modifiers to clients.

I think this should be correct but it needs testing, so leaving as a draft for now.