### PR TITLE
anvil: Set text input focus, without requring keyboard grab

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -63,7 +63,7 @@ use smithay::{
         shm::{ShmHandler, ShmState},
         socket::ListeningSocketSource,
         tablet_manager::TabletSeatTrait,
-        text_input::TextInputManagerState,
+        text_input::{TextInputManagerState, TextInputSeat},
         viewporter::ViewporterState,
         virtual_keyboard::VirtualKeyboardManagerState,
         xdg_activation::{
@@ -259,6 +259,10 @@ impl<BackendData: Backend> SeatHandler for AnvilState<BackendData> {
             .and_then(|s| dh.get_client(s.id()).ok());
         set_data_device_focus(dh, seat, focus.clone());
         set_primary_focus(dh, seat, focus);
+
+        let text_input = seat.text_input();
+        let surface = target.and_then(WaylandFocus::wl_surface);
+        text_input.set_focus(surface.as_ref(), || {});
     }
     fn cursor_image(&mut self, _seat: &Seat<Self>, image: CursorImageStatus) {
         *self.cursor_status.lock().unwrap() = image;

--- a/src/wayland/text_input/mod.rs
+++ b/src/wayland/text_input/mod.rs
@@ -60,6 +60,20 @@ const MANAGER_VERSION: u32 = 1;
 
 mod text_input_handle;
 
+/// Extends [Seat] with text input functionality
+pub trait TextInputSeat {
+    /// Get text input associated with this seat
+    fn text_input(&self) -> &TextInputHandle;
+}
+
+impl<D: SeatHandler + 'static> TextInputSeat for Seat<D> {
+    fn text_input(&self) -> &TextInputHandle {
+        let user_data = self.user_data();
+        user_data.insert_if_missing(TextInputHandle::default);
+        user_data.get::<TextInputHandle>().unwrap()
+    }
+}
+
 /// State of wp text input protocol
 #[derive(Debug)]
 pub struct TextInputManagerState {


### PR DESCRIPTION
Also adds a `TextInputSeat` trait, like `InputMethodSeat`.

Draft, because I'm not entirely sure how this is supposed to work. I needed to make this change to get fcitx5 to work with Anvil. Smithay is already calling `set_focus` in response to `GrabKeyboard` events from the IME. But fcitx5 doesn't seem to call `grab_keyboard` until it receives `activate`, which is only sent when the text input client calls `zwp_text_input_v3::enable`, but clients only do that once they get focus through `zwp_text_input_v3::enter`...

Comparing wlroots/sway, the keyboard grab doesn't seem to be involved in setting text input focus. So maybe this is the more correct way to do so? If so, should the `set_focus` call be removed?

Presumably without this change some other IME may work, and that's what this was being tested with? Though I'd expect fcitx5 to be the most prominent user of the `input-method-unstable-v2` protocol. (IBus doesn't support v2 yet: https://github.com/ibus/ibus/pull/2256.)

For reference, I tested by configuring pinyin input in `fcitx5-configtool`, and running these commands in separate terminals to watch what was going on in the protocol:

```
WAYLAND_DISPLAY=wayland-2 WAYLAND_DEBUG=1 fcitx5 |& grep input_method
GTK_IM_MODULE=wayland WAYLAND_DISPLAY=wayland-2 WAYLAND_DEBUG=1 gedit |& grep text_input
```

CC @rano-oss