### PR TITLE
xwm: Don't include override-redirect windows in `_NET_CLIENT_LIST*`

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1414,25 +1414,26 @@ fn handle_event<D: XwmHandler + 'static>(
                       x.mapped_window_id() == Some(n.window))
                 .cloned()
             {
-                xwm.client_list.push(surface.window_id());
-                xwm.client_list_stacking.push(surface.window_id());
-                conn.change_property32(
-                    PropMode::APPEND,
-                    xwm.screen.root,
-                    xwm.atoms._NET_CLIENT_LIST,
-                    AtomEnum::WINDOW,
-                    &[surface.window_id()],
-                )?;
-                conn.change_property32(
-                    PropMode::APPEND,
-                    xwm.screen.root,
-                    xwm.atoms._NET_CLIENT_LIST_STACKING,
-                    AtomEnum::WINDOW,
-                    &[surface.window_id()],
-                )?;
                 if surface.is_override_redirect() {
                     drop(_guard);
                     state.mapped_override_redirect_window(xwm_id, surface);
+                } else {
+                    xwm.client_list.push(surface.window_id());
+                    xwm.client_list_stacking.push(surface.window_id());
+                    conn.change_property32(
+                        PropMode::APPEND,
+                        xwm.screen.root,
+                        xwm.atoms._NET_CLIENT_LIST,
+                        AtomEnum::WINDOW,
+                        &[surface.window_id()],
+                    )?;
+                    conn.change_property32(
+                        PropMode::APPEND,
+                        xwm.screen.root,
+                        xwm.atoms._NET_CLIENT_LIST_STACKING,
+                        AtomEnum::WINDOW,
+                        &[surface.window_id()],
+                    )?;
                 }
             }
         }


### PR DESCRIPTION
This seems to match Mutter and i3. As defined in EWMH these contain "all X Windows managed by the Window Manager". I think override-redirect windows are not considered to be "managed by" the WM. A non-compositing X WM can simply ignore override-redirect windows entirely and leave them to the application and X server to deal with.

More importantly, this prevents `configure_window` from being called on override-redirect windows when updating stacking order. (Presumably an X WM should never send configure for override-redirect windows.) This fixes submenus in Gimp on cosmic-comp.