### PR TITLE
multigpu: initialize format, when adding mapping to empty MultiTexture

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1400,6 +1400,7 @@ impl MultiTexture {
                     warn!(has = ?format, got = ?mapping_fmt, "Multi-SubTexture Mapping with wrong format!");
                     false
                 } else {
+                    tex.format = Some(mapping_fmt);
                     true
                 }
             })


### PR DESCRIPTION
When initializing a MultiTexture with a Mapping first (due to `early_import` being called), it currently doesn't get a format. This will cause any later texture inserts to fail, as the format is `None` and textures already existing.
Fix this by also setting the format when initializing the MultiTexture first with a mapping instead with a finished texture.