### PR TITLE
xwm: Add XwmHandler::cursor_changed

### DIFF
--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -26,6 +26,23 @@ pub use modifiers_state::ModifiersState;
 mod xkb_config;
 pub use xkb_config::XkbConfig;
 
+const MODIFIER_KEYSYMS: [Keysym; 14] = [
+    xkb::KEY_Shift_L,
+    xkb::KEY_Shift_R,
+    xkb::KEY_Control_L,
+    xkb::KEY_Control_R,
+    xkb::KEY_Caps_Lock,
+    xkb::KEY_Shift_Lock,
+    xkb::KEY_Meta_L,
+    xkb::KEY_Meta_R,
+    xkb::KEY_Alt_L,
+    xkb::KEY_Alt_R,
+    xkb::KEY_Super_L,
+    xkb::KEY_Super_R,
+    xkb::KEY_Hyper_L,
+    xkb::KEY_Hyper_R,
+];
+
 /// Trait representing object that can receive keyboard interactions
 pub trait KeyboardTarget<D>: IsAlive + PartialEq + Clone + fmt::Debug + Send
 where
@@ -751,14 +768,16 @@ impl<'a, D: SeatHandler + 'static> KeyboardInnerHandle<'a, D> {
                     .inner
                     .pressed_keys
                     .iter()
-                    .map(|keycode| {
-                        KeysymHandle {
-                            // Offset the keycode by 8, as the evdev XKB rules reflect X's
-                            // broken keycode system, which starts at 8.
-                            keycode: keycode + 8,
-                            state: &self.inner.state,
-                            keymap: &self.inner.keymap,
-                        }
+                    .filter_map(|keycode| {
+                        MODIFIER_KEYSYMS.contains(keycode).then(|| {
+                            KeysymHandle {
+                                // Offset the keycode by 8, as the evdev XKB rules reflect X's
+                                // broken keycode system, which starts at 8.
+                                keycode: keycode + 8,
+                                state: &self.inner.state,
+                                keymap: &self.inner.keymap,
+                            }
+                        })
                     })
                     .collect();
                 focus.enter(self.seat, data, keys, serial);


### PR DESCRIPTION
An example of how this can be used is:
```rs
fn cursor_changed(&mut self, _xwm: XwmId, serial: u32) {
    self.active_cursor = Some(serial);
    if self.cursors.contains_key(&serial) {
        return;
    }
    let (width, height, xhot, yhot, data) =
        self.xwm.as_ref().unwrap().get_cursor_image().unwrap();
    let data: Vec<u8> = data.iter().flat_map(|val| val.to_le_bytes()).collect();
    let texture = self
        .renderer
        .import_memory(
            data.as_slice(),
            Fourcc::Argb8888,
            (width as i32, height as i32).into(),
            false,
        )
        .unwrap();
    self.cursors
        .insert(serial, (xhot as f64, yhot as f64, texture));
}
```