### PR TITLE
Feature/egl fence

### DIFF
--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -1,13 +1,13 @@
 use smithay::{
     backend::renderer::{
-        damage::{Error as OutputDamageTrackerError, OutputDamageTracker},
+        damage::{Error as OutputDamageTrackerError, OutputDamageTracker, RenderOutputResult},
         element::{
             surface::WaylandSurfaceRenderElement,
             utils::{
                 ConstrainAlign, ConstrainScaleBehavior, CropRenderElement, RelocateRenderElement,
                 RescaleRenderElement,
             },
-            AsRenderElements, RenderElement, RenderElementStates, Wrap,
+            AsRenderElements, RenderElement, Wrap,
         },
         ImportAll, ImportMem, Renderer,
     },
@@ -15,7 +15,7 @@ use smithay::{
         constrain_space_element, ConstrainBehavior, ConstrainReference, Space, SpaceRenderElements,
     },
     output::Output,
-    utils::{Physical, Point, Rectangle, Size},
+    utils::{Point, Rectangle, Size},
 };
 
 #[cfg(feature = "debug")]
@@ -202,7 +202,7 @@ pub fn render_output<R>(
     damage_tracker: &mut OutputDamageTracker,
     age: usize,
     show_window_preview: bool,
-) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), OutputDamageTrackerError<R>>
+) -> Result<RenderOutputResult, OutputDamageTrackerError<R>>
 where
     R: Renderer + ImportAll + ImportMem,
     R::TextureId: Clone + 'static,

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -359,9 +359,9 @@ pub fn run_winit() {
             });
 
             match render_res {
-                Ok((damage, states)) => {
-                    let has_rendered = damage.is_some();
-                    if let Some(damage) = damage {
+                Ok(render_output_result) => {
+                    let has_rendered = render_output_result.damage.is_some();
+                    if let Some(damage) = render_output_result.damage {
                         if let Err(err) = backend.submit(Some(&*damage)) {
                             warn!("Failed to submit buffer: {}", err);
                         }
@@ -382,11 +382,11 @@ pub fn run_winit() {
 
                     // Send frame events so that client start drawing their next frame
                     let time = state.clock.now();
-                    post_repaint(&output, &states, &state.space, None, time);
+                    post_repaint(&output, &render_output_result.states, &state.space, None, time);
 
                     if has_rendered {
                         let mut output_presentation_feedback =
-                            take_presentation_feedback(&output, &state.space, &states);
+                            take_presentation_feedback(&output, &state.space, &render_output_result.states);
                         output_presentation_feedback.presented(
                             time,
                             output

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -404,7 +404,7 @@ pub fn run_x11() {
             );
 
             match render_res {
-                Ok((damage, states)) => {
+                Ok(render_output_result) => {
                     trace!("Finished rendering");
                     if let Err(err) = backend_data.surface.submit() {
                         backend_data.surface.reset_buffers();
@@ -414,7 +414,7 @@ pub fn run_x11() {
                     };
 
                     #[cfg(feature = "debug")]
-                    if damage.is_some() {
+                    if render_output_result.damage.is_some() {
                         if let Some(renderdoc) = state.renderdoc.as_mut() {
                             renderdoc.end_frame_capture(
                                 state.backend_data.renderer.egl_context().get_context_handle(),
@@ -430,11 +430,11 @@ pub fn run_x11() {
 
                     // Send frame events so that client start drawing their next frame
                     let time = state.clock.now();
-                    post_repaint(&output, &states, &state.space, None, time);
+                    post_repaint(&output, &render_output_result.states, &state.space, None, time);
 
-                    if damage.is_some() {
+                    if render_output_result.damage.is_some() {
                         let mut output_presentation_feedback =
-                            take_presentation_feedback(&output, &state.space, &states);
+                            take_presentation_feedback(&output, &state.space, &render_output_result.states);
                         output_presentation_feedback.presented(
                             time,
                             output

--- a/build.rs
+++ b/build.rs
@@ -43,6 +43,8 @@ fn gl_generate() {
                 "EGL_EXT_buffer_age",
                 "EGL_EXT_swap_buffers_with_damage",
                 "EGL_KHR_swap_buffers_with_damage",
+                "EGL_KHR_fence_sync",
+                "EGL_ANDROID_native_fence_sync",
             ],
         )
         .write_bindings(gl_generator::GlobalGenerator, &mut file)
@@ -61,6 +63,7 @@ fn gl_generate() {
                 "GL_OES_EGL_image_external",
                 "GL_EXT_texture_format_BGRA8888",
                 "GL_EXT_unpack_subimage",
+                "GL_OES_EGL_sync",
             ],
         )
         .write_bindings(gl_generator::StructGenerator, &mut file)

--- a/examples/buffer_test.rs
+++ b/examples/buffer_test.rs
@@ -305,7 +305,7 @@ where
             &[Rectangle::from_loc_and_size((w / 2, h / 2), (w / 2, h / 2))],
         )
         .expect("Render error");
-    frame.finish().expect("Failed to finish render frame");
+    frame.finish().expect("Failed to finish render frame").wait();
 }
 
 fn render_from<R, T>(renderer: &mut R, buffer: Dmabuf, w: i32, h: i32, dump: Option<String>)
@@ -332,7 +332,7 @@ where
             1.0,
         )
         .expect("Failed to sample dmabuf");
-    frame.finish().expect("Failed to finish render frame");
+    frame.finish().expect("Failed to finish render frame").wait();
 
     if let Some(path) = dump {
         let mapping = renderer

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -202,7 +202,8 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
         let mut frame = backend.renderer().render(size, Transform::Flipped180).unwrap();
         frame.clear([0.1, 0.0, 0.0, 1.0], &[damage]).unwrap();
         draw_render_elements(&mut frame, 1.0, &elements, &[damage]).unwrap();
-        frame.finish().unwrap();
+        // We rely on the nested compositor to do the sync for us
+        let _ = frame.finish().unwrap();
 
         for surface in state.xdg_shell_state.toplevel_surfaces() {
             send_frames_surface_tree(surface.wl_surface(), start_time.elapsed().as_millis() as u32);

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -123,7 +123,7 @@
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
-    os::unix::io::AsFd,
+    os::unix::io::{AsFd, OwnedFd},
     rc::Rc,
     sync::{Arc, Mutex},
 };
@@ -143,7 +143,7 @@ use crate::{
             gbm::{GbmAllocator, GbmDevice},
             Allocator, Buffer, Slot, Swapchain,
         },
-        drm::{DrmError, PlaneDamageClips},
+        drm::{plane_has_property, DrmError, PlaneDamageClips},
         renderer::{
             buffer_y_inverted,
             damage::{Error as OutputDamageTrackerError, OutputDamageTracker, OutputNoMode},
@@ -151,6 +151,7 @@ use crate::{
                 Element, Id, RenderElement, RenderElementPresentationState, RenderElementState,
                 RenderElementStates, RenderingReason, UnderlyingStorage,
             },
+            sync::SyncPoint,
             utils::{CommitCounter, DamageBag, DamageSnapshot},
             Bind, Blit, DebugFlags, ExportMem, Frame as RendererFrame, Offscreen, Renderer, Texture,
         },
@@ -331,6 +332,7 @@ struct PlaneConfig<B> {
     pub alpha: f32,
     pub buffer: Owned<B>,
     pub plane_claim: PlaneClaim,
+    pub sync: Option<(SyncPoint, Option<Arc<OwnedFd>>)>,
 }
 
 impl<B> Clone for PlaneConfig<B> {
@@ -343,6 +345,7 @@ impl<B> Clone for PlaneConfig<B> {
             alpha: self.alpha,
             buffer: self.buffer.clone(),
             plane_claim: self.plane_claim.clone(),
+            sync: self.sync.clone(),
         }
     }
 }
@@ -481,6 +484,7 @@ impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
     fn test_state(
         &mut self,
         surface: &DrmSurface,
+        supports_fencing: bool,
         plane: plane::Handle,
         state: PlaneState<B>,
         allow_modeset: bool,
@@ -492,24 +496,7 @@ impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
         let backup = current_config.clone();
         *current_config = state;
 
-        let res = surface.test_state(
-            self.planes
-                .iter()
-                // Filter out any skipped planes
-                .filter(|(_, state)| !state.skip)
-                .map(|(handle, state)| super::surface::PlaneState {
-                    handle: *handle,
-                    config: state.config.as_ref().map(|config| super::PlaneConfig {
-                        src: config.src,
-                        dst: config.dst,
-                        transform: config.transform,
-                        alpha: config.alpha,
-                        damage_clips: config.damage_clips.as_ref().map(|d| d.blob()),
-                        fb: *config.buffer.as_ref(),
-                    }),
-                }),
-            allow_modeset,
-        );
+        let res = surface.test_state(self.build_planes(supports_fencing, true), allow_modeset);
 
         if res.is_err() {
             // test failed, restore previous state
@@ -519,46 +506,66 @@ impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
         res
     }
 
-    fn commit(&self, surface: &DrmSurface, event: bool) -> Result<(), crate::backend::drm::error::Error> {
-        surface.commit(
-            self.planes
-                .iter()
-                // Filter out any skipped planes
-                .filter(|(_, state)| !state.skip)
-                .map(|(handle, state)| super::surface::PlaneState {
-                    handle: *handle,
-                    config: state.config.as_ref().map(|config| super::PlaneConfig {
-                        src: config.src,
-                        dst: config.dst,
-                        alpha: config.alpha,
-                        transform: config.transform,
-                        damage_clips: config.damage_clips.as_ref().map(|d| d.blob()),
-                        fb: *config.buffer.as_ref(),
-                    }),
-                }),
-            event,
-        )
+    fn commit(
+        &mut self,
+        surface: &DrmSurface,
+        supports_fencing: bool,
+        event: bool,
+    ) -> Result<(), crate::backend::drm::error::Error> {
+        surface.commit(self.build_planes(supports_fencing, false), event)
     }
 
-    fn page_flip(&self, surface: &DrmSurface, event: bool) -> Result<(), crate::backend::drm::error::Error> {
-        surface.page_flip(
-            self.planes
-                .iter()
-                // Filter out any skipped planes
-                .filter(|(_, state)| !state.skip)
-                .map(|(handle, state)| super::surface::PlaneState {
-                    handle: *handle,
-                    config: state.config.as_ref().map(|config| super::PlaneConfig {
-                        src: config.src,
-                        dst: config.dst,
-                        alpha: config.alpha,
-                        transform: config.transform,
-                        damage_clips: config.damage_clips.as_ref().map(|d| d.blob()),
-                        fb: *config.buffer.as_ref(),
-                    }),
+    fn page_flip(
+        &mut self,
+        surface: &DrmSurface,
+        supports_fencing: bool,
+        event: bool,
+    ) -> Result<(), crate::backend::drm::error::Error> {
+        surface.page_flip(self.build_planes(supports_fencing, false), event)
+    }
+
+    fn build_planes(
+        &mut self,
+        supports_fencing: bool,
+        test_only: bool,
+    ) -> impl IntoIterator<Item = super::PlaneState<'_>> {
+        for (_, state) in self.planes.iter_mut().filter(|(_, state)| !state.skip) {
+            if let Some(config) = state.config.as_mut() {
+                // Try to extract a native fence out of the supplied sync point if any
+                // If the sync point has no native fence or the surface does not support
+                // fencing force a wait
+                if let Some((sync, fence)) = config.sync.as_mut() {
+                    if supports_fencing && fence.is_none() {
+                        *fence = sync.export().map(Arc::new);
+                    }
+
+                    // Don't wait if we are only testing the state
+                    if !test_only && fence.is_none() {
+                        sync.wait();
+                    }
+                }
+            }
+        }
+
+        self.planes
+            .iter_mut()
+            // Filter out any skipped planes
+            .filter(|(_, state)| !state.skip)
+            .map(move |(handle, state)| super::surface::PlaneState {
+                handle: *handle,
+                config: state.config.as_mut().map(|config| super::PlaneConfig {
+                    src: config.src,
+                    dst: config.dst,
+                    alpha: config.alpha,
+                    transform: config.transform,
+                    damage_clips: config.damage_clips.as_ref().map(|d| d.blob()),
+                    fb: *config.buffer.as_ref(),
+                    fence: config
+                        .sync
+                        .as_ref()
+                        .and_then(|(_, fence)| fence.as_ref().map(|fence| fence.as_fd())),
                 }),
-            event,
-        )
+            })
     }
 }
 
@@ -663,6 +670,8 @@ type RenderFrameErrorType<A, F, R> = RenderFrameError<
 pub struct PrimarySwapchainElement<B: Buffer, F: AsRef<framebuffer::Handle>> {
     /// The slot from the swapchain
     slot: Owned<DrmScanoutBuffer<B, F>>,
+    /// Sync point
+    pub sync: SyncPoint,
     /// The transform applied during rendering
     pub transform: Transform,
     /// The damage on the primary plane
@@ -720,6 +729,18 @@ pub struct RenderFrameResult<'a, B: Buffer, F: AsRef<framebuffer::Handle>, E> {
     pub cursor_element: Option<&'a E>,
 
     primary_plane_element_id: Id,
+    supports_fencing: bool,
+}
+
+impl<'a, B: Buffer, F: AsRef<framebuffer::Handle>, E> RenderFrameResult<'a, B, F, E> {
+    /// Returns whether the frame would block the current thread when queued
+    pub fn would_block(&self) -> bool {
+        if let PrimaryPlaneElement::Swapchain(ref element) = self.primary_element {
+            !element.sync.is_reached() && (!self.supports_fencing || !element.sync.is_exportable())
+        } else {
+            false
+        }
+    }
 }
 
 struct SwapchainElement<'a, 'b, B: Buffer> {
@@ -892,6 +913,7 @@ where
                 slot,
                 transform,
                 damage,
+                ..
             }) => FrameResultDamageElement::Swapchain(SwapchainElement {
                 id: self.primary_plane_element_id.clone(),
                 transform: *transform,
@@ -926,7 +948,7 @@ where
         renderer: &mut R,
         damage: impl IntoIterator<Item = Rectangle<i32, Physical>>,
         filter: impl IntoIterator<Item = Id>,
-    ) -> Result<(), BlitFrameResultError<<R as Renderer>::Error, <B as AsDmabuf>::Error>>
+    ) -> Result<SyncPoint, BlitFrameResultError<<R as Renderer>::Error, <B as AsDmabuf>::Error>>
     where
         R: Renderer + Blit<Dmabuf>,
         <R as Renderer>::TextureId: 'static,
@@ -939,7 +961,7 @@ where
 
         // If we have no damage we can exit early
         if damage.is_empty() {
-            return Ok(());
+            return Ok(SyncPoint::signaled());
         }
 
         let mut opaque_regions: Vec<Rectangle<i32, Physical>> = Vec::new();
@@ -964,7 +986,7 @@ where
         }
 
         let primary_dmabuf = match &self.primary_element {
-            PrimaryPlaneElement::Swapchain(PrimarySwapchainElement { slot, .. }) => {
+            PrimaryPlaneElement::Swapchain(PrimarySwapchainElement { slot, sync, .. }) => {
                 let dmabuf = match &slot.0.buffer {
                     ScanoutBuffer::Swapchain(slot) => slot.export().map_err(BlitFrameResultError::Export)?,
                     _ => unreachable!(),
@@ -975,7 +997,7 @@ where
                     size.to_logical(1, Transform::Normal).to_physical(1),
                 );
                 opaque_regions.push(geometry);
-                Some((dmabuf, geometry))
+                Some((sync.clone(), dmabuf, geometry))
             }
             PrimaryPlaneElement::Element(e) => {
                 elements_to_render.push(*e);
@@ -991,6 +1013,7 @@ where
                 .collect::<Vec<_>>()
         });
 
+        let mut sync: Option<SyncPoint> = None;
         if !clear_damage.is_empty() {
             trace!("clearing frame damage {:#?}", clear_damage);
 
@@ -1002,11 +1025,11 @@ where
                 .clear([0f32, 0f32, 0f32, 1f32], &clear_damage)
                 .map_err(BlitFrameResultError::Rendering)?;
 
-            frame.finish().map_err(BlitFrameResultError::Rendering)?;
+            sync = Some(frame.finish().map_err(BlitFrameResultError::Rendering)?);
         }
 
         // first do the potential blit
-        if let Some((dmabuf, geometry)) = primary_dmabuf {
+        if let Some((sync, dmabuf, geometry)) = primary_dmabuf {
             let blit_damage = damage
                 .iter()
                 .filter_map(|d| d.intersection(geometry))
@@ -1014,6 +1037,7 @@ where
 
             trace!("blitting frame with damage: {:#?}", blit_damage);
 
+            sync.wait();
             for rect in blit_damage {
                 renderer
                     .blit_from(
@@ -1059,9 +1083,9 @@ where
                     .map_err(BlitFrameResultError::Rendering)?;
             }
 
-            frame.finish().map_err(BlitFrameResultError::Rendering)
+            Ok(frame.finish().map_err(BlitFrameResultError::Rendering)?)
         } else {
-            Ok(())
+            Ok(sync.unwrap_or_default())
         }
     }
 }
@@ -1189,6 +1213,7 @@ where
     damage_tracker: OutputDamageTracker,
     primary_plane_element_id: Id,
     primary_plane_damage_bag: DamageBag<i32, BufferCoords>,
+    supports_fencing: bool,
 
     framebuffer_exporter: F,
 
@@ -1271,11 +1296,14 @@ where
 
         let cursor_size = Size::from((cursor_size.w as i32, cursor_size.h as i32));
         let damage_tracker = OutputDamageTracker::from_output(output);
+        let supports_fencing =
+            !surface.is_legacy() && plane_has_property(&*surface, surface.plane(), "IN_FENCE_FD")?;
 
         for format in color_formats {
             debug!("Testing color format: {}", format);
             match Self::find_supported_format(
                 surface.clone(),
+                supports_fencing,
                 &planes,
                 allocator,
                 &framebuffer_exporter,
@@ -1315,6 +1343,7 @@ where
                         planes,
                         overlay_plane_element_ids,
                         element_states: IndexMap::new(),
+                        supports_fencing,
                         debug_flags: DebugFlags::empty(),
                         span,
                     };
@@ -1333,6 +1362,7 @@ where
 
     fn find_supported_format(
         drm: Arc<DrmSurface>,
+        supports_fencing: bool,
         planes: &Planes,
         allocator: A,
         framebuffer_exporter: &F,
@@ -1478,10 +1508,12 @@ where
                     fb: handle,
                 }),
                 plane_claim,
+                sync: None,
             }),
         };
 
-        match current_frame_state.test_state(&drm, planes.primary.handle, plane_state, true) {
+        match current_frame_state.test_state(&drm, supports_fencing, planes.primary.handle, plane_state, true)
+        {
             Ok(_) => {
                 debug!("Chosen format: {:?}", dmabuf.format());
                 Ok((swapchain, current_frame_state))
@@ -1630,6 +1662,7 @@ where
                     fb,
                 }),
                 plane_claim,
+                sync: None,
             }),
         };
 
@@ -1640,6 +1673,7 @@ where
         next_frame_state
             .test_state(
                 &self.surface,
+                self.supports_fencing,
                 self.planes.primary.handle,
                 primary_plane_state,
                 self.surface.commit_pending(),
@@ -1920,8 +1954,8 @@ where
             renderer.set_debug_flags(renderer_debug_flags);
 
             match render_res {
-                Ok((render_damage, states)) => {
-                    for (id, state) in states.states.into_iter() {
+                Ok(render_output_result) => {
+                    for (id, state) in render_output_result.states.states.into_iter() {
                         // Skip the state for our fake elements
                         if self.overlay_plane_element_ids.contains_plane_id(&id) {
                             continue;
@@ -1955,7 +1989,7 @@ where
                     let config = primary_plane_state.config.as_mut().unwrap();
 
                     if !had_direct_scan_out {
-                        if let Some(render_damage) = render_damage {
+                        if let Some(render_damage) = render_output_result.damage {
                             trace!("rendering damage: {:?}", render_damage);
 
                             self.primary_plane_damage_bag.add(render_damage.iter().map(|d| {
@@ -1974,6 +2008,7 @@ where
                             )
                             .ok()
                             .flatten();
+                            config.sync = Some((render_output_result.sync.clone(), None));
                         } else {
                             trace!("skipping primary plane, no damage");
 
@@ -1994,6 +2029,8 @@ where
                                 Transform::Normal,
                                 &output_geometry.size.to_logical(1),
                             )]);
+
+                        config.sync = Some((render_output_result.sync.clone(), None));
                     }
                 }
                 Err(err) => {
@@ -2008,7 +2045,7 @@ where
         self.next_frame = Some(next_frame_state);
 
         let primary_plane_element = if render {
-            let slot = {
+            let (slot, sync) = {
                 let primary_plane_state = self
                     .next_frame
                     .as_ref()
@@ -2016,12 +2053,21 @@ where
                     .plane_state(self.planes.primary.handle)
                     .unwrap();
                 let config = primary_plane_state.config.as_ref().unwrap();
-                config.buffer.clone()
+                (
+                    config.buffer.clone(),
+                    config
+                        .sync
+                        .as_ref()
+                        .map(|(sync, _)| sync.clone())
+                        .unwrap_or_default(),
+                )
             };
+
             PrimaryPlaneElement::Swapchain(PrimarySwapchainElement {
                 slot,
                 transform: output_transform,
                 damage: self.primary_plane_damage_bag.snapshot(),
+                sync,
             })
         } else {
             PrimaryPlaneElement::Element(primary_plane_scanout_element.unwrap())
@@ -2039,6 +2085,7 @@ where
             cursor_element: cursor_plane_element,
             states: render_element_states,
             primary_plane_element_id: self.primary_plane_element_id.clone(),
+            supports_fencing: self.supports_fencing,
         };
 
         Ok(frame_reference)
@@ -2085,12 +2132,12 @@ where
     }
 
     fn submit(&mut self) -> FrameResult<(), A, F> {
-        let (state, user_data) = self.queued_frame.take().unwrap();
+        let (mut state, user_data) = self.queued_frame.take().unwrap();
 
         let flip = if self.surface.commit_pending() {
-            state.commit(&self.surface, true)
+            state.commit(&self.surface, self.supports_fencing, true)
         } else {
-            state.page_flip(&self.surface, true)
+            state.page_flip(&self.surface, self.supports_fencing, true)
         };
         if flip.is_ok() {
             self.pending_frame = Some((state, user_data));
@@ -2456,7 +2503,13 @@ where
             let mut plane_state = previous_state.plane_state(plane_info.handle).unwrap().clone();
             plane_state.skip = true;
 
-            let res = frame_state.test_state(&self.surface, plane_info.handle, plane_state, false);
+            let res = frame_state.test_state(
+                &self.surface,
+                self.supports_fencing,
+                plane_info.handle,
+                plane_state,
+                false,
+            );
 
             if res.is_ok() {
                 return Some(*plane_info);
@@ -2472,7 +2525,13 @@ where
             plane_state.skip = false;
             let config = plane_state.config.as_mut().unwrap();
             config.dst.loc = cursor_plane_location;
-            let res = frame_state.test_state(&self.surface, plane_info.handle, plane_state, false);
+            let res = frame_state.test_state(
+                &self.surface,
+                self.supports_fencing,
+                plane_info.handle,
+                plane_state,
+                false,
+            );
 
             if res.is_ok() {
                 return Some(*plane_info);
@@ -2570,7 +2629,7 @@ where
             let dst = Rectangle::from_loc_and_size((0, 0), element_geometry.size);
             element.draw(&mut frame, src, dst, &[dst])?;
 
-            frame.finish()?;
+            frame.finish()?.wait();
 
             Ok::<(), <R as Renderer>::Error>(())
         };
@@ -2620,6 +2679,7 @@ where
                 fb: OwnedFramebuffer::new(DrmFramebuffer::Gbm(framebuffer)),
             }),
             plane_claim,
+            sync: None,
         });
 
         let plane_state = PlaneState {
@@ -2628,7 +2688,13 @@ where
             config,
         };
 
-        let res = frame_state.test_state(&self.surface, plane_info.handle, plane_state, false);
+        let res = frame_state.test_state(
+            &self.surface,
+            self.supports_fencing,
+            plane_info.handle,
+            plane_state,
+            false,
+        );
 
         if res.is_ok() {
             cursor_state.previous_output_scale = Some(scale);
@@ -2994,10 +3060,17 @@ where
                     buffer: ScanoutBuffer::from(underlying_storage.clone()),
                 }),
                 plane_claim,
+                sync: None,
             }),
         };
 
-        let res = frame_state.test_state(&self.surface, plane.handle, plane_state, false);
+        let res = frame_state.test_state(
+            &self.surface,
+            self.supports_fencing,
+            plane.handle,
+            plane_state,
+            false,
+        );
 
         if res.is_ok() {
             output_damage.extend(element_output_damage);

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1037,7 +1037,7 @@ where
 
             trace!("blitting frame with damage: {:#?}", blit_damage);
 
-            sync.wait();
+            renderer.wait(&sync).map_err(BlitFrameResultError::Rendering)?;
             for rect in blit_damage {
                 renderer
                     .blit_from(

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -131,7 +131,7 @@ impl Clone for PlaneDamageClips {
 }
 
 /// State of a single plane
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PlaneState<'a> {
     /// Handle of the plane
     pub handle: plane::Handle,
@@ -142,7 +142,7 @@ pub struct PlaneState<'a> {
 }
 
 /// Configuration for a single plane
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct PlaneConfig<'a> {
     /// Source [`Rectangle`] of the attached framebuffer
     pub src: Rectangle<f64, Buffer>,
@@ -156,6 +156,8 @@ pub struct PlaneConfig<'a> {
     pub damage_clips: Option<drm::control::property::Value<'a>>,
     /// Framebuffer handle
     pub fb: framebuffer::Handle,
+    /// Optional fence
+    pub fence: Option<BorrowedFd<'a>>,
 }
 
 #[derive(Debug)]
@@ -183,6 +185,11 @@ impl DrmSurface {
             DrmSurfaceInternal::Atomic(surf) => surf.device_fd(),
             DrmSurfaceInternal::Legacy(surf) => surf.device_fd(),
         }
+    }
+
+    /// Returns whether this surface is using the legacy api
+    pub fn is_legacy(&self) -> bool {
+        matches!(&*self.internal, DrmSurfaceInternal::Legacy(_))
     }
 
     /// Returns the underlying [`crtc`](drm::control::crtc) of this surface

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -79,6 +79,8 @@ pub struct EGLDisplay {
     dmabuf_import_formats: HashSet<DrmFormat>,
     dmabuf_render_formats: HashSet<DrmFormat>,
     surface_type: ffi::EGLint,
+    pub(super) has_fences: bool,
+    pub(super) supports_native_fences: bool,
     pub(super) span: tracing::Span,
 }
 
@@ -193,6 +195,9 @@ impl EGLDisplay {
             .map_err(|source| Error::OpenGlesNotSupported(Some(source)))?;
 
         let surface_type = native.surface_type();
+        let has_fences = extensions.iter().any(|s| s == "EGL_KHR_fence_sync");
+        let supports_native_fences =
+            has_fences && extensions.iter().any(|s| s == "EGL_ANDROID_native_fence_sync");
 
         Ok(EGLDisplay {
             display: Arc::new(EGLDisplayHandle {
@@ -204,6 +209,8 @@ impl EGLDisplay {
             extensions,
             dmabuf_import_formats,
             dmabuf_render_formats,
+            has_fences,
+            supports_native_fences,
             span,
         })
     }
@@ -277,6 +284,9 @@ impl EGLDisplay {
 
             surface_type.assume_init()
         };
+        let has_fences = extensions.iter().any(|s| s == "EGL_KHR_fence_sync");
+        let supports_native_fences =
+            has_fences && extensions.iter().any(|s| s == "EGL_ANDROID_native_fence_sync");
 
         Ok(EGLDisplay {
             display: Arc::new(EGLDisplayHandle {
@@ -288,6 +298,8 @@ impl EGLDisplay {
             extensions,
             dmabuf_import_formats,
             dmabuf_render_formats,
+            has_fences,
+            supports_native_fences,
             span,
         })
     }

--- a/src/backend/egl/fence.rs
+++ b/src/backend/egl/fence.rs
@@ -1,0 +1,170 @@
+//! EGL fence related structs
+
+use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::backend::egl::{ffi, wrap_egl_call, EGLDisplay, EGLDisplayHandle, Error};
+
+#[derive(Debug)]
+struct InnerEGLFence {
+    display_handle: Arc<EGLDisplayHandle>,
+    handle: ffi::egl::types::EGLSync,
+    native: bool,
+}
+unsafe impl Send for InnerEGLFence {}
+unsafe impl Sync for InnerEGLFence {}
+
+impl Drop for InnerEGLFence {
+    fn drop(&mut self) {
+        unsafe {
+            // Not much we can do about when this fails
+            ffi::egl::DestroySync(**self.display_handle, self.handle);
+        }
+    }
+}
+
+/// A EGL fence
+#[derive(Debug, Clone)]
+pub struct EGLFence(Arc<InnerEGLFence>);
+
+impl EGLFence {
+    /// Returns whether the display supports creating fences from native fences
+    pub fn supports_importing(display: &EGLDisplay) -> bool {
+        display.supports_native_fences
+    }
+
+    /// Import a native fence fd
+    pub fn import(display: &EGLDisplay, native: OwnedFd) -> Result<Self, Error> {
+        // SAFETY: we do not have to test for EGL_KHR_fence_sync as EGL_ANDROID_native_fence_sync
+        // requires it already
+        if !display.supports_native_fences {
+            return Err(Error::EglExtensionNotSupported(&[
+                "EGL_ANDROID_native_fence_sync",
+            ]));
+        }
+
+        let display_handle = display.get_display_handle();
+        let fd = native.into_raw_fd();
+        let attributes: [ffi::egl::types::EGLAttrib; 3] = [
+            ffi::egl::SYNC_NATIVE_FENCE_FD_ANDROID as ffi::egl::types::EGLAttrib,
+            fd as ffi::egl::types::EGLAttrib,
+            ffi::egl::NONE as ffi::egl::types::EGLAttrib,
+        ];
+
+        let res = wrap_egl_call(|| unsafe {
+            ffi::egl::CreateSync(
+                **display_handle,
+                ffi::egl::SYNC_NATIVE_FENCE_ANDROID,
+                attributes.as_ptr(),
+            )
+        })
+        .map_err(Error::CreationFailed);
+
+        // In case of an error we have to close the fd to not leak it
+        if res.is_err() {
+            let _ = ::nix::unistd::close(fd);
+        }
+
+        let handle = res?;
+
+        Ok(Self(Arc::new(InnerEGLFence {
+            display_handle,
+            handle,
+            native: true,
+        })))
+    }
+
+    /// Create a new egl fence
+    ///
+    /// This will create a `EGL_SYNC_NATIVE_FENCE_ANDROID` or a `EGL_SYNC_FENCE_KHR` depending
+    /// on the availability of the `EGL_ANDROID_native_fence_sync` extension.
+    ///
+    /// Returns `Err` if the `EGL_KHR_fence_sync` is not present or creating the fence failed.
+    ///
+    /// Note: It is the callers responsibility to make sure the current bound client API supports
+    /// fences. For OpenglES the `GL_OES_EGL_sync` extension indicates support for fences.
+    pub fn create(display: &EGLDisplay) -> Result<Self, Error> {
+        if !display.has_fences {
+            return Err(Error::EglExtensionNotSupported(&["EGL_KHR_fence_sync"]));
+        }
+
+        let (type_, native) = if display.supports_native_fences {
+            (ffi::egl::SYNC_NATIVE_FENCE_ANDROID, true)
+        } else {
+            (ffi::egl::SYNC_FENCE, false)
+        };
+
+        let display_handle = display.get_display_handle();
+        let handle =
+            wrap_egl_call(|| unsafe { ffi::egl::CreateSync(**display_handle, type_, std::ptr::null()) })
+                .map_err(Error::CreationFailed)?;
+
+        Ok(Self(Arc::new(InnerEGLFence {
+            display_handle,
+            handle,
+            native,
+        })))
+    }
+
+    /// Indicates if this fence represents a native fence
+    pub fn is_native(&self) -> bool {
+        self.0.native
+    }
+
+    /// Export this [`EGLFence`] as a native fence fd
+    pub fn export(&self) -> Result<OwnedFd, Error> {
+        if !self.0.native {
+            return Err(Error::EglExtensionNotSupported(&[
+                "EGL_ANDROID_native_fence_sync",
+            ]));
+        }
+
+        let fd = wrap_egl_call(|| unsafe {
+            ffi::egl::DupNativeFenceFDANDROID(**self.0.display_handle, self.0.handle)
+        })
+        .map_err(Error::CreationFailed)?;
+        // SAFETY: eglDupNativeFenceFDANDROID generates EGL_BAD_PARAMETER in case of an error, so fd should always
+        // contain a valid fd
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
+
+    /// Tries to insert the fence in the current bound client context
+    ///
+    /// Returns `Err` if the supplied display does not match the display
+    /// used at creation time of the fence.
+    pub fn wait(&self, display: &EGLDisplay) -> Result<(), Error> {
+        if **display.get_display_handle() != **self.0.display_handle {
+            return Err(Error::DisplayNotSupported);
+        }
+
+        wrap_egl_call(|| unsafe { ffi::egl::WaitSync(**self.0.display_handle, self.0.handle, 0) })
+            .map_err(Error::CreationFailed)?;
+        Ok(())
+    }
+
+    /// Blocks the current thread until the fence is signaled or the supplied
+    /// timeout is reached.
+    ///
+    /// If the timeout is reached `false` is returned
+    pub fn client_wait(&self, timeout: Option<Duration>, flush: bool) -> bool {
+        let timeout = timeout
+            .map(|t| t.as_nanos() as ffi::egl::types::EGLuint64KHR)
+            .unwrap_or(ffi::egl::FOREVER);
+        let flags = if flush {
+            ffi::egl::SYNC_FLUSH_COMMANDS_BIT as ffi::egl::types::EGLint
+        } else {
+            0
+        };
+        // SAFETY: eglClientWaitSyncKHR only defines two errors
+        // 1. If <sync> is not a valid sync object for <dpy>, EGL_FALSE is returned and an EGL_BAD_PARAMETER error is generated.
+        // 2. If <dpy> does not match the EGLDisplay passed to eglCreateSyncKHR when <sync> was created, the behaviour is undefined.
+        // Both should not be possible as we own both, the handle and the display the handle was created on
+        let status = wrap_egl_call(|| unsafe {
+            ffi::egl::ClientWaitSync(**self.0.display_handle, self.0.handle, flags, timeout)
+        })
+        .unwrap();
+
+        status == ffi::egl::CONDITION_SATISFIED as ffi::EGLint
+    }
+}

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -42,10 +42,12 @@ use nix::libc::c_void;
 
 #[allow(non_camel_case_types, dead_code, unused_mut, non_upper_case_globals)]
 pub mod ffi;
+use self::display::EGLDisplayHandle;
 #[cfg(feature = "wayland_frontend")]
-use self::{display::EGLDisplayHandle, ffi::egl::types::EGLImage};
+use self::ffi::egl::types::EGLImage;
 
 pub mod display;
+pub mod fence;
 pub mod native;
 pub mod surface;
 pub use self::device::EGLDevice;

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -23,7 +23,7 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter},
+//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
 //! #     utils::{Buffer, Physical},
 //! # };
 //! #
@@ -74,7 +74,7 @@
 //! #     fn transformation(&self) -> Transform {
 //! #         unimplemented!()
 //! #     }
-//! #     fn finish(self) -> Result<(), Self::Error> { unimplemented!() }
+//! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 //! # }
 //! #
 //! # struct FakeRenderer;

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -1198,7 +1198,7 @@ macro_rules! render_elements_internal {
 /// # use smithay::{
 /// #     backend::{
 /// #         allocator::Fourcc,
-/// #         renderer::{DebugFlags, Frame, Renderer, Texture, TextureFilter},
+/// #         renderer::{DebugFlags, Frame, Renderer, Texture, TextureFilter, sync::SyncPoint},
 /// #     },
 /// #     utils::{Buffer, Physical, Rectangle, Size, Transform},
 /// # };
@@ -1250,7 +1250,7 @@ macro_rules! render_elements_internal {
 /// #     fn transformation(&self) -> Transform {
 /// #         unimplemented!()
 /// #     }
-/// #     fn finish(self) -> Result<(), Self::Error> { unimplemented!() }
+/// #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 /// # }
 /// #
 /// # struct MyRenderer;

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -6,7 +6,7 @@
 //! # use smithay::{
 //! #     backend::{
 //! #         allocator::Fourcc,
-//! #         renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter},
+//! #         renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
 //! #     },
 //! #     utils::{Buffer, Physical, Rectangle, Transform},
 //! # };
@@ -59,7 +59,7 @@
 //! #     fn transformation(&self) -> Transform {
 //! #         unimplemented!()
 //! #     }
-//! #     fn finish(self) -> Result<(), Self::Error> {
+//! #     fn finish(self) -> Result<SyncPoint, Self::Error> {
 //! #         unimplemented!()
 //! #     }
 //! # }

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -24,7 +24,7 @@
 //! #     backend::allocator::{Fourcc, dmabuf::Dmabuf},
 //! #     backend::renderer::{
 //! #         DebugFlags, Frame, ImportDma, ImportDmaWl, ImportMem, ImportMemWl, Renderer, Texture,
-//! #         TextureFilter,
+//! #         TextureFilter, sync::SyncPoint,
 //! #     },
 //! #     utils::{Buffer, Physical},
 //! #     wayland::compositor::SurfaceData,
@@ -77,7 +77,7 @@
 //! #     fn transformation(&self) -> Transform {
 //! #         unimplemented!()
 //! #     }
-//! #     fn finish(self) -> Result<(), Self::Error> { unimplemented!() }
+//! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 //! # }
 //! #
 //! # struct FakeRenderer;

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -41,7 +41,7 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter},
+//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
 //! #     utils::{Buffer, Physical, Rectangle, Size},
 //! # };
 //! #
@@ -92,7 +92,7 @@
 //! #     fn transformation(&self) -> Transform {
 //! #         unimplemented!()
 //! #     }
-//! #     fn finish(self) -> Result<(), Self::Error> { unimplemented!() }
+//! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 //! # }
 //! #
 //! # struct FakeRenderer;
@@ -194,7 +194,7 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter},
+//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
 //! #     utils::{Buffer, Physical},
 //! # };
 //! #
@@ -245,7 +245,7 @@
 //! #     fn transformation(&self) -> Transform {
 //! #         unimplemented!()
 //! #     }
-//! #     fn finish(self) -> Result<(), Self::Error> { unimplemented!() }
+//! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 //! # }
 //! #
 //! # struct FakeRenderer;

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -38,17 +38,20 @@ pub use uniform::*;
 use self::version::GlVersion;
 
 use super::{
-    Bind, Blit, DebugFlags, ExportMem, Frame, ImportDma, ImportMem, Offscreen, Renderer, Texture,
-    TextureFilter, TextureMapping, Unbind,
-};
-use crate::backend::allocator::{
-    dmabuf::{Dmabuf, WeakDmabuf},
-    format::{get_bpp, get_opaque, get_transparent, has_alpha},
-    Format, Fourcc,
+    sync::SyncPoint, Bind, Blit, DebugFlags, ExportMem, Frame, ImportDma, ImportMem, Offscreen, Renderer,
+    Texture, TextureFilter, TextureMapping, Unbind,
 };
 use crate::backend::egl::{
     ffi::egl::{self as ffi_egl, types::EGLImage},
     EGLContext, EGLSurface, MakeCurrentError,
+};
+use crate::backend::{
+    allocator::{
+        dmabuf::{Dmabuf, WeakDmabuf},
+        format::{get_bpp, get_opaque, get_transparent, has_alpha},
+        Format, Fourcc,
+    },
+    egl::fence::EGLFence,
 };
 use crate::utils::{Buffer as BufferCoord, Physical, Rectangle, Size, Transform};
 
@@ -364,6 +367,8 @@ pub enum Capability {
     Renderbuffer,
     /// GlesRenderer supports color transformations
     ColorTransformations,
+    /// GlesRenderer supports fencing,
+    Fencing,
 }
 
 /// A renderer utilizing OpenGL ES
@@ -582,6 +587,10 @@ impl GlesRenderer {
                     capabilities.push(Capability::ColorTransformations);
                     debug!("Color Transformations are supported");
                 }
+            }
+            if exts.iter().any(|ext| ext == "GL_OES_EGL_sync") {
+                debug!("Fencing is supported");
+                capabilities.push(Capability::Fencing);
             }
 
             let gl_debug_span = if exts.iter().any(|ext| ext == "GL_KHR_debug") {
@@ -2349,17 +2358,17 @@ impl<'frame> Frame for GlesFrame<'frame> {
         self.transform
     }
 
-    fn finish(mut self) -> Result<(), Self::Error> {
+    fn finish(mut self) -> Result<SyncPoint, Self::Error> {
         self.finish_internal()
     }
 }
 
 impl<'frame> GlesFrame<'frame> {
-    fn finish_internal(&mut self) -> Result<(), GlesError> {
+    fn finish_internal(&mut self) -> Result<SyncPoint, GlesError> {
         let _guard = self.span.enter();
 
         if self.finished.swap(true, Ordering::SeqCst) {
-            return Ok(());
+            return Ok(SyncPoint::signaled());
         }
 
         unsafe {
@@ -2426,24 +2435,21 @@ impl<'frame> GlesFrame<'frame> {
             }
         }
 
+        // if we support egl fences we should use it
+        if self.renderer.capabilities.contains(&Capability::Fencing) {
+            if let Ok(fence) = EGLFence::create(self.renderer.egl.display()) {
+                unsafe {
+                    self.renderer.gl.Flush();
+                }
+                return Ok(SyncPoint::from(fence));
+            }
+        }
+
+        // as a last option we force finish, this is unlikely to happen
         unsafe {
-            // We need to wait for the previously submitted GL commands to complete
-            // or otherwise the buffer could be submitted to the drm surface while
-            // still writing to the buffer which results in flickering on the screen.
-            // The proper solution would be to create a fence just before calling
-            // glFlush that the backend can use to wait for the commands to be finished.
-            // In case of a drm atomic backend the fence could be supplied by using the
-            // IN_FENCE_FD property.
-            // See https://01.org/linuxgraphics/gfx-docs/drm/gpu/drm-kms.html#explicit-fencing-properties for
-            // the topic on submitting a IN_FENCE_FD and the mesa kmskube example
-            // https://gitlab.freedesktop.org/mesa/kmscube/-/blob/9f63f359fab1b5d8e862508e4e51c9dfe339ccb0/drm-atomic.c
-            // especially here
-            // https://gitlab.freedesktop.org/mesa/kmscube/-/blob/9f63f359fab1b5d8e862508e4e51c9dfe339ccb0/drm-atomic.c#L147
-            // and here
-            // https://gitlab.freedesktop.org/mesa/kmscube/-/blob/9f63f359fab1b5d8e862508e4e51c9dfe339ccb0/drm-atomic.c#L235
             self.renderer.gl.Finish();
         }
-        Ok(())
+        Ok(SyncPoint::signaled())
     }
 
     /// Overrides the default texture shader used, if none is specified.
@@ -3054,8 +3060,13 @@ impl<'frame> GlesFrame<'frame> {
 
 impl<'frame> Drop for GlesFrame<'frame> {
     fn drop(&mut self) {
-        if let Err(err) = self.finish_internal() {
-            warn!("Ignored error finishing GlesFrame on drop: {}", err);
+        match self.finish_internal() {
+            Ok(sync) => {
+                sync.wait();
+            }
+            Err(err) => {
+                warn!("Ignored error finishing GlesFrame on drop: {}", err);
+            }
         }
     }
 }

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -202,6 +202,10 @@ impl Renderer for GlowRenderer {
             glow,
         })
     }
+
+    fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
+        self.gl.wait(sync)
+    }
 }
 
 impl<'frame> Frame for GlowFrame<'frame> {

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -16,8 +16,8 @@ use crate::{
         renderer::{
             element::UnderlyingStorage,
             gles::{element::*, *},
-            Bind, Blit, DebugFlags, ExportMem, ImportDma, ImportMem, Offscreen, Renderer, TextureFilter,
-            Unbind,
+            sync, Bind, Blit, DebugFlags, ExportMem, ImportDma, ImportMem, Offscreen, Renderer,
+            TextureFilter, Unbind,
         },
     },
     utils::{Buffer as BufferCoord, Physical, Rectangle, Size, Transform},
@@ -270,17 +270,21 @@ impl<'frame> Frame for GlowFrame<'frame> {
         )
     }
 
-    fn finish(mut self) -> Result<(), Self::Error> {
+    fn finish(mut self) -> Result<sync::SyncPoint, Self::Error> {
         self.finish_internal()
+    }
+
+    fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
+        self.frame.as_mut().unwrap().wait(sync)
     }
 }
 
 impl<'frame> GlowFrame<'frame> {
-    fn finish_internal(&mut self) -> Result<(), GlesError> {
+    fn finish_internal(&mut self) -> Result<sync::SyncPoint, GlesError> {
         if let Some(frame) = self.frame.take() {
             frame.finish()
         } else {
-            Ok(())
+            Ok(sync::SyncPoint::default())
         }
     }
 }

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -228,7 +228,7 @@ pub trait Frame {
     /// Leaking the frame instead will leak resources and can cause any of the previous effects.
     /// Leaking might make the renderer return Errors and force it's recreation.
     /// Leaking may not cause otherwise undefined behavior and program execution will always continue normally.
-    fn finish(self) -> Result<(), Self::Error>;
+    fn finish(self) -> Result<sync::SyncPoint, Self::Error>;
 }
 
 bitflags::bitflags! {

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -218,6 +218,12 @@ pub trait Frame {
     /// Output transformation that is applied to this frame
     fn transformation(&self) -> Transform;
 
+    /// Wait for a [`SyncPoint`](sync::SyncPoint) to be signaled
+    fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
+        sync.wait();
+        Ok(())
+    }
+
     /// Finish this [`Frame`] returning any error that may happen during any cleanup.
     ///
     /// Dropping the frame instead may result in any of the following and is implementation dependent:
@@ -279,6 +285,12 @@ pub trait Renderer {
         output_size: Size<i32, Physical>,
         dst_transform: Transform,
     ) -> Result<Self::Frame<'_>, Self::Error>;
+
+    /// Wait for a [`SyncPoint`](sync::SyncPoint) to be signaled
+    fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
+        sync.wait();
+        Ok(())
+    }
 }
 
 /// Trait for renderers that support creating offscreen framebuffers to render into.

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -43,6 +43,8 @@ pub mod element;
 
 pub mod damage;
 
+pub mod sync;
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 /// Texture filtering methods
 pub enum TextureFilter {

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -56,6 +56,7 @@ use crate::{
     backend::{
         allocator::{dmabuf::AnyError, Allocator, Buffer as BufferTrait, Format, Fourcc},
         drm::DrmNode,
+        renderer::sync,
         SwapBuffersError,
     },
     utils::{Buffer as BufferCoords, Physical, Size},
@@ -1097,9 +1098,9 @@ where
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
-    fn finish_internal(&mut self) -> Result<(), Error<R, T>> {
+    fn finish_internal(&mut self) -> Result<sync::SyncPoint, Error<R, T>> {
         if let Some(frame) = self.frame.take() {
-            frame.finish().map_err(Error::Render)?;
+            let sync = frame.finish().map_err(Error::Render)?;
 
             // now the frame is gone, lets use our unholy ptr till the end of this call:
             // SAFETY:
@@ -1142,9 +1143,9 @@ where
                             1.0,
                         )
                         .map_err(Error::Target)?;
-                    frame.finish().map_err(Error::Target)?;
+                    let sync = frame.finish().map_err(Error::Target)?;
 
-                    return Ok(());
+                    return Ok(sync);
                 }
 
                 let format = if target
@@ -1193,6 +1194,7 @@ where
                     mappings.push(mapping);
                 }
 
+                let mut sync: Option<sync::SyncPoint> = None;
                 for (mapping, rect) in mappings {
                     let slice = ExportMem::map_texture(render.renderer_mut(), &mapping)
                         .map_err(Error::Render::<R, T>)?;
@@ -1218,12 +1220,15 @@ where
                             .render_texture_from_to(&texture, src, dst, damage, Transform::Normal, 1.0)
                             .map_err(Error::Target)?;
                     }
-                    frame.finish().map_err(Error::Target)?;
+                    sync = Some(frame.finish().map_err(Error::Target)?);
                 }
+                return Ok(sync.unwrap_or_default());
             }
+
+            return Ok(sync);
         }
 
-        Ok(())
+        Ok(sync::SyncPoint::signaled())
     }
 }
 
@@ -1519,7 +1524,7 @@ where
         self.frame.as_ref().unwrap().transformation()
     }
 
-    fn finish(mut self) -> Result<(), Self::Error> {
+    fn finish(mut self) -> Result<sync::SyncPoint, Self::Error> {
         self.finish_internal()
     }
 }

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1084,6 +1084,10 @@ where
             span,
         })
     }
+
+    fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
+        self.render.renderer_mut().wait(sync).map_err(Error::Render)
+    }
 }
 
 impl<'render, 'target, 'alloc, 'frame, R: GraphicsApi, T: GraphicsApi>
@@ -1526,6 +1530,10 @@ where
 
     fn finish(mut self) -> Result<sync::SyncPoint, Self::Error> {
         self.finish_internal()
+    }
+
+    fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
+        self.frame.as_mut().unwrap().wait(sync).map_err(Error::Render)
     }
 }
 

--- a/src/backend/renderer/sync/egl.rs
+++ b/src/backend/renderer/sync/egl.rs
@@ -1,0 +1,21 @@
+use std::{os::unix::io::OwnedFd, time::Duration};
+
+use crate::backend::{egl::fence::EGLFence, renderer::sync::Fence};
+
+impl Fence for EGLFence {
+    fn wait(&self) {
+        self.client_wait(None, false);
+    }
+
+    fn is_exportable(&self) -> bool {
+        self.is_native()
+    }
+
+    fn export(&self) -> Option<OwnedFd> {
+        self.export().ok()
+    }
+
+    fn is_signaled(&self) -> bool {
+        self.client_wait(Some(Duration::ZERO), false)
+    }
+}

--- a/src/backend/renderer/sync/mod.rs
+++ b/src/backend/renderer/sync/mod.rs
@@ -1,0 +1,92 @@
+//! Helper for synchronizing rendering operations
+use std::{os::unix::io::OwnedFd, sync::Arc};
+
+use downcast_rs::{impl_downcast, Downcast};
+
+#[cfg(feature = "backend_egl")]
+mod egl;
+
+/// A fence that will be signaled in finite time
+pub trait Fence: std::fmt::Debug + Send + Sync + Downcast {
+    /// Queries the state of the fence
+    fn is_signaled(&self) -> bool;
+
+    /// Blocks the current thread until the fence is signaled
+    fn wait(&self);
+
+    /// Returns whether this fence can be exported
+    /// as a native fence fd
+    fn is_exportable(&self) -> bool;
+
+    /// Export this fence as a native fence fd
+    fn export(&self) -> Option<OwnedFd>;
+}
+impl_downcast!(Fence);
+
+/// A sync point the will be signaled in finite time
+#[derive(Debug, Clone)]
+#[must_use = "this `SyncPoint` may contain a fence that should be awaited, failing to do so may result in unexpected rendering artifacts"]
+pub struct SyncPoint {
+    fence: Option<Arc<dyn Fence>>,
+}
+
+impl Default for SyncPoint {
+    fn default() -> Self {
+        Self::signaled()
+    }
+}
+
+impl SyncPoint {
+    /// Create an already signaled sync point
+    pub fn signaled() -> Self {
+        Self {
+            fence: Default::default(),
+        }
+    }
+
+    /// Get a reference to the underlying [`Fence`] if any
+    ///
+    /// Returns `None` if the sync point does not contain a fence
+    /// or contains a different type of fence
+    pub fn get<F: Fence + 'static>(&self) -> Option<&F> {
+        self.fence.as_ref().and_then(|f| f.downcast_ref())
+    }
+
+    /// Queries the state of the sync point
+    ///
+    /// Will always return `true` in case the sync point does not contain a fence
+    pub fn is_reached(&self) -> bool {
+        self.fence.as_ref().map(|f| f.is_signaled()).unwrap_or(true)
+    }
+
+    /// Blocks the current thread until the sync point is signaled
+    ///
+    /// If the sync point does not contain a fence this will never block.
+    pub fn wait(&self) {
+        if let Some(fence) = self.fence.as_ref() {
+            fence.wait();
+        }
+    }
+
+    /// Returns whether this sync point can be exported as a native fence fd
+    ///
+    /// Will always return `false` in case the sync point does not contain a fence
+    pub fn is_exportable(&self) -> bool {
+        self.fence.as_ref().map(|f| f.is_exportable()).unwrap_or(false)
+    }
+
+    /// Export this [`SyncPoint`] as a native fence fd
+    ///
+    /// Will always return `None` in case the sync point does not contain a fence
+    pub fn export(&self) -> Option<OwnedFd> {
+        self.fence.as_ref().and_then(|f| f.export())
+    }
+}
+
+impl<T: Fence + 'static> From<T> for SyncPoint {
+    fn from(value: T) -> Self {
+        SyncPoint {
+            fence: Some(Arc::new(value)),
+        }
+    }
+}

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -5,12 +5,13 @@ use crate::{
     backend::renderer::{
         damage::{
             Error as OutputDamageTrackerError, OutputDamageTracker, OutputDamageTrackerMode, OutputNoMode,
+            RenderOutputResult,
         },
-        element::{AsRenderElements, RenderElement, RenderElementStates, Wrap},
+        element::{AsRenderElements, RenderElement, Wrap},
         Renderer, Texture,
     },
     output::Output,
-    utils::{IsAlive, Logical, Physical, Point, Rectangle, Scale, Transform},
+    utils::{IsAlive, Logical, Point, Rectangle, Scale, Transform},
 };
 #[cfg(feature = "wayland_frontend")]
 use crate::{
@@ -674,7 +675,7 @@ pub fn render_output<
     custom_elements: &'a [C],
     damage_tracker: &mut OutputDamageTracker,
     clear_color: [f32; 4],
-) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), OutputDamageTrackerError<R>>
+) -> Result<RenderOutputResult, OutputDamageTrackerError<R>>
 where
     <R as Renderer>::TextureId: Texture + 'static,
     <E as AsRenderElements<R>>::RenderElement: 'a,

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -4,8 +4,8 @@ use smithay::{
     backend::{
         allocator::{dmabuf::Dmabuf, Fourcc},
         renderer::{
-            DebugFlags, Frame, ImportDma, ImportDmaWl, ImportEgl, ImportMem, ImportMemWl, Renderer, Texture,
-            TextureFilter,
+            sync::SyncPoint, DebugFlags, Frame, ImportDma, ImportDmaWl, ImportEgl, ImportMem, ImportMemWl,
+            Renderer, Texture, TextureFilter,
         },
         SwapBuffersError,
     },
@@ -195,8 +195,8 @@ impl Frame for DummyFrame {
         Transform::Normal
     }
 
-    fn finish(self) -> Result<(), Self::Error> {
-        Ok(())
+    fn finish(self) -> Result<SyncPoint, Self::Error> {
+        Ok(SyncPoint::default())
     }
 }
 


### PR DESCRIPTION
This PR tries to get rid of `glFinish` in most cases.
It is doing so by introduction a `SyncPoint` that is returned from `Frame::finish` which can be used to wait
for the rendering to fully realize.
Additional the `SyncPoint` can transport a fence, that in case it represents a native fence, be forwarded to kms
to let the driver wait for us.