### PR TITLE
Expose swapchain's reset_buffer_age function

### DIFF
--- a/src/backend/allocator/swapchain.rs
+++ b/src/backend/allocator/swapchain.rs
@@ -244,7 +244,7 @@ where
     ///
     /// Resetting the buffer age will discard all damage information and force a
     /// full redraw for the next frame.
-    pub fn reset_buffer_age(&mut self) {
+    pub fn reset_buffer_ages(&mut self) {
         for slot in &mut self.slots {
             match Arc::get_mut(slot) {
                 Some(slot) => slot.age = AtomicU8::new(0),

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -2121,6 +2121,14 @@ where
         self.swapchain.reset_buffers();
     }
 
+    /// Reset the age for all buffers.
+    ///
+    /// This can be used to efficiently clear the damage history without having to
+    /// modify the damage for each surface.
+    pub fn reset_buffer_ages(&mut self) {
+        self.swapchain.reset_buffer_ages();
+    }
+
     /// Returns the underlying [`crtc`](drm::control::crtc) of this surface
     pub fn crtc(&self) -> crtc::Handle {
         self.surface.crtc()

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -343,6 +343,14 @@ where
         self.swapchain.reset_buffers()
     }
 
+    /// Reset the age for all buffers.
+    ///
+    /// This can be used to efficiently clear the damage history without having to
+    /// modify the damage for each surface.
+    pub fn reset_buffer_ages(&mut self) {
+        self.swapchain.reset_buffer_ages();
+    }
+
     /// Returns the underlying [`crtc`](drm::control::crtc) of this surface
     pub fn crtc(&self) -> crtc::Handle {
         self.drm.crtc()

--- a/src/backend/x11/surface.rs
+++ b/src/backend/x11/surface.rs
@@ -119,11 +119,19 @@ impl X11Surface {
         Ok(())
     }
 
-    /// Resets the internal buffers, e.g. to reset age values
+    /// Resets the internal buffers.
     #[instrument(level = "trace", parent = &self.span, skip(self))]
     pub fn reset_buffers(&mut self) {
         self.swapchain.reset_buffers();
         self.buffer = None;
+    }
+
+    /// Reset the age for all internal buffers.
+    ///
+    /// This can be used to clear the damage history.
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
+    pub fn reset_buffer_ages(&mut self) {
+        self.swapchain.reset_buffer_ages();
     }
 
     fn resize(&mut self, size: Size<u16, Logical>) {


### PR DESCRIPTION
In a1e4cf3, the new `reset_buffer_age` function was added to the swapchain for resetting damage without having to reset the buffers themselves.

This function is not used anywhere in Smithay but could be a simpler and more clear API for users to "force" redraws. However the swapchain itself is not directly accessible to users.

This patch adds a public `reset_buffer_ages` function to all structs providing a `reset_buffers` method as an alternative for Smithay's consumers.

The original `reset_buffer_age` function has also been renamed to `reset_buffer_ages` to be more in line with `reset_buffers` and signify that there's multiple buffers being involved here.