### PR TITLE
egl: Support ANGLE EGL platform on winit Wayland

### DIFF
--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -356,4 +356,9 @@ pub mod egl {
     // Accepted in the <attribute> parameter of eglQueryWaylandBufferWL:
     pub const EGL_TEXTURE_FORMAT: i32 = 0x3080;
     pub const WAYLAND_Y_INVERTED_WL: i32 = 0x31DB;
+
+    pub const PLATFORM_ANGLE_ANGLE: u32 = 0x3202;
+    pub const PLATFORM_ANGLE_TYPE_ANGLE: i32 = 0x3203;
+    pub const PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE: i32 = 0x348F;
+    pub const PLATFORM_ANGLE_TYPE_VULKAN_ANGLE: i32 = 0x3450;
 }

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -171,6 +171,23 @@ impl EGLNativeDisplay for Arc<WinitWindow> {
                 egl_platform!(PLATFORM_WAYLAND_KHR, display, &["EGL_KHR_platform_wayland"]),
                 // see: https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_platform_wayland.txt
                 egl_platform!(PLATFORM_WAYLAND_EXT, display, &["EGL_EXT_platform_wayland"]),
+                // see: https://raw.githubusercontent.com/google/angle/main/extensions/EGL_ANGLE_platform_angle.txt
+                egl_platform!(
+                    PLATFORM_ANGLE_ANGLE,
+                    display,
+                    &[
+                        "EGL_ANGLE_platform_angle",
+                        "EGL_ANGLE_platform_angle_vulkan",
+                        "EGL_EXT_platform_wayland",
+                    ],
+                    vec![
+                        ffi::egl::PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE,
+                        ffi::egl::PLATFORM_WAYLAND_EXT as _,
+                        ffi::egl::PLATFORM_ANGLE_TYPE_ANGLE,
+                        ffi::egl::PLATFORM_ANGLE_TYPE_VULKAN_ANGLE,
+                        ffi::egl::NONE as ffi::EGLint
+                    ]
+                ),
             ]
         } else if let Some(display) = self.xlib_display() {
             vec![

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -195,6 +195,19 @@ impl EGLNativeDisplay for Arc<WinitWindow> {
                 egl_platform!(PLATFORM_X11_KHR, display, &["EGL_KHR_platform_x11"]),
                 // see: https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_platform_x11.txt
                 egl_platform!(PLATFORM_X11_EXT, display, &["EGL_EXT_platform_x11"]),
+                // see: https://raw.githubusercontent.com/google/angle/main/extensions/EGL_ANGLE_platform_angle.txt
+                egl_platform!(
+                    PLATFORM_ANGLE_ANGLE,
+                    display,
+                    &["EGL_ANGLE_platform_angle", "EGL_ANGLE_platform_angle_vulkan"],
+                    vec![
+                        ffi::egl::PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE,
+                        ffi::egl::PLATFORM_X11_EXT as _,
+                        ffi::egl::PLATFORM_ANGLE_TYPE_ANGLE,
+                        ffi::egl::PLATFORM_ANGLE_TYPE_VULKAN_ANGLE,
+                        ffi::egl::NONE as ffi::EGLint
+                    ]
+                ),
             ]
         } else {
             unreachable!("No backends for winit other then Wayland and X11 are supported")


### PR DESCRIPTION
For this to work I also had to modify `LIB` to point to the `libEGL.so` from ANGLE. And set `VK_ICD_FILENAMES`, because naturally it wasn't working with Nvidia drivers, but was with Intel.

This uses Vulkan. It seems ANGLE only provides the Wayland platform with Vulkan.

This then runs, but errors with "Depth/stencil buffer format combination not allowed for blit." It seems it needs to use `DEPTH24_STENCIL8`. Presumably that's what the default framebuffer is using?