### PR TITLE
anvil: Show new window on output with cursor, not first output

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -430,7 +430,7 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
                     let new_scale = current_scale + 0.25;
                     output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
 
-                    crate::shell::fixup_positions(&mut self.space);
+                    crate::shell::fixup_positions(&mut self.space, self.pointer_location);
                     self.backend_data.reset_buffers(&output);
                 }
 
@@ -446,7 +446,7 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
                     let new_scale = f64::max(1.0, current_scale - 0.25);
                     output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
 
-                    crate::shell::fixup_positions(&mut self.space);
+                    crate::shell::fixup_positions(&mut self.space, self.pointer_location);
                     self.backend_data.reset_buffers(&output);
                 }
 
@@ -467,7 +467,7 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
                         _ => Transform::Normal,
                     };
                     output.change_current_state(None, Some(new_transform), None, None);
-                    crate::shell::fixup_positions(&mut self.space);
+                    crate::shell::fixup_positions(&mut self.space, self.pointer_location);
                     self.backend_data.reset_buffers(&output);
                 }
 
@@ -574,7 +574,7 @@ impl AnvilState<UdevData> {
                         pointer_output_location.y *= rescale;
                         self.pointer_location = output_location + pointer_output_location;
 
-                        crate::shell::fixup_positions(&mut self.space);
+                        crate::shell::fixup_positions(&mut self.space, self.pointer_location);
                         let under = self.surface_under();
                         if let Some(ptr) = self.seat.get_pointer() {
                             ptr.motion(
@@ -613,7 +613,7 @@ impl AnvilState<UdevData> {
                         pointer_output_location.y *= rescale;
                         self.pointer_location = output_location + pointer_output_location;
 
-                        crate::shell::fixup_positions(&mut self.space);
+                        crate::shell::fixup_positions(&mut self.space, self.pointer_location);
                         let under = self.surface_under();
                         if let Some(ptr) = self.seat.get_pointer() {
                             ptr.motion(
@@ -647,7 +647,7 @@ impl AnvilState<UdevData> {
                             _ => Transform::Normal,
                         };
                         output.change_current_state(None, Some(new_transform), None, None);
-                        crate::shell::fixup_positions(&mut self.space);
+                        crate::shell::fixup_positions(&mut self.space, self.pointer_location);
                         self.backend_data.reset_buffers(&output);
                     }
                 }

--- a/anvil/src/shell/x11.rs
+++ b/anvil/src/shell/x11.rs
@@ -52,7 +52,7 @@ impl<BackendData: Backend> XwmHandler for CalloopData<BackendData> {
     fn map_window_request(&mut self, _xwm: XwmId, window: X11Surface) {
         window.set_mapped(true).unwrap();
         let window = WindowElement::X11(window);
-        place_new_window(&mut self.state.space, &window, true);
+        place_new_window(&mut self.state.space, self.state.pointer_location, &window, true);
         let bbox = self.state.space.element_bbox(&window).unwrap();
         let WindowElement::X11(xsurface) = &window else { unreachable!() };
         xsurface.configure(Some(bbox)).unwrap();

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -47,7 +47,7 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
         // of a xdg_surface has to be sent during the commit if
         // the surface is not already configured
         let window = WindowElement::Wayland(Window::new(surface));
-        place_new_window(&mut self.space, &window, true);
+        place_new_window(&mut self.space, self.pointer_location, &window, true);
     }
 
     fn new_popup(&mut self, surface: PopupSurface, positioner: PositionerState) {

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -1015,7 +1015,7 @@ impl AnvilState<UdevData> {
         }
 
         // fixup window coordinates
-        crate::shell::fixup_positions(&mut self.space);
+        crate::shell::fixup_positions(&mut self.space, self.pointer_location);
     }
 
     fn device_removed(&mut self, node: DrmNode) {
@@ -1049,7 +1049,7 @@ impl AnvilState<UdevData> {
             debug!("Dropping device");
         }
 
-        crate::shell::fixup_positions(&mut self.space);
+        crate::shell::fixup_positions(&mut self.space, self.pointer_location);
     }
 
     fn frame_finish(&mut self, dev_id: DrmNode, crtc: crtc::Handle, metadata: &mut Option<DrmEventMetadata>) {

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -223,7 +223,7 @@ pub fn run_winit() {
                     };
                     output.change_current_state(Some(mode), None, None, None);
                     output.set_preferred(mode);
-                    crate::shell::fixup_positions(&mut state.space);
+                    crate::shell::fixup_positions(&mut state.space, state.pointer_location);
                 }
                 WinitEvent::Input(event) => {
                     state.process_input_event_windowed(&display.handle(), event, OUTPUT_NAME)

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -269,7 +269,7 @@ pub fn run_x11() {
                 output.delete_mode(output.current_mode().unwrap());
                 output.change_current_state(Some(data.state.backend_data.mode), None, None, None);
                 output.set_preferred(data.state.backend_data.mode);
-                crate::shell::fixup_positions(&mut data.state.space);
+                crate::shell::fixup_positions(&mut data.state.space, data.state.pointer_location);
 
                 data.state.backend_data.render = true;
             }


### PR DESCRIPTION
Behavior with only one output should be unchanged. This seems fairly important for usability with multiple outputs. Especially with dialog windows.

A full-featured compositor may have much fancier logic, but for Anvil this seems better at least.