### PR TITLE
WIP Use `PopupKind`/`PopupManager` for input method surface

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -273,7 +273,6 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                         self.pointer_location - output_geo.loc.to_f64(),
                         WindowSurfaceType::ALL,
                     ) {
-                        input_method.set_point(&point);
                         #[cfg(feature = "xwayland")]
                         if let WindowElement::X11(surf) = &window {
                             self.xwm.as_mut().unwrap().raise_window(surf).unwrap();
@@ -295,7 +294,6 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                                 - layers.layer_geometry(layer).unwrap().loc.to_f64(),
                             WindowSurfaceType::ALL,
                         ) {
-                            input_method.set_point(&point);
                             keyboard.set_focus(self, Some(layer.clone().into()), serial);
                             return;
                         }
@@ -309,7 +307,6 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 .map(|(w, p)| (w.clone(), p))
             {
                 self.space.raise_element(&window, true);
-                input_method.set_point(&point);
                 keyboard.set_focus(self, Some(window.clone().into()), serial);
                 #[cfg(feature = "xwayland")]
                 if let WindowElement::X11(surf) = &window {
@@ -332,7 +329,6 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                                 - layers.layer_geometry(layer).unwrap().loc.to_f64(),
                             WindowSurfaceType::ALL,
                         ) {
-                            input_method.set_point(&point);
                             keyboard.set_focus(self, Some(layer.clone().into()), serial);
                         }
                     }

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -263,7 +263,14 @@ fn ensure_initial_configure(surface: &WlSurface, space: &Space<WindowElement>, p
     }
 
     if let Some(popup) = popups.find_popup(surface) {
-        let PopupKind::Xdg(ref popup) = popup;
+        let popup = match popup {
+            PopupKind::Xdg(ref popup) => popup,
+            // Doesn't require configure
+            PopupKind::InputMethod(_) => {
+                return;
+            }
+        };
+
         let initial_configure_sent = with_states(surface, |states| {
             states
                 .data_map

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -20,7 +20,7 @@ use smithay::{
             surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
             update_surface_primary_scanout_output, OutputPresentationFeedback,
         },
-        PopupManager, Space,
+        PopupKind, PopupManager, Space,
     },
     input::{keyboard::XkbConfig, pointer::CursorImageStatus, Seat, SeatHandler, SeatState},
     output::Output,
@@ -44,7 +44,7 @@ use smithay::{
         },
         dmabuf::DmabufFeedback,
         fractional_scale::{with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState},
-        input_method::InputMethodManagerState,
+        input_method::{InputMethodHandler, InputMethodManagerState, InputMethodPopupSurfaceHandle},
         keyboard_shortcuts_inhibit::{
             KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
         },
@@ -269,6 +269,14 @@ delegate_seat!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 delegate_tablet_manager!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 delegate_text_input_manager!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+
+impl<BackendData: Backend> InputMethodHandler for AnvilState<BackendData> {
+    fn new_popup(&mut self, surface: InputMethodPopupSurfaceHandle) {
+        if let Err(err) = self.popups.track_popup(PopupKind::from(surface)) {
+            warn!("Failed to track popup: {}", err);
+        }
+    }
+}
 
 delegate_input_method_manager!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -1467,21 +1467,6 @@ fn render_surface<'a, 'b>(
     let scale = Scale::from(output.current_scale().fractional_scale());
 
     let mut custom_elements: Vec<CustomRenderElements<_>> = Vec::new();
-    // draw input method surface if any
-    let rectangle = input_method.coordinates();
-    let position = Point::from((
-        rectangle.loc.x + rectangle.size.w,
-        rectangle.loc.y + rectangle.size.h,
-    ));
-    input_method.with_surface(|surface| {
-        custom_elements.extend(AsRenderElements::<UdevRenderer<'a, 'b>>::render_elements(
-            &SurfaceTree::from_surface(surface),
-            renderer,
-            position.to_physical_precise_round(scale),
-            scale,
-            1.0,
-        ));
-    });
 
     if output_geometry.to_f64().contains(pointer_location) {
         let cursor_hotspot = if let CursorImageStatus::Surface(ref surface) = cursor_status {

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -311,22 +311,6 @@ pub fn run_winit() {
 
                 elements.extend(pointer_element.render_elements(renderer, cursor_pos_scaled, scale, 1.0));
 
-                // draw input method surface if any
-                let rectangle = input_method.coordinates();
-                let position = Point::from((
-                    rectangle.loc.x + rectangle.size.w,
-                    rectangle.loc.y + rectangle.size.h,
-                ));
-                input_method.with_surface(|surface| {
-                    elements.extend(AsRenderElements::<GlesRenderer>::render_elements(
-                        &smithay::desktop::space::SurfaceTree::from_surface(surface),
-                        renderer,
-                        position.to_physical_precise_round(scale),
-                        scale,
-                        1.0,
-                    ));
-                });
-
                 // draw the dnd icon if any
                 if let Some(surface) = dnd_icon {
                     if surface.alive() {

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -363,23 +363,6 @@ pub fn run_x11() {
                 1.0,
             ));
 
-            // draw input method surface if any
-            let input_method = state.seat.input_method();
-            let rectangle = input_method.coordinates();
-            let position = Point::from((
-                rectangle.loc.x + rectangle.size.w,
-                rectangle.loc.y + rectangle.size.h,
-            ));
-            input_method.with_surface(|surface| {
-                elements.extend(AsRenderElements::<GlesRenderer>::render_elements(
-                    &smithay::desktop::space::SurfaceTree::from_surface(surface),
-                    &mut backend_data.renderer,
-                    position.to_physical_precise_round(scale),
-                    scale,
-                    1.0,
-                ));
-            });
-
             // draw the dnd icon if any
             if let Some(surface) = state.dnd_icon.as_ref() {
                 if surface.alive() {

--- a/src/desktop/wayland/popup/manager.rs
+++ b/src/desktop/wayland/popup/manager.rs
@@ -88,6 +88,9 @@ impl PopupManager {
                     return Err(PopupGrabError::InvalidGrab);
                 }
             }
+            PopupKind::InputMethod(_) => {
+                return Err(PopupGrabError::InvalidGrab); // TODO?
+            }
         }
 
         // The primary store for the grab is the seat, additional we store it

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -16,14 +16,12 @@ use crate::input::{
 };
 use crate::wayland::{seat::WaylandFocus, text_input::TextInputHandle};
 
-use super::input_method_popup_surface::InputMethodPopupSurfaceHandle;
 use super::InputMethodManagerState;
 
 #[derive(Default, Debug)]
 pub(crate) struct InputMethodKeyboard {
     pub grab: Option<ZwpInputMethodKeyboardGrabV2>,
     pub text_input_handle: TextInputHandle,
-    pub popup_handle: InputMethodPopupSurfaceHandle,
 }
 
 /// Handle to an input method instance

--- a/src/wayland/input_method/mod.rs
+++ b/src/wayland/input_method/mod.rs
@@ -75,6 +75,11 @@ const MANAGER_VERSION: u32 = 1;
 mod input_method_handle;
 mod input_method_keyboard_grab;
 mod input_method_popup_surface;
+pub use input_method_popup_surface::InputMethodPopupSurfaceHandle;
+
+pub trait InputMethodHandler {
+    fn new_popup(&mut self, surface: InputMethodPopupSurfaceHandle);
+}
 
 /// Extends [Seat] with input method functionality
 pub trait InputMethodSeat {


### PR DESCRIPTION
Fix for https://github.com/Smithay/smithay/issues/1045. This eliminates the need for `set_point`, and for the compositor to have separate code for rendering IME popups.

This seems to work at least as well as the previous version with fcitx5 in anvil? The use of `set_point` previously wasn't correct. But some work is still needed.

The current version of the protocol also has some fundamental issues that may be problematic here. We can bring anything like that up in discussion of the v3 protocol.