### PR TITLE
Fix unnecessary damage

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1910,7 +1910,7 @@ where
             // This is used to transport the opaque regions for elements that
             // have been assigned to planes and to realize hole punching for
             // underlays. We use an Id per plane/element combination to not
-            // interfer with the element damage state in the output damage tracker.
+            // interfere with the element damage state in the output damage tracker.
             // Using the original element id would store the commit in the
             // OutputDamageTracker without actual rendering anything -> bad
             // Using a id per plane could result in an issue when a different
@@ -1920,7 +1920,7 @@ where
             // on that plane.
             let mut elements = overlay_plane_elements
                 .iter()
-                .map(|(p, element)| {
+                .filter_map(|(p, element)| {
                     let id = self
                         .overlay_plane_element_ids
                         .plane_id_for_element_id(p, element.id());
@@ -1928,9 +1928,10 @@ where
                     let is_underlay = overlay_plane_lookup.get(p).unwrap().zpos.unwrap_or_default()
                         < self.planes.primary.zpos.unwrap_or_default();
                     if is_underlay {
-                        HolepunchRenderElement::from_render_element(id, element, output_scale).into()
+                        Some(HolepunchRenderElement::from_render_element(id, element, output_scale).into())
                     } else {
-                        OverlayPlaneElement::from_render_element(id, *element).into()
+                        OverlayPlaneElement::from_render_element(id, *element, output_scale)
+                            .map(DrmRenderElements::from)
                     }
                 })
                 .collect::<Vec<_>>();

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -2648,7 +2648,7 @@ where
         }
 
         let copy_rect = Rectangle::from_loc_and_size((0, 0), cursor_buffer_size);
-        let mapping = match renderer.copy_framebuffer(copy_rect, DrmFourcc::Abgr8888) {
+        let mapping = match renderer.copy_framebuffer(copy_rect, DrmFourcc::Argb8888) {
             Ok(mapping) => mapping,
             Err(err) => {
                 info!("failed to export cursor offscreen buffer: {}", err);

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -731,7 +731,7 @@ impl OutputDamageTracker {
             trace!("age of {} recent enough, using old damage", age);
             // We do not need even older states anymore
             self.last_state.old_damage.truncate(age);
-            damage.extend(self.last_state.old_damage.iter().flatten().copied());
+            damage.extend(self.last_state.old_damage.iter().take(age - 1).flatten().copied());
         } else {
             trace!(
                 "no old damage available, re-render everything. age: {} old_damage len: {}",

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -208,6 +208,8 @@ use super::{
 
 use super::{Renderer, Texture};
 
+const MAX_AGE: usize = 4;
+
 #[derive(Debug, Clone, Copy)]
 struct ElementInstanceState {
     last_geometry: Rectangle<i32, Physical>,
@@ -738,6 +740,10 @@ impl OutputDamageTracker {
                 age,
                 self.last_state.old_damage.len(),
             );
+            // we still truncate the old damage to prevent growing
+            // indefinitely in case we are continuously called with
+            // an age of 0
+            self.last_state.old_damage.truncate(MAX_AGE);
             // just damage everything, if we have no damage
             *damage = vec![output_geo];
         };


### PR DESCRIPTION
This PR tries to reduce damage on the primary plane.

The `OutputDamageTracker` now automatically damages areas no longer covered by opaque regions.
This enables us to return to only report opaque regions from overlay plane elements in the `DrmCompositor`
and no longer forward damage of the original element.

~~The last commit changes the `Element` trait to return an `Option` for opaque regions.  This can save us from some allocations for non opaque elements. They were already tracked as on Option in most elements anyway.
The commit is fully optional, so I can easily drop it if we do not want to change the api.~~
