### PR TITLE
Add buffer age reset function

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.65.0"

--- a/src/backend/allocator/swapchain.rs
+++ b/src/backend/allocator/swapchain.rs
@@ -233,7 +233,7 @@ where
         self.slots = Default::default();
     }
 
-    /// Remove all internally cached buffers to e.g. reset age values
+    /// Remove all internally cached buffers.
     pub fn reset_buffers(&mut self) {
         for slot in &mut self.slots {
             if let Some(internal_slot) = Arc::get_mut(slot) {
@@ -243,6 +243,19 @@ where
                 };
             } else {
                 *slot = Default::default();
+            }
+        }
+    }
+
+    /// Reset the age for each buffer.
+    ///
+    /// Resetting the buffer age will discard all damage information and force a
+    /// full redraw for the next frame.
+    pub fn reset_buffer_age(&mut self) {
+        for slot in &mut self.slots {
+            match Arc::get_mut(slot) {
+                Some(slot) => slot.age = AtomicU8::new(0),
+                None => *slot = Default::default(),
             }
         }
     }

--- a/src/backend/allocator/swapchain.rs
+++ b/src/backend/allocator/swapchain.rs
@@ -236,14 +236,7 @@ where
     /// Remove all internally cached buffers.
     pub fn reset_buffers(&mut self) {
         for slot in &mut self.slots {
-            if let Some(internal_slot) = Arc::get_mut(slot) {
-                *internal_slot = InternalSlot {
-                    buffer: internal_slot.buffer.take(),
-                    ..Default::default()
-                };
-            } else {
-                *slot = Default::default();
-            }
+            *slot = Default::default();
         }
     }
 


### PR DESCRIPTION
The PPP's driver seems to run into non-recoverable framebuffer errors when the `reset_buffers` function is called and the `InternalSlot` is reset while the `InternalSlot::buffer` is kept.

This patch adds a new function which only resets each slot's buffer age rather than resetting the entire slot, allowing a force-redraw on the PPP without triggering the framebuffer error.

---

This was the only solution me and @cmeissl could come up with, but he suggested to either go for something like this or to just always reset the entire slot in `reset_buffers` without keeping the buffer around. Both of those fix the issue on the PPP based on my testing.

Leaving the decision on which solution to go with to @Drakulix (unless you have an even better suggestion).