### PR TITLE
Security Context protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,7 @@ jobs:
       - name: Build Documentation
         env: 
           RUSTDOCFLAGS: --cfg=docsrs
-        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.26.2 -p udev -p slog -p wayland-server -p wayland-backend -p wayland-protocols:0.30.1 -p winit -p x11rb
+        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.26.4 -p udev -p slog -p wayland-server -p wayland-backend -p wayland-protocols:0.30.1 -p winit -p x11rb
         
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tempfile = { version = "3.0", optional = true }
 thiserror = "1.0.25"
 udev = { version = "0.7", optional = true }
 wayland-egl = { version = "0.30.0", optional = true }
-wayland-protocols = { version = "0.30.0", features = ["unstable", "staging", "server"], optional = true }
+wayland-protocols = { version = "0.30.1", features = ["unstable", "staging", "server"], optional = true }
 wayland-protocols-wlr = { version = "0.1.0", features = ["server"], optional = true }
 wayland-protocols-misc = { version = "0.1.0", features = ["server"], optional = true }
 wayland-server = { version = "0.30.0", optional = true }

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -73,12 +73,12 @@
 #[cfg(all(feature = "wayland_frontend", feature = "backend_gbm"))]
 pub mod compositor;
 pub(crate) mod device;
-pub(self) mod error;
+mod error;
 #[cfg(feature = "backend_gbm")]
 pub mod gbm;
 pub mod node;
 
-pub(self) mod surface;
+mod surface;
 
 use crate::utils::DevPath;
 pub use device::{

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -463,7 +463,9 @@ impl DrmSurface {
                             .cast::<u8>()
                             .offset(fmt_mod_blob.modifiers_offset as isize)
                             as *const _;
+                        #[allow(clippy::unnecessary_cast)]
                         let formats_ptr = formats_ptr as *const u32;
+                        #[allow(clippy::unnecessary_cast)]
                         let modifiers_ptr = modifiers_ptr as *const drm_ffi::drm_format_modifier;
 
                         for i in 0..fmt_mod_blob.count_modifiers {

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -942,6 +942,7 @@ unsafe impl Send for EGLBufferReader {}
 #[cfg(feature = "use_system_lib")]
 impl EGLBufferReader {
     fn new(display: Arc<EGLDisplayHandle>, wayland: *mut wl_display) -> Self {
+        #[allow(clippy::arc_with_non_send_sync)]
         Self {
             display,
             wayland: Some(Arc::new(wayland)),

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -392,6 +392,7 @@ impl MemoryRenderBuffer {
         opaque_regions: Option<Vec<Rectangle<i32, Buffer>>>,
     ) -> Self {
         let inner = MemoryRenderBufferInner::new(format, size, scale, transform, opaque_regions);
+        #[allow(clippy::arc_with_non_send_sync)]
         MemoryRenderBuffer {
             id: Id::new(),
             inner: Arc::new(Mutex::new(inner)),
@@ -408,6 +409,7 @@ impl MemoryRenderBuffer {
         opaque_regions: Option<Vec<Rectangle<i32, Buffer>>>,
     ) -> Self {
         let inner = MemoryRenderBufferInner::from_memory(mem, format, size, scale, transform, opaque_regions);
+        #[allow(clippy::arc_with_non_send_sync)]
         MemoryRenderBuffer {
             id: Id::new(),
             inner: Arc::new(Mutex::new(inner)),

--- a/src/backend/vulkan/inner.rs
+++ b/src/backend/vulkan/inner.rs
@@ -39,7 +39,7 @@ impl Drop for InstanceInner {
                     .debug_utils
                     .destroy_debug_utils_messenger(debug.debug_messenger, None);
             }
-            Some(unsafe { Box::from_raw(debug.span_ptr as *mut tracing::Span) })
+            Some(unsafe { Box::from_raw(debug.span_ptr) })
         } else {
             None
         };

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -335,6 +335,7 @@ impl Instance {
         info!("Created new instance");
         info!("Enabled instance extensions: {:?}", inner.enabled_extensions);
 
+        #[allow(clippy::arc_with_non_send_sync)]
         Ok(Instance(Arc::new(inner)))
     }
 

--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -77,10 +77,7 @@ impl<Kind> Time<Kind> {
 
 impl<Kind> Clone for Time<Kind> {
     fn clone(&self) -> Self {
-        Self {
-            tp: self.tp,
-            _kind: self._kind,
-        }
+        *self
     }
 }
 

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -59,6 +59,7 @@ pub mod presentation;
 pub mod primary_selection;
 pub mod relative_pointer;
 pub mod seat;
+pub mod security_context;
 pub mod shell;
 pub mod shm;
 pub mod socket;

--- a/src/wayland/security_context/listener_source.rs
+++ b/src/wayland/security_context/listener_source.rs
@@ -1,0 +1,81 @@
+// TODO calloop source
+// - poll POLLHUP/POLLIN on close_fd
+// - poll for accept
+
+use calloop::{
+    generic::Generic, EventSource, Interest, Mode, Poll, PostAction, Readiness, Token, TokenFactory,
+};
+use std::{
+    io,
+    os::unix::{
+        io::OwnedFd,
+        net::{UnixListener, UnixStream},
+    },
+};
+
+/// Security context listener event source.
+///
+/// This implements [`EventSource`] and may be inserted into an event loop.
+#[derive(Debug)]
+pub struct SecurityContextListenerSource {
+    listen_fd: Generic<UnixListener>,
+    close_fd: Generic<OwnedFd>,
+}
+
+impl SecurityContextListenerSource {
+    pub(super) fn new(listen_fd: UnixListener, close_fd: OwnedFd) -> io::Result<Self> {
+        listen_fd.set_nonblocking(true)?;
+        let listen_fd = Generic::new(listen_fd, Interest::READ, Mode::Level);
+        // close_fd.set_nonblocking(true);
+        // XXX POLLHUP
+        let close_fd = Generic::new(close_fd, Interest::READ, Mode::Level);
+        Ok(Self { listen_fd, close_fd })
+    }
+}
+
+impl EventSource for SecurityContextListenerSource {
+    type Event = UnixStream;
+    type Metadata = ();
+    type Ret = ();
+    type Error = io::Error;
+
+    fn process_events<F: FnMut(Self::Event, &mut ())>(
+        &mut self,
+        readiness: Readiness,
+        token: Token,
+        mut callback: F,
+    ) -> io::Result<PostAction> {
+        self.listen_fd.process_events(readiness, token, |_, socket| {
+            loop {
+                match socket.accept() {
+                    Ok((stream, _)) => callback(stream, &mut ()),
+                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        break;
+                    }
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            }
+            Ok(PostAction::Continue)
+        })?;
+
+        self.listen_fd
+            .process_events(readiness, token, |_, _fd| Ok(PostAction::Remove))
+    }
+
+    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> calloop::Result<()> {
+        self.listen_fd.register(poll, token_factory)?;
+        self.close_fd.register(poll, token_factory)
+    }
+
+    fn reregister(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> calloop::Result<()> {
+        self.listen_fd.reregister(poll, token_factory)?;
+        self.close_fd.reregister(poll, token_factory)
+    }
+
+    fn unregister(&mut self, poll: &mut Poll) -> calloop::Result<()> {
+        self.close_fd.unregister(poll)?;
+        self.listen_fd.unregister(poll)
+    }
+}

--- a/src/wayland/security_context/mod.rs
+++ b/src/wayland/security_context/mod.rs
@@ -1,0 +1,241 @@
+//! Utilities for handling the security context protocol
+
+use std::{
+    os::unix::{io::OwnedFd, net::UnixListener},
+    sync::Mutex,
+};
+use tracing::error;
+use wayland_protocols::wp::security_context::v1::server::{
+    wp_security_context_manager_v1::{self, WpSecurityContextManagerV1},
+    wp_security_context_v1::{self, WpSecurityContextV1},
+};
+use wayland_server::{
+    backend::GlobalId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+};
+
+mod listener_source;
+pub use listener_source::SecurityContextListenerSource;
+
+const MANAGER_VERSION: u32 = 1;
+
+/// Handler for security context protocol
+pub trait SecurityContextHandler {
+    /// A client has created a security context. `source` is a callop `EventSource` that listens on
+    /// the socket and produces streams when clients connect. `context` has the metadata associated
+    /// with the security context.
+    fn context_created(&mut self, source: SecurityContextListenerSource, context: SecurityContext);
+}
+
+/// State of the [WpSecurityContextManagerV1] global
+#[derive(Debug)]
+pub struct SecurityContextState {
+    global: GlobalId,
+}
+
+/// User data for a `WpSecurityContextV1`
+#[derive(Debug)]
+pub struct SecurityContextUserData(Mutex<Option<SecurityContextBuilder>>);
+
+#[derive(Debug)]
+struct SecurityContextBuilder {
+    listen_fd: UnixListener,
+    close_fd: OwnedFd,
+    sandbox_engine: Option<String>,
+    app_id: Option<String>,
+    instance_id: Option<String>,
+}
+
+/// A security context associated with a listener created through security
+/// context protocol, and with clients connected through that listener.
+#[derive(Clone, Debug)]
+pub struct SecurityContext {
+    /// Name of the sandbox engine associated with the security context
+    pub sandbox_engine: Option<String>,
+    /// Opaque sandbox-specific ID for an application
+    pub app_id: Option<String>,
+    /// Opaque sandbox-specific ID for an instance of an application
+    pub instance_id: Option<String>,
+}
+
+impl SecurityContextState {
+    /// Register new [WpSecurityContextManagerV1] global
+    ///
+    /// Filter determines if what clients see the global. It *must* exclude clients
+    /// created through a security context for the protcol to be correct and secure.
+    pub fn new<D, F>(display: &DisplayHandle, filter: F) -> Self
+    where
+        D: GlobalDispatch<WpSecurityContextManagerV1, SecurityContextGlobalData>,
+        D: Dispatch<WpSecurityContextManagerV1, ()>,
+        D: Dispatch<WpSecurityContextV1, SecurityContextUserData>,
+        D: 'static,
+        F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
+    {
+        let global_data = SecurityContextGlobalData {
+            filter: Box::new(filter),
+        };
+        let global = display.create_global::<D, WpSecurityContextManagerV1, _>(MANAGER_VERSION, global_data);
+
+        Self { global }
+    }
+
+    /// [WpSecurityContextManagerV1] GlobalId getter
+    pub fn global(&self) -> GlobalId {
+        self.global.clone()
+    }
+}
+
+/// User data for a `WpSecurityContextManagerV1` global
+#[allow(missing_debug_implementations)]
+pub struct SecurityContextGlobalData {
+    filter: Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>,
+}
+
+impl<D> GlobalDispatch<WpSecurityContextManagerV1, SecurityContextGlobalData, D> for SecurityContextState
+where
+    D: GlobalDispatch<WpSecurityContextManagerV1, SecurityContextGlobalData>,
+    D: Dispatch<WpSecurityContextManagerV1, ()>,
+    D: 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _dh: &DisplayHandle,
+        _client: &Client,
+        resource: New<WpSecurityContextManagerV1>,
+        _global_data: &SecurityContextGlobalData,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(resource, ());
+    }
+
+    fn can_view(client: Client, global_data: &SecurityContextGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+impl<D> Dispatch<WpSecurityContextManagerV1, (), D> for SecurityContextState
+where
+    D: Dispatch<WpSecurityContextManagerV1, ()>,
+    D: Dispatch<WpSecurityContextV1, SecurityContextUserData>,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &wayland_server::Client,
+        _manager: &WpSecurityContextManagerV1,
+        request: wp_security_context_manager_v1::Request,
+        _data: &(),
+        _dh: &DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            wp_security_context_manager_v1::Request::CreateListener {
+                id,
+                listen_fd,
+                close_fd,
+            } => {
+                let data = SecurityContextUserData(Mutex::new(Some(SecurityContextBuilder {
+                    listen_fd: UnixListener::from(listen_fd),
+                    close_fd,
+                    sandbox_engine: None,
+                    app_id: None,
+                    instance_id: None,
+                })));
+                data_init.init(id, data);
+            }
+            wp_security_context_manager_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<WpSecurityContextV1, SecurityContextUserData, D> for SecurityContextState
+where
+    D: Dispatch<WpSecurityContextV1, SecurityContextUserData> + 'static,
+    D: SecurityContextHandler,
+{
+    fn request(
+        state: &mut D,
+        _client: &wayland_server::Client,
+        context: &WpSecurityContextV1,
+        request: wp_security_context_v1::Request,
+        data: &SecurityContextUserData,
+        _dh: &DisplayHandle,
+        _data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        let mut data = data.0.lock().unwrap();
+
+        if matches!(request, wp_security_context_v1::Request::Destroy) {
+            return;
+        }
+
+        let Some(builder) = &mut *data else {
+            context.post_error(
+                wp_security_context_v1::Error::AlreadyUsed,
+                "Security context already used",
+            );
+            return;
+        };
+
+        match request {
+            wp_security_context_v1::Request::SetSandboxEngine { name } => {
+                if builder.sandbox_engine.is_some() {
+                    context.post_error(
+                        wp_security_context_v1::Error::AlreadySet,
+                        "Security context already has a sandbox engine",
+                    );
+                }
+                builder.sandbox_engine = Some(name);
+            }
+            wp_security_context_v1::Request::SetAppId { app_id } => {
+                if builder.app_id.is_some() {
+                    context.post_error(
+                        wp_security_context_v1::Error::AlreadySet,
+                        "Security context already has an app id",
+                    );
+                }
+                builder.app_id = Some(app_id);
+            }
+            wp_security_context_v1::Request::SetInstanceId { instance_id } => {
+                if builder.instance_id.is_some() {
+                    context.post_error(
+                        wp_security_context_v1::Error::AlreadySet,
+                        "Security context already has an instance id",
+                    );
+                }
+                builder.instance_id = Some(instance_id);
+            }
+            wp_security_context_v1::Request::Commit => {
+                let builder = data.take().unwrap();
+                let listener_source = SecurityContextListenerSource::new(builder.listen_fd, builder.close_fd);
+                let security_context = SecurityContext {
+                    sandbox_engine: builder.sandbox_engine,
+                    app_id: builder.app_id,
+                    instance_id: builder.instance_id,
+                };
+                match listener_source {
+                    Ok(listener_source) => state.context_created(listener_source, security_context),
+                    Err(e) => {
+                        error!(error = ?e, "Failed to create security context listener source");
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Macro to delegate implementation of the security context protocol
+#[macro_export]
+macro_rules! delegate_security_context {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::security_context::v1::server::wp_security_context_manager_v1::WpSecurityContextManagerV1: $crate::wayland::security_context::SecurityContextGlobalData
+        ] => $crate::wayland::security_context::SecurityContextState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::security_context::v1::server::wp_security_context_manager_v1::WpSecurityContextManagerV1: ()
+        ] => $crate::wayland::security_context::SecurityContextState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::security_context::v1::server::wp_security_context_v1::WpSecurityContextV1: $crate::wayland::security_context::SecurityContextUserData
+        ] => $crate::wayland::security_context::SecurityContextState);
+    };
+}


### PR DESCRIPTION
The compositor should not expose the `wp_security_context_manager_v1` global to clients connected to a security context. Otherwise, I guess this would be up to the compositor to set its own restrictions.

This implementation is currently incomplete.