### PR TITLE
Add static output mode support for DrmCompositor

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1284,7 +1284,13 @@ where
         )
     }
 
-    /// TODO
+    /// Initialize a new [`DrmCompositor`] with custom output mode source.
+    ///
+    /// This method should only be used when trying to create a [`DrmCompositor`] that manually
+    /// updates its output mode through [`DrmCompositor::set_output_mode_source`]. If you want the
+    /// mode changes to be handled automatically, use [`DrmCompositor::new`] instead.
+    ///
+    /// See also: [`DrmCompositor::new`]
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip(allocator, framebuffer_exporter))]
     pub fn new_with_output_mode_source(

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -331,9 +331,9 @@ impl OutputDamageTracker {
     /// This should only be used when trying to support both static and automatic output mode
     /// sources. For known modes use [`OutputDamageTracker::new`] or
     /// [`OutputDamageTracker::from_output`] instead.
-    pub fn from_mode_source(output_mode_source: OutputModeSource) -> Self {
+    pub fn from_mode_source(output_mode_source: impl Into<OutputModeSource>) -> Self {
         Self {
-            mode: output_mode_source,
+            mode: output_mode_source.into(),
             last_state: Default::default(),
             span: info_span!("render_damage"),
         }

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -3,14 +3,11 @@
 
 use crate::{
     backend::renderer::{
-        damage::{
-            Error as OutputDamageTrackerError, OutputDamageTracker, OutputDamageTrackerMode, OutputNoMode,
-            RenderOutputResult,
-        },
+        damage::{Error as OutputDamageTrackerError, OutputDamageTracker, RenderOutputResult},
         element::{AsRenderElements, RenderElement, Wrap},
         Renderer, Texture,
     },
-    output::Output,
+    output::{Output, OutputModeSource, OutputNoMode},
     utils::{IsAlive, Logical, Point, Rectangle, Scale, Transform},
 };
 #[cfg(feature = "wayland_frontend")]
@@ -686,7 +683,7 @@ where
     SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>:
         From<Wrap<<E as AsRenderElements<R>>::RenderElement>>,
 {
-    if let OutputDamageTrackerMode::Auto(renderer_output) = damage_tracker.mode() {
+    if let OutputModeSource::Auto(renderer_output) = damage_tracker.mode() {
         assert!(renderer_output == output);
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -457,6 +457,12 @@ pub enum OutputModeSource {
     },
 }
 
+impl From<&Output> for OutputModeSource {
+    fn from(output: &Output) -> Self {
+        Self::Auto(output.clone())
+    }
+}
+
 impl TryFrom<&OutputModeSource> for (Size<i32, Physical>, utils::Scale<f64>, Transform) {
     type Error = OutputNoMode;
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -63,7 +63,7 @@ use drm::control::{Mode as DrmMode, ModeFlags};
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::{backend::WeakHandle, protocol::wl_output::WlOutput};
 
-use crate::utils::{user_data::UserDataMap, Logical, Physical, Point, Raw, Size, Transform};
+use crate::utils::{self, user_data::UserDataMap, Logical, Physical, Point, Raw, Size, Transform};
 
 /// An output mode
 ///
@@ -440,3 +440,51 @@ impl PartialEq<Output> for WeakOutput {
         self.upgrade().map(|o| &o == other).unwrap_or(false)
     }
 }
+
+/// Source for determining output mode information.
+#[derive(PartialEq, Clone, Debug)]
+pub enum OutputModeSource {
+    /// Automatic mode based on an [`Output`].
+    Auto(Output),
+    /// Static output mode.
+    Static {
+        /// Size of the static output
+        size: Size<i32, Physical>,
+        /// Scale of the static output
+        scale: utils::Scale<f64>,
+        /// Transform of the static output
+        transform: Transform,
+    },
+}
+
+impl TryFrom<&OutputModeSource> for (Size<i32, Physical>, utils::Scale<f64>, Transform) {
+    type Error = OutputNoMode;
+
+    fn try_from(mode: &OutputModeSource) -> Result<Self, Self::Error> {
+        match mode {
+            OutputModeSource::Auto(output) => Ok((
+                output.current_mode().ok_or(OutputNoMode)?.size,
+                output.current_scale().fractional_scale().into(),
+                output.current_transform(),
+            )),
+            OutputModeSource::Static {
+                size,
+                scale,
+                transform,
+            } => Ok((*size, *scale, *transform)),
+        }
+    }
+}
+
+impl TryFrom<OutputModeSource> for (Size<i32, Physical>, utils::Scale<f64>, Transform) {
+    type Error = OutputNoMode;
+
+    fn try_from(mode: OutputModeSource) -> Result<Self, Self::Error> {
+        Self::try_from(&mode)
+    }
+}
+
+/// Output has no active mode
+#[derive(Debug, thiserror::Error)]
+#[error("Output has no active mode")]
+pub struct OutputNoMode;


### PR DESCRIPTION
This patch adds new functions to the `DrmCompositor` to allow users to control when its output mode should be updated, rather than using the Output to update the mode automatically.

---

This *seems* to work with my compositor and fixes my issues. Though no guarantees it doesn't mess with damage tracking somehow.