### PR TITLE
Add get_or_insert abstractions for surface data

### DIFF
--- a/src/utils/user_data.rs
+++ b/src/utils/user_data.rs
@@ -132,7 +132,7 @@ impl UserDataMap {
         match self.get() {
             Some(data) => data,
             None => {
-                // Innsert the new node.
+                // Insert the new node.
                 self.insert(init);
 
                 // Return it again immediately.
@@ -146,7 +146,7 @@ impl UserDataMap {
         match self.get() {
             Some(data) => data,
             None => {
-                // Innsert the new node.
+                // Insert the new node.
                 self.insert_threadsafe(init);
 
                 // Return it again immediately.


### PR DESCRIPTION
This adds two new public methods to the `UserDataMap` stored for surfaces, aimed at making developers' lives a little easier.

The `get_or_insert` and `get_or_insert_threadsafe` methods allow getting guaranteed access to the user data without any `unwrap` in the user's code.

The `insert` and `insert_threadsafe` methods have been added as an internal abstraction to ensure the code stays consistent. I've kept them private assuming that the `if_missing` checks are necessary because the underlying storage has no deduplication mechanisms.