### PR TITLE
Updates for next `calloop` version, using `BorrowedFd`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,11 +354,8 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-registry-
 
       - name: Rust toolchain
-        # nightly changed no_coverage to coverage(off) which breaks the build
-        # see: https://github.com/rust-lang/rust/pull/114656
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2023-06-17
           components: llvm-tools-preview
 
       - name: grcov cache
@@ -446,7 +443,7 @@ jobs:
       - name: Build Documentation
         env: 
           RUSTDOCFLAGS: --cfg=docsrs
-        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.26.4 -p udev -p wayland-server -p wayland-backend -p wayland-protocols:0.30.1 -p winit -p x11rb
+        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.27.1 -p udev -p wayland-server -p wayland-backend -p wayland-protocols:0.31.0 -p winit -p x11rb
         
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,7 @@ jobs:
       - name: Build Documentation
         env: 
           RUSTDOCFLAGS: --cfg=docsrs
-        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.27.1 -p udev -p wayland-server -p wayland-backend -p wayland-protocols:0.31.0 -p winit -p x11rb
+        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.27.1 -p udev:0.8.0 -p wayland-server -p wayland-backend -p wayland-protocols:0.31.0 -p winit -p x11rb
         
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ appendlist = "1.4"
 # Intentionally pick a commit from "0.37-stable" branch since additions for 0.37.1 are used
 ash = { version = "0.37.1", optional = true }
 bitflags = "2.2.1"
-calloop = "0.10.1"
+calloop = "0.11.0"
 cgmath = "0.18.0"
 downcast-rs = "1.2.0"
 drm-fourcc = "^2.2.0"
@@ -51,7 +51,7 @@ scopeguard = { version = "1.1.0", optional = true }
 tracing = "0.1.37"
 tempfile = { version = "3.0", optional = true }
 thiserror = "1.0.25"
-udev = { version = "0.7", optional = true }
+udev = { version = "0.8.0", optional = true }
 wayland-egl = { version = "0.32.0", optional = true }
 wayland-protocols = { version = "0.31.0", features = ["unstable", "staging", "server"], optional = true }
 wayland-protocols-wlr = { version = "0.2.0", features = ["server"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ calloop = "0.10.1"
 cgmath = "0.18.0"
 downcast-rs = "1.2.0"
 drm-fourcc = "^2.2.0"
-drm = { version = "0.9.0", optional = true }
-drm-ffi = { version = "0.5.0", optional = true }
+drm = { version = "0.10.0", optional = true }
+drm-ffi = { version = "0.6.0", optional = true }
 
-gbm = { version = "0.12.0", optional = true, default-features = false, features = ["drm-support"] }
+gbm = { version = "0.13.0", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.12", optional = true }
 input = { version = "0.8.2", default-features = false, features=["libinput_1_14"], optional = true }
 indexmap = "1.9"
@@ -44,7 +44,7 @@ lazy_static = "1"
 libc = "0.2.103"
 libseat = { version = "0.2.1", optional = true, default_features = false }
 libloading = { version="0.8.0", optional = true }
-nix = "0.26.0"
+nix = { version = "0.27.0", features = ["fs", "mman", "signal", "socket", "poll"] }
 once_cell = "1.8.0"
 rand = "0.8.4"
 scopeguard = { version = "1.1.0", optional = true }
@@ -52,13 +52,13 @@ tracing = "0.1.37"
 tempfile = { version = "3.0", optional = true }
 thiserror = "1.0.25"
 udev = { version = "0.7", optional = true }
-wayland-egl = { version = "0.30.0", optional = true }
-wayland-protocols = { version = "0.30.1", features = ["unstable", "staging", "server"], optional = true }
-wayland-protocols-wlr = { version = "0.1.0", features = ["server"], optional = true }
-wayland-protocols-misc = { version = "0.1.0", features = ["server"], optional = true }
-wayland-server = { version = "0.30.0", optional = true }
-wayland-sys = { version = "0.30.1", optional = true }
-wayland-backend = { version = "0.1.0", optional = true }
+wayland-egl = { version = "0.32.0", optional = true }
+wayland-protocols = { version = "0.31.0", features = ["unstable", "staging", "server"], optional = true }
+wayland-protocols-wlr = { version = "0.2.0", features = ["server"], optional = true }
+wayland-protocols-misc = { version = "0.2.0", features = ["server"], optional = true }
+wayland-server = { version = "0.31.0", optional = true }
+wayland-sys = { version = "0.31", optional = true }
+wayland-backend = { version = "0.3.0", optional = true }
 winit = { version = "0.28.0", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
 x11rb = { version = "0.11.1", optional = true }
 xkbcommon = { version = "0.5.0", features = ["wayland"]}

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -129,7 +129,7 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
                     let res = state.handle.insert_source(source, move |_, _, data| {
                         data.state
                             .client_compositor_state(&client)
-                            .blocker_cleared(&mut data.state, &data.display.handle());
+                            .blocker_cleared(&mut data.state, &data.display_handle);
                         Ok(())
                     });
                     if res.is_ok() {

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -87,7 +87,8 @@ impl Backend for WinitData {
 
 pub fn run_winit() {
     let mut event_loop = EventLoop::try_new().unwrap();
-    let mut display = Display::new().unwrap();
+    let display = Display::new().unwrap();
+    let mut display_handle = display.handle();
 
     #[cfg_attr(not(feature = "egl"), allow(unused_mut))]
     let (mut backend, mut winit) = match winit::init::<GlesRenderer>() {
@@ -189,7 +190,7 @@ pub fn run_winit() {
             fps: fps_ticker::Fps::default(),
         }
     };
-    let mut state = AnvilState::init(&mut display, event_loop.handle(), data, true);
+    let mut state = AnvilState::init(display, event_loop.handle(), data, true);
     state
         .shm_state
         .update_formats(state.backend_data.backend.renderer().shm_formats());
@@ -226,7 +227,7 @@ pub fn run_winit() {
                     crate::shell::fixup_positions(&mut state.space, state.pointer.current_location());
                 }
                 WinitEvent::Input(event) => {
-                    state.process_input_event_windowed(&display.handle(), event, OUTPUT_NAME)
+                    state.process_input_event_windowed(&display_handle, event, OUTPUT_NAME)
                 }
                 _ => (),
             })
@@ -417,16 +418,22 @@ pub fn run_winit() {
             }
         }
 
-        let mut calloop_data = CalloopData { state, display };
+        let mut calloop_data = CalloopData {
+            state,
+            display_handle,
+        };
         let result = event_loop.dispatch(Some(Duration::from_millis(1)), &mut calloop_data);
-        CalloopData { state, display } = calloop_data;
+        CalloopData {
+            state,
+            display_handle,
+        } = calloop_data;
 
         if result.is_err() {
             state.running.store(false, Ordering::SeqCst);
         } else {
             state.space.refresh();
             state.popups.cleanup();
-            display.flush_clients().unwrap();
+            display_handle.flush_clients().unwrap();
         }
 
         #[cfg(feature = "debug")]

--- a/smallvil/src/main.rs
+++ b/smallvil/src/main.rs
@@ -7,12 +7,15 @@ mod input;
 mod state;
 mod winit;
 
-use smithay::reexports::{calloop::EventLoop, wayland_server::Display};
+use smithay::reexports::{
+    calloop::EventLoop,
+    wayland_server::{Display, DisplayHandle},
+};
 pub use state::Smallvil;
 
 pub struct CalloopData {
     state: Smallvil,
-    display: Display<Smallvil>,
+    display_handle: DisplayHandle,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -24,10 +27,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut event_loop: EventLoop<CalloopData> = EventLoop::try_new()?;
 
-    let mut display: Display<Smallvil> = Display::new()?;
-    let state = Smallvil::new(&mut event_loop, &mut display);
+    let display: Display<Smallvil> = Display::new()?;
+    let display_handle = display.handle();
+    let state = Smallvil::new(&mut event_loop, display);
 
-    let mut data = CalloopData { state, display };
+    let mut data = CalloopData {
+        state,
+        display_handle,
+    };
 
     crate::winit::init_winit(&mut event_loop, &mut data)?;
 

--- a/smallvil/src/state.rs
+++ b/smallvil/src/state.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsString, os::unix::io::AsRawFd, sync::Arc};
+use std::{ffi::OsString, sync::Arc};
 
 use smithay::{
     desktop::{PopupManager, Space, Window, WindowSurfaceType},
@@ -45,7 +45,7 @@ pub struct Smallvil {
 }
 
 impl Smallvil {
-    pub fn new(event_loop: &mut EventLoop<CalloopData>, display: &mut Display<Self>) -> Self {
+    pub fn new(event_loop: &mut EventLoop<CalloopData>, display: Display<Self>) -> Self {
         let start_time = std::time::Instant::now();
 
         let dh = display.handle();
@@ -101,7 +101,7 @@ impl Smallvil {
     }
 
     fn init_wayland_listener(
-        display: &mut Display<Smallvil>,
+        display: Display<Smallvil>,
         event_loop: &mut EventLoop<CalloopData>,
     ) -> OsString {
         // Creates a new listening socket, automatically choosing the next available `wayland` socket name.
@@ -120,8 +120,7 @@ impl Smallvil {
                 //
                 // You may also associate some data with the client when inserting the client.
                 state
-                    .display
-                    .handle()
+                    .display_handle
                     .insert_client(client_stream, Arc::new(ClientState::default()))
                     .unwrap();
             })
@@ -130,13 +129,9 @@ impl Smallvil {
         // You also need to add the display itself to the event loop, so that client events will be processed by wayland-server.
         handle
             .insert_source(
-                Generic::new(
-                    display.backend().poll_fd().as_raw_fd(),
-                    Interest::READ,
-                    Mode::Level,
-                ),
-                |_, _, state| {
-                    state.display.dispatch_clients(&mut state.state).unwrap();
+                Generic::new(display, Interest::READ, Mode::Level),
+                |_, display, state| {
+                    display.dispatch_clients(&mut state.state).unwrap();
                     Ok(PostAction::Continue)
                 },
             )

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -21,7 +21,7 @@ pub fn init_winit(
     event_loop: &mut EventLoop<CalloopData>,
     data: &mut CalloopData,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let display = &mut data.display;
+    let display_handle = &mut data.display_handle;
     let state = &mut data.state;
 
     let (mut backend, mut winit) = winit::init()?;
@@ -40,7 +40,7 @@ pub fn init_winit(
             model: "Winit".into(),
         },
     );
-    let _global = output.create_global::<Smallvil>(&display.handle());
+    let _global = output.create_global::<Smallvil>(display_handle);
     output.change_current_state(Some(mode), Some(Transform::Flipped180), None, Some((0, 0).into()));
     output.set_preferred(mode);
 
@@ -66,7 +66,7 @@ pub fn winit_dispatch(
     output: &Output,
     damage_tracker: &mut OutputDamageTracker,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let display = &mut data.display;
+    let display_handle = &mut data.display_handle;
     let state = &mut data.state;
 
     let res = winit.dispatch_new_events(|event| match event {
@@ -121,7 +121,7 @@ pub fn winit_dispatch(
 
     state.space.refresh();
     state.popups.cleanup();
-    display.flush_clients()?;
+    display_handle.flush_clients()?;
 
     Ok(())
 }

--- a/smithay-drm-extras/Cargo.toml
+++ b/smithay-drm-extras/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 edid-rs = "0.1.0"
-drm = { version = "0.9.0" }
+drm = { version = "0.10.0" }
 
 [features]
 default = []

--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -396,12 +396,10 @@ impl DmabufSource {
             Subsource::Empty,
         ];
         for (idx, handle) in dmabuf.handles().enumerate() {
-            // SAFETY: This is stored together with the Dmabuf holding the owned file descriptors
-            let fd = handle.as_raw_fd();
             if matches!(
                 poll::poll(
                     &mut [poll::PollFd::new(
-                        fd,
+                        &handle,
                         if interest.writable {
                             poll::PollFlags::POLLOUT
                         } else {
@@ -414,7 +412,7 @@ impl DmabufSource {
             ) {
                 continue;
             }
-            sources[idx] = Subsource::Active(Generic::new(fd, interest, Mode::OneShot));
+            sources[idx] = Subsource::Active(Generic::new(handle.as_raw_fd(), interest, Mode::OneShot));
         }
         if sources
             .iter()

--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -19,7 +19,7 @@ use crate::utils::{Buffer as BufferCoords, Size};
 #[cfg(feature = "wayland_frontend")]
 use crate::wayland::compositor::{Blocker, BlockerState};
 use std::hash::{Hash, Hasher};
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 use std::{error, fmt};
@@ -341,8 +341,8 @@ impl Blocker for DmabufBlocker {
 
 #[derive(Debug)]
 enum Subsource {
-    Active(Generic<RawFd, std::io::Error>),
-    Done(Generic<RawFd, std::io::Error>),
+    Active(Generic<BorrowedFd<'static>, std::io::Error>),
+    Done(Generic<BorrowedFd<'static>, std::io::Error>),
     Empty,
 }
 
@@ -412,7 +412,9 @@ impl DmabufSource {
             ) {
                 continue;
             }
-            sources[idx] = Subsource::Active(Generic::new(handle.as_raw_fd(), interest, Mode::OneShot));
+            // SAFETY: This is stored together with the Dmabuf holding the owned file descriptors
+            let fd = unsafe { BorrowedFd::borrow_raw(handle.as_raw_fd()) };
+            sources[idx] = Subsource::Active(Generic::new(fd, interest, Mode::OneShot));
         }
         if sources
             .iter()

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::io;
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd};
+use std::os::unix::io::{AsFd, BorrowedFd};
 use std::sync::atomic::Ordering;
 use std::sync::{atomic::AtomicBool, Arc, Mutex, Weak};
 use std::time::{Duration, SystemTime};
@@ -512,7 +512,7 @@ impl EventSource for DrmDeviceNotifier {
     fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
         self.token = Some(factory.token());
         poll.register(
-            self.internal.as_fd().as_raw_fd(),
+            self.internal.as_fd(),
             Interest::READ,
             calloop::Mode::Level,
             self.token.unwrap(),
@@ -522,7 +522,7 @@ impl EventSource for DrmDeviceNotifier {
     fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
         self.token = Some(factory.token());
         poll.reregister(
-            self.internal.as_fd().as_raw_fd(),
+            self.internal.as_fd(),
             Interest::READ,
             calloop::Mode::Level,
             self.token.unwrap(),
@@ -531,6 +531,6 @@ impl EventSource for DrmDeviceNotifier {
 
     fn unregister(&mut self, poll: &mut Poll) -> calloop::Result<()> {
         self.token = None;
-        poll.unregister(self.internal.as_fd().as_raw_fd())
+        poll.unregister(self.internal.as_fd())
     }
 }

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -12,7 +12,7 @@ use input::event;
 
 use std::{
     io,
-    os::unix::io::{AsRawFd, RawFd},
+    os::unix::io::{AsFd, BorrowedFd},
     path::PathBuf,
 };
 #[cfg(feature = "backend_session")]
@@ -619,9 +619,9 @@ impl<S: Session> libinput::LibinputInterface for LibinputSessionInterface<S> {
     }
 }
 
-impl AsRawFd for LibinputInputBackend {
-    fn as_raw_fd(&self) -> RawFd {
-        self.context.as_raw_fd()
+impl AsFd for LibinputInputBackend {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.context.as_fd()
     }
 }
 
@@ -769,16 +769,16 @@ impl EventSource for LibinputInputBackend {
 
     fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
         self.token = Some(factory.token());
-        poll.register(self.as_raw_fd(), Interest::READ, Mode::Level, self.token.unwrap())
+        poll.register(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap())
     }
 
     fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
         self.token = Some(factory.token());
-        poll.reregister(self.as_raw_fd(), Interest::READ, Mode::Level, self.token.unwrap())
+        poll.reregister(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap())
     }
 
     fn unregister(&mut self, poll: &mut Poll) -> calloop::Result<()> {
         self.token = None;
-        poll.unregister(self.as_raw_fd())
+        poll.unregister(self.as_fd())
     }
 }

--- a/src/backend/session/libseat.rs
+++ b/src/backend/session/libseat.rs
@@ -242,8 +242,9 @@ impl EventSource for LibSeatSessionNotifier {
         self.rx.register(poll, factory)?;
 
         self.token = Some(factory.token());
+        let mut seat = self.internal.seat.borrow_mut();
         poll.register(
-            self.internal.seat.borrow_mut().get_fd().unwrap().as_raw_fd(),
+            seat.get_fd().unwrap(),
             calloop::Interest::READ,
             calloop::Mode::Level,
             self.token.unwrap(),
@@ -254,8 +255,9 @@ impl EventSource for LibSeatSessionNotifier {
         self.rx.reregister(poll, factory)?;
 
         self.token = Some(factory.token());
+        let mut seat = self.internal.seat.borrow_mut();
         poll.reregister(
-            self.internal.seat.borrow_mut().get_fd().unwrap().as_raw_fd(),
+            seat.get_fd().unwrap(),
             calloop::Interest::READ,
             calloop::Mode::Level,
             self.token.unwrap(),
@@ -266,7 +268,8 @@ impl EventSource for LibSeatSessionNotifier {
         self.rx.unregister(poll)?;
 
         self.token = None;
-        poll.unregister(self.internal.seat.borrow_mut().get_fd().unwrap().as_raw_fd())
+        let mut seat = self.internal.seat.borrow_mut();
+        poll.unregister(seat.get_fd().unwrap())
     }
 }
 

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -42,7 +42,7 @@ use std::{
     collections::HashMap,
     ffi::OsString,
     fmt, io,
-    os::unix::io::{AsRawFd, RawFd},
+    os::unix::io::{AsFd, BorrowedFd},
     path::{Path, PathBuf},
 };
 use udev::{Enumerator, EventType, MonitorBuilder, MonitorSocket};
@@ -74,9 +74,9 @@ impl fmt::Debug for UdevBackend {
     }
 }
 
-impl AsRawFd for UdevBackend {
-    fn as_raw_fd(&self) -> RawFd {
-        self.monitor.as_raw_fd()
+impl AsFd for UdevBackend {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.monitor.as_fd()
     }
 }
 
@@ -192,17 +192,17 @@ impl EventSource for UdevBackend {
 
     fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
         self.token = Some(factory.token());
-        poll.register(self.as_raw_fd(), Interest::READ, Mode::Level, self.token.unwrap())
+        poll.register(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap())
     }
 
     fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
         self.token = Some(factory.token());
-        poll.reregister(self.as_raw_fd(), Interest::READ, Mode::Level, self.token.unwrap())
+        poll.reregister(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap())
     }
 
     fn unregister(&mut self, poll: &mut Poll) -> calloop::Result<()> {
         self.token = None;
-        poll.unregister(self.as_raw_fd())
+        poll.unregister(self.as_fd())
     }
 }
 

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -394,13 +394,13 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         let mut keymap_file = self.arc.keymap.lock().unwrap();
         keymap_file.change_keymap(keymap);
 
-        use std::os::unix::io::AsRawFd;
+        use std::os::unix::io::AsFd;
         use tracing::warn;
         use wayland_server::{protocol::wl_keyboard::KeymapFormat, Resource};
         let known_kbds = &self.arc.known_kbds;
         for kbd in &*known_kbds.lock().unwrap() {
             let res = keymap_file.with_fd(kbd.version() >= 7, |fd, size| {
-                kbd.keymap(KeymapFormat::XkbV1, fd.as_raw_fd(), size as u32)
+                kbd.keymap(KeymapFormat::XkbV1, fd.as_fd(), size as u32)
             });
             if let Err(e) = res {
                 warn!(

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -7,7 +7,7 @@ use std::{
     ffi::CString,
     fs::File,
     io::Write,
-    os::unix::io::{AsRawFd, FromRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd},
 };
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ impl SealedFile {
             MemFdCreateFlag::MFD_CLOEXEC | MemFdCreateFlag::MFD_ALLOW_SEALING,
         )?;
 
-        let mut file = unsafe { File::from_raw_fd(fd) };
+        let mut file: File = fd.into();
         file.write_all(data)?;
         file.flush()?;
 
@@ -110,5 +110,11 @@ impl SealedFile {
 impl AsRawFd for SealedFile {
     fn as_raw_fd(&self) -> RawFd {
         self.file.as_raw_fd()
+    }
+}
+
+impl AsFd for SealedFile {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.file.as_fd()
     }
 }

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -292,28 +292,20 @@ where
     fn destroyed(
         state: &mut D,
         _client_id: wayland_server::backend::ClientId,
-        object_id: wayland_server::backend::ObjectId,
+        surface: &WlSurface,
         data: &SurfaceUserData,
     ) {
-        let surface = state
-            .compositor_state()
-            .surfaces
-            .iter()
-            .find(|surface| surface.id() == object_id)
-            .cloned()
-            .unwrap();
-
         // We let the destruction hooks run first and then tell the compositor handler the surface was
         // destroyed.
         data.alive_tracker.destroy_notify();
-        state.destroyed(&surface);
+        state.destroyed(surface);
 
         // Remove the surface after the callback is invoked.
         state
             .compositor_state()
             .surfaces
-            .retain(|surface| surface.id() != object_id);
-        PrivateSurfaceData::cleanup(state, data, object_id);
+            .retain(|s| s.id() != surface.id());
+        PrivateSurfaceData::cleanup(state, data, surface.id());
     }
 }
 
@@ -569,7 +561,7 @@ where
     fn destroyed(
         _state: &mut D,
         _client_id: wayland_server::backend::ClientId,
-        _object_id: wayland_server::backend::ObjectId,
+        _object: &WlSubsurface,
         data: &SubsurfaceUserData,
     ) {
         PrivateSurfaceData::unset_parent(&data.surface);

--- a/src/wayland/content_type/dispatch.rs
+++ b/src/wayland/content_type/dispatch.rs
@@ -3,8 +3,7 @@ use wayland_protocols::wp::content_type::v1::server::{
     wp_content_type_v1::{self, WpContentTypeV1},
 };
 use wayland_server::{
-    backend::{ClientId, ObjectId},
-    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+    backend::ClientId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
 
 use super::{ContentTypeState, ContentTypeSurfaceCachedState, ContentTypeSurfaceData, ContentTypeUserData};
@@ -131,7 +130,7 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _client: ClientId, _object: ObjectId, _data: &ContentTypeUserData) {
+    fn destroyed(_state: &mut D, _client: ClientId, _object: &WpContentTypeV1, _data: &ContentTypeUserData) {
         // Nothing to do here, graceful Destroy is already handled with double buffering
         // and in case of client close WlSurface destroyed handler will clean up the data anyway,
         // so there is no point in queuing new update

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    os::unix::io::{AsRawFd, OwnedFd},
+    os::unix::io::{AsFd, OwnedFd},
     sync::{Arc, Mutex},
 };
 
@@ -370,7 +370,14 @@ where
         None
     }
 
-    fn destroyed(&self, _data: &mut D, _client_id: ClientId, _object_id: ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &Handle,
+        _data: &mut D,
+        _client_id: ClientId,
+        _object_id: ObjectId,
+    ) {
+    }
 }
 
 fn handle_dnd<D>(handler: &mut D, offer: &WlDataOffer, request: wl_data_offer::Request, data: &DndDataOffer)
@@ -400,7 +407,7 @@ where
                 && source.alive()
                 && data.active;
             if valid {
-                source.send(mime_type, fd.as_raw_fd());
+                source.send(mime_type, fd.as_fd());
             }
         }
         Request::Destroy => {}

--- a/src/wayland/data_device/mod.rs
+++ b/src/wayland/data_device/mod.rs
@@ -66,7 +66,7 @@
 
 use std::{
     cell::{Ref, RefCell},
-    os::unix::io::{AsRawFd, OwnedFd},
+    os::unix::io::{AsFd, OwnedFd},
 };
 
 use tracing::instrument;
@@ -335,7 +335,7 @@ where
             {
                 Err(SelectionRequestError::InvalidMimetype)
             } else {
-                source.send(mime_type, fd.as_raw_fd());
+                source.send(mime_type, fd.as_fd());
                 Ok(())
             }
         }

--- a/src/wayland/data_device/seat_data.rs
+++ b/src/wayland/data_device/seat_data.rs
@@ -1,5 +1,5 @@
 use std::{
-    os::unix::io::{AsRawFd, OwnedFd},
+    os::unix::io::{AsFd, OwnedFd},
     sync::Arc,
 };
 
@@ -224,7 +224,14 @@ where
         None
     }
 
-    fn destroyed(&self, _data: &mut D, _client_id: ClientId, _object_id: ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &Handle,
+        _data: &mut D,
+        _client_id: ClientId,
+        _object_id: ObjectId,
+    ) {
+    }
 }
 
 fn handle_client_selection(request: wl_data_offer::Request, source: &WlDataSource) {
@@ -239,7 +246,7 @@ fn handle_client_selection(request: wl_data_offer::Request, source: &WlDataSourc
             // deny the receive
             debug!("Denying a wl_data_offer.receive with invalid source.");
         } else {
-            source.send(mime_type, fd.as_raw_fd());
+            source.send(mime_type, fd.as_fd());
         }
     }
 }
@@ -274,7 +281,14 @@ where
         None
     }
 
-    fn destroyed(&self, _data: &mut D, _client_id: ClientId, _object_id: ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &Handle,
+        _data: &mut D,
+        _client_id: ClientId,
+        _object_id: ObjectId,
+    ) {
+    }
 }
 
 pub fn handle_server_selection<D>(

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -345,7 +345,14 @@ where
         None
     }
 
-    fn destroyed(&self, _data: &mut D, _client_id: ClientId, _object_id: ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &Handle,
+        _data: &mut D,
+        _client_id: ClientId,
+        _object_id: ObjectId,
+    ) {
+    }
 }
 
 fn handle_server_dnd<D>(

--- a/src/wayland/data_device/source.rs
+++ b/src/wayland/data_device/source.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 use tracing::error;
 
 use wayland_server::{
-    backend::{ClientId, ObjectId},
+    backend::ClientId,
     protocol::wl_data_source::{self},
     protocol::{wl_data_device_manager::DndAction, wl_data_source::WlDataSource},
     Dispatch, DisplayHandle, Resource,
@@ -80,7 +80,7 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _client: ClientId, _resource: ObjectId, data: &DataSourceUserData) {
+    fn destroyed(_state: &mut D, _client: ClientId, _resource: &WlDataSource, data: &DataSourceUserData) {
         data.alive_tracker.destroy_notify();
     }
 }

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -194,7 +194,7 @@ use std::{
     convert::TryFrom,
     ffi::CString,
     ops::Sub,
-    os::unix::io::AsRawFd,
+    os::unix::io::{AsFd, AsRawFd},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -444,7 +444,7 @@ impl DmabufFeedback {
     pub fn send(&self, feedback: &zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1) {
         feedback.main_device(self.0.main_device.to_ne_bytes().to_vec());
         feedback.format_table(
-            self.0.format_table.file.as_raw_fd(),
+            self.0.format_table.file.as_fd(),
             self.0.format_table.file.size() as u32,
         );
 

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -8,7 +8,7 @@ use wayland_protocols_misc::zwp_input_method_v2::server::{
     zwp_input_method_v2::{self, ZwpInputMethodV2},
     zwp_input_popup_surface_v2::ZwpInputPopupSurfaceV2,
 };
-use wayland_server::backend::{ClientId, ObjectId};
+use wayland_server::backend::ClientId;
 use wayland_server::{
     protocol::{wl_keyboard::KeymapFormat, wl_surface::WlSurface},
     Client, DataInit, Dispatch, DisplayHandle, Resource,
@@ -216,7 +216,12 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _client: ClientId, _input_method: ObjectId, data: &InputMethodUserData<D>) {
+    fn destroyed(
+        _state: &mut D,
+        _client: ClientId,
+        _input_method: &ZwpInputMethodV2,
+        data: &InputMethodUserData<D>,
+    ) {
         data.handle.inner.lock().unwrap().instance = None;
         data.text_input_handle.with_focused_text_input(|ti, surface, _| {
             ti.leave(surface);

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -6,7 +6,7 @@ use std::{
 use wayland_protocols_misc::zwp_input_method_v2::server::zwp_input_method_keyboard_grab_v2::{
     self, ZwpInputMethodKeyboardGrabV2,
 };
-use wayland_server::backend::{ClientId, ObjectId};
+use wayland_server::backend::ClientId;
 use wayland_server::Dispatch;
 
 use crate::backend::input::KeyState;
@@ -99,7 +99,12 @@ impl<D: SeatHandler> fmt::Debug for InputMethodKeyboardUserData<D> {
 impl<D: SeatHandler + 'static> Dispatch<ZwpInputMethodKeyboardGrabV2, InputMethodKeyboardUserData<D>, D>
     for InputMethodManagerState
 {
-    fn destroyed(_state: &mut D, _client: ClientId, _id: ObjectId, data: &InputMethodKeyboardUserData<D>) {
+    fn destroyed(
+        _state: &mut D,
+        _client: ClientId,
+        _object: &ZwpInputMethodKeyboardGrabV2,
+        data: &InputMethodKeyboardUserData<D>,
+    ) {
         data.handle.inner.lock().unwrap().grab = None;
         data.keyboard_handle.unset_grab();
     }

--- a/src/wayland/input_method/input_method_popup_surface.rs
+++ b/src/wayland/input_method/input_method_popup_surface.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use wayland_protocols_misc::zwp_input_method_v2::server::zwp_input_popup_surface_v2::{
     self, ZwpInputPopupSurfaceV2,
 };
-use wayland_server::backend::{ClientId, ObjectId};
+use wayland_server::backend::ClientId;
 use wayland_server::{protocol::wl_surface::WlSurface, Dispatch};
 
 use crate::utils::{Logical, Physical, Point, Rectangle};
@@ -74,7 +74,12 @@ impl<D> Dispatch<ZwpInputPopupSurfaceV2, InputMethodPopupSurfaceUserData, D> for
         }
     }
 
-    fn destroyed(_state: &mut D, _client: ClientId, _id: ObjectId, data: &InputMethodPopupSurfaceUserData) {
+    fn destroyed(
+        _state: &mut D,
+        _client: ClientId,
+        _object: &ZwpInputPopupSurfaceV2,
+        data: &InputMethodPopupSurfaceUserData,
+    ) {
         data.handle.inner.lock().unwrap().surface_role = None;
     }
 }

--- a/src/wayland/keyboard_shortcuts_inhibit/dispatch.rs
+++ b/src/wayland/keyboard_shortcuts_inhibit/dispatch.rs
@@ -132,7 +132,7 @@ where
     fn destroyed(
         handler: &mut D,
         _client: ClientId,
-        id: ObjectId,
+        wl_inhibitor: &ZwpKeyboardShortcutsInhibitorV1,
         data: &KeyboardShortcutsInhibitorUserData,
     ) {
         data.is_active.store(false, atomic::Ordering::Release);
@@ -140,7 +140,7 @@ where
         let state = handler.keyboard_shortcuts_inhibit_state();
 
         if let Entry::Occupied(mut entry) = state.inhibitors.entry(data.seat.clone()) {
-            let inhibitor = entry.get_mut().borrow_mut().remove(id);
+            let inhibitor = entry.get_mut().borrow_mut().remove(wl_inhibitor.id());
 
             if entry.get().borrow().is_empty() {
                 entry.remove();

--- a/src/wayland/output/handlers.rs
+++ b/src/wayland/output/handlers.rs
@@ -97,7 +97,7 @@ where
     fn destroyed(
         _state: &mut D,
         _client_id: wayland_server::backend::ClientId,
-        object_id: wayland_server::backend::ObjectId,
+        output: &WlOutput,
         data: &OutputUserData,
     ) {
         data.global_data
@@ -105,7 +105,7 @@ where
             .lock()
             .unwrap()
             .instances
-            .retain(|o| o.id() != object_id);
+            .retain(|o| o.id() != output.id());
     }
 }
 
@@ -195,7 +195,7 @@ where
     fn destroyed(
         _state: &mut D,
         _client_id: wayland_server::backend::ClientId,
-        object_id: wayland_server::backend::ObjectId,
+        xdg_output: &ZxdgOutputV1,
         data: &XdgOutputUserData,
     ) {
         data.xdg_output
@@ -203,6 +203,6 @@ where
             .lock()
             .unwrap()
             .instances
-            .retain(|o| o.id() != object_id);
+            .retain(|o| o.id() != xdg_output.id());
     }
 }

--- a/src/wayland/pointer_gestures.rs
+++ b/src/wayland/pointer_gestures.rs
@@ -94,7 +94,7 @@ use wayland_protocols::wp::pointer_gestures::zv1::server::{
     zwp_pointer_gestures_v1::{self, ZwpPointerGesturesV1},
 };
 use wayland_server::{
-    backend::{ClientId, GlobalId, ObjectId},
+    backend::{ClientId, GlobalId},
     protocol::wl_surface::WlSurface,
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
@@ -238,13 +238,18 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _: ClientId, object_id: ObjectId, data: &PointerGestureUserData<D>) {
+    fn destroyed(
+        _state: &mut D,
+        _: ClientId,
+        object: &ZwpPointerGestureSwipeV1,
+        data: &PointerGestureUserData<D>,
+    ) {
         if let Some(ref handle) = data.handle {
             handle
                 .known_swipe_gestures
                 .lock()
                 .unwrap()
-                .retain(|p| p.id() != object_id);
+                .retain(|p| p.id() != object.id());
         }
     }
 }
@@ -270,13 +275,18 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _: ClientId, object_id: ObjectId, data: &PointerGestureUserData<D>) {
+    fn destroyed(
+        _state: &mut D,
+        _: ClientId,
+        object: &ZwpPointerGesturePinchV1,
+        data: &PointerGestureUserData<D>,
+    ) {
         if let Some(ref handle) = data.handle {
             handle
                 .known_pinch_gestures
                 .lock()
                 .unwrap()
-                .retain(|p| p.id() != object_id);
+                .retain(|p| p.id() != object.id());
         }
     }
 }
@@ -302,13 +312,18 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _: ClientId, object_id: ObjectId, data: &PointerGestureUserData<D>) {
+    fn destroyed(
+        _state: &mut D,
+        _: ClientId,
+        object: &ZwpPointerGestureHoldV1,
+        data: &PointerGestureUserData<D>,
+    ) {
         if let Some(ref handle) = data.handle {
             handle
                 .known_hold_gestures
                 .lock()
                 .unwrap()
-                .retain(|p| p.id() != object_id);
+                .retain(|p| p.id() != object.id());
         }
     }
 }

--- a/src/wayland/primary_selection/mod.rs
+++ b/src/wayland/primary_selection/mod.rs
@@ -61,7 +61,7 @@
 
 use std::{
     cell::{Ref, RefCell},
-    os::unix::io::{AsRawFd, OwnedFd},
+    os::unix::io::{AsFd, OwnedFd},
 };
 
 use tracing::instrument;
@@ -221,7 +221,7 @@ where
             {
                 Err(SelectionRequestError::InvalidMimetype)
             } else {
-                source.send(mime_type, fd.as_raw_fd());
+                source.send(mime_type, fd.as_fd());
                 Ok(())
             }
         }

--- a/src/wayland/primary_selection/seat_data.rs
+++ b/src/wayland/primary_selection/seat_data.rs
@@ -1,5 +1,5 @@
 use std::{
-    os::unix::io::{AsRawFd, OwnedFd},
+    os::unix::io::{AsFd, OwnedFd},
     sync::Arc,
 };
 
@@ -220,7 +220,14 @@ where
         None
     }
 
-    fn destroyed(&self, _data: &mut D, _client_id: ClientId, _object_id: ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &Handle,
+        _data: &mut D,
+        _client_id: ClientId,
+        _object_id: ObjectId,
+    ) {
+    }
 }
 
 fn handle_client_selection(request: primary_offer::Request, source: &PrimarySource) {
@@ -235,7 +242,7 @@ fn handle_client_selection(request: primary_offer::Request, source: &PrimarySour
             // deny the receive
             debug!("Denying a zwp_primary_selection_offer_v1.receive with invalid source.");
         } else {
-            source.send(mime_type, fd.as_raw_fd());
+            source.send(mime_type, fd.as_fd());
         }
     }
 }
@@ -270,7 +277,14 @@ where
         None
     }
 
-    fn destroyed(&self, _data: &mut D, _client_id: ClientId, _object_id: ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &Handle,
+        _data: &mut D,
+        _client_id: ClientId,
+        _object_id: ObjectId,
+    ) {
+    }
 }
 
 pub fn handle_server_selection<D>(

--- a/src/wayland/primary_selection/source.rs
+++ b/src/wayland/primary_selection/source.rs
@@ -3,10 +3,7 @@ use std::sync::Mutex;
 use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_source_v1::{
     self as primary_source, ZwpPrimarySelectionSourceV1 as PrimarySource,
 };
-use wayland_server::{
-    backend::{ClientId, ObjectId},
-    Dispatch, DisplayHandle, Resource,
-};
+use wayland_server::{backend::ClientId, Dispatch, DisplayHandle, Resource};
 
 use crate::utils::{alive_tracker::AliveTracker, IsAlive};
 
@@ -62,7 +59,7 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _client: ClientId, _resource: ObjectId, data: &PrimarySourceUserData) {
+    fn destroyed(_state: &mut D, _client: ClientId, _resource: &PrimarySource, data: &PrimarySourceUserData) {
         data.alive_tracker.destroy_notify();
     }
 }

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -78,7 +78,7 @@ use wayland_protocols::wp::relative_pointer::zv1::server::{
     zwp_relative_pointer_v1::{self, ZwpRelativePointerV1},
 };
 use wayland_server::{
-    backend::{ClientId, GlobalId, ObjectId},
+    backend::{ClientId, GlobalId},
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
 
@@ -195,13 +195,18 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _: ClientId, object_id: ObjectId, data: &RelativePointerUserData<D>) {
+    fn destroyed(
+        _state: &mut D,
+        _: ClientId,
+        object: &ZwpRelativePointerV1,
+        data: &RelativePointerUserData<D>,
+    ) {
         if let Some(ref handle) = data.handle {
             handle
                 .known_relative_pointers
                 .lock()
                 .unwrap()
-                .retain(|p| p.id() != object_id);
+                .retain(|p| p.id() != object.id());
         }
     }
 }

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -111,14 +111,14 @@ where
     ) {
     }
 
-    fn destroyed(_state: &mut D, _client_id: ClientId, object_id: ObjectId, data: &KeyboardUserData<D>) {
+    fn destroyed(_state: &mut D, _client_id: ClientId, keyboard: &WlKeyboard, data: &KeyboardUserData<D>) {
         if let Some(ref handle) = data.handle {
             handle
                 .arc
                 .known_kbds
                 .lock()
                 .unwrap()
-                .retain(|k| k.id() != object_id)
+                .retain(|k| k.id() != keyboard.id())
         }
     }
 }

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -366,13 +366,13 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _: ClientId, object_id: ObjectId, data: &SeatUserData<D>) {
+    fn destroyed(_state: &mut D, _: ClientId, seat: &WlSeat, data: &SeatUserData<D>) {
         data.arc
             .inner
             .lock()
             .unwrap()
             .known_seats
-            .retain(|s| s.id() != object_id);
+            .retain(|s| s.id() != seat.id());
     }
 }
 

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -9,7 +9,7 @@ use wayland_protocols::wp::{
     relative_pointer::zv1::server::zwp_relative_pointer_v1::ZwpRelativePointerV1,
 };
 use wayland_server::{
-    backend::{ClientId, ObjectId},
+    backend::ClientId,
     protocol::{
         wl_pointer::{
             self, Axis as WlAxis, AxisSource as WlAxisSource, ButtonState as WlButtonState, Request,
@@ -506,13 +506,13 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _: ClientId, object_id: ObjectId, data: &PointerUserData<D>) {
+    fn destroyed(_state: &mut D, _: ClientId, pointer: &WlPointer, data: &PointerUserData<D>) {
         if let Some(ref handle) = data.handle {
             handle
                 .known_pointers
                 .lock()
                 .unwrap()
-                .retain(|p| p.id() != object_id);
+                .retain(|p| p.id() != pointer.id());
         }
     }
 }

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use wayland_server::{
-    backend::{ClientId, ObjectId},
+    backend::ClientId,
     protocol::wl_touch::{self, WlTouch},
     Dispatch, DisplayHandle, Resource,
 };
@@ -204,14 +204,14 @@ where
     ) {
     }
 
-    fn destroyed(_state: &mut D, _client_id: ClientId, object_id: ObjectId, data: &TouchUserData) {
+    fn destroyed(_state: &mut D, _client_id: ClientId, touch: &WlTouch, data: &TouchUserData) {
         if let Some(ref handle) = data.handle {
             handle
                 .inner
                 .lock()
                 .unwrap()
                 .known_handles
-                .retain(|k| k.id() != object_id)
+                .retain(|k| k.id() != touch.id())
         }
     }
 }

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -324,7 +324,7 @@ where
     fn destroyed(
         state: &mut D,
         _client_id: wayland_server::backend::ClientId,
-        object_id: wayland_server::backend::ObjectId,
+        layer_surface: &ZwlrLayerSurfaceV1,
         data: &WlrLayerSurfaceUserData,
     ) {
         data.alive_tracker.destroy_notify();
@@ -333,7 +333,7 @@ where
         let mut layers = data.shell_data.known_layers.lock().unwrap();
         if let Some(index) = layers
             .iter()
-            .position(|layer| layer.shell_surface.id() == object_id)
+            .position(|layer| layer.shell_surface.id() == layer_surface.id())
         {
             let layer = layers.remove(index);
             drop(layers);

--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -10,10 +10,7 @@ use crate::{
 
 use wayland_protocols::xdg::shell::server::xdg_popup::{self, XdgPopup};
 
-use wayland_server::{
-    backend::{ClientId, ObjectId},
-    DataInit, Dispatch, DisplayHandle, Resource,
-};
+use wayland_server::{backend::ClientId, DataInit, Dispatch, DisplayHandle, Resource};
 
 use super::{PopupConfigure, XdgShellHandler, XdgShellState, XdgShellSurfaceUserData, XdgSurfaceUserData};
 
@@ -67,7 +64,7 @@ where
         }
     }
 
-    fn destroyed(state: &mut D, _client_id: ClientId, object_id: ObjectId, data: &XdgShellSurfaceUserData) {
+    fn destroyed(state: &mut D, _client_id: ClientId, xdg_popup: &XdgPopup, data: &XdgShellSurfaceUserData) {
         data.alive_tracker.destroy_notify();
 
         // remove this surface from the known ones (as well as any leftover dead surface)
@@ -75,7 +72,7 @@ where
             .xdg_shell_state()
             .known_popups
             .iter()
-            .position(|pop| pop.shell_surface.id() == object_id)
+            .position(|pop| pop.shell_surface.id() == xdg_popup.id())
         {
             let popup = state.xdg_shell_state().known_popups.remove(index);
             let surface = popup.wl_surface().clone();

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -8,9 +8,7 @@ use crate::{
 use wayland_protocols::xdg::shell::server::xdg_toplevel::{self, XdgToplevel};
 
 use wayland_server::{
-    backend::{ClientId, ObjectId},
-    protocol::wl_surface,
-    DataInit, Dispatch, DisplayHandle, Resource, WEnum,
+    backend::ClientId, protocol::wl_surface, DataInit, Dispatch, DisplayHandle, Resource, WEnum,
 };
 
 use super::{
@@ -122,7 +120,12 @@ where
         }
     }
 
-    fn destroyed(state: &mut D, _client_id: ClientId, object_id: ObjectId, data: &XdgShellSurfaceUserData) {
+    fn destroyed(
+        state: &mut D,
+        _client_id: ClientId,
+        xdg_toplevel: &XdgToplevel,
+        data: &XdgShellSurfaceUserData,
+    ) {
         data.alive_tracker.destroy_notify();
         data.decoration.lock().unwrap().take();
 
@@ -130,7 +133,7 @@ where
             .xdg_shell_state()
             .known_toplevels
             .iter()
-            .position(|top| top.shell_surface.id() == object_id)
+            .position(|top| top.shell_surface.id() == xdg_toplevel.id())
         {
             let toplevel = state.xdg_shell_state().known_toplevels.remove(index);
             let surface = toplevel.wl_surface().clone();

--- a/src/wayland/shell/xdg/handlers/wm_base.rs
+++ b/src/wayland/shell/xdg/handlers/wm_base.rs
@@ -12,8 +12,7 @@ use wayland_protocols::xdg::shell::server::{
 };
 
 use wayland_server::{
-    backend::{ClientId, ObjectId},
-    DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
+    backend::ClientId, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
 };
 
 use super::{ShellClient, ShellClientData, XdgPositionerUserData, XdgShellHandler, XdgSurfaceUserData};
@@ -107,7 +106,7 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _client_id: ClientId, _object_id: ObjectId, data: &XdgWmBaseUserData) {
+    fn destroyed(_state: &mut D, _client_id: ClientId, _object: &XdgWmBase, data: &XdgWmBaseUserData) {
         data.alive_tracker.destroy_notify();
     }
 }

--- a/src/wayland/tablet_manager/tablet.rs
+++ b/src/wayland/tablet_manager/tablet.rs
@@ -8,9 +8,7 @@ use wayland_protocols::wp::tablet::zv2::server::{
     zwp_tablet_v2::{self, ZwpTabletV2},
 };
 use wayland_server::{
-    backend::{ClientId, ObjectId},
-    protocol::wl_surface::WlSurface,
-    Client, DataInit, Dispatch, DisplayHandle, Resource,
+    backend::ClientId, protocol::wl_surface::WlSurface, Client, DataInit, Dispatch, DisplayHandle, Resource,
 };
 
 use crate::backend::input::Device;
@@ -122,12 +120,12 @@ where
     ) {
     }
 
-    fn destroyed(_state: &mut D, _client: ClientId, tablet: ObjectId, data: &TabletUserData) {
+    fn destroyed(_state: &mut D, _client: ClientId, tablet: &ZwpTabletV2, data: &TabletUserData) {
         data.handle
             .inner
             .lock()
             .unwrap()
             .instances
-            .retain(|i| Resource::id(i) != tablet);
+            .retain(|i| Resource::id(i) != Resource::id(tablet));
     }
 }

--- a/src/wayland/tablet_manager/tablet_seat.rs
+++ b/src/wayland/tablet_manager/tablet_seat.rs
@@ -3,10 +3,7 @@ use wayland_protocols::wp::tablet::zv2::server::{
     zwp_tablet_tool_v2::ZwpTabletToolV2,
     zwp_tablet_v2::ZwpTabletV2,
 };
-use wayland_server::{
-    backend::{ClientId, ObjectId},
-    Client, DataInit, Dispatch, DisplayHandle, Resource,
-};
+use wayland_server::{backend::ClientId, Client, DataInit, Dispatch, DisplayHandle, Resource};
 
 use crate::backend::input::TabletToolDescriptor;
 use crate::input::pointer::CursorImageStatus;
@@ -232,12 +229,12 @@ where
     ) {
     }
 
-    fn destroyed(_state: &mut D, _client: ClientId, seat: ObjectId, data: &TabletSeatUserData) {
+    fn destroyed(_state: &mut D, _client: ClientId, seat: &ZwpTabletSeatV2, data: &TabletSeatUserData) {
         data.handle
             .inner
             .lock()
             .unwrap()
             .instances
-            .retain(|i| i.id() != seat);
+            .retain(|i| i.id() != seat.id());
     }
 }

--- a/src/wayland/tablet_manager/tablet_tool.rs
+++ b/src/wayland/tablet_manager/tablet_tool.rs
@@ -10,10 +10,7 @@ use wayland_protocols::wp::tablet::zv2::server::{
     zwp_tablet_tool_v2::{self, ZwpTabletToolV2},
 };
 use wayland_server::protocol::wl_surface::WlSurface;
-use wayland_server::{
-    backend::{ClientId, ObjectId},
-    Client, DataInit, Dispatch, DisplayHandle, Resource,
-};
+use wayland_server::{backend::ClientId, Client, DataInit, Dispatch, DisplayHandle, Resource};
 
 use crate::{utils::Serial, wayland::compositor};
 
@@ -501,12 +498,12 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _client: ClientId, resource: ObjectId, data: &TabletToolUserData) {
+    fn destroyed(_state: &mut D, _client: ClientId, resource: &ZwpTabletToolV2, data: &TabletToolUserData) {
         data.handle
             .inner
             .lock()
             .unwrap()
             .instances
-            .retain(|i| i.id() != resource);
+            .retain(|i| i.id() != resource.id());
     }
 }

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use wayland_protocols::wp::text_input::zv3::server::zwp_text_input_v3::{self, ZwpTextInputV3};
-use wayland_server::backend::{ClientId, ObjectId};
+use wayland_server::backend::ClientId;
 use wayland_server::{protocol::wl_surface::WlSurface, Dispatch, Resource};
 
 use crate::utils::IsAlive;
@@ -161,7 +161,7 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _client: ClientId, ti: ObjectId, data: &TextInputUserData) {
+    fn destroyed(_state: &mut D, _client: ClientId, ti: &ZwpTextInputV3, data: &TextInputUserData) {
         // Ensure IME is deactivated when text input dies.
         data.input_method_handle.with_instance(|input_method| {
             input_method.deactivate();
@@ -173,6 +173,6 @@ where
             .lock()
             .unwrap()
             .instances
-            .retain(|i| i.instance.id() != ti);
+            .retain(|i| i.instance.id() != ti.id());
     }
 }

--- a/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
+++ b/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
@@ -12,7 +12,7 @@ use wayland_protocols_misc::zwp_virtual_keyboard_v1::server::zwp_virtual_keyboar
     self, ZwpVirtualKeyboardV1,
 };
 use wayland_server::{
-    backend::{ClientId, ObjectId},
+    backend::ClientId,
     protocol::wl_keyboard::{KeyState, KeymapFormat},
     Client, DataInit, Dispatch, DisplayHandle,
 };
@@ -140,7 +140,7 @@ where
     fn destroyed(
         _state: &mut D,
         _client: ClientId,
-        _virtual_keyboard: ObjectId,
+        _virtual_keyboard: &ZwpVirtualKeyboardV1,
         data: &VirtualKeyboardUserData<D>,
     ) {
         let mut inner = data.handle.inner.lock().unwrap();

--- a/src/wayland/xdg_activation/dispatch.rs
+++ b/src/wayland/xdg_activation/dispatch.rs
@@ -5,8 +5,7 @@ use std::sync::{
 
 use wayland_protocols::xdg::activation::v1::server::{xdg_activation_token_v1, xdg_activation_v1};
 use wayland_server::{
-    backend::{ClientId, ObjectId},
-    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+    backend::ClientId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
 
 use super::{
@@ -170,7 +169,12 @@ where
         }
     }
 
-    fn destroyed(state: &mut D, _: ClientId, _: ObjectId, data: &ActivationTokenData) {
+    fn destroyed(
+        state: &mut D,
+        _: ClientId,
+        _: &xdg_activation_token_v1::XdgActivationTokenV1,
+        data: &ActivationTokenData,
+    ) {
         let guard = data.token.lock().unwrap();
 
         if let Some(token) = &*guard {

--- a/src/xwayland/x11_sockets.rs
+++ b/src/xwayland/x11_sockets.rs
@@ -1,6 +1,9 @@
 use std::{
     io::{Read, Write},
-    os::unix::{io::FromRawFd, net::UnixStream},
+    os::unix::{
+        io::{AsRawFd, FromRawFd},
+        net::UnixStream,
+    },
 };
 
 use tracing::{debug, info, warn};
@@ -168,13 +171,13 @@ fn open_socket(addr: socket::UnixAddr) -> nix::Result<UnixStream> {
         None,
     )?;
     // bind it to requested address
-    if let Err(e) = socket::bind(fd, &addr) {
-        let _ = ::nix::unistd::close(fd);
+    if let Err(e) = socket::bind(fd.as_raw_fd(), &addr) {
+        let _ = ::nix::unistd::close(fd.as_raw_fd());
         return Err(e);
     }
-    if let Err(e) = socket::listen(fd, 1) {
-        let _ = ::nix::unistd::close(fd);
+    if let Err(e) = socket::listen(&fd, 1) {
+        let _ = ::nix::unistd::close(fd.as_raw_fd());
         return Err(e);
     }
-    Ok(unsafe { FromRawFd::from_raw_fd(fd) })
+    Ok(unsafe { FromRawFd::from_raw_fd(fd.as_raw_fd()) })
 }

--- a/src/xwayland/x11_sockets.rs
+++ b/src/xwayland/x11_sockets.rs
@@ -1,9 +1,6 @@
 use std::{
     io::{Read, Write},
-    os::unix::{
-        io::{AsRawFd, FromRawFd},
-        net::UnixStream,
-    },
+    os::unix::{io::AsRawFd, net::UnixStream},
 };
 
 use tracing::{debug, info, warn};
@@ -171,13 +168,7 @@ fn open_socket(addr: socket::UnixAddr) -> nix::Result<UnixStream> {
         None,
     )?;
     // bind it to requested address
-    if let Err(e) = socket::bind(fd.as_raw_fd(), &addr) {
-        let _ = ::nix::unistd::close(fd.as_raw_fd());
-        return Err(e);
-    }
-    if let Err(e) = socket::listen(&fd, 1) {
-        let _ = ::nix::unistd::close(fd.as_raw_fd());
-        return Err(e);
-    }
-    Ok(unsafe { FromRawFd::from_raw_fd(fd.as_raw_fd()) })
+    socket::bind(fd.as_raw_fd(), &addr)?;
+    socket::listen(&fd, 1)?;
+    Ok(UnixStream::from(fd))
 }

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -18,7 +18,7 @@ use smithay::{
             channel::{Channel, Event as ChannelEvent},
             EventLoop,
         },
-        wayland_server::{protocol::wl_surface, Client, Display, Resource},
+        wayland_server::{protocol::wl_surface, Client, Display, DisplayHandle, Resource},
     },
     utils::{IsAlive, Point, Scale, SERIAL_COUNTER as SCOUNTER},
     wayland::{compositor, input_method::InputMethodSeat},
@@ -47,20 +47,20 @@ pub fn run(channel: Channel<WlcsEvent>) {
     let mut event_loop =
         EventLoop::<CalloopData<TestState>>::try_new().expect("Failed to init the event loop.");
 
-    let mut display = Display::new().expect("Failed to init display");
-    let dh = display.handle();
+    let display = Display::new().expect("Failed to init display");
+    let mut display_handle = display.handle();
 
     let test_state = TestState {
         clients: HashMap::new(),
     };
 
-    let mut state = AnvilState::init(&mut display, event_loop.handle(), test_state, false);
+    let mut state = AnvilState::init(display, event_loop.handle(), test_state, false);
 
     event_loop
         .handle()
         .insert_source(channel, move |event, &mut (), data| match event {
-            ChannelEvent::Msg(evt) => handle_event(evt, &mut data.state, &mut data.display),
-            ChannelEvent::Closed => handle_event(WlcsEvent::Exit, &mut data.state, &mut data.display),
+            ChannelEvent::Msg(evt) => handle_event(evt, &mut data.state, &mut data.display_handle),
+            ChannelEvent::Closed => handle_event(WlcsEvent::Exit, &mut data.state, &mut data.display_handle),
         })
         .unwrap();
 
@@ -80,7 +80,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
             model: "WLCS".into(),
         },
     );
-    let _global = output.create_global::<AnvilState<TestState>>(&dh);
+    let _global = output.create_global::<AnvilState<TestState>>(&display_handle);
     output.change_current_state(Some(mode), None, None, Some((0, 0).into()));
     output.set_preferred(mode);
     state.space.map_output(&output, (0, 0));
@@ -172,30 +172,31 @@ pub fn run(channel: Channel<WlcsEvent>) {
             })
         });
 
-        let mut calloop_data = CalloopData { state, display };
+        let mut calloop_data = CalloopData {
+            state,
+            display_handle,
+        };
         let result = event_loop.dispatch(Some(Duration::from_millis(16)), &mut calloop_data);
-        CalloopData { state, display } = calloop_data;
+        CalloopData {
+            state,
+            display_handle,
+        } = calloop_data;
 
         if result.is_err() {
             state.running.store(false, Ordering::SeqCst);
         } else {
             state.space.refresh();
             state.popups.cleanup();
-            display.flush_clients().unwrap();
+            display_handle.flush_clients().unwrap();
         }
     }
 }
 
-fn handle_event(
-    event: WlcsEvent,
-    state: &mut AnvilState<TestState>,
-    display: &mut Display<AnvilState<TestState>>,
-) {
+fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>, display_handle: &mut DisplayHandle) {
     match event {
         WlcsEvent::Exit => state.running.store(false, Ordering::SeqCst),
         WlcsEvent::NewClient { stream, client_id } => {
-            let client = display
-                .handle()
+            let client = display_handle
                 .insert_client(stream, Arc::new(ClientState::default()))
                 .expect("Failed to insert client");
             state.backend_data.clients.insert(client_id, client);
@@ -209,7 +210,7 @@ fn handle_event(
             let client = state.backend_data.clients.get(&client_id);
             let toplevel = state.space.elements().find(|w| {
                 if let Some(surface) = w.wl_surface() {
-                    display.handle().get_client(surface.id()).ok().as_ref() == client
+                    display_handle.get_client(surface.id()).ok().as_ref() == client
                         && surface.id().protocol_id() == surface_id
                 } else {
                     false


### PR DESCRIPTION
Supersedes https://github.com/Smithay/smithay/pull/839, the other parts of which should be merged now.

This is blocked on release of `calloop` and `udev`.

The same awkwardness exists as in the previous PR around `display.backend().poll_fd()`. That returns a `BorrowedFd<'_>` that we can't simply insert into an event loop.

This is also a bit awkward with `child_stdout` in `xserver.rs` (I guess we want to remove the event source without closing that?)