### PR TITLE
drm/atomic: Use new mode when testing

### DIFF
--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -442,10 +442,10 @@ impl AtomicDrmSurface {
             [&PlaneState {
                 handle: self.plane,
                 config: Some(PlaneConfig {
-                    src: Rectangle::from_loc_and_size(Point::default(), pending.mode.size()).to_f64(),
+                    src: Rectangle::from_loc_and_size(Point::default(), mode.size()).to_f64(),
                     dst: Rectangle::from_loc_and_size(
                         Point::default(),
-                        (pending.mode.size().0 as i32, pending.mode.size().1 as i32),
+                        (mode.size().0 as i32, mode.size().1 as i32),
                     ),
                     transform: Transform::Normal,
                     alpha: 1.0,


### PR DESCRIPTION
When using the `DrmSurface::use_mode` function, we are currently testing the plane config with the old mode previously set, which will fail on most (if not all) drivers.
