### PR TITLE
input: Only forward modifiers in KeyboardInnerHandle::set_focus

### DIFF
--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -26,23 +26,6 @@ pub use modifiers_state::ModifiersState;
 mod xkb_config;
 pub use xkb_config::XkbConfig;
 
-const MODIFIER_KEYSYMS: [Keysym; 14] = [
-    xkb::KEY_Shift_L,
-    xkb::KEY_Shift_R,
-    xkb::KEY_Control_L,
-    xkb::KEY_Control_R,
-    xkb::KEY_Caps_Lock,
-    xkb::KEY_Shift_Lock,
-    xkb::KEY_Meta_L,
-    xkb::KEY_Meta_R,
-    xkb::KEY_Alt_L,
-    xkb::KEY_Alt_R,
-    xkb::KEY_Super_L,
-    xkb::KEY_Super_R,
-    xkb::KEY_Hyper_L,
-    xkb::KEY_Hyper_R,
-];
-
 /// Trait representing object that can receive keyboard interactions
 pub trait KeyboardTarget<D>: IsAlive + PartialEq + Clone + fmt::Debug + Send
 where
@@ -764,22 +747,7 @@ impl<'a, D: SeatHandler + 'static> KeyboardInnerHandle<'a, D> {
             // set new focus
             self.inner.focus = focus.map(|f| (f, serial));
             if let Some((focus, _)) = self.inner.focus.as_mut() {
-                let keys = self
-                    .inner
-                    .pressed_keys
-                    .iter()
-                    .filter_map(|keycode| {
-                        MODIFIER_KEYSYMS.contains(keycode).then(|| {
-                            KeysymHandle {
-                                // Offset the keycode by 8, as the evdev XKB rules reflect X's
-                                // broken keycode system, which starts at 8.
-                                keycode: keycode + 8,
-                                state: &self.inner.state,
-                                keymap: &self.inner.keymap,
-                            }
-                        })
-                    })
-                    .collect();
+                let keys = Vec::new();
                 focus.enter(self.seat, data, keys, serial);
                 focus.modifiers(self.seat, data, self.inner.mods_state, serial);
             };

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -26,6 +26,23 @@ pub use modifiers_state::ModifiersState;
 mod xkb_config;
 pub use xkb_config::XkbConfig;
 
+const MODIFIER_KEYSYMS: [Keysym; 14] = [
+    xkb::KEY_Shift_L,
+    xkb::KEY_Shift_R,
+    xkb::KEY_Control_L,
+    xkb::KEY_Control_R,
+    xkb::KEY_Caps_Lock,
+    xkb::KEY_Shift_Lock,
+    xkb::KEY_Meta_L,
+    xkb::KEY_Meta_R,
+    xkb::KEY_Alt_L,
+    xkb::KEY_Alt_R,
+    xkb::KEY_Super_L,
+    xkb::KEY_Super_R,
+    xkb::KEY_Hyper_L,
+    xkb::KEY_Hyper_R,
+];
+
 /// Trait representing object that can receive keyboard interactions
 pub trait KeyboardTarget<D>: IsAlive + PartialEq + Clone + fmt::Debug + Send
 where
@@ -751,14 +768,16 @@ impl<'a, D: SeatHandler + 'static> KeyboardInnerHandle<'a, D> {
                     .inner
                     .pressed_keys
                     .iter()
-                    .map(|keycode| {
-                        KeysymHandle {
-                            // Offset the keycode by 8, as the evdev XKB rules reflect X's
-                            // broken keycode system, which starts at 8.
-                            keycode: keycode + 8,
-                            state: &self.inner.state,
-                            keymap: &self.inner.keymap,
-                        }
+                    .filter_map(|keycode| {
+                        MODIFIER_KEYSYMS.contains(keycode).then(|| {
+                            KeysymHandle {
+                                // Offset the keycode by 8, as the evdev XKB rules reflect X's
+                                // broken keycode system, which starts at 8.
+                                keycode: keycode + 8,
+                                state: &self.inner.state,
+                                keymap: &self.inner.keymap,
+                            }
+                        })
                     })
                     .collect();
                 focus.enter(self.seat, data, keys, serial);

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -59,6 +59,7 @@ pub(crate) struct KbdInternal<D: SeatHandler> {
     pub(crate) focus: Option<(<D as SeatHandler>::KeyboardFocus, Serial)>,
     pending_focus: Option<<D as SeatHandler>::KeyboardFocus>,
     pub(crate) pressed_keys: HashSet<u32>,
+    pub(crate) forwarded_pressed_keys: HashSet<u32>,
     pub(crate) mods_state: ModifiersState,
     context: xkb::Context,
     pub(crate) keymap: xkb::Keymap,
@@ -75,6 +76,7 @@ impl<D: SeatHandler> fmt::Debug for KbdInternal<D> {
             .field("focus", &self.focus)
             .field("pending_focus", &self.pending_focus)
             .field("pressed_keys", &self.pressed_keys)
+            .field("forwarded_pressed_keys", &self.forwarded_pressed_keys)
             .field("mods_state", &self.mods_state)
             .field("keymap", &self.keymap.get_raw_ptr())
             .field("state", &self.state.get_raw_ptr())
@@ -103,6 +105,7 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
             focus: None,
             pending_focus: None,
             pressed_keys: HashSet::new(),
+            forwarded_pressed_keys: HashSet::new(),
             mods_state: ModifiersState::default(),
             context,
             keymap,
@@ -518,6 +521,15 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
             return Some(val);
         }
 
+        match state {
+            KeyState::Pressed => {
+                guard.forwarded_pressed_keys.insert(keycode);
+            }
+            KeyState::Released => {
+                guard.forwarded_pressed_keys.remove(&keycode);
+            }
+        };
+
         // forward to client if no keybinding is triggered
         let seat = self.get_seat(data);
         let modifiers = mods_changed.then_some(guard.mods_state);
@@ -747,7 +759,20 @@ impl<'a, D: SeatHandler + 'static> KeyboardInnerHandle<'a, D> {
             // set new focus
             self.inner.focus = focus.map(|f| (f, serial));
             if let Some((focus, _)) = self.inner.focus.as_mut() {
-                let keys = Vec::new();
+                let keys = self
+                    .inner
+                    .forwarded_pressed_keys
+                    .iter()
+                    .map(|keycode| {
+                        KeysymHandle {
+                            // Offset the keycode by 8, as the evdev XKB rules reflect X's
+                            // broken keycode system, which starts at 8.
+                            keycode: keycode + 8,
+                            state: &self.inner.state,
+                            keymap: &self.inner.keymap,
+                        }
+                    })
+                    .collect();
                 focus.enter(self.seat, data, keys, serial);
                 focus.modifiers(self.seat, data, self.inner.mods_state, serial);
             };


### PR DESCRIPTION
This should fix #1107.