### PR TITLE
portability: Fallback for `SealedFile`, and remove `Boottime`

### DIFF
--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -15,26 +15,6 @@ impl ClockSource for Monotonic {
 
 impl NonNegativeClockSource for Monotonic {}
 
-/// Clock based on boottime
-#[derive(Debug)]
-pub struct Boottime;
-
-#[cfg(target_os = "linux")]
-impl ClockSource for Boottime {
-    fn id() -> libc::clockid_t {
-        libc::CLOCK_BOOTTIME
-    }
-}
-
-#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-impl ClockSource for Boottime {
-    fn id() -> libc::clockid_t {
-        libc::CLOCK_UPTIME
-    }
-}
-
-impl NonNegativeClockSource for Boottime {}
-
 /// Realtime clock
 #[derive(Debug)]
 pub struct Realtime;
@@ -214,21 +194,13 @@ fn clock_get_time(clk_id: libc::clockid_t) -> Result<libc::timespec, std::io::Er
 mod test {
     use std::time::Duration;
 
-    use crate::utils::{Boottime, Clock, Monotonic, Time};
+    use crate::utils::{Clock, Monotonic, Time};
 
     #[test]
     fn monotonic() {
         let clock_source: Clock<Monotonic> = Clock::new().unwrap();
         let now = clock_source.now();
         let zero = Time::<Monotonic>::from(Duration::ZERO);
-        assert_eq!(zero.duration_since(now), now.into());
-    }
-
-    #[test]
-    fn boottime() {
-        let clock_source: Clock<Boottime> = Clock::new().unwrap();
-        let now = clock_source.now();
-        let zero = Time::<Boottime>::from(Duration::ZERO);
         assert_eq!(zero.duration_since(now), now.into());
     }
 }

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -3,14 +3,10 @@
 //! This mechanism is useful for giving clients access to large amounts of
 //! information such as keymaps without them being able to write to the handle.
 
-use nix::{
-    fcntl::{FcntlArg, SealFlag},
-    sys::memfd::MemFdCreateFlag,
-};
 use std::{
     ffi::CString,
     fs::File,
-    io::{Seek, Write},
+    io::Write,
     os::unix::io::{AsRawFd, FromRawFd, RawFd},
 };
 
@@ -25,7 +21,14 @@ impl SealedFile {
         Self::with_data(name, contents.as_bytes_with_nul())
     }
 
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "android"))]
     pub fn with_data(name: CString, data: &[u8]) -> Result<Self, std::io::Error> {
+        use nix::{
+            fcntl::{FcntlArg, SealFlag},
+            sys::memfd::MemFdCreateFlag,
+        };
+        use std::io::Seek;
+
         let fd = nix::sys::memfd::memfd_create(
             &name,
             MemFdCreateFlag::MFD_CLOEXEC | MemFdCreateFlag::MFD_ALLOW_SEALING,
@@ -49,6 +52,51 @@ impl SealedFile {
 
         Ok(Self {
             file,
+            size: data.len(),
+        })
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "android")))]
+    pub fn with_data(name: CString, data: &[u8]) -> Result<Self, std::io::Error> {
+        use nix::{
+            errno::Errno,
+            fcntl::OFlag,
+            sys::{mman, stat::Mode},
+        };
+        use rand::{distributions::Alphanumeric, Rng};
+
+        let mut rng = rand::thread_rng();
+
+        // `memfd_create` isn't available. Instead, try `shm_open` with a randomized name, and
+        // loop a couple times if it exists.
+        let mut n = 0;
+        let (shm_name, mut file) = loop {
+            let mut shm_name = name.as_bytes().to_owned();
+            shm_name.push(b'-');
+            shm_name.extend((0..7).map(|_| rng.sample(Alphanumeric)));
+            let fd = mman::shm_open(
+                shm_name.as_slice(),
+                OFlag::O_RDWR | OFlag::O_CREAT | OFlag::O_EXCL,
+                Mode::S_IRWXU,
+            );
+            if fd != Err(Errno::EEXIST) || n > 3 {
+                break (shm_name, unsafe { File::from_raw_fd(fd?) });
+            }
+            n += 1;
+        };
+
+        // Sealing isn't available, so re-open read-only.
+        let fd_rdonly = mman::shm_open(shm_name.as_slice(), OFlag::O_RDONLY, Mode::empty())?;
+        let file_rdonly = unsafe { File::from_raw_fd(fd_rdonly) };
+
+        // Unlink so another process can't open shm file.
+        let _ = mman::shm_unlink(shm_name.as_slice());
+
+        file.write_all(data)?;
+        file.flush()?;
+
+        Ok(Self {
+            file: file_rdonly,
             size: data.len(),
         })
     }


### PR DESCRIPTION
`memfd_create` and sealing only exist on Linux and on recent versions of FreeBSD. For NetBSD, OpenBSD, Illumos, Darwin, etc. it is necessary to fallback to something like `shm_open`.

Using `shm_open` twice to get a writable and read-only fd seems to match what wlroots does (in `allocate_shm_file_pair`). They don't seem to use `memfd_create` and sealing at all.

`CLOCK_BOOTTIME` and `CLOCK_UPTIME` don't seem to exist on platforms like NetBSD. Getting system uptime is possible, but involves `sysctl` and not a `clockid_t`. OpenBSD seems to have both `CLOCK_BOOTTIME` and `CLOCK_UPTIME`. But they are different (`CLOCK_UPTIME` excludes time spent suspended.) This isn't used anywhere. So unless it's expected to be important for something, may be simplest to remove it?
