### PR TITLE
layer_map: Don't ignore dead surfaces

### DIFF
--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -203,10 +203,6 @@ impl LayerMap {
         surface: &WlSurface,
         surface_type: WindowSurfaceType,
     ) -> Option<&LayerSurface> {
-        if !surface.alive() {
-            return None;
-        }
-
         if surface_type.contains(WindowSurfaceType::TOPLEVEL) {
             if let Some(layer) = self.layers.iter().find(|l| l.wl_surface() == surface) {
                 return Some(layer);


### PR DESCRIPTION
This check makes it impossible to figure out which `LayerSurface` belonged to a `WlrLayerSurface` passed to `WlrLayerShellHandler::layer_destroyed`.

This is completely unnecessary, as all the state should still be available, when this handler is triggered. This is especially useful to figure out what output a now dead layer-surface was previously shown on to re-render said output.