### PR TITLE
text-input: Set focus on keyboard `enter`/`leave`

### DIFF
--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -83,6 +83,13 @@ impl InputMethodHandle {
         }
     }
 
+    /// Convenience function to close popup surfaces
+    pub(crate) fn close_popup(&self) {
+        let inner = self.inner.lock().unwrap();
+        let mut popup = inner.popup.inner.lock().unwrap();
+        popup.surface_role = None;
+    }
+
     /// Used to access the relative location of an input popup surface
     pub fn coordinates(&self) -> Rectangle<i32, Physical> {
         let inner = self.inner.lock().unwrap();

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -73,12 +73,6 @@ where
         focus: Option<<D as SeatHandler>::KeyboardFocus>,
         serial: crate::utils::Serial,
     ) {
-        let inner = self.inner.lock().unwrap();
-        let surface = focus.as_ref().and_then(|f| f.wl_surface());
-        inner.text_input_handle.set_focus(surface.as_ref(), || {
-            let mut popup = inner.popup_handle.inner.lock().unwrap();
-            popup.surface_role = None;
-        });
         handle.set_focus(data, focus, serial)
     }
 

--- a/src/wayland/text_input/mod.rs
+++ b/src/wayland/text_input/mod.rs
@@ -60,6 +60,20 @@ const MANAGER_VERSION: u32 = 1;
 
 mod text_input_handle;
 
+/// Extends [Seat] with text input functionality
+pub trait TextInputSeat {
+    /// Get text input associated with this seat
+    fn text_input(&self) -> &TextInputHandle;
+}
+
+impl<D: SeatHandler + 'static> TextInputSeat for Seat<D> {
+    fn text_input(&self) -> &TextInputHandle {
+        let user_data = self.user_data();
+        user_data.insert_if_missing(TextInputHandle::default);
+        user_data.get::<TextInputHandle>().unwrap()
+    }
+}
+
 /// State of wp text input protocol
 #[derive(Debug)]
 pub struct TextInputManagerState {

--- a/src/wayland/text_input/mod.rs
+++ b/src/wayland/text_input/mod.rs
@@ -3,6 +3,8 @@
 //! This module provides you with utilities to handle text input surfaces,
 //! it is usually used in conjunction with the input method module.
 //!
+//! Text input focus is automatically set to the same surface that has keyboard focus.
+//!
 //! ```
 //! use smithay::{
 //!     delegate_seat, delegate_tablet_manager, delegate_text_input_manager,
@@ -37,10 +39,6 @@
 //! TextInputManagerState::new::<State>(&display_handle);
 //!
 //! ```
-//!
-//! | Warning! |
-//! |:-|
-//! | Text input focus is set automatically if an input method grabs the keyboard, but on a mobile platform the input method will normally not grab a keyboard and hence one will have to set text input focus manually using the `set_focus` function. |
 //!
 
 use wayland_protocols::wp::text_input::zv3::server::{

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -65,7 +65,7 @@ impl TextInputHandle {
 
     /// Sets text input focus to a surface, the hook can be used to e.g.
     /// delete the popup surface role so it does not flicker between focused surfaces
-    pub fn set_focus<F>(&self, focus: Option<&WlSurface>, focus_changed_hook: F)
+    pub(crate) fn set_focus<F>(&self, focus: Option<&WlSurface>, focus_changed_hook: F)
     where
         F: Fn(),
     {


### PR DESCRIPTION
Presumably text input on a seat should always go to the surface that has keyboard focus on the seat. So that should be done automatically, and a way to set the text input focus isn't needed in the public API.

I'm still looking into other issues with fcitx5. But it works better with this (shows up at all), so it's an improvement as long as this doesn't negatively impact any other IME client.

Supersedes https://github.com/Smithay/smithay/pull/1038.

CC @rano-oss