### PR TITLE
Add back manual `Debug` impls removed in f628336b

### DIFF
--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    fmt,
+    sync::{Arc, Mutex},
+};
 
 use wayland_server::{protocol::wl_surface::WlSurface, Resource};
 
@@ -216,7 +219,6 @@ impl PopupGrabInner {
 /// timeout.
 ///
 /// The grab is obtained by calling [`PopupManager::grap_popup`](super::PopupManager::grab_popup).
-#[derive(Debug)]
 pub struct PopupGrab<D>
 where
     D: SeatHandler + 'static,
@@ -230,6 +232,24 @@ where
     keyboard_handle: Option<KeyboardHandle<D>>,
     keyboard_grab_start_data: KeyboardGrabStartData<D>,
     pointer_grab_start_data: PointerGrabStartData<D>,
+}
+
+impl<D> fmt::Debug for PopupGrab<D>
+where
+    D: SeatHandler + 'static,
+    <D as SeatHandler>::KeyboardFocus: WaylandFocus,
+    <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PopupGrab")
+            .field("root", &self.root)
+            .field("serial", &self.serial)
+            .field("previous_serial", &self.previous_serial)
+            .field("keyboard_handle", &self.keyboard_handle)
+            .field("keyboard_grab_start_data", &self.keyboard_grab_start_data)
+            .field("pointer_grab_start_data", &self.pointer_grab_start_data)
+            .finish()
+    }
 }
 
 impl<D> Clone for PopupGrab<D>
@@ -373,7 +393,6 @@ where
 /// on the topmost popup until the grab has ended. If the
 /// grab has ended it will restore the focus on the root of the grab
 /// and unset the [`KeyboardGrab`]
-#[derive(Debug)]
 pub struct PopupKeyboardGrab<D>
 where
     D: SeatHandler + 'static,
@@ -381,6 +400,19 @@ where
     <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
 {
     popup_grab: PopupGrab<D>,
+}
+
+impl<D> fmt::Debug for PopupKeyboardGrab<D>
+where
+    D: SeatHandler + 'static,
+    <D as SeatHandler>::KeyboardFocus: WaylandFocus,
+    <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PopupKeyboardGrab")
+            .field("popup_grab", &self.popup_grab)
+            .finish()
+    }
 }
 
 impl<D> PopupKeyboardGrab<D>
@@ -467,7 +499,6 @@ where
 /// [`PointerGrab`] is unset. Additional it will unset an active
 /// [`KeyboardGrab`] that matches the [`Serial`] of this grab and
 /// restore the keyboard focus like described in [`PopupKeyboardGrab`]
-#[derive(Debug)]
 pub struct PopupPointerGrab<D>
 where
     D: SeatHandler + 'static,
@@ -475,6 +506,19 @@ where
     <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
 {
     popup_grab: PopupGrab<D>,
+}
+
+impl<D> fmt::Debug for PopupPointerGrab<D>
+where
+    D: SeatHandler + 'static,
+    <D as SeatHandler>::KeyboardFocus: WaylandFocus,
+    <D as SeatHandler>::PointerFocus: From<<D as SeatHandler>::KeyboardFocus> + WaylandFocus,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PopupPointerGrab")
+            .field("popup_grab", &self.popup_grab)
+            .finish()
+    }
 }
 
 impl<D> PopupPointerGrab<D>

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    fmt,
+    sync::{Arc, Mutex},
+};
 
 use wayland_protocols_misc::zwp_input_method_v2::server::{
     zwp_input_method_keyboard_grab_v2::ZwpInputMethodKeyboardGrabV2,
@@ -103,11 +106,20 @@ impl InputMethodHandle {
 }
 
 /// User data of ZwpInputMethodV2 object
-#[derive(Debug)]
 pub struct InputMethodUserData<D: SeatHandler> {
     pub(super) handle: InputMethodHandle,
     pub(crate) text_input_handle: TextInputHandle,
     pub(crate) keyboard_handle: KeyboardHandle<D>,
+}
+
+impl<D: SeatHandler> fmt::Debug for InputMethodUserData<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InputMethodUserData")
+            .field("handle", &self.handle)
+            .field("text_input_handle", &self.text_input_handle)
+            .field("keyboard_handle", &self.keyboard_handle)
+            .finish()
+    }
 }
 
 impl<D> Dispatch<ZwpInputMethodV2, InputMethodUserData<D>, D> for InputMethodManagerState

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    fmt,
+    sync::{Arc, Mutex},
+};
 
 use wayland_protocols_misc::zwp_input_method_v2::server::zwp_input_method_keyboard_grab_v2::{
     self, ZwpInputMethodKeyboardGrabV2,
@@ -79,10 +82,18 @@ where
 }
 
 /// User data of ZwpInputKeyboardGrabV2 object
-#[derive(Debug)]
 pub struct InputMethodKeyboardUserData<D: SeatHandler> {
     pub(super) handle: InputMethodKeyboardGrab,
     pub(crate) keyboard_handle: KeyboardHandle<D>,
+}
+
+impl<D: SeatHandler> fmt::Debug for InputMethodKeyboardUserData<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InputMethodKeyboardUserData")
+            .field("handle", &self.handle)
+            .field("keyboard_handle", &self.keyboard_handle)
+            .finish()
+    }
 }
 
 impl<D: SeatHandler + 'static> Dispatch<ZwpInputMethodKeyboardGrabV2, InputMethodKeyboardUserData<D>, D>

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use tracing::{error, instrument, trace, warn};
 use wayland_server::{
     backend::{ClientId, ObjectId},
@@ -81,9 +83,16 @@ where
 }
 
 /// User data for keyboard
-#[derive(Debug)]
 pub struct KeyboardUserData<D: SeatHandler> {
     pub(crate) handle: Option<KeyboardHandle<D>>,
+}
+
+impl<D: SeatHandler> fmt::Debug for KeyboardUserData<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyboardUserData")
+            .field("handle", &self.handle)
+            .finish()
+    }
 }
 
 impl<D> Dispatch<WlKeyboard, KeyboardUserData<D>, D> for SeatState<D>

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -61,7 +61,7 @@ pub(crate) mod keyboard;
 mod pointer;
 mod touch;
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use crate::input::{Inner, Seat, SeatHandler, SeatRc, SeatState};
 
@@ -133,9 +133,14 @@ impl<D: SeatHandler> Inner<D> {
 }
 
 /// Global data of WlSeat
-#[derive(Debug)]
 pub struct SeatGlobalData<D: SeatHandler> {
     arc: Arc<SeatRc<D>>,
+}
+
+impl<D: SeatHandler> fmt::Debug for SeatGlobalData<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SeatGlobalData").field("arc", &self.arc).finish()
+    }
 }
 
 impl<D: SeatHandler + 'static> SeatState<D> {
@@ -252,9 +257,14 @@ impl<D: SeatHandler + 'static> Seat<D> {
 }
 
 /// User data for seat
-#[derive(Debug)]
 pub struct SeatUserData<D: SeatHandler> {
     arc: Arc<SeatRc<D>>,
+}
+
+impl<D: SeatHandler> fmt::Debug for SeatUserData<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SeatUserData").field("arc", &self.arc).finish()
+    }
 }
 
 #[allow(missing_docs)] // TODO

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use std::{fmt, sync::Mutex};
 
 use wayland_protocols::wp::relative_pointer::zv1::server::zwp_relative_pointer_v1::ZwpRelativePointerV1;
 use wayland_server::{
@@ -180,9 +180,16 @@ where
 }
 
 /// User data for pointer
-#[derive(Debug)]
 pub struct PointerUserData<D: SeatHandler> {
     pub(crate) handle: Option<PointerHandle<D>>,
+}
+
+impl<D: SeatHandler> fmt::Debug for PointerUserData<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PointerUserData")
+            .field("handle", &self.handle)
+            .finish()
+    }
 }
 
 impl<D> Dispatch<WlPointer, PointerUserData<D>, D> for SeatState<D>

--- a/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
+++ b/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::Read;
 use std::os::unix::io::{FromRawFd, OwnedFd};
 use std::{
+    fmt,
     os::unix::io::AsRawFd,
     sync::{Arc, Mutex},
 };
@@ -57,10 +58,18 @@ impl VirtualKeyboardHandle {
 }
 
 /// User data of ZwpVirtualKeyboardV1 object
-#[derive(Debug)]
 pub struct VirtualKeyboardUserData<D: SeatHandler> {
     pub(super) handle: VirtualKeyboardHandle,
     pub(crate) seat: Seat<D>,
+}
+
+impl<D: SeatHandler> fmt::Debug for VirtualKeyboardUserData<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VirtualKeyboardUserData")
+            .field("handle", &self.handle)
+            .field("seat", &self.seat.arc)
+            .finish()
+    }
 }
 
 impl<D> Dispatch<ZwpVirtualKeyboardV1, VirtualKeyboardUserData<D>, D> for VirtualKeyboardManagerState


### PR DESCRIPTION
These are still needed to implemented `Debug` without a `D: Debug` bound.

If there were *one* manual debug impl like this I'd add a comment noting that it is the same as the derived implementation but with a different bound, and link to https://github.com/rust-lang/rust/issues/26925. But adding that comment everywhere would be verbose...

This still slightly simplifies many of these implementations, since they used to require `Debug` bounds for `::KeyboardFocus`, `::PointerFocus` etc. When removing those I switched to deriving `Debug` since that *seemed* to work.