### PR TITLE
Reduce log level of common warnings

### DIFF
--- a/src/backend/drm/device/fd.rs
+++ b/src/backend/drm/device/fd.rs
@@ -3,7 +3,7 @@ use std::{
     os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd},
     sync::Arc,
 };
-use tracing::{error, info, warn};
+use tracing::{debug, error, info};
 
 use crate::utils::{DevPath, DeviceFd};
 
@@ -69,7 +69,7 @@ impl DrmDeviceFd {
         // This is only needed on older kernels. Newer kernels grant this permission,
         // if no other process is already the *master*. So we skip over this error.
         if dev.acquire_master_lock().is_err() {
-            warn!("Unable to become drm master, assuming unprivileged mode");
+            debug!("Unable to become drm master, assuming unprivileged mode");
         } else {
             dev.privileged = true;
         }

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -570,7 +570,7 @@ impl AtomicDrmSurface {
             } else {
                 if current.mode != pending.mode {
                     if let Err(err) = self.fd.destroy_property_blob(current.blob.into()) {
-                        warn!("Failed to destory old mode property blob: {}", err);
+                        debug!("Failed to destory old mode property blob: {}", err);
                     }
                 }
 

--- a/src/wayland/keyboard_shortcuts_inhibit/mod.rs
+++ b/src/wayland/keyboard_shortcuts_inhibit/mod.rs
@@ -231,7 +231,7 @@ pub trait KeyboardShortcutsInhibitHandler {
     /// You may also postpone activation based on your compositor specific policy.
     fn new_inhibitor(&mut self, inhibitor: KeyboardShortcutsInhibitor) {}
 
-    /// Inhibitor got destoryed
+    /// Inhibitor got destroyed
     fn inhibitor_destroyed(&mut self, inhibitor: KeyboardShortcutsInhibitor) {}
 }
 


### PR DESCRIPTION
Log levels of warning and above should indicate unexpected behavior to the user. If the application is performing as expected, users shouldn't be misguided by log messages that are not relevant to potential issues.

If an issue is encountered because of these warnings without any other relevant details in the log, then the log level can still be increased to get a full debug log.

---

From my understanding of what @Drakulix said on IRC, these messages are expected and I cannot change the behavior to avoid their emission. As such I'd rather not have them visible on my compositor's default log level.

I've already excluded Smithay's info messages from my default log level since these are very verbose, but I think that should be fine. I'd really like to be able to emit Smithay warnings by default. If this patch isn't appropriate, I think my only alternative would be exclusively logging errors.