### PR TITLE
allocator/dumb: Pass correct pitch in `AsDmabuf::export`

### DIFF
--- a/src/backend/allocator/dumb.rs
+++ b/src/backend/allocator/dumb.rs
@@ -98,7 +98,7 @@ impl AsDmabuf for DumbBuffer {
     fn export(&self) -> Result<Dmabuf, Self::Error> {
         let fd = unsafe { OwnedFd::from_raw_fd(self.fd.buffer_to_prime_fd(self.handle.handle(), 0)?) };
         let mut builder = Dmabuf::builder(self.size(), self.format.code, DmabufFlags::empty());
-        builder.add_plane(fd, 0, 0, 0, Modifier::Linear);
+        builder.add_plane(fd, 0, 0, self.handle.pitch(), Modifier::Linear);
         builder.build().ok_or(drm::SystemError::InvalidFileDescriptor)
     }
 }


### PR DESCRIPTION
Without this I get `[EGL] 0x3002 (BAD_ACCESS) eglCreateImageKHR: invalid pitch`

Though using `buffer_test` with `--dump` with this still doesn't produce quite the right output.