### PR TITLE
Use a thread-local for thread ID in `UserDataMap::get`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ encoding = { version = "0.2.33", optional = true }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
+criterion = { version = "0.4" }
 image = "0.24"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
@@ -119,3 +120,7 @@ required-features = ["backend_vulkan"]
 [[example]]
 name = "buffer_test"
 required-features = ["backend_drm", "backend_gbm", "backend_egl", "backend_vulkan", "renderer_gl"]
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,18 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use smithay::utils::user_data::UserDataMap;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("UserDataMap::get", |b| {
+        let udata_map = UserDataMap::new();
+        udata_map.insert_if_missing(|| 17i32);
+        b.iter(|| udata_map.get::<i32>())
+    });
+    c.bench_function("UserDataMap::get threadsafe", |b| {
+        let udata_map = UserDataMap::new();
+        udata_map.insert_if_missing_threadsafe(|| 17i32);
+        b.iter(|| udata_map.get::<i32>())
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Profiling suggests the compositor was spending a surprising amount of time getting the thread ID. It seems `thread::current().id()` is a bit slow. Calling this once and storing the result in a thread-local seems to make the performance roughly match the thread-safe variant, if the benchmark added here is accurate.