### PR TITLE
anvil: Don't store `pointer_location`, use from `PointerHandle`

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -173,7 +173,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
 
         let inhibited = self
             .space
-            .element_under(self.pointer_location)
+            .element_under(self.pointer.current_location())
             .and_then(|(window, _)| {
                 let surface = window.wl_surface()?;
                 self.seat.keyboard_shortcuts_inhibitor_for_surface(&surface)
@@ -236,7 +236,8 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         if wl_pointer::ButtonState::Pressed == state {
             self.update_keyboard_focus(serial);
         };
-        self.seat.get_pointer().unwrap().button(
+        let pointer = self.pointer.clone();
+        pointer.button(
             self,
             &ButtonEvent {
                 button,
@@ -248,7 +249,6 @@ impl<BackendData: Backend> AnvilState<BackendData> {
     }
 
     fn update_keyboard_focus(&mut self, serial: Serial) {
-        let pointer = self.seat.get_pointer().unwrap();
         let keyboard = self.seat.get_keyboard().unwrap();
         let input_method = self.seat.input_method();
         // change the keyboard focus unless the pointer or keyboard is grabbed
@@ -260,8 +260,12 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         // subsurface menus (for example firefox-wayland).
         // see here for a discussion about that issue:
         // https://gitlab.freedesktop.org/wayland/wayland/-/issues/294
-        if !pointer.is_grabbed() && (!keyboard.is_grabbed() || input_method.keyboard_grabbed()) {
-            let output = self.space.output_under(self.pointer_location).next().cloned();
+        if !self.pointer.is_grabbed() && (!keyboard.is_grabbed() || input_method.keyboard_grabbed()) {
+            let output = self
+                .space
+                .output_under(self.pointer.current_location())
+                .next()
+                .cloned();
             if let Some(output) = output.as_ref() {
                 let output_geo = self.space.output_geometry(output).unwrap();
                 if let Some(window) = output
@@ -270,7 +274,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                     .and_then(|f| f.get())
                 {
                     if let Some((_, point)) = window.surface_under(
-                        self.pointer_location - output_geo.loc.to_f64(),
+                        self.pointer.current_location() - output_geo.loc.to_f64(),
                         WindowSurfaceType::ALL,
                     ) {
                         input_method.set_point(&point);
@@ -285,12 +289,12 @@ impl<BackendData: Backend> AnvilState<BackendData> {
 
                 let layers = layer_map_for_output(output);
                 if let Some(layer) = layers
-                    .layer_under(WlrLayer::Overlay, self.pointer_location)
-                    .or_else(|| layers.layer_under(WlrLayer::Top, self.pointer_location))
+                    .layer_under(WlrLayer::Overlay, self.pointer.current_location())
+                    .or_else(|| layers.layer_under(WlrLayer::Top, self.pointer.current_location()))
                 {
                     if layer.can_receive_keyboard_focus() {
                         if let Some((_, point)) = layer.surface_under(
-                            self.pointer_location
+                            self.pointer.current_location()
                                 - output_geo.loc.to_f64()
                                 - layers.layer_geometry(layer).unwrap().loc.to_f64(),
                             WindowSurfaceType::ALL,
@@ -305,7 +309,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
 
             if let Some((window, point)) = self
                 .space
-                .element_under(self.pointer_location)
+                .element_under(self.pointer.current_location())
                 .map(|(w, p)| (w.clone(), p))
             {
                 self.space.raise_element(&window, true);
@@ -322,12 +326,12 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 let output_geo = self.space.output_geometry(output).unwrap();
                 let layers = layer_map_for_output(output);
                 if let Some(layer) = layers
-                    .layer_under(WlrLayer::Bottom, self.pointer_location)
-                    .or_else(|| layers.layer_under(WlrLayer::Background, self.pointer_location))
+                    .layer_under(WlrLayer::Bottom, self.pointer.current_location())
+                    .or_else(|| layers.layer_under(WlrLayer::Background, self.pointer.current_location()))
                 {
                     if layer.can_receive_keyboard_focus() {
                         if let Some((_, point)) = layer.surface_under(
-                            self.pointer_location
+                            self.pointer.current_location()
                                 - output_geo.loc.to_f64()
                                 - layers.layer_geometry(layer).unwrap().loc.to_f64(),
                             WindowSurfaceType::ALL,
@@ -341,8 +345,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         }
     }
 
-    pub fn surface_under(&self) -> Option<(FocusTarget, Point<i32, Logical>)> {
-        let pos = self.pointer_location;
+    pub fn surface_under(&self, pos: Point<f64, Logical>) -> Option<(FocusTarget, Point<i32, Logical>)> {
         let output = self.space.outputs().find(|o| {
             let geometry = self.space.output_geometry(o).unwrap();
             geometry.contains(pos.to_i32_round())
@@ -403,7 +406,8 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             } else if evt.source() == AxisSource::Finger {
                 frame = frame.stop(Axis::Vertical);
             }
-            self.seat.get_pointer().unwrap().axis(self, frame);
+            let pointer = self.pointer.clone();
+            pointer.axis(self, frame);
         }
     }
 }
@@ -430,7 +434,7 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
                     let new_scale = current_scale + 0.25;
                     output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
 
-                    crate::shell::fixup_positions(&mut self.space, self.pointer_location);
+                    crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
                     self.backend_data.reset_buffers(&output);
                 }
 
@@ -446,7 +450,7 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
                     let new_scale = f64::max(1.0, current_scale - 0.25);
                     output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
 
-                    crate::shell::fixup_positions(&mut self.space, self.pointer_location);
+                    crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
                     self.backend_data.reset_buffers(&output);
                 }
 
@@ -467,7 +471,7 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
                         _ => Transform::Normal,
                     };
                     output.change_current_state(None, Some(new_transform), None, None);
-                    crate::shell::fixup_positions(&mut self.space, self.pointer_location);
+                    crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
                     self.backend_data.reset_buffers(&output);
                 }
 
@@ -510,11 +514,11 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
         let output_geo = self.space.output_geometry(output).unwrap();
 
         let pos = evt.position_transformed(output_geo.size) + output_geo.loc.to_f64();
-        self.pointer_location = pos;
         let serial = SCOUNTER.next_serial();
 
-        let under = self.surface_under();
-        self.seat.get_pointer().unwrap().motion(
+        let pointer = self.pointer.clone();
+        let under = self.surface_under(pos);
+        pointer.motion(
             self,
             under,
             &MotionEvent {
@@ -548,11 +552,22 @@ impl AnvilState<UdevData> {
                     if let Some(geometry) = geometry {
                         let x = geometry.loc.x as f64 + geometry.size.w as f64 / 2.0;
                         let y = geometry.size.h as f64 / 2.0;
-                        self.pointer_location = (x, y).into()
+                        let location = (x, y).into();
+                        let pointer = self.pointer.clone();
+                        let under = self.surface_under(location);
+                        pointer.motion(
+                            self,
+                            under,
+                            &MotionEvent {
+                                location,
+                                serial: SCOUNTER.next_serial(),
+                                time: 0,
+                            },
+                        );
                     }
                 }
                 KeyAction::ScaleUp => {
-                    let pos = self.pointer_location.to_i32_round();
+                    let pos = self.pointer.current_location().to_i32_round();
                     let output = self
                         .space
                         .outputs()
@@ -569,29 +584,28 @@ impl AnvilState<UdevData> {
 
                         let rescale = scale / new_scale;
                         let output_location = output_location.to_f64();
-                        let mut pointer_output_location = self.pointer_location - output_location;
+                        let mut pointer_output_location = self.pointer.current_location() - output_location;
                         pointer_output_location.x *= rescale;
                         pointer_output_location.y *= rescale;
-                        self.pointer_location = output_location + pointer_output_location;
+                        let pointer_location = output_location + pointer_output_location;
 
-                        crate::shell::fixup_positions(&mut self.space, self.pointer_location);
-                        let under = self.surface_under();
-                        if let Some(ptr) = self.seat.get_pointer() {
-                            ptr.motion(
-                                self,
-                                under,
-                                &MotionEvent {
-                                    location: self.pointer_location,
-                                    serial: SCOUNTER.next_serial(),
-                                    time: 0,
-                                },
-                            );
-                        }
+                        crate::shell::fixup_positions(&mut self.space, pointer_location);
+                        let pointer = self.pointer.clone();
+                        let under = self.surface_under(pointer_location);
+                        pointer.motion(
+                            self,
+                            under,
+                            &MotionEvent {
+                                location: pointer_location,
+                                serial: SCOUNTER.next_serial(),
+                                time: 0,
+                            },
+                        );
                         self.backend_data.reset_buffers(&output);
                     }
                 }
                 KeyAction::ScaleDown => {
-                    let pos = self.pointer_location.to_i32_round();
+                    let pos = self.pointer.current_location().to_i32_round();
                     let output = self
                         .space
                         .outputs()
@@ -608,29 +622,28 @@ impl AnvilState<UdevData> {
 
                         let rescale = scale / new_scale;
                         let output_location = output_location.to_f64();
-                        let mut pointer_output_location = self.pointer_location - output_location;
+                        let mut pointer_output_location = self.pointer.current_location() - output_location;
                         pointer_output_location.x *= rescale;
                         pointer_output_location.y *= rescale;
-                        self.pointer_location = output_location + pointer_output_location;
+                        let pointer_location = output_location + pointer_output_location;
 
-                        crate::shell::fixup_positions(&mut self.space, self.pointer_location);
-                        let under = self.surface_under();
-                        if let Some(ptr) = self.seat.get_pointer() {
-                            ptr.motion(
-                                self,
-                                under,
-                                &MotionEvent {
-                                    location: self.pointer_location,
-                                    serial: SCOUNTER.next_serial(),
-                                    time: 0,
-                                },
-                            );
-                        }
+                        crate::shell::fixup_positions(&mut self.space, pointer_location);
+                        let pointer = self.pointer.clone();
+                        let under = self.surface_under(pointer_location);
+                        pointer.motion(
+                            self,
+                            under,
+                            &MotionEvent {
+                                location: pointer_location,
+                                serial: SCOUNTER.next_serial(),
+                                time: 0,
+                            },
+                        );
                         self.backend_data.reset_buffers(&output);
                     }
                 }
                 KeyAction::RotateOutput => {
-                    let pos = self.pointer_location.to_i32_round();
+                    let pos = self.pointer.current_location().to_i32_round();
                     let output = self
                         .space
                         .outputs()
@@ -647,7 +660,7 @@ impl AnvilState<UdevData> {
                             _ => Transform::Normal,
                         };
                         output.change_current_state(None, Some(new_transform), None, None);
-                        crate::shell::fixup_positions(&mut self.space, self.pointer_location);
+                        crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
                         self.backend_data.reset_buffers(&output);
                     }
                 }
@@ -699,35 +712,37 @@ impl AnvilState<UdevData> {
     }
 
     fn on_pointer_move<B: InputBackend>(&mut self, _dh: &DisplayHandle, evt: B::PointerMotionEvent) {
+        let mut pointer_location = self.pointer.current_location();
+
         let serial = SCOUNTER.next_serial();
-        self.pointer_location += evt.delta();
+        pointer_location += evt.delta();
 
         // clamp to screen limits
         // this event is never generated by winit
-        self.pointer_location = self.clamp_coords(self.pointer_location);
+        pointer_location = self.clamp_coords(pointer_location);
 
-        let under = self.surface_under();
-        if let Some(ptr) = self.seat.get_pointer() {
-            ptr.motion(
-                self,
-                under.clone(),
-                &MotionEvent {
-                    location: self.pointer_location,
-                    serial,
-                    time: evt.time_msec(),
-                },
-            );
+        let pointer = self.pointer.clone();
+        let under = self.surface_under(pointer_location);
 
-            ptr.relative_motion(
-                self,
-                under,
-                &RelativeMotionEvent {
-                    delta: evt.delta(),
-                    delta_unaccel: evt.delta_unaccel(),
-                    utime: evt.time(),
-                },
-            )
-        }
+        pointer.motion(
+            self,
+            under.clone(),
+            &MotionEvent {
+                location: pointer_location,
+                serial,
+                time: evt.time_msec(),
+            },
+        );
+
+        pointer.relative_motion(
+            self,
+            under,
+            &RelativeMotionEvent {
+                delta: evt.delta(),
+                delta_unaccel: evt.delta_unaccel(),
+                utime: evt.time(),
+            },
+        )
     }
 
     fn on_pointer_move_absolute<B: InputBackend>(
@@ -750,24 +765,23 @@ impl AnvilState<UdevData> {
 
         let max_y = self.space.output_geometry(max_h_output).unwrap().size.h;
 
-        self.pointer_location.x = evt.x_transformed(max_x);
-        self.pointer_location.y = evt.y_transformed(max_y);
+        let mut pointer_location = (evt.x_transformed(max_x), evt.y_transformed(max_y)).into();
 
         // clamp to screen limits
-        self.pointer_location = self.clamp_coords(self.pointer_location);
+        pointer_location = self.clamp_coords(pointer_location);
 
-        let under = self.surface_under();
-        if let Some(ptr) = self.seat.get_pointer() {
-            ptr.motion(
-                self,
-                under,
-                &MotionEvent {
-                    location: self.pointer_location,
-                    serial,
-                    time: evt.time_msec(),
-                },
-            );
-        }
+        let pointer = self.pointer.clone();
+        let under = self.surface_under(pointer_location);
+
+        pointer.motion(
+            self,
+            under,
+            &MotionEvent {
+                location: pointer_location,
+                serial,
+                time: evt.time_msec(),
+            },
+        );
     }
 
     fn on_tablet_tool_axis<B: InputBackend>(&mut self, evt: B::TabletToolAxisEvent) {
@@ -780,11 +794,22 @@ impl AnvilState<UdevData> {
             .map(|o| self.space.output_geometry(o).unwrap());
 
         if let Some(rect) = output_geometry {
-            self.pointer_location = evt.position_transformed(rect.size) + rect.loc.to_f64();
+            let pointer_location = evt.position_transformed(rect.size) + rect.loc.to_f64();
 
-            let under = self.surface_under();
+            let pointer = self.pointer.clone();
+            let under = self.surface_under(pointer_location);
             let tablet = tablet_seat.get_tablet(&TabletDescriptor::from(&evt.device()));
             let tool = tablet_seat.get_tool(&evt.tool());
+
+            pointer.motion(
+                self,
+                under.clone(),
+                &MotionEvent {
+                    location: pointer_location,
+                    serial: SCOUNTER.next_serial(),
+                    time: 0,
+                },
+            );
 
             if let (Some(tablet), Some(tool)) = (tablet, tool) {
                 if evt.pressure_has_changed() {
@@ -807,7 +832,7 @@ impl AnvilState<UdevData> {
                 }
 
                 tool.motion(
-                    self.pointer_location,
+                    pointer_location,
                     under.and_then(|(f, loc)| f.wl_surface().map(|s| (s, loc))),
                     &tablet,
                     SCOUNTER.next_serial(),
@@ -834,11 +859,22 @@ impl AnvilState<UdevData> {
             let tool = evt.tool();
             tablet_seat.add_tool::<Self>(dh, &tool);
 
-            self.pointer_location = evt.position_transformed(rect.size) + rect.loc.to_f64();
+            let pointer_location = evt.position_transformed(rect.size) + rect.loc.to_f64();
 
-            let under = self.surface_under();
+            let pointer = self.pointer.clone();
+            let under = self.surface_under(pointer_location);
             let tablet = tablet_seat.get_tablet(&TabletDescriptor::from(&evt.device()));
             let tool = tablet_seat.get_tool(&tool);
+
+            pointer.motion(
+                self,
+                under.clone(),
+                &MotionEvent {
+                    location: pointer_location,
+                    serial: SCOUNTER.next_serial(),
+                    time: 0,
+                },
+            );
 
             if let (Some(under), Some(tablet), Some(tool)) = (
                 under.and_then(|(f, loc)| f.wl_surface().map(|s| (s, loc))),
@@ -847,7 +883,7 @@ impl AnvilState<UdevData> {
             ) {
                 match evt.state() {
                     ProximityState::In => tool.proximity_in(
-                        self.pointer_location,
+                        pointer_location,
                         under,
                         &tablet,
                         SCOUNTER.next_serial(),

--- a/anvil/src/shell/x11.rs
+++ b/anvil/src/shell/x11.rs
@@ -52,7 +52,12 @@ impl<BackendData: Backend> XwmHandler for CalloopData<BackendData> {
     fn map_window_request(&mut self, _xwm: XwmId, window: X11Surface) {
         window.set_mapped(true).unwrap();
         let window = WindowElement::X11(window);
-        place_new_window(&mut self.state.space, self.state.pointer_location, &window, true);
+        place_new_window(
+            &mut self.state.space,
+            self.state.pointer.current_location(),
+            &window,
+            true,
+        );
         let bbox = self.state.space.element_bbox(&window).unwrap();
         let WindowElement::X11(xsurface) = &window else {
             unreachable!()
@@ -206,9 +211,8 @@ impl<BackendData: Backend> XwmHandler for CalloopData<BackendData> {
     }
 
     fn resize_request(&mut self, _xwm: XwmId, window: X11Surface, _button: u32, edges: X11ResizeEdge) {
-        let seat = &self.state.seat; // luckily anvil only supports one seat anyway...
-        let pointer = seat.get_pointer().unwrap();
-        let start_data = pointer.grab_start_data().unwrap();
+        // luckily anvil only supports one seat anyway...
+        let start_data = self.state.pointer.grab_start_data().unwrap();
 
         let Some(element) = self
             .state
@@ -245,6 +249,7 @@ impl<BackendData: Backend> XwmHandler for CalloopData<BackendData> {
             last_window_size: initial_window_size,
         };
 
+        let pointer = self.state.pointer.clone();
         pointer.set_grab(&mut self.state, grab, SERIAL_COUNTER.next_serial(), Focus::Clear);
     }
 
@@ -340,9 +345,8 @@ impl<BackendData: Backend> AnvilState<BackendData> {
     }
 
     pub fn move_request_x11(&mut self, window: &X11Surface) {
-        let seat = &self.seat; // luckily anvil only supports one seat anyway...
-        let pointer = seat.get_pointer().unwrap();
-        let Some(start_data) = pointer.grab_start_data() else {
+        // luckily anvil only supports one seat anyway...
+        let Some(start_data) = self.pointer.grab_start_data() else {
             return;
         };
 
@@ -359,7 +363,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         // If surface is maximized then unmaximize it
         if window.is_maximized() {
             window.set_maximized(false).unwrap();
-            let pos = pointer.current_location();
+            let pos = self.pointer.current_location();
             initial_window_location = (pos.x as i32, pos.y as i32).into();
             if let Some(old_geo) = window
                 .user_data()
@@ -381,6 +385,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             initial_window_location,
         };
 
+        let pointer = self.pointer.clone();
         pointer.set_grab(self, grab, SERIAL_COUNTER.next_serial(), Focus::Clear);
     }
 }

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -47,7 +47,7 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
         // of a xdg_surface has to be sent during the commit if
         // the surface is not already configured
         let window = WindowElement::Wayland(Window::new(surface));
-        place_new_window(&mut self.space, self.pointer_location, &window, true);
+        place_new_window(&mut self.space, self.pointer.current_location(), &window, true);
     }
 
     fn new_popup(&mut self, surface: PopupSurface, positioner: PositionerState) {

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -1053,7 +1053,7 @@ impl AnvilState<UdevData> {
         }
 
         // fixup window coordinates
-        crate::shell::fixup_positions(&mut self.space, self.pointer_location);
+        crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
     }
 
     fn device_removed(&mut self, node: DrmNode) {
@@ -1087,7 +1087,7 @@ impl AnvilState<UdevData> {
             debug!("Dropping device");
         }
 
-        crate::shell::fixup_positions(&mut self.space, self.pointer_location);
+        crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
     }
 
     fn frame_finish(&mut self, dev_id: DrmNode, crtc: crtc::Handle, metadata: &mut Option<DrmEventMetadata>) {
@@ -1351,7 +1351,7 @@ impl AnvilState<UdevData> {
             &self.space,
             &output,
             self.seat.input_method(),
-            self.pointer_location,
+            self.pointer.current_location(),
             &pointer_image,
             &mut self.backend_data.pointer_element,
             &self.dnd_icon,

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -223,7 +223,7 @@ pub fn run_winit() {
                     };
                     output.change_current_state(Some(mode), None, None, None);
                     output.set_preferred(mode);
-                    crate::shell::fixup_positions(&mut state.space, state.pointer_location);
+                    crate::shell::fixup_positions(&mut state.space, state.pointer.current_location());
                 }
                 WinitEvent::Input(event) => {
                     state.process_input_event_windowed(&display.handle(), event, OUTPUT_NAME)
@@ -283,7 +283,7 @@ pub fn run_winit() {
             } else {
                 (0, 0).into()
             };
-            let cursor_pos = state.pointer_location - cursor_hotspot.to_f64();
+            let cursor_pos = state.pointer.current_location() - cursor_hotspot.to_f64();
             let cursor_pos_scaled = cursor_pos.to_physical(scale).to_i32_round();
 
             #[cfg(feature = "debug")]

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -269,7 +269,7 @@ pub fn run_x11() {
                 output.delete_mode(output.current_mode().unwrap());
                 output.change_current_state(Some(data.state.backend_data.mode), None, None, None);
                 output.set_preferred(data.state.backend_data.mode);
-                crate::shell::fixup_positions(&mut data.state.space, data.state.pointer_location);
+                crate::shell::fixup_positions(&mut data.state.space, data.state.pointer.current_location());
 
                 data.state.backend_data.render = true;
             }
@@ -352,7 +352,7 @@ pub fn run_x11() {
             } else {
                 (0, 0).into()
             };
-            let cursor_pos = state.pointer_location - cursor_hotspot.to_f64();
+            let cursor_pos = state.pointer.current_location() - cursor_hotspot.to_f64();
             let cursor_pos_scaled = cursor_pos.to_physical(scale).to_i32_round();
 
             pointer_element.set_status(cursor_guard.clone());


### PR DESCRIPTION
If the pointer location is tracked within Smithay, it seems bad for to have a separate copy of it. Assuming we never want them to get out of sync.

Defining a method for `pointer_location()` is awkward since we can't split borrows in method calls, so the call has to be moved earlier, in some uses. But the code is slightly verbose to duplicate everywhere it's used. Maybe just store a copy of `PointerHandle` in the state, to avoid having to get it from the seat and unwrap?

More importantly, there are a few cases marked `XXX` where pointer events were not generated.
(https://github.com/Smithay/smithay/issues/1087 is one of them). Do we want to just generate pointer motion (but not relative motion) events in all of these cases?