### PR TITLE
gles: Support more formats for GlesTexture

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1735,7 +1735,9 @@ impl Offscreen<GlesTexture> for GlesRenderer {
             get_transparent(format).ok_or(GlesError::UnsupportedPixelFormat(format))?
         })
         .ok_or(GlesError::UnsupportedPixelFormat(format))?;
-        if internal != ffi::RGBA8 && !self.capabilities.contains(&Capability::ColorTransformations) {
+        if (internal != ffi::RGBA8 && internal != ffi::BGRA_EXT)
+            && !self.capabilities.contains(&Capability::ColorTransformations)
+        {
             return Err(GlesError::UnsupportedPixelLayout);
         }
 


### PR DESCRIPTION
Currently the only texture format that can be sampled from as an offscreen texture is RGBA8 persuant to the GLES2 spec. Since BGRA is already required, and since buffers that are allocated for textures end up being BGRA, allow this format as well.