### PR TITLE
fix: offscreen texture has_alpha determination

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1738,7 +1738,7 @@ impl Offscreen<GlesTexture> for GlesRenderer {
             tex
         };
 
-        Ok(unsafe { GlesTexture::from_raw(self, Some(internal), has_alpha, tex, size) })
+        Ok(unsafe { GlesTexture::from_raw(self, Some(internal), !has_alpha, tex, size) })
     }
 }
 


### PR DESCRIPTION
GlesTexture::from_raw takes an `opaque` parameter. When creating an offscreen texture this parameter was set to `has_alpha` which would imply transparency, I.E. the opposite of opaque.