### PR TITLE
Move some `Debug` bounds to traits, simplifying a lot of things

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -57,10 +57,7 @@ render_elements! {
     Texture=TextureRenderElement<<R as Renderer>::TextureId>,
 }
 
-impl<R: Renderer> std::fmt::Debug for PointerRenderElement<R>
-where
-    <R as Renderer>::TextureId: std::fmt::Debug,
-{
+impl<R: Renderer> std::fmt::Debug for PointerRenderElement<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Surface(arg0) => f.debug_tuple("Surface").field(arg0).finish(),

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -38,10 +38,7 @@ smithay::backend::renderer::element::render_elements! {
     Fps=FpsElement<<R as Renderer>::TextureId>,
 }
 
-impl<R: Renderer + std::fmt::Debug> std::fmt::Debug for CustomRenderElements<R>
-where
-    <R as Renderer>::TextureId: std::fmt::Debug,
-{
+impl<R: Renderer> std::fmt::Debug for CustomRenderElements<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Pointer(arg0) => f.debug_tuple("Pointer").field(arg0).finish(),
@@ -61,10 +58,8 @@ smithay::backend::renderer::element::render_elements! {
     Preview=CropRenderElement<RelocateRenderElement<RescaleRenderElement<WindowRenderElement<R>>>>,
 }
 
-impl<R: Renderer + ImportAll + ImportMem + std::fmt::Debug, E: RenderElement<R> + std::fmt::Debug>
-    std::fmt::Debug for OutputRenderElements<R, E>
-where
-    <R as Renderer>::TextureId: std::fmt::Debug,
+impl<R: Renderer + ImportAll + ImportMem, E: RenderElement<R> + std::fmt::Debug> std::fmt::Debug
+    for OutputRenderElements<R, E>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -467,7 +467,7 @@ render_elements!(
     Decoration=SolidColorRenderElement,
 );
 
-impl<R: Renderer + std::fmt::Debug> std::fmt::Debug for WindowRenderElement<R> {
+impl<R: Renderer> std::fmt::Debug for WindowRenderElement<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Window(arg0) => f.debug_tuple("Window").field(arg0).finish(),

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -31,7 +31,7 @@
 //! #     utils::{Buffer, Physical, Rectangle, Size},
 //! # };
 //! #
-//! # #[derive(Clone)]
+//! # #[derive(Clone, Debug)]
 //! # struct FakeTexture;
 //! #
 //! # impl Texture for FakeTexture {
@@ -81,6 +81,7 @@
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 //! # }
 //! #
+//! # #[derive(Debug)]
 //! # struct FakeRenderer;
 //! #
 //! # impl Renderer for FakeRenderer {

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -27,7 +27,7 @@
 //! #     utils::{Buffer, Physical},
 //! # };
 //! #
-//! # #[derive(Clone)]
+//! # #[derive(Clone, Debug)]
 //! # struct FakeTexture;
 //! #
 //! # impl Texture for FakeTexture {
@@ -77,6 +77,7 @@
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 //! # }
 //! #
+//! # #[derive(Debug)]
 //! # struct FakeRenderer;
 //! #
 //! # impl Renderer for FakeRenderer {

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -1203,7 +1203,7 @@ macro_rules! render_elements_internal {
 /// #     utils::{Buffer, Physical, Rectangle, Size, Transform},
 /// # };
 /// #
-/// # #[derive(Clone)]
+/// # #[derive(Clone, Debug)]
 /// # struct MyRendererTextureId;
 /// #
 /// # impl Texture for MyRendererTextureId {
@@ -1253,6 +1253,7 @@ macro_rules! render_elements_internal {
 /// #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 /// # }
 /// #
+/// # #[derive(Debug)]
 /// # struct MyRenderer;
 /// #
 /// # impl Renderer for MyRenderer {

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -10,7 +10,7 @@
 //! #     },
 //! #     utils::{Buffer, Physical, Rectangle, Transform},
 //! # };
-//! # #[derive(Clone)]
+//! # #[derive(Clone, Debug)]
 //! # struct FakeTexture;
 //! #
 //! # impl Texture for FakeTexture {
@@ -64,6 +64,7 @@
 //! #     }
 //! # }
 //! #
+//! # #[derive(Debug)]
 //! # struct FakeRenderer;
 //! #
 //! # impl Renderer for FakeRenderer {

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -30,7 +30,7 @@
 //! #     wayland::compositor::SurfaceData,
 //! # };
 //! #
-//! # #[derive(Clone)]
+//! # #[derive(Clone, Debug)]
 //! # struct FakeTexture;
 //! #
 //! # impl Texture for FakeTexture {
@@ -80,6 +80,7 @@
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 //! # }
 //! #
+//! # #[derive(Debug)]
 //! # struct FakeRenderer;
 //! #
 //! # impl Renderer for FakeRenderer {

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -45,7 +45,7 @@
 //! #     utils::{Buffer, Physical, Rectangle, Size},
 //! # };
 //! #
-//! # #[derive(Clone)]
+//! # #[derive(Clone, Debug)]
 //! # struct FakeTexture;
 //! #
 //! # impl Texture for FakeTexture {
@@ -95,6 +95,7 @@
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 //! # }
 //! #
+//! # #[derive(Debug)]
 //! # struct FakeRenderer;
 //! #
 //! # impl Renderer for FakeRenderer {
@@ -198,7 +199,7 @@
 //! #     utils::{Buffer, Physical},
 //! # };
 //! #
-//! # #[derive(Clone)]
+//! # #[derive(Clone, Debug)]
 //! # struct FakeTexture;
 //! #
 //! # impl Texture for FakeTexture {
@@ -248,6 +249,7 @@
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
 //! # }
 //! #
+//! # #[derive(Debug)]
 //! # struct FakeRenderer;
 //! #
 //! # impl Renderer for FakeRenderer {

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -9,6 +9,7 @@
 
 use std::collections::HashSet;
 use std::error::Error;
+use std::fmt;
 
 use crate::utils::{Buffer as BufferCoord, Physical, Point, Rectangle, Scale, Size, Transform};
 use cgmath::Matrix3;
@@ -111,7 +112,7 @@ pub trait Unbind: Renderer {
 }
 
 /// A two dimensional texture
-pub trait Texture {
+pub trait Texture: fmt::Debug {
     /// Size of the texture plane
     fn size(&self) -> Size<i32, BufferCoord> {
         Size::from((self.width() as i32, self.height() as i32))
@@ -246,7 +247,7 @@ bitflags::bitflags! {
     }
 }
 /// Abstraction of commonly used rendering operations for compositors.
-pub trait Renderer {
+pub trait Renderer: fmt::Debug {
     /// Error type returned by the rendering operations of this renderer.
     type Error: Error;
     /// Texture Handle type used by this renderer.

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -637,7 +637,7 @@ pub trait GraphicsApi {
 }
 
 /// A device produced by a [`GraphicsApi`].
-pub trait ApiDevice {
+pub trait ApiDevice: fmt::Debug {
     /// The [`Renderer`](super::Renderer) this devices contains
     type Renderer: Renderer;
 
@@ -660,10 +660,6 @@ pub struct MultiRenderer<'render, 'target, 'alloc, R: GraphicsApi, T: GraphicsAp
 
 impl<'render, 'target, 'alloc, R: GraphicsApi, T: GraphicsApi> fmt::Debug
     for MultiRenderer<'render, 'target, 'alloc, R, T>
-where
-    <<T::Device as ApiDevice>::Renderer as Renderer>::TextureId: fmt::Debug,
-    R::Device: fmt::Debug,
-    T::Device: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MultiRenderer")

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use wayland_server::{protocol::wl_surface::WlSurface, Resource};
 
@@ -219,6 +216,7 @@ impl PopupGrabInner {
 /// timeout.
 ///
 /// The grab is obtained by calling [`PopupManager::grap_popup`](super::PopupManager::grab_popup).
+#[derive(Debug)]
 pub struct PopupGrab<D>
 where
     D: SeatHandler + 'static,
@@ -232,24 +230,6 @@ where
     keyboard_handle: Option<KeyboardHandle<D>>,
     keyboard_grab_start_data: KeyboardGrabStartData<D>,
     pointer_grab_start_data: PointerGrabStartData<D>,
-}
-
-impl<D> fmt::Debug for PopupGrab<D>
-where
-    D: SeatHandler + 'static,
-    <D as SeatHandler>::KeyboardFocus: WaylandFocus + fmt::Debug,
-    <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PopupGrab")
-            .field("root", &self.root)
-            .field("serial", &self.serial)
-            .field("previous_serial", &self.previous_serial)
-            .field("keyboard_handle", &self.keyboard_handle)
-            .field("keyboard_grab_start_data", &self.keyboard_grab_start_data)
-            .field("pointer_grab_start_data", &self.pointer_grab_start_data)
-            .finish()
-    }
 }
 
 impl<D> Clone for PopupGrab<D>
@@ -393,6 +373,7 @@ where
 /// on the topmost popup until the grab has ended. If the
 /// grab has ended it will restore the focus on the root of the grab
 /// and unset the [`KeyboardGrab`]
+#[derive(Debug)]
 pub struct PopupKeyboardGrab<D>
 where
     D: SeatHandler + 'static,
@@ -400,19 +381,6 @@ where
     <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
 {
     popup_grab: PopupGrab<D>,
-}
-
-impl<D> fmt::Debug for PopupKeyboardGrab<D>
-where
-    D: SeatHandler + 'static,
-    <D as SeatHandler>::KeyboardFocus: WaylandFocus + fmt::Debug,
-    <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PopupKeyboardGrab")
-            .field("popup_grab", &self.popup_grab)
-            .finish()
-    }
 }
 
 impl<D> PopupKeyboardGrab<D>
@@ -499,6 +467,7 @@ where
 /// [`PointerGrab`] is unset. Additional it will unset an active
 /// [`KeyboardGrab`] that matches the [`Serial`] of this grab and
 /// restore the keyboard focus like described in [`PopupKeyboardGrab`]
+#[derive(Debug)]
 pub struct PopupPointerGrab<D>
 where
     D: SeatHandler + 'static,
@@ -506,19 +475,6 @@ where
     <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
 {
     popup_grab: PopupGrab<D>,
-}
-
-impl<D> fmt::Debug for PopupPointerGrab<D>
-where
-    D: SeatHandler + 'static,
-    <D as SeatHandler>::KeyboardFocus: WaylandFocus + fmt::Debug,
-    <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PopupPointerGrab")
-            .field("popup_grab", &self.popup_grab)
-            .finish()
-    }
 }
 
 impl<D> PopupPointerGrab<D>

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -27,7 +27,7 @@ mod xkb_config;
 pub use xkb_config::XkbConfig;
 
 /// Trait representing object that can receive keyboard interactions
-pub trait KeyboardTarget<D>: IsAlive + PartialEq + Clone + Send
+pub trait KeyboardTarget<D>: IsAlive + PartialEq + Clone + fmt::Debug + Send
 where
     D: SeatHandler,
 {
@@ -69,10 +69,7 @@ pub(crate) struct KbdInternal<D: SeatHandler> {
 }
 
 // focus_hook does not implement debug, so we have to impl Debug manually
-impl<D: SeatHandler> fmt::Debug for KbdInternal<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-{
+impl<D: SeatHandler> fmt::Debug for KbdInternal<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("KbdInternal")
             .field("focus", &self.focus)
@@ -194,20 +191,14 @@ pub(crate) struct KbdRc<D: SeatHandler> {
 }
 
 #[cfg(not(feature = "wayland_frontend"))]
-impl<D: SeatHandler> fmt::Debug for KbdRc<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-{
+impl<D: SeatHandler> fmt::Debug for KbdRc<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("KbdRc").field("internal", &self.internal).finish()
     }
 }
 
 #[cfg(feature = "wayland_frontend")]
-impl<D: SeatHandler> fmt::Debug for KbdRc<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-{
+impl<D: SeatHandler> fmt::Debug for KbdRc<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("KbdRc")
             .field("internal", &self.internal)
@@ -273,10 +264,7 @@ pub struct GrabStartData<D: SeatHandler> {
     pub focus: Option<<D as SeatHandler>::KeyboardFocus>,
 }
 
-impl<D: SeatHandler + 'static> fmt::Debug for GrabStartData<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-{
+impl<D: SeatHandler + 'static> fmt::Debug for GrabStartData<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GrabStartData")
             .field("focus", &self.focus)
@@ -349,10 +337,7 @@ pub struct KeyboardHandle<D: SeatHandler> {
     pub(crate) arc: Arc<KbdRc<D>>,
 }
 
-impl<D: SeatHandler> fmt::Debug for KeyboardHandle<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-{
+impl<D: SeatHandler> fmt::Debug for KeyboardHandle<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("KeyboardHandle").field("arc", &self.arc).finish()
     }
@@ -642,10 +627,7 @@ pub struct KeyboardInnerHandle<'a, D: SeatHandler> {
     seat: &'a Seat<D>,
 }
 
-impl<'a, D: SeatHandler> fmt::Debug for KeyboardInnerHandle<'a, D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-{
+impl<'a, D: SeatHandler> fmt::Debug for KeyboardInnerHandle<'a, D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("KeyboardInnerHandle")
             .field("inner", &self.inner)

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -98,7 +98,6 @@
 //!
 
 use std::{
-    fmt,
     hash::Hash,
     sync::{Arc, Mutex},
 };
@@ -131,18 +130,9 @@ pub trait SeatHandler: Sized {
 /// Delegate type for all [Seat] globals.
 ///
 /// Events will be forwarded to an instance of the Seat global.
+#[derive(Debug)]
 pub struct SeatState<D: SeatHandler> {
     pub(crate) seats: Vec<Seat<D>>,
-}
-
-impl<D: SeatHandler> fmt::Debug for SeatState<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SeatState").field("seats", &self.seats).finish()
-    }
 }
 
 /// A Seat handle
@@ -153,18 +143,9 @@ where
 /// This is an handle to the inner logic, it can be cloned.
 ///
 /// See module-level documentation for details of use.
+#[derive(Debug)]
 pub struct Seat<D: SeatHandler> {
     pub(crate) arc: Arc<SeatRc<D>>,
-}
-
-impl<D: SeatHandler> fmt::Debug for Seat<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Seat").field("arc", &self.arc).finish()
-    }
 }
 
 impl<D: SeatHandler> PartialEq for Seat<D> {
@@ -180,6 +161,7 @@ impl<D: SeatHandler> Hash for Seat<D> {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct Inner<D: SeatHandler> {
     pub(crate) pointer: Option<PointerHandle<D>>,
     pub(crate) keyboard: Option<KeyboardHandle<D>>,
@@ -192,57 +174,13 @@ pub(crate) struct Inner<D: SeatHandler> {
     pub(crate) known_seats: Vec<wayland_server::Weak<wayland_server::protocol::wl_seat::WlSeat>>,
 }
 
-#[cfg(not(feature = "wayland_frontend"))]
-impl<D: SeatHandler> fmt::Debug for Inner<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Inner")
-            .field("pointer", &self.pointer)
-            .field("keyboard", &self.keyboard)
-            .finish()
-    }
-}
-
-#[cfg(feature = "wayland_frontend")]
-impl<D: SeatHandler> fmt::Debug for Inner<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Inner")
-            .field("pointer", &self.pointer)
-            .field("keyboard", &self.keyboard)
-            .field("touch", &self.touch)
-            .field("global", &self.global)
-            .field("known_seats", &self.known_seats)
-            .finish()
-    }
-}
-
+#[derive(Debug)]
 pub(crate) struct SeatRc<D: SeatHandler> {
     #[allow(dead_code)]
     pub(crate) name: String,
     pub(crate) inner: Mutex<Inner<D>>,
     span: tracing::Span,
     user_data_map: UserDataMap,
-}
-
-impl<D: SeatHandler> fmt::Debug for SeatRc<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SeatRc")
-            .field("name", &self.name)
-            .field("inner", &self.inner)
-            .field("user_data_map", &self.user_data_map)
-            .finish()
-    }
 }
 
 impl<D: SeatHandler> Clone for Seat<D> {

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -41,10 +41,7 @@ pub struct PointerHandle<D: SeatHandler> {
 }
 
 #[cfg(not(feature = "wayland_frontend"))]
-impl<D: SeatHandler> fmt::Debug for PointerHandle<D>
-where
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
+impl<D: SeatHandler> fmt::Debug for PointerHandle<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PointerHandle")
             .field("inner", &self.inner)
@@ -53,10 +50,7 @@ where
 }
 
 #[cfg(feature = "wayland_frontend")]
-impl<D: SeatHandler> fmt::Debug for PointerHandle<D>
-where
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
+impl<D: SeatHandler> fmt::Debug for PointerHandle<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PointerHandle")
             .field("inner", &self.inner)
@@ -89,7 +83,7 @@ impl<D: SeatHandler> ::std::cmp::PartialEq for PointerHandle<D> {
 }
 
 /// Trait representing object that can receive pointer interactions
-pub trait PointerTarget<D>: IsAlive + PartialEq + Clone + Send
+pub trait PointerTarget<D>: IsAlive + PartialEq + Clone + fmt::Debug + Send
 where
     D: SeatHandler,
 {
@@ -278,10 +272,7 @@ pub struct PointerInnerHandle<'a, D: SeatHandler> {
     seat: &'a Seat<D>,
 }
 
-impl<'a, D: SeatHandler> fmt::Debug for PointerInnerHandle<'a, D>
-where
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
+impl<'a, D: SeatHandler> fmt::Debug for PointerInnerHandle<'a, D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PointerInnerHandle")
             .field("inner", &self.inner)
@@ -393,10 +384,7 @@ pub(crate) struct PointerInternal<D: SeatHandler> {
 }
 
 // image_callback does not implement debug, so we have to impl Debug manually
-impl<D: SeatHandler> fmt::Debug for PointerInternal<D>
-where
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
+impl<D: SeatHandler> fmt::Debug for PointerInternal<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PointerInternal")
             .field("focus", &self.focus)

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use wayland_protocols_misc::zwp_input_method_v2::server::{
     zwp_input_method_keyboard_grab_v2::ZwpInputMethodKeyboardGrabV2,
@@ -106,23 +103,11 @@ impl InputMethodHandle {
 }
 
 /// User data of ZwpInputMethodV2 object
+#[derive(Debug)]
 pub struct InputMethodUserData<D: SeatHandler> {
     pub(super) handle: InputMethodHandle,
     pub(crate) text_input_handle: TextInputHandle,
     pub(crate) keyboard_handle: KeyboardHandle<D>,
-}
-
-impl<D: SeatHandler> fmt::Debug for InputMethodUserData<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InputMethodUserData")
-            .field("handle", &self.handle)
-            .field("text_input_handle", &self.text_input_handle)
-            .field("keyboard_handle", &self.keyboard_handle)
-            .finish()
-    }
 }
 
 impl<D> Dispatch<ZwpInputMethodV2, InputMethodUserData<D>, D> for InputMethodManagerState

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use wayland_protocols_misc::zwp_input_method_v2::server::zwp_input_method_keyboard_grab_v2::{
     self, ZwpInputMethodKeyboardGrabV2,
@@ -82,21 +79,10 @@ where
 }
 
 /// User data of ZwpInputKeyboardGrabV2 object
+#[derive(Debug)]
 pub struct InputMethodKeyboardUserData<D: SeatHandler> {
     pub(super) handle: InputMethodKeyboardGrab,
     pub(crate) keyboard_handle: KeyboardHandle<D>,
-}
-
-impl<D: SeatHandler> fmt::Debug for InputMethodKeyboardUserData<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InputMethodKeyboardUserData")
-            .field("handle", &self.handle)
-            .field("keyboard_handle", &self.keyboard_handle)
-            .finish()
-    }
 }
 
 impl<D: SeatHandler + 'static> Dispatch<ZwpInputMethodKeyboardGrabV2, InputMethodKeyboardUserData<D>, D>

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -61,7 +61,6 @@
 //! delegate_relative_pointer!(State);
 //! ```
 
-use std::fmt;
 use wayland_protocols::wp::relative_pointer::zv1::server::{
     zwp_relative_pointer_manager_v1::{self, ZwpRelativePointerManagerV1},
     zwp_relative_pointer_v1::{self, ZwpRelativePointerV1},
@@ -79,19 +78,9 @@ use crate::{
 const MANAGER_VERSION: u32 = 1;
 
 /// User data of ZwpRelativePointerV1 object
+#[derive(Debug)]
 pub struct RelativePointerUserData<D: SeatHandler> {
     handle: Option<PointerHandle<D>>,
-}
-
-impl<D: SeatHandler> fmt::Debug for RelativePointerUserData<D>
-where
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RelativePointerUserData")
-            .field("handle", &self.handle)
-            .finish()
-    }
 }
 
 /// State of the relative pointer manager

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use tracing::{error, instrument, trace, warn};
 use wayland_server::{
     backend::{ClientId, ObjectId},
@@ -82,19 +81,9 @@ where
 }
 
 /// User data for keyboard
+#[derive(Debug)]
 pub struct KeyboardUserData<D: SeatHandler> {
     pub(crate) handle: Option<KeyboardHandle<D>>,
-}
-
-impl<D: SeatHandler> fmt::Debug for KeyboardUserData<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("KeyboardUserData")
-            .field("handle", &self.handle)
-            .finish()
-    }
 }
 
 impl<D> Dispatch<WlKeyboard, KeyboardUserData<D>, D> for SeatState<D>

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -61,7 +61,7 @@ pub(crate) mod keyboard;
 mod pointer;
 mod touch;
 
-use std::{fmt, sync::Arc};
+use std::sync::Arc;
 
 use crate::input::{Inner, Seat, SeatHandler, SeatRc, SeatState};
 
@@ -133,18 +133,9 @@ impl<D: SeatHandler> Inner<D> {
 }
 
 /// Global data of WlSeat
+#[derive(Debug)]
 pub struct SeatGlobalData<D: SeatHandler> {
     arc: Arc<SeatRc<D>>,
-}
-
-impl<D: SeatHandler> fmt::Debug for SeatGlobalData<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SeatGlobalData").field("arc", &self.arc).finish()
-    }
 }
 
 impl<D: SeatHandler + 'static> SeatState<D> {
@@ -261,18 +252,9 @@ impl<D: SeatHandler + 'static> Seat<D> {
 }
 
 /// User data for seat
+#[derive(Debug)]
 pub struct SeatUserData<D: SeatHandler> {
     arc: Arc<SeatRc<D>>,
-}
-
-impl<D: SeatHandler> fmt::Debug for SeatUserData<D>
-where
-    <D as SeatHandler>::KeyboardFocus: fmt::Debug,
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SeatUserData").field("arc", &self.arc).finish()
-    }
 }
 
 #[allow(missing_docs)] // TODO

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Mutex};
+use std::sync::Mutex;
 
 use wayland_protocols::wp::relative_pointer::zv1::server::zwp_relative_pointer_v1::ZwpRelativePointerV1;
 use wayland_server::{
@@ -180,19 +180,9 @@ where
 }
 
 /// User data for pointer
+#[derive(Debug)]
 pub struct PointerUserData<D: SeatHandler> {
     pub(crate) handle: Option<PointerHandle<D>>,
-}
-
-impl<D: SeatHandler> fmt::Debug for PointerUserData<D>
-where
-    <D as SeatHandler>::PointerFocus: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PointerUserData")
-            .field("handle", &self.handle)
-            .finish()
-    }
 }
 
 impl<D> Dispatch<WlPointer, PointerUserData<D>, D> for SeatState<D>

--- a/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
+++ b/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
@@ -2,7 +2,6 @@ use std::fs::File;
 use std::io::Read;
 use std::os::unix::io::{FromRawFd, OwnedFd};
 use std::{
-    fmt::Debug,
     os::unix::io::AsRawFd,
     sync::{Arc, Mutex},
 };
@@ -58,22 +57,10 @@ impl VirtualKeyboardHandle {
 }
 
 /// User data of ZwpVirtualKeyboardV1 object
+#[derive(Debug)]
 pub struct VirtualKeyboardUserData<D: SeatHandler> {
     pub(super) handle: VirtualKeyboardHandle,
     pub(crate) seat: Seat<D>,
-}
-
-impl<D: SeatHandler> Debug for VirtualKeyboardUserData<D>
-where
-    <D as SeatHandler>::KeyboardFocus: Debug,
-    <D as SeatHandler>::PointerFocus: Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VirtualKeyboardUserData")
-            .field("handle", &self.handle)
-            .field("seat", &self.seat.arc)
-            .finish()
-    }
 }
 
 impl<D> Dispatch<ZwpVirtualKeyboardV1, VirtualKeyboardUserData<D>, D> for VirtualKeyboardManagerState

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -14,6 +14,7 @@ use smithay::{
     wayland::compositor::SurfaceData,
 };
 
+#[derive(Debug)]
 pub struct DummyRenderer {}
 
 impl DummyRenderer {
@@ -200,7 +201,7 @@ impl Frame for DummyFrame {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DummyTexture {
     width: u32,
     height: u32,


### PR DESCRIPTION
In general, I don't think there's any reason to use types that don't implement `Debug` here? And a crate can always implement `Debug` in some way for its own types, even if it isn't derivable.

With this, a lot of `Debug` implementations can just be derived, and code can assume these types are printable without additional bounds. The latter should  generally be an API improvement. (The reason I looked at this was that I tried to add a print and got a complaint that a debug bound would be needed somewhere.)