### PR TITLE
Fix clippy lints on Rust 1.72

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,7 @@ jobs:
       - name: Build Documentation
         env: 
           RUSTDOCFLAGS: --cfg=docsrs
-        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.26.2 -p udev -p slog -p wayland-server -p wayland-backend -p wayland-protocols:0.30.1 -p winit -p x11rb
+        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.26.4 -p udev -p slog -p wayland-server -p wayland-backend -p wayland-protocols:0.30.1 -p winit -p x11rb
         
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -73,12 +73,12 @@
 #[cfg(all(feature = "wayland_frontend", feature = "backend_gbm"))]
 pub mod compositor;
 pub(crate) mod device;
-pub(self) mod error;
+mod error;
 #[cfg(feature = "backend_gbm")]
 pub mod gbm;
 pub mod node;
 
-pub(self) mod surface;
+mod surface;
 
 use crate::utils::DevPath;
 pub use device::{

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -463,7 +463,9 @@ impl DrmSurface {
                             .cast::<u8>()
                             .offset(fmt_mod_blob.modifiers_offset as isize)
                             as *const _;
+                        #[allow(clippy::unnecessary_cast)]
                         let formats_ptr = formats_ptr as *const u32;
+                        #[allow(clippy::unnecessary_cast)]
                         let modifiers_ptr = modifiers_ptr as *const drm_ffi::drm_format_modifier;
 
                         for i in 0..fmt_mod_blob.count_modifiers {

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -942,6 +942,7 @@ unsafe impl Send for EGLBufferReader {}
 #[cfg(feature = "use_system_lib")]
 impl EGLBufferReader {
     fn new(display: Arc<EGLDisplayHandle>, wayland: *mut wl_display) -> Self {
+        #[allow(clippy::arc_with_non_send_sync)]
         Self {
             display,
             wayland: Some(Arc::new(wayland)),

--- a/src/backend/vulkan/inner.rs
+++ b/src/backend/vulkan/inner.rs
@@ -17,6 +17,11 @@ pub struct InstanceInner {
     pub enabled_extensions: Vec<&'static CStr>,
 }
 
+// SAFETY: Destruction is externally synchronized (`InstanceInner` owns the
+// `Instance`, and is held by a single thread when `Drop` is called).
+unsafe impl Send for InstanceInner {}
+unsafe impl Sync for InstanceInner {}
+
 pub struct DebugState {
     pub debug_utils: DebugUtils,
     pub debug_messenger: vk::DebugUtilsMessengerEXT,
@@ -39,7 +44,7 @@ impl Drop for InstanceInner {
                     .debug_utils
                     .destroy_debug_utils_messenger(debug.debug_messenger, None);
             }
-            Some(unsafe { Box::from_raw(debug.span_ptr as *mut tracing::Span) })
+            Some(unsafe { Box::from_raw(debug.span_ptr) })
         } else {
             None
         };

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -335,6 +335,7 @@ impl Instance {
         info!("Created new instance");
         info!("Enabled instance extensions: {:?}", inner.enabled_extensions);
 
+        #[allow(clippy::arc_with_non_send_sync)]
         Ok(Instance(Arc::new(inner)))
     }
 
@@ -383,10 +384,6 @@ impl Instance {
         &self.0.instance
     }
 }
-
-// SAFETY: Destruction is externally synchronized (using an internal Arc).
-unsafe impl Send for Instance {}
-unsafe impl Sync for Instance {}
 
 /// A Vulkan physical device.
 ///

--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -77,10 +77,7 @@ impl<Kind> Time<Kind> {
 
 impl<Kind> Clone for Time<Kind> {
     fn clone(&self) -> Self {
-        Self {
-            tp: self.tp,
-            _kind: self._kind,
-        }
+        *self
     }
 }
 


### PR DESCRIPTION
Should fix CI build.

I'm not sure about the use of `Arc` in `MemoryRenderBuffer`. It seems `MemoryRenderBufferInner` isn't `Send` because `Box<dyn Any>>` isn't. `Send` can be added there if a `Send` bound is added on `TextureId`. But then `GlesTexture` isn't `Send` so that presumably isn't desired in general.