### PR TITLE
gles: Don't copy from shadowbuffer instead of texture

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1304,6 +1304,10 @@ impl ExportMem for GlesRenderer {
         let mut pbo = 0;
         let old_target = self.target.take();
         self.bind(texture.clone())?;
+        self.target
+            .as_ref()
+            .unwrap()
+            .make_current_no_shadow(&self.gl, &self.egl, None)?;
 
         let (_, format, layout) = fourcc_to_gl_formats(fourcc).ok_or(GlesError::UnknownPixelFormat)?;
         let bpp = gl_bpp(format, layout).expect("We check the format before") / 8;


### PR DESCRIPTION
If the user wants to copy contents from a texture, don't copy from it's shadow buffer instead...