### PR TITLE
Perf/profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ x11rb = { version = "0.11.1", optional = true }
 xkbcommon = { version = "0.5.0", features = ["wayland"]}
 scan_fmt = { version = "0.2.3", default-features = false }
 encoding = { version = "0.2.33", optional = true }
+profiling = "1.0"
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -124,3 +125,7 @@ required-features = ["backend_drm", "backend_gbm", "backend_egl", "backend_vulka
 [[bench]]
 name = "benchmark"
 harness = false
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -18,6 +18,8 @@ xcursor = {version = "0.3.3", optional = true}
 xkbcommon = "0.5.0"
 renderdoc = {version = "0.11.0", optional = true}
 smithay-drm-extras = {path = "../smithay-drm-extras", optional = true}
+puffin_http = { version = "0.9", optional = true }
+profiling = { version = "1.0" }
 
 [dependencies.smithay]
 default-features = false
@@ -55,3 +57,5 @@ udev = [
 winit = ["smithay/backend_winit", "smithay/backend_drm"]
 x11 = ["smithay/backend_x11", "x11rb", "smithay/renderer_gl", "smithay/backend_vulkan"]
 xwayland = ["smithay/xwayland", "x11rb", "smithay/x11rb_event_source", "xcursor"]
+profile-with-puffin = ["profiling/profile-with-puffin", "puffin_http"]
+profile-with-tracy = ["profiling/profile-with-tracy"]

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -59,3 +59,4 @@ x11 = ["smithay/backend_x11", "x11rb", "smithay/renderer_gl", "smithay/backend_v
 xwayland = ["smithay/xwayland", "x11rb", "smithay/x11rb_event_source", "xcursor"]
 profile-with-puffin = ["profiling/profile-with-puffin", "puffin_http"]
 profile-with-tracy = ["profiling/profile-with-tracy"]
+renderer_sync = []

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -7,6 +7,11 @@ static POSSIBLE_BACKENDS: &[&str] = &[
     "--x11 : Run anvil as an X11 client.",
 ];
 
+#[cfg(feature = "profile-with-tracy")]
+#[global_allocator]
+static GLOBAL: profiling::tracy_client::ProfiledAllocator<std::alloc::System> =
+    profiling::tracy_client::ProfiledAllocator::new(std::alloc::System, 10);
+
 fn main() {
     if let Ok(env_filter) = tracing_subscriber::EnvFilter::try_from_default_env() {
         tracing_subscriber::fmt()
@@ -16,6 +21,16 @@ fn main() {
     } else {
         tracing_subscriber::fmt().compact().init();
     }
+
+    #[cfg(feature = "profile-with-tracy")]
+    profiling::tracy_client::Client::start();
+
+    profiling::register_thread!("Main Thread");
+
+    #[cfg(feature = "profile-with-puffin")]
+    let _server = puffin_http::Server::new(&format!("0.0.0.0:{}", puffin_http::DEFAULT_PORT)).unwrap();
+    #[cfg(feature = "profile-with-puffin")]
+    profiling::puffin::set_scopes_on(true);
 
     let arg = ::std::env::args().nth(1);
     match arg.as_ref().map(|s| &s[..]) {

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -140,6 +140,7 @@ where
         })
 }
 
+#[profiling::function]
 pub fn output_elements<R>(
     output: &Output,
     space: &Space<WindowElement>,

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -471,6 +471,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                     Mode::Level,
                 ),
                 |_, _, data| {
+                    profiling::scope!("dispatch_clients");
                     data.display.dispatch_clients(&mut data.state).unwrap();
                     Ok(PostAction::Continue)
                 },
@@ -599,6 +600,7 @@ pub struct SurfaceDmabufFeedback<'a> {
     pub scanout_feedback: &'a DmabufFeedback,
 }
 
+#[profiling::function]
 pub fn post_repaint(
     output: &Output,
     render_element_states: &RenderElementStates,
@@ -672,6 +674,7 @@ pub fn post_repaint(
     }
 }
 
+#[profiling::function]
 pub fn take_presentation_feedback(
     output: &Output,
     space: &Space<WindowElement>,

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -554,6 +554,7 @@ impl SurfaceComposition {
         }
     }
 
+    #[profiling::function]
     fn queue_frame(
         &mut self,
         sync: Option<SyncPoint>,
@@ -570,6 +571,7 @@ impl SurfaceComposition {
         }
     }
 
+    #[profiling::function]
     fn render_frame<R, E, Target>(
         &mut self,
         renderer: &mut R,
@@ -1249,6 +1251,10 @@ impl AnvilState<UdevData> {
     }
 
     fn render_surface(&mut self, node: DrmNode, crtc: crtc::Handle) {
+        profiling::scope!(
+            "render_surface",
+            &format!("{:?}:{crtc:?}", node.dev_path().unwrap())
+        );
         let device = if let Some(device) = self.backend_data.backends.get_mut(&node) {
             device
         } else {
@@ -1387,6 +1393,8 @@ impl AnvilState<UdevData> {
             let elapsed = start.elapsed();
             tracing::trace!(?elapsed, "rendered surface");
         }
+
+        profiling::finish_frame!();
     }
 
     fn schedule_initial_render(
@@ -1430,6 +1438,7 @@ impl AnvilState<UdevData> {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[profiling::function]
 fn render_surface<'a, 'b>(
     surface: &'a mut SurfaceData,
     renderer: &mut UdevRenderer<'a, 'b>,

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -299,6 +299,8 @@ pub fn run_x11() {
 
     while state.running.load(Ordering::SeqCst) {
         if state.backend_data.render {
+            profiling::scope!("render_frame");
+
             let backend_data = &mut state.backend_data;
             // We need to borrow everything we want to refer to inside the renderer callback otherwise rustc is unhappy.
             let cursor_status = &state.cursor_status;
@@ -310,6 +312,7 @@ pub fn run_x11() {
             let (buffer, age) = backend_data.surface.buffer().expect("gbm device was destroyed");
             if let Err(err) = backend_data.renderer.bind(buffer) {
                 error!("Error while binding buffer: {}", err);
+                profiling::finish_frame!();
                 continue;
             }
 
@@ -464,6 +467,7 @@ pub fn run_x11() {
             #[cfg(feature = "debug")]
             state.backend_data.fps.tick();
             window.set_cursor_visible(cursor_visible);
+            profiling::finish_frame!();
         }
 
         let mut calloop_data = CalloopData { state, display };

--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -230,6 +230,7 @@ impl Dmabuf {
     ///
     /// Usually used to block applying surface state on the readiness of an attached dmabuf.
     #[cfg(feature = "wayland_frontend")]
+    #[profiling::function]
     pub fn generate_blocker(
         &self,
         interest: Interest,
@@ -307,6 +308,7 @@ where
     type Buffer = Dmabuf;
     type Error = AnyError;
 
+    #[profiling::function]
     fn create_buffer(
         &mut self,
         width: u32,
@@ -381,6 +383,7 @@ impl DmabufSource {
     /// To monitor for new fences added at a later time a new DmabufSource needs to be created.
     ///
     /// Returns `AlreadyReady` if all corresponding fences are already signalled or if `interest` is empty.
+    #[profiling::function]
     pub fn new(dmabuf: Dmabuf, interest: Interest) -> Result<Self, AlreadyReady> {
         if !interest.readable && !interest.writable {
             return Err(AlreadyReady);
@@ -435,6 +438,7 @@ impl EventSource for DmabufSource {
 
     type Error = std::io::Error;
 
+    #[profiling::function]
     fn process_events<F>(
         &mut self,
         readiness: calloop::Readiness,

--- a/src/backend/allocator/dumb.rs
+++ b/src/backend/allocator/dumb.rs
@@ -34,6 +34,7 @@ impl Allocator for DrmDevice {
     type Error = drm::SystemError;
 
     #[instrument(level = "trace", err)]
+    #[profiling::function]
     fn create_buffer(
         &mut self,
         width: u32,
@@ -92,6 +93,8 @@ impl DumbBuffer {
 
 impl AsDmabuf for DumbBuffer {
     type Error = drm::SystemError;
+
+    #[profiling::function]
     fn export(&self) -> Result<Dmabuf, Self::Error> {
         let fd = unsafe { OwnedFd::from_raw_fd(self.fd.buffer_to_prime_fd(self.handle.handle(), 0)?) };
         let mut builder = Dmabuf::builder(self.size(), self.format.code, DmabufFlags::empty());

--- a/src/backend/allocator/gbm.rs
+++ b/src/backend/allocator/gbm.rs
@@ -54,6 +54,7 @@ impl<A: AsFd + 'static> GbmAllocator<A> {
     /// Alternative to [`Allocator::create_buffer`], if you need a one-off buffer with
     /// a different set of usage flags.
     #[instrument(level = "trace", skip(self), fields(self.device = ?self.device, err))]
+    #[profiling::function]
     pub fn create_buffer_with_flags(
         &mut self,
         width: u32,
@@ -92,6 +93,7 @@ impl<A: AsFd + 'static> Allocator for GbmAllocator<A> {
     type Buffer = GbmBuffer<()>;
     type Error = std::io::Error;
 
+    #[profiling::function]
     fn create_buffer(
         &mut self,
         width: u32,
@@ -147,6 +149,7 @@ impl<T> AsDmabuf for GbmBuffer<T> {
     type Error = GbmConvertError;
 
     #[cfg(feature = "backend_gbm_has_fd_for_plane")]
+    #[profiling::function]
     fn export(&self) -> Result<Dmabuf, GbmConvertError> {
         let planes = self.plane_count()? as i32;
 
@@ -168,6 +171,7 @@ impl<T> AsDmabuf for GbmBuffer<T> {
     }
 
     #[cfg(not(feature = "backend_gbm_has_fd_for_plane"))]
+    #[profiling::function]
     fn export(&self) -> Result<Dmabuf, GbmConvertError> {
         let planes = self.plane_count()? as i32;
 
@@ -209,6 +213,7 @@ impl<T> AsDmabuf for GbmBuffer<T> {
 
 impl Dmabuf {
     /// Import a Dmabuf using libgbm, creating a gbm Buffer Object to the same underlying data.
+    #[profiling::function]
     pub fn import_to<A: AsFd + 'static, T>(
         &self,
         gbm: &GbmDevice<A>,

--- a/src/backend/allocator/swapchain.rs
+++ b/src/backend/allocator/swapchain.rs
@@ -158,6 +158,7 @@ where
     /// The swapchain has an internal maximum of four re-usable buffers.
     /// This function returns the first free one.
     #[instrument(level = "trace", skip_all, err)]
+    #[profiling::function]
     pub fn acquire(&mut self) -> Result<Option<Slot<A::Buffer>>, A::Error> {
         if let Some(free_slot) = self
             .slots

--- a/src/backend/allocator/vulkan/mod.rs
+++ b/src/backend/allocator/vulkan/mod.rs
@@ -290,6 +290,7 @@ impl VulkanAllocator {
     /// - The size of the buffer is too large for the `usage`, `fourcc` format or `modifiers`.
     /// - The `fourcc` format and `modifiers` do not support the specified usage.
     #[instrument(level = "trace", err)]
+    #[profiling::function]
     pub fn create_buffer_with_usage(
         &mut self,
         width: u32,
@@ -415,6 +416,7 @@ impl Buffer for VulkanImage {
 impl AsDmabuf for VulkanImage {
     type Error = ExportError;
 
+    #[profiling::function]
     fn export(&self) -> Result<Dmabuf, Self::Error> {
         let device = self.device.upgrade().ok_or(ExportError::AllocatorDestroyed)?;
 

--- a/src/backend/drm/compositor/gbm.rs
+++ b/src/backend/drm/compositor/gbm.rs
@@ -14,6 +14,7 @@ impl<A: AsFd + 'static, T> ExportFramebuffer<BufferObject<T>> for gbm::Device<A>
     type Framebuffer = GbmFramebuffer;
     type Error = Error;
 
+    #[profiling::function]
     fn add_framebuffer(
         &self,
         drm: &DrmDeviceFd,

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -481,6 +481,7 @@ impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
 }
 
 impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
+    #[profiling::function]
     fn test_state(
         &mut self,
         surface: &DrmSurface,
@@ -506,6 +507,7 @@ impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
         res
     }
 
+    #[profiling::function]
     fn commit(
         &mut self,
         surface: &DrmSurface,
@@ -515,6 +517,7 @@ impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
         surface.commit(self.build_planes(supports_fencing), event)
     }
 
+    #[profiling::function]
     fn page_flip(
         &mut self,
         surface: &DrmSurface,
@@ -524,6 +527,7 @@ impl<B: AsRef<framebuffer::Handle>> FrameState<B> {
         surface.page_flip(self.build_planes(supports_fencing), event)
     }
 
+    #[profiling::function]
     fn build_planes(&mut self, supports_fencing: bool) -> impl IntoIterator<Item = super::PlaneState<'_>> {
         for (_, state) in self.planes.iter_mut().filter(|(_, state)| !state.skip) {
             if let Some(config) = state.config.as_mut() {
@@ -1524,6 +1528,7 @@ where
     ///
     /// - `elements` for this frame in front-to-back order
     #[instrument(level = "trace", parent = &self.span, skip_all)]
+    #[profiling::function]
     pub fn render_frame<'a, R, E, Target>(
         &mut self,
         renderer: &mut R,
@@ -2098,6 +2103,7 @@ where
     /// Otherwise the underlying swapchain will eventually run out of buffers.
     ///
     /// `user_data` can be used to attach some data to a specific buffer and later retrieved with [`DrmCompositor::frame_submitted`]
+    #[profiling::function]
     pub fn queue_frame(&mut self, user_data: U) -> FrameResult<(), A, F> {
         let next_frame = self.next_frame.take().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
 
@@ -2125,6 +2131,7 @@ where
         Ok(())
     }
 
+    #[profiling::function]
     fn submit(&mut self) -> FrameResult<(), A, F> {
         let (mut state, user_data) = self.queued_frame.take().unwrap();
 
@@ -2282,6 +2289,7 @@ where
 
     #[allow(clippy::too_many_arguments)]
     #[instrument(level = "trace", skip_all)]
+    #[profiling::function]
     fn try_assign_element<'a, R, E, Target>(
         &mut self,
         renderer: &mut R,
@@ -2368,6 +2376,7 @@ where
 
     #[allow(clippy::too_many_arguments)]
     #[instrument(level = "trace", skip_all)]
+    #[profiling::function]
     fn try_assign_cursor_plane<R, E, Target>(
         &mut self,
         renderer: &mut R,
@@ -2703,6 +2712,7 @@ where
 
     #[allow(clippy::too_many_arguments)]
     #[instrument(level = "trace", skip_all)]
+    #[profiling::function]
     fn try_assign_overlay_plane<'a, R, E>(
         &self,
         renderer: &mut R,
@@ -2830,6 +2840,7 @@ where
 
     #[allow(clippy::too_many_arguments)]
     #[instrument(level = "trace", skip_all)]
+    #[profiling::function]
     fn try_assign_primary_plane<R, E>(
         &self,
         renderer: &mut R,
@@ -2879,6 +2890,7 @@ where
 
     #[allow(clippy::too_many_arguments)]
     #[instrument(level = "trace", skip_all)]
+    #[profiling::function]
     fn try_assign_plane<R, E>(
         &self,
         element: &E,

--- a/src/backend/drm/gbm.rs
+++ b/src/backend/drm/gbm.rs
@@ -54,6 +54,7 @@ impl AsRef<framebuffer::Handle> for GbmFramebuffer {
 /// Returns `Ok(None)` for unknown buffer types and buffer types that do not
 /// support attaching a framebuffer (e.g. shm-buffers)
 #[cfg(feature = "wayland_frontend")]
+#[profiling::function]
 pub fn framebuffer_from_wayland_buffer<A: AsFd + 'static>(
     drm: &DrmDeviceFd,
     gbm: &gbm::Device<A>,
@@ -123,6 +124,7 @@ pub enum Error {
 ///
 /// This tries to import the [`Dmabuf`] using gbm and attach
 /// a [`framebuffer::Handle`] for the imported [`BufferObject`]
+#[profiling::function]
 pub fn framebuffer_from_dmabuf<A: AsFd + 'static>(
     drm: &DrmDeviceFd,
     gbm: &gbm::Device<A>,
@@ -198,6 +200,7 @@ impl TryFrom<super::DrmError> for AccessError {
 }
 
 /// Attach a [`framebuffer::Handle`] to an [`BufferObject`]
+#[profiling::function]
 pub fn framebuffer_from_bo<T>(
     drm: &DrmDeviceFd,
     bo: &BufferObject<T>,
@@ -282,6 +285,7 @@ where
     }
 }
 
+#[profiling::function]
 fn framebuffer_from_bo_internal<D, T>(
     drm: &D,
     bo: BufferObjectInternal<'_, T>,

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -172,6 +172,7 @@ impl AtomicDrmSurface {
 
     // we need a framebuffer to do test commits, which we use to verify our pending state.
     // here we create a dumbbuffer for that purpose.
+    #[profiling::function]
     fn create_test_buffer(&self, size: (u16, u16), plane: plane::Handle) -> Result<TestBuffer, Error> {
         let (w, h) = size;
         let needs_alpha = plane_type(&*self.fd, plane)? != PlaneType::Primary;
@@ -479,6 +480,7 @@ impl AtomicDrmSurface {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self, planes))]
+    #[profiling::function]
     pub fn test_state<'a>(
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,
@@ -513,6 +515,7 @@ impl AtomicDrmSurface {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self, planes))]
+    #[profiling::function]
     pub fn commit<'a>(
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,
@@ -625,6 +628,7 @@ impl AtomicDrmSurface {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self, planes))]
+    #[profiling::function]
     pub fn page_flip<'a>(
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,
@@ -675,6 +679,7 @@ impl AtomicDrmSurface {
 
     // If a mode is set a matching blob needs to be set (the inverse is not true)
     #[allow(clippy::too_many_arguments)]
+    #[profiling::function]
     pub fn build_request<'a>(
         &self,
         new_connectors: &mut dyn Iterator<Item = &connector::Handle>,

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -245,6 +245,7 @@ where
     /// *Note*: This function can be called multiple times and
     /// will return the same buffer until it is queued (see [`GbmBufferedSurface::queue_buffer`]).
     #[instrument(level = "trace", skip_all, parent = &self.span, err)]
+    #[profiling::function]
     pub fn next_buffer(&mut self) -> Result<(Dmabuf, u8), Error<A::Error>> {
         if self.next_fb.is_none() {
             let slot = self
@@ -277,6 +278,7 @@ where
     /// Otherwise the underlying swapchain will eventually run out of buffers.
     ///
     /// `user_data` can be used to attach some data to a specific buffer and later retrieved with [`GbmBufferedSurface::frame_submitted`]
+    #[profiling::function]
     pub fn queue_buffer(
         &mut self,
         sync: Option<SyncPoint>,
@@ -307,6 +309,7 @@ where
     ///
     /// Returns the user data that was stored with [`GbmBufferedSurface::queue_buffer`] if a buffer was pending, otherwise
     /// `None` is returned.
+    #[profiling::function]
     pub fn frame_submitted(&mut self) -> Result<Option<U>, Error<A::Error>> {
         if let Some((mut pending, user_data)) = self.pending_fb.take() {
             std::mem::swap(&mut pending, &mut self.current_fb);
@@ -319,6 +322,7 @@ where
         }
     }
 
+    #[profiling::function]
     fn submit(&mut self) -> Result<(), Error<A::Error>> {
         // yes it does not look like it, but both of these lines should be safe in all cases.
         let QueuedFb {

--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -214,6 +214,7 @@ impl LegacyDrmSurface {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     pub fn commit(&self, framebuffer: framebuffer::Handle, event: bool) -> Result<(), Error> {
         if !self.active.load(Ordering::SeqCst) {
             return Err(Error::DeviceInactive);
@@ -305,6 +306,7 @@ impl LegacyDrmSurface {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     pub fn page_flip(&self, framebuffer: framebuffer::Handle, event: bool) -> Result<(), Error> {
         trace!("Queueing Page flip");
 
@@ -331,6 +333,7 @@ impl LegacyDrmSurface {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     pub fn test_buffer(&self, fb: framebuffer::Handle, mode: &Mode) -> Result<(), Error> {
         if !self.active.load(Ordering::SeqCst) {
             return Err(Error::DeviceInactive);

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -319,6 +319,7 @@ impl DrmSurface {
     ///
     /// *Note*: This will always return `Ok` for legacy devices if `allow_modeset = false`.
     /// The legacy drm api has no way to test a buffer without triggering a modeset.
+    #[profiling::function]
     pub fn test_state<'a>(
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,
@@ -351,6 +352,7 @@ impl DrmSurface {
     /// but will trigger a `vblank` event once done.
     /// Make sure to have the device registered in your event loop prior to invoking this, to not miss
     /// any generated event.
+    #[profiling::function]
     pub fn commit<'a>(
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,
@@ -372,6 +374,7 @@ impl DrmSurface {
     ///
     /// This operation is not blocking and will produce a `vblank` event once swapping is done.
     /// Make sure to have the device registered in your event loop to not miss the event.
+    #[profiling::function]
     pub fn page_flip<'a>(
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -217,6 +217,7 @@ impl EGLContext {
     /// This function is marked unsafe, because the context cannot be made current on another thread without
     /// being unbound again (see [`EGLContext::unbind`]).
     #[instrument(level = "trace", skip_all, parent = &self.span, err)]
+    #[profiling::function]
     pub unsafe fn make_current(&self) -> Result<(), MakeCurrentError> {
         wrap_egl_call(|| {
             ffi::egl::MakeCurrent(
@@ -237,6 +238,7 @@ impl EGLContext {
     ///
     /// This function is marked unsafe, because the context cannot be made current on another thread without
     /// being unbound again (see [`EGLContext::unbind`]).
+    #[profiling::function]
     pub unsafe fn make_current_with_surface(&self, surface: &EGLSurface) -> Result<(), MakeCurrentError> {
         self.make_current_with_draw_and_read_surface(surface, surface)
     }
@@ -249,6 +251,7 @@ impl EGLContext {
     /// This function is marked unsafe, because the context cannot be made current on another thread without
     /// being unbound again (see [`EGLContext::unbind`]).
     #[instrument(level = "trace", skip_all, parent = &self.span, err)]
+    #[profiling::function]
     pub unsafe fn make_current_with_draw_and_read_surface(
         &self,
         draw_surface: &EGLSurface,
@@ -287,6 +290,7 @@ impl EGLContext {
     ///
     /// This does nothing if this context is not the current context.
     #[instrument(level = "trace", skip_all, parent = &self.span, err)]
+    #[profiling::function]
     pub fn unbind(&self) -> Result<(), MakeCurrentError> {
         if self.is_current() {
             wrap_egl_call(|| unsafe {

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -551,6 +551,7 @@ impl EGLDisplay {
     /// Exports an [`EGLImage`] as a [`Dmabuf`]
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[instrument(level = "trace", skip(self), parent = &self.span, err)]
+    #[profiling::function]
     pub fn create_dmabuf_from_image(
         &self,
         image: EGLImage,
@@ -634,6 +635,7 @@ impl EGLDisplay {
 
     /// Imports a [`Dmabuf`] as an [`EGLImage`]
     #[instrument(level = "trace", skip(self), parent = &self.span, err)]
+    #[profiling::function]
     pub fn create_image_from_dmabuf(&self, dmabuf: &Dmabuf) -> Result<EGLImage, Error> {
         if !self.extensions.iter().any(|s| s == "EGL_KHR_image_base")
             && !self
@@ -949,6 +951,7 @@ impl EGLBufferReader {
     ///
     /// In case the buffer is not managed by EGL (but e.g. the [`wayland::shm` module](crate::wayland::shm))
     /// a [`BufferAccessError::NotManaged`](crate::backend::egl::BufferAccessError::NotManaged) is returned.
+    #[profiling::function]
     pub fn egl_buffer_contents(
         &self,
         buffer: &WlBuffer,
@@ -1069,6 +1072,7 @@ impl EGLBufferReader {
     ///
     /// In case the buffer is not managed by EGL (but e.g. the [`wayland::shm` module](crate::wayland::shm)) or the
     /// context has been lost, `None` is returned.
+    #[profiling::function]
     pub fn egl_buffer_dimensions(
         &self,
         buffer: &WlBuffer,

--- a/src/backend/egl/fence.rs
+++ b/src/backend/egl/fence.rs
@@ -35,6 +35,7 @@ impl EGLFence {
     }
 
     /// Import a native fence fd
+    #[profiling::function]
     pub fn import(display: &EGLDisplay, native: OwnedFd) -> Result<Self, Error> {
         // SAFETY: we do not have to test for EGL_KHR_fence_sync as EGL_ANDROID_native_fence_sync
         // requires it already
@@ -84,6 +85,7 @@ impl EGLFence {
     ///
     /// Note: It is the callers responsibility to make sure the current bound client API supports
     /// fences. For OpenglES the `GL_OES_EGL_sync` extension indicates support for fences.
+    #[profiling::function]
     pub fn create(display: &EGLDisplay) -> Result<Self, Error> {
         if !display.has_fences {
             return Err(Error::EglExtensionNotSupported(&["EGL_KHR_fence_sync"]));
@@ -113,6 +115,7 @@ impl EGLFence {
     }
 
     /// Export this [`EGLFence`] as a native fence fd
+    #[profiling::function]
     pub fn export(&self) -> Result<OwnedFd, Error> {
         if !self.0.native {
             return Err(Error::EglExtensionNotSupported(&[
@@ -133,6 +136,7 @@ impl EGLFence {
     ///
     /// Returns `Err` if the supplied display does not match the display
     /// used at creation time of the fence.
+    #[profiling::function]
     pub fn wait(&self, display: &EGLDisplay) -> Result<(), Error> {
         if **display.get_display_handle() != **self.0.display_handle {
             return Err(Error::DisplayNotSupported);
@@ -147,6 +151,7 @@ impl EGLFence {
     /// timeout is reached.
     ///
     /// If the timeout is reached `false` is returned
+    #[profiling::function]
     pub fn client_wait(&self, timeout: Option<Duration>, flush: bool) -> bool {
         let timeout = timeout
             .map(|t| t.as_nanos() as ffi::egl::types::EGLuint64KHR)

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -287,6 +287,7 @@ pub unsafe trait EGLNativeSurface: Send {
     /// [EGLSurface::swap_buffers](crate::backend::egl::surface::EGLSurface::swap_buffers)
     ///
     /// Only implement if required by the backend.
+    #[profiling::function]
     fn swap_buffers(
         &self,
         display: &Arc<EGLDisplayHandle>,

--- a/src/backend/egl/surface.rs
+++ b/src/backend/egl/surface.rs
@@ -91,6 +91,7 @@ impl EGLSurface {
     }
 
     /// Returns the buffer age of the underlying back buffer
+    #[profiling::function]
     pub fn buffer_age(&self) -> Option<i32> {
         let surface = self.surface.load(Ordering::SeqCst);
         let mut age = 0;
@@ -115,6 +116,7 @@ impl EGLSurface {
     }
 
     /// Returns the size of the underlying back buffer
+    #[profiling::function]
     pub fn get_size(&self) -> Option<Size<i32, Physical>> {
         let surface = self.surface.load(Ordering::SeqCst);
         let mut height = 0;
@@ -150,6 +152,7 @@ impl EGLSurface {
 
     /// Swaps buffers at the end of a frame.
     #[instrument(level = "trace", parent = &self.span, skip(self), err)]
+    #[profiling::function]
     pub fn swap_buffers(
         &self,
         damage: Option<&mut [Rectangle<i32, Physical>]>,
@@ -199,6 +202,7 @@ impl EGLSurface {
     }
 
     /// Returns true if the OpenGL surface is the current one in the thread.
+    #[profiling::function]
     pub fn is_current(&self) -> bool {
         let surface = self.surface.load(Ordering::SeqCst);
         unsafe {

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -631,6 +631,7 @@ impl EventSource for LibinputInputBackend {
     type Ret = ();
     type Error = io::Error;
 
+    #[profiling::function]
     fn process_events<F>(&mut self, _: Readiness, token: Token, mut callback: F) -> io::Result<PostAction>
     where
         F: FnMut(Self::Event, &mut ()) -> Self::Ret,

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -371,6 +371,7 @@ impl OutputDamageTracker {
     ///
     /// - `elements` for this output in front-to-back order
     #[instrument(level = "trace", parent = &self.span, skip(renderer, elements))]
+    #[profiling::function]
     pub fn render_output<E, R>(
         &mut self,
         renderer: &mut R,
@@ -509,6 +510,7 @@ impl OutputDamageTracker {
     ///
     /// - `elements` for this output in front-to-back order
     #[instrument(level = "trace", parent = &self.span, skip(elements))]
+    #[profiling::function]
     pub fn damage_output<E>(
         &mut self,
         age: usize,
@@ -545,6 +547,7 @@ impl OutputDamageTracker {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[profiling::function]
     fn damage_output_internal<'a, E>(
         &mut self,
         age: usize,

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -320,6 +320,7 @@ impl MemoryRenderBufferInner {
     }
 
     #[instrument(level = "trace", skip(renderer))]
+    #[profiling::function]
     fn import_texture<R>(&mut self, renderer: &mut R) -> Result<(), <R as Renderer>::Error>
     where
         R: Renderer + ImportMem,
@@ -662,6 +663,7 @@ where
     <R as Renderer>::TextureId: 'static,
 {
     #[instrument(level = "trace", skip(self, frame))]
+    #[profiling::function]
     fn draw<'a>(
         &self,
         frame: &mut <R as Renderer>::Frame<'a>,

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -292,6 +292,7 @@ impl Element for SolidColorRenderElement {
 }
 
 impl<R: Renderer> RenderElement<R> for SolidColorRenderElement {
+    #[profiling::function]
     fn draw(
         &self,
         frame: &mut <R as Renderer>::Frame<'_>,

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -227,6 +227,7 @@ use super::{CommitCounter, Element, Id, RenderElement, UnderlyingStorage};
 
 /// Retrieve the [`WaylandSurfaceRenderElement`]s for a surface tree
 #[instrument(level = "trace", skip(renderer, location, scale))]
+#[profiling::function]
 pub fn render_elements_from_surface_tree<R, E>(
     renderer: &mut R,
     surface: &wl_surface::WlSurface,
@@ -314,6 +315,7 @@ impl<R> fmt::Debug for WaylandSurfaceRenderElement<R> {
 
 impl<R: Renderer + ImportAll> WaylandSurfaceRenderElement<R> {
     /// Create a render element from a surface
+    #[profiling::function]
     pub fn from_surface(
         renderer: &mut R,
         surface: &wl_surface::WlSurface,
@@ -496,6 +498,7 @@ where
     }
 
     #[instrument(level = "trace", skip(frame))]
+    #[profiling::function]
     fn draw<'a>(
         &self,
         frame: &mut <R as Renderer>::Frame<'a>,

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -874,6 +874,7 @@ where
     T: Texture,
 {
     #[instrument(level = "trace", skip(self, frame))]
+    #[profiling::function]
     fn draw<'a>(
         &self,
         frame: &mut <R as Renderer>::Frame<'a>,

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -433,6 +433,7 @@ bitflags::bitflags! {
 /// Convenience function to constrain something that implements [`AsRenderElements`]
 ///
 /// See [`constrain_render_elements`] for more information
+#[profiling::function]
 #[allow(clippy::too_many_arguments)]
 pub fn constrain_as_render_elements<R, E, C>(
     element: &E,
@@ -479,6 +480,7 @@ where
 /// * `behavior` - Defines the behavior for scaling the elements reference in the constrain
 /// * `align` - Defines how the scaled elements should be aligned within the constrain
 /// * `scale` - The scale that was used to create the original elements
+#[profiling::function]
 pub fn constrain_render_elements<E>(
     elements: impl IntoIterator<Item = E>,
     origin: impl Into<Point<i32, Physical>>,

--- a/src/backend/renderer/gles/element.rs
+++ b/src/backend/renderer/gles/element.rs
@@ -99,6 +99,7 @@ impl Element for PixelShaderElement {
 }
 
 impl RenderElement<GlesRenderer> for PixelShaderElement {
+    #[profiling::function]
     fn draw(
         &self,
         frame: &mut GlesFrame<'_>,

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -222,6 +222,7 @@ impl GlesTarget {
         }
     }
 
+    #[profiling::function]
     fn make_current(&self, gl: &ffi::Gles2, egl: &EGLContext) -> Result<(), MakeCurrentError> {
         unsafe {
             if let GlesTarget::Surface { surface, shadow, .. } = self {
@@ -266,6 +267,7 @@ impl GlesTarget {
         }
     }
 
+    #[profiling::function]
     fn make_current_no_shadow(
         &self,
         gl: &ffi::Gles2,
@@ -763,6 +765,7 @@ impl GlesRenderer {
         Ok(renderer)
     }
 
+    #[profiling::function]
     pub(crate) fn make_current(&mut self) -> Result<(), MakeCurrentError> {
         if let Some(target) = self.target.as_ref() {
             target.make_current(&self.gl, &self.egl)?;
@@ -774,6 +777,7 @@ impl GlesRenderer {
         Ok(())
     }
 
+    #[profiling::function]
     fn cleanup(&mut self) {
         #[cfg(feature = "wayland_frontend")]
         self.dmabuf_cache.retain(|entry, _tex| entry.upgrade().is_some());
@@ -830,6 +834,7 @@ impl GlesRenderer {
 #[cfg(feature = "wayland_frontend")]
 impl ImportMemWl for GlesRenderer {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn import_shm_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
@@ -1000,6 +1005,7 @@ const SUPPORTED_MEM_FORMATS_3: &[Fourcc] = &[
 
 impl ImportMem for GlesRenderer {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn import_memory(
         &mut self,
         data: &[u8],
@@ -1079,6 +1085,7 @@ impl ImportMem for GlesRenderer {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn update_memory(
         &mut self,
         texture: &<Self as Renderer>::TextureId,
@@ -1164,6 +1171,7 @@ impl ImportEgl for GlesRenderer {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn import_egl_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
@@ -1217,6 +1225,7 @@ impl ImportEgl for GlesRenderer {
 
 impl ImportDma for GlesRenderer {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn import_dmabuf(
         &mut self,
         buffer: &Dmabuf,
@@ -1272,6 +1281,7 @@ impl ImportDma for GlesRenderer {
 impl ImportDmaWl for GlesRenderer {}
 
 impl GlesRenderer {
+    #[profiling::function]
     fn existing_dmabuf_texture(&self, buffer: &Dmabuf) -> Result<Option<GlesTexture>, GlesError> {
         let existing_texture = self
             .dmabuf_cache
@@ -1294,6 +1304,7 @@ impl GlesRenderer {
         }
     }
 
+    #[profiling::function]
     fn import_egl_image(
         &self,
         image: EGLImage,
@@ -1324,6 +1335,7 @@ impl ExportMem for GlesRenderer {
     type TextureMapping = GlesMapping;
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn copy_framebuffer(
         &mut self,
         region: Rectangle<i32, BufferCoord>,
@@ -1385,6 +1397,7 @@ impl ExportMem for GlesRenderer {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn copy_texture(
         &mut self,
         texture: &Self::TextureId,
@@ -1448,6 +1461,7 @@ impl ExportMem for GlesRenderer {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn map_texture<'a>(
         &mut self,
         texture_mapping: &'a Self::TextureMapping,
@@ -1481,6 +1495,7 @@ impl ExportMem for GlesRenderer {
 }
 
 impl GlesRenderer {
+    #[profiling::function]
     fn create_shadow_buffer(&self, size: Size<i32, BufferCoord>) -> Result<Option<ShadowBuffer>, GlesError> {
         trace!(?size, "Creating shadow framebuffer");
 
@@ -1562,6 +1577,7 @@ impl GlesRenderer {
 
 impl Bind<Rc<EGLSurface>> for GlesRenderer {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn bind(&mut self, surface: Rc<EGLSurface>) -> Result<(), GlesError> {
         self.unbind()?;
         self.target = Some(GlesTarget::Surface {
@@ -1588,6 +1604,7 @@ impl Bind<Rc<EGLSurface>> for GlesRenderer {
 
 impl Bind<Dmabuf> for GlesRenderer {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn bind(&mut self, dmabuf: Dmabuf) -> Result<(), GlesError> {
         self.unbind()?;
         self.make_current()?;
@@ -1663,6 +1680,7 @@ impl Bind<Dmabuf> for GlesRenderer {
 
 impl Bind<GlesTexture> for GlesRenderer {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn bind(&mut self, texture: GlesTexture) -> Result<(), GlesError> {
         self.unbind()?;
         self.make_current()?;
@@ -1702,6 +1720,7 @@ impl Bind<GlesTexture> for GlesRenderer {
 
 impl Offscreen<GlesTexture> for GlesRenderer {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn create_buffer(
         &mut self,
         format: Fourcc,
@@ -1744,6 +1763,7 @@ impl Offscreen<GlesTexture> for GlesRenderer {
 
 impl Bind<GlesRenderbuffer> for GlesRenderer {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn bind(&mut self, renderbuffer: GlesRenderbuffer) -> Result<(), GlesError> {
         self.unbind()?;
         self.make_current()?;
@@ -1783,6 +1803,7 @@ impl Bind<GlesRenderbuffer> for GlesRenderer {
 
 impl Offscreen<GlesRenderbuffer> for GlesRenderer {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn create_buffer(
         &mut self,
         format: Fourcc,
@@ -1829,6 +1850,7 @@ where
     Self: Bind<Target>,
 {
     #[instrument(level = "trace", parent = &self.span, skip(self, to))]
+    #[profiling::function]
     fn blit_to(
         &mut self,
         to: Target,
@@ -1850,6 +1872,7 @@ where
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self, from))]
+    #[profiling::function]
     fn blit_from(
         &mut self,
         from: Target,
@@ -1873,6 +1896,7 @@ where
 }
 
 impl GlesRenderer {
+    #[profiling::function]
     fn blit(
         &mut self,
         src_target: &GlesTarget,
@@ -1961,6 +1985,7 @@ impl GlesRenderer {
 }
 
 impl Unbind for GlesRenderer {
+    #[profiling::function]
     fn unbind(&mut self) -> Result<(), <Self as Renderer>::Error> {
         unsafe {
             self.egl.make_current()?;
@@ -2234,6 +2259,7 @@ impl Renderer for GlesRenderer {
         Ok(())
     }
 
+    #[profiling::function]
     fn render(
         &mut self,
         mut output_size: Size<i32, Physical>,
@@ -2313,6 +2339,7 @@ impl Renderer for GlesRenderer {
         self.debug_flags
     }
 
+    #[profiling::function]
     fn wait(&mut self, sync: &super::sync::SyncPoint) -> Result<(), Self::Error> {
         self.make_current()?;
 
@@ -2411,6 +2438,7 @@ impl<'frame> Frame for GlesFrame<'frame> {
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), GlesError> {
         if at.is_empty() {
             return Ok(());
@@ -2430,6 +2458,7 @@ impl<'frame> Frame for GlesFrame<'frame> {
     }
 
     #[instrument(level = "trace", skip(self), parent = &self.span)]
+    #[profiling::function]
     fn draw_solid(
         &mut self,
         dst: Rectangle<i32, Physical>,
@@ -2461,6 +2490,7 @@ impl<'frame> Frame for GlesFrame<'frame> {
     }
 
     #[instrument(level = "trace", skip(self), parent = &self.span)]
+    #[profiling::function]
     fn render_texture_from_to(
         &mut self,
         texture: &GlesTexture,
@@ -2477,16 +2507,19 @@ impl<'frame> Frame for GlesFrame<'frame> {
         self.transform
     }
 
+    #[profiling::function]
     fn finish(mut self) -> Result<SyncPoint, Self::Error> {
         self.finish_internal()
     }
 
+    #[profiling::function]
     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> {
         self.renderer.wait(sync)
     }
 }
 
 impl<'frame> GlesFrame<'frame> {
+    #[profiling::function]
     fn finish_internal(&mut self) -> Result<SyncPoint, GlesError> {
         let _guard = self.span.enter();
 
@@ -2595,6 +2628,7 @@ impl<'frame> GlesFrame<'frame> {
 
     /// Draw a solid color to the current target at the specified destination with the specified color.
     #[instrument(skip(self), parent = &self.span)]
+    #[profiling::function]
     pub fn draw_solid(
         &mut self,
         dest: Rectangle<i32, Physical>,
@@ -2733,6 +2767,7 @@ impl<'frame> GlesFrame<'frame> {
     ///
     /// Optionally allows a custom texture program and matching additional uniforms to be passed in.
     #[instrument(level = "trace", skip(self), parent = &self.span)]
+    #[profiling::function]
     #[allow(clippy::too_many_arguments)]
     pub fn render_texture_from_to(
         &mut self,
@@ -2843,6 +2878,7 @@ impl<'frame> GlesFrame<'frame> {
     ///
     /// Optionally allows a custom texture program and matching additional uniforms to be passed in.
     #[instrument(level = "trace", skip(self), parent = &self.span)]
+    #[profiling::function]
     #[allow(clippy::too_many_arguments)]
     pub fn render_texture(
         &mut self,
@@ -3008,6 +3044,7 @@ impl<'frame> GlesFrame<'frame> {
     }
 
     /// Render a pixel shader into the current target at a given `dest`-region.
+    #[profiling::function]
     pub fn render_pixel_shader_to(
         &mut self,
         pixel_shader: &GlesPixelProgram,

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -216,6 +216,7 @@ impl Renderer for GlowRenderer {
         self.gl.debug_flags()
     }
 
+    #[profiling::function]
     fn render(
         &mut self,
         output_size: Size<i32, Physical>,
@@ -229,6 +230,7 @@ impl Renderer for GlowRenderer {
         })
     }
 
+    #[profiling::function]
     fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
         self.gl.wait(sync)
     }
@@ -242,10 +244,12 @@ impl<'frame> Frame for GlowFrame<'frame> {
         self.frame.as_ref().unwrap().id()
     }
 
+    #[profiling::function]
     fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
         self.frame.as_mut().unwrap().clear(color, at)
     }
 
+    #[profiling::function]
     fn draw_solid(
         &mut self,
         dst: Rectangle<i32, Physical>,
@@ -255,6 +259,7 @@ impl<'frame> Frame for GlowFrame<'frame> {
         self.frame.as_mut().unwrap().draw_solid(dst, damage, color)
     }
 
+    #[profiling::function]
     fn render_texture_from_to(
         &mut self,
         texture: &Self::TextureId,
@@ -279,6 +284,7 @@ impl<'frame> Frame for GlowFrame<'frame> {
         self.frame.as_ref().unwrap().transformation()
     }
 
+    #[profiling::function]
     fn render_texture_at(
         &mut self,
         texture: &Self::TextureId,
@@ -300,16 +306,19 @@ impl<'frame> Frame for GlowFrame<'frame> {
         )
     }
 
+    #[profiling::function]
     fn finish(mut self) -> Result<sync::SyncPoint, Self::Error> {
         self.finish_internal()
     }
 
+    #[profiling::function]
     fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
         self.frame.as_mut().unwrap().wait(sync)
     }
 }
 
 impl<'frame> GlowFrame<'frame> {
+    #[profiling::function]
     fn finish_internal(&mut self) -> Result<sync::SyncPoint, GlesError> {
         if let Some(frame) = self.frame.take() {
             frame.finish()
@@ -329,6 +338,7 @@ impl<'frame> Drop for GlowFrame<'frame> {
 
 #[cfg(feature = "wayland_frontend")]
 impl ImportMemWl for GlowRenderer {
+    #[profiling::function]
     fn import_shm_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
@@ -344,6 +354,7 @@ impl ImportMemWl for GlowRenderer {
 }
 
 impl ImportMem for GlowRenderer {
+    #[profiling::function]
     fn import_memory(
         &mut self,
         data: &[u8],
@@ -354,6 +365,7 @@ impl ImportMem for GlowRenderer {
         self.gl.import_memory(data, format, size, flipped)
     }
 
+    #[profiling::function]
     fn update_memory(
         &mut self,
         texture: &<Self as Renderer>::TextureId,
@@ -389,6 +401,7 @@ impl ImportEgl for GlowRenderer {
         self.gl.egl_reader()
     }
 
+    #[profiling::function]
     fn import_egl_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
@@ -400,6 +413,7 @@ impl ImportEgl for GlowRenderer {
 }
 
 impl ImportDma for GlowRenderer {
+    #[profiling::function]
     fn import_dmabuf(
         &mut self,
         buffer: &Dmabuf,
@@ -418,6 +432,7 @@ impl ImportDmaWl for GlowRenderer {}
 impl ExportMem for GlowRenderer {
     type TextureMapping = GlesMapping;
 
+    #[profiling::function]
     fn copy_framebuffer(
         &mut self,
         region: Rectangle<i32, BufferCoord>,
@@ -426,6 +441,7 @@ impl ExportMem for GlowRenderer {
         self.gl.copy_framebuffer(region, format)
     }
 
+    #[profiling::function]
     fn copy_texture(
         &mut self,
         texture: &Self::TextureId,
@@ -435,6 +451,7 @@ impl ExportMem for GlowRenderer {
         self.gl.copy_texture(texture, region, format)
     }
 
+    #[profiling::function]
     fn map_texture<'a>(
         &mut self,
         texture_mapping: &'a Self::TextureMapping,
@@ -447,6 +464,7 @@ impl<T> Bind<T> for GlowRenderer
 where
     GlesRenderer: Bind<T>,
 {
+    #[profiling::function]
     fn bind(&mut self, target: T) -> Result<(), GlesError> {
         self.gl.bind(target)
     }
@@ -459,6 +477,7 @@ impl<T> Offscreen<T> for GlowRenderer
 where
     GlesRenderer: Offscreen<T>,
 {
+    #[profiling::function]
     fn create_buffer(&mut self, format: Fourcc, size: Size<i32, BufferCoord>) -> Result<T, GlesError> {
         self.gl.create_buffer(format, size)
     }
@@ -468,6 +487,7 @@ impl<Target> Blit<Target> for GlowRenderer
 where
     GlesRenderer: Blit<Target>,
 {
+    #[profiling::function]
     fn blit_to(
         &mut self,
         to: Target,
@@ -478,6 +498,7 @@ where
         self.gl.blit_to(to, src, dst, filter)
     }
 
+    #[profiling::function]
     fn blit_from(
         &mut self,
         from: Target,
@@ -496,6 +517,7 @@ impl Unbind for GlowRenderer {
 }
 
 impl RenderElement<GlowRenderer> for PixelShaderElement {
+    #[profiling::function]
     fn draw(
         &self,
         frame: &mut GlowFrame<'_>,

--- a/src/backend/renderer/multigpu/egl.rs
+++ b/src/backend/renderer/multigpu/egl.rs
@@ -200,6 +200,7 @@ where
         self.render.renderer().egl_reader()
     }
 
+    #[profiling::function]
     fn import_egl_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
@@ -251,6 +252,7 @@ where
         + ExportMem
         + 'static,
 {
+    #[profiling::function]
     fn try_import_egl(
         renderer: &mut R,
         buffer: &wl_buffer::WlBuffer,

--- a/src/backend/renderer/multigpu/gbm.rs
+++ b/src/backend/renderer/multigpu/gbm.rs
@@ -222,6 +222,7 @@ where
         self.render.renderer().egl_reader()
     }
 
+    #[profiling::function]
     fn import_egl_buffer(
         &mut self,
         buffer: &wl_buffer::WlBuffer,
@@ -272,6 +273,7 @@ where
         + ExportMem
         + 'static,
 {
+    #[profiling::function]
     fn try_import_egl(
         renderer: &mut R,
         buffer: &wl_buffer::WlBuffer,

--- a/src/backend/renderer/sync/mod.rs
+++ b/src/backend/renderer/sync/mod.rs
@@ -62,6 +62,7 @@ impl SyncPoint {
     /// Blocks the current thread until the sync point is signaled
     ///
     /// If the sync point does not contain a fence this will never block.
+    #[profiling::function]
     pub fn wait(&self) {
         if let Some(fence) = self.fence.as_ref() {
             fence.wait();
@@ -78,6 +79,7 @@ impl SyncPoint {
     /// Export this [`SyncPoint`] as a native fence fd
     ///
     /// Will always return `None` in case the sync point does not contain a fence
+    #[profiling::function]
     pub fn export(&self) -> Option<OwnedFd> {
         self.fence.as_ref().and_then(|f| f.export())
     }

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -93,6 +93,7 @@ impl PartialEq<WlBuffer> for &Buffer {
 }
 
 impl RendererSurfaceState {
+    #[profiling::function]
     pub(crate) fn update_buffer(&mut self, states: &SurfaceData) {
         let mut attrs = states.cached_state.current::<SurfaceAttributes>();
         self.buffer_delta = attrs.buffer_delta.take();
@@ -319,6 +320,7 @@ impl RendererSurfaceState {
 /// not be accessible anymore, but [`draw_surface_tree`] and other
 /// `draw_*` helpers of the [desktop module](`crate::desktop`) will
 /// become usable for surfaces handled this way.
+#[profiling::function]
 pub fn on_commit_buffer_handler<D: 'static>(surface: &WlSurface) {
     if !is_sync_subsurface(surface) {
         let mut new_surfaces = Vec::new();
@@ -429,6 +431,7 @@ where
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
 #[instrument(level = "trace", skip_all)]
+#[profiling::function]
 pub fn import_surface<R>(renderer: &mut R, states: &SurfaceData) -> Result<(), <R as Renderer>::Error>
 where
     R: Renderer + ImportAll,
@@ -471,6 +474,7 @@ where
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
 #[instrument(level = "trace", skip_all)]
+#[profiling::function]
 pub fn import_surface_tree<R>(renderer: &mut R, surface: &WlSurface) -> Result<(), <R as Renderer>::Error>
 where
     R: Renderer + ImportAll,
@@ -525,6 +529,7 @@ where
 /// [`crate::backend::renderer::utils::on_commit_buffer_handler`]
 /// to let smithay handle buffer management.
 #[instrument(level = "trace", skip(frame, scale, elements))]
+#[profiling::function]
 pub fn draw_render_elements<'a, R, S, E>(
     frame: &mut <R as Renderer>::Frame<'a>,
     scale: S,

--- a/src/backend/session/libseat.rs
+++ b/src/backend/session/libseat.rs
@@ -206,6 +206,7 @@ impl EventSource for LibSeatSessionNotifier {
     type Ret = ();
     type Error = Error;
 
+    #[profiling::function]
     fn process_events<F>(
         &mut self,
         readiness: Readiness,

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -128,6 +128,7 @@ impl EventSource for UdevBackend {
     type Ret = ();
     type Error = io::Error;
 
+    #[profiling::function]
     fn process_events<F>(
         &mut self,
         _: Readiness,

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -310,6 +310,7 @@ where
 
     /// Bind the underlying window to the underlying renderer
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     pub fn bind(&mut self) -> Result<(), crate::backend::SwapBuffersError> {
         // apparently the nvidia-driver doesn't like `wl_egl_window_resize`, if the surface is not current.
         // So the order here is important.
@@ -350,6 +351,7 @@ where
 
     /// Submits the back buffer to the window by swapping, requires the window to be previously bound (see [`WinitGraphicsBackend::bind`]).
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     pub fn submit(
         &mut self,
         damage: Option<&[Rectangle<i32, Physical>]>,
@@ -398,6 +400,7 @@ impl WinitEventLoop {
     /// The linked [`WinitGraphicsBackend`] will error with a lost context and should
     /// not be used anymore as well.
     #[instrument(level = "trace", parent = &self.span, skip_all)]
+    #[profiling::function]
     pub fn dispatch_new_events<F>(&mut self, mut callback: F) -> Result<(), WinitError>
     where
         F: FnMut(WinitEvent),

--- a/src/backend/x11/buffer.rs
+++ b/src/backend/x11/buffer.rs
@@ -73,6 +73,7 @@ impl<'c, C> PixmapWrapperExt<'c, C> for PixmapWrapper<'c, C>
 where
     C: Connection,
 {
+    #[profiling::function]
     fn with_dmabuf(
         connection: &'c C,
         window: &Window,
@@ -164,6 +165,7 @@ where
         Ok(PixmapWrapper::for_pixmap(connection, xid))
     }
 
+    #[profiling::function]
     fn present(self, connection: &C, window: &Window) -> Result<u32, X11Error> {
         let next_serial = window.0.next_serial.fetch_add(1, Ordering::SeqCst);
         // We want to present as soon as possible, so wait 1ms so the X server will present when next convenient.

--- a/src/backend/x11/mod.rs
+++ b/src/backend/x11/mod.rs
@@ -545,6 +545,7 @@ impl EventSource for X11Backend {
     type Ret = ();
     type Error = X11Error;
 
+    #[profiling::function]
     fn process_events<F>(
         &mut self,
         readiness: Readiness,
@@ -616,6 +617,7 @@ impl X11Inner {
         inner.windows.get(id).cloned()
     }
 
+    #[profiling::function]
     fn process_event<F>(inner: &Arc<Mutex<X11Inner>>, event: x11::Event, callback: &mut F)
     where
         F: FnMut(X11Event, &mut ()),

--- a/src/backend/x11/surface.rs
+++ b/src/backend/x11/surface.rs
@@ -69,6 +69,7 @@ impl X11Surface {
     /// This function will return the same buffer until [`submit`](Self::submit) is called
     /// or [`reset_buffers`](Self::reset_buffers) is used to reset the buffers.
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     pub fn buffer(&mut self) -> Result<(Dmabuf, u8), AllocateBuffersError> {
         if let Some(new_size) = self.resize.try_iter().last() {
             self.resize(new_size);
@@ -90,6 +91,7 @@ impl X11Surface {
 
     /// Consume and submit the buffer to the window.
     #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
     pub fn submit(&mut self) -> Result<(), X11Error> {
         if let Some(connection) = self.connection.upgrade() {
             // Get a new buffer

--- a/src/desktop/space/element/mod.rs
+++ b/src/desktop/space/element/mod.rs
@@ -165,6 +165,7 @@ where
 {
     type RenderElement = SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>;
 
+    #[profiling::function]
     fn render_elements<C: From<Self::RenderElement>>(
         &self,
         renderer: &mut R,

--- a/src/desktop/space/element/wayland.rs
+++ b/src/desktop/space/element/wayland.rs
@@ -33,6 +33,7 @@ where
 {
     type RenderElement = WaylandSurfaceRenderElement<R>;
 
+    #[profiling::function]
     fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
         &self,
         renderer: &mut R,

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -377,6 +377,7 @@ impl<E: SpaceElement + PartialEq> Space<E> {
     /// this will not contain layer surfaces.
     /// Use [`Space::render_elements_for_output`], if you care about this.
     #[instrument(level = "trace", skip(self, renderer, scale), parent = &self.span)]
+    #[profiling::function]
     pub fn render_elements_for_region<'a, R: Renderer, S: Into<Scale<f64>>>(
         &'a self,
         renderer: &mut R,
@@ -413,6 +414,7 @@ impl<E: SpaceElement + PartialEq> Space<E> {
 
     /// Retrieve the render elements for an output
     #[instrument(level = "trace", skip(self, renderer), parent = &self.span)]
+    #[profiling::function]
     pub fn render_elements_for_output<
         'a,
         #[cfg(feature = "wayland_frontend")] R: Renderer + ImportAll,
@@ -571,6 +573,7 @@ crate::backend::renderer::element::render_elements! {
 /// this will include layer-shell surfaces added to this
 /// outputs [`LayerMap`].
 #[instrument(level = "trace", skip(spaces, renderer))]
+#[profiling::function]
 pub fn space_render_elements<
     'a,
     #[cfg(feature = "wayland_frontend")] R: Renderer + ImportAll,
@@ -659,6 +662,7 @@ where
 /// If multiple spaces are given their elements will be stacked
 /// the same way.
 #[allow(clippy::too_many_arguments)]
+#[profiling::function]
 pub fn render_output<
     'a,
     #[cfg(feature = "wayland_frontend")] R: Renderer + ImportAll,

--- a/src/desktop/space/utils.rs
+++ b/src/desktop/space/utils.rs
@@ -37,6 +37,7 @@ pub struct ConstrainBehavior {
 /// Constrain the render elements of a [`SpaceElement`]
 ///
 /// see [`constrain_as_render_elements`]
+#[profiling::function]
 pub fn constrain_space_element<R, E, C>(
     renderer: &mut R,
     element: &E,

--- a/src/desktop/space/wayland/layer.rs
+++ b/src/desktop/space/wayland/layer.rs
@@ -17,6 +17,7 @@ where
 {
     type RenderElement = WaylandSurfaceRenderElement<R>;
 
+    #[profiling::function]
     fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
         &self,
         renderer: &mut R,

--- a/src/desktop/space/wayland/mod.rs
+++ b/src/desktop/space/wayland/mod.rs
@@ -28,6 +28,7 @@ fn output_surfaces(o: &Output) -> RefMut<'_, HashSet<WlWeak<WlSurface>>> {
 }
 
 #[instrument(level = "debug", skip(output), fields(output = output.name()))]
+#[profiling::function]
 fn output_update(output: &Output, output_overlap: Rectangle<i32, Logical>, surface: &WlSurface) {
     let mut surface_list = output_surfaces(output);
 

--- a/src/desktop/space/wayland/window.rs
+++ b/src/desktop/space/wayland/window.rs
@@ -101,6 +101,7 @@ where
 {
     type RenderElement = WaylandSurfaceRenderElement<R>;
 
+    #[profiling::function]
     fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
         &self,
         renderer: &mut R,

--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -99,6 +99,7 @@ where
 {
     type RenderElement = WaylandSurfaceRenderElement<R>;
 
+    #[profiling::function]
     fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
         &self,
         renderer: &mut R,

--- a/src/utils/x11rb.rs
+++ b/src/utils/x11rb.rs
@@ -97,6 +97,7 @@ impl EventSource for X11Source {
     type Ret = ();
     type Error = ChannelError;
 
+    #[profiling::function]
     fn process_events<C>(
         &mut self,
         readiness: Readiness,

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -330,6 +330,7 @@ impl calloop::EventSource for XWaylandSource {
     type Ret = ();
     type Error = io::Error;
 
+    #[profiling::function]
     fn process_events<F>(
         &mut self,
         readiness: calloop::Readiness,


### PR DESCRIPTION
Some changes I have been using locally for profiling anvil/smithay, mainly with `tracy`.

Example:

![Screenshot from 2023-06-29 11-53-02](https://github.com/Smithay/smithay/assets/4582663/db976c11-597f-4f18-9d74-894e0eff27ac)
