### PR TITLE
Update wayland-protocols for docs action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,7 @@ jobs:
       - name: Build Documentation
         env: 
           RUSTDOCFLAGS: --cfg=docsrs
-        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.26.2 -p udev -p slog -p wayland-server -p wayland-backend -p wayland-protocols:0.30.0 -p winit -p x11rb
+        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.26.2 -p udev -p slog -p wayland-server -p wayland-backend -p wayland-protocols:0.30.1 -p winit -p x11rb
         
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html


### PR DESCRIPTION
wayland-protocols 0.30.1 exists now, so CI is unhappy about the hardcoded 0.30.0, which is not pulled anymore.