### PR TITLE
Touchpad gestures

### DIFF
--- a/anvil/src/focus.rs
+++ b/anvil/src/focus.rs
@@ -1,3 +1,7 @@
+use smithay::input::pointer::{
+    GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent,
+    GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent,
+};
 pub use smithay::{
     backend::input::KeyState,
     desktop::{LayerSurface, PopupKind},
@@ -111,6 +115,102 @@ impl<BackendData: Backend> PointerTarget<AnvilState<BackendData>> for FocusTarge
             FocusTarget::Window(w) => PointerTarget::leave(w, seat, data, serial, time),
             FocusTarget::LayerSurface(l) => PointerTarget::leave(l, seat, data, serial, time),
             FocusTarget::Popup(p) => PointerTarget::leave(p.wl_surface(), seat, data, serial, time),
+        }
+    }
+    fn gesture_swipe_begin(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        match self {
+            FocusTarget::Window(w) => PointerTarget::gesture_swipe_begin(w, seat, data, event),
+            FocusTarget::LayerSurface(l) => PointerTarget::gesture_swipe_begin(l, seat, data, event),
+            FocusTarget::Popup(p) => PointerTarget::gesture_swipe_begin(p.wl_surface(), seat, data, event),
+        }
+    }
+    fn gesture_swipe_update(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        match self {
+            FocusTarget::Window(w) => PointerTarget::gesture_swipe_update(w, seat, data, event),
+            FocusTarget::LayerSurface(l) => PointerTarget::gesture_swipe_update(l, seat, data, event),
+            FocusTarget::Popup(p) => PointerTarget::gesture_swipe_update(p.wl_surface(), seat, data, event),
+        }
+    }
+    fn gesture_swipe_end(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        match self {
+            FocusTarget::Window(w) => PointerTarget::gesture_swipe_end(w, seat, data, event),
+            FocusTarget::LayerSurface(l) => PointerTarget::gesture_swipe_end(l, seat, data, event),
+            FocusTarget::Popup(p) => PointerTarget::gesture_swipe_end(p.wl_surface(), seat, data, event),
+        }
+    }
+    fn gesture_pinch_begin(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        match self {
+            FocusTarget::Window(w) => PointerTarget::gesture_pinch_begin(w, seat, data, event),
+            FocusTarget::LayerSurface(l) => PointerTarget::gesture_pinch_begin(l, seat, data, event),
+            FocusTarget::Popup(p) => PointerTarget::gesture_pinch_begin(p.wl_surface(), seat, data, event),
+        }
+    }
+    fn gesture_pinch_update(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        match self {
+            FocusTarget::Window(w) => PointerTarget::gesture_pinch_update(w, seat, data, event),
+            FocusTarget::LayerSurface(l) => PointerTarget::gesture_pinch_update(l, seat, data, event),
+            FocusTarget::Popup(p) => PointerTarget::gesture_pinch_update(p.wl_surface(), seat, data, event),
+        }
+    }
+    fn gesture_pinch_end(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &GesturePinchEndEvent,
+    ) {
+        match self {
+            FocusTarget::Window(w) => PointerTarget::gesture_pinch_end(w, seat, data, event),
+            FocusTarget::LayerSurface(l) => PointerTarget::gesture_pinch_end(l, seat, data, event),
+            FocusTarget::Popup(p) => PointerTarget::gesture_pinch_end(p.wl_surface(), seat, data, event),
+        }
+    }
+    fn gesture_hold_begin(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        match self {
+            FocusTarget::Window(w) => PointerTarget::gesture_hold_begin(w, seat, data, event),
+            FocusTarget::LayerSurface(l) => PointerTarget::gesture_hold_begin(l, seat, data, event),
+            FocusTarget::Popup(p) => PointerTarget::gesture_hold_begin(p.wl_surface(), seat, data, event),
+        }
+    }
+    fn gesture_hold_end(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &GestureHoldEndEvent,
+    ) {
+        match self {
+            FocusTarget::Window(w) => PointerTarget::gesture_hold_end(w, seat, data, event),
+            FocusTarget::LayerSurface(l) => PointerTarget::gesture_hold_end(l, seat, data, event),
+            FocusTarget::Popup(p) => PointerTarget::gesture_hold_end(p.wl_surface(), seat, data, event),
         }
     }
 }

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -50,12 +50,17 @@ use crate::state::Backend;
 use smithay::{
     backend::{
         input::{
-            Device, DeviceCapability, PointerMotionEvent, ProximityState, TabletToolButtonEvent,
+            Device, DeviceCapability, GestureBeginEvent, GestureEndEvent, GesturePinchUpdateEvent as _,
+            GestureSwipeUpdateEvent as _, PointerMotionEvent, ProximityState, TabletToolButtonEvent,
             TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent, TabletToolTipState,
         },
         session::Session,
     },
-    input::pointer::RelativeMotionEvent,
+    input::pointer::{
+        GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent,
+        GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent,
+        RelativeMotionEvent,
+    },
     wayland::{
         seat::WaylandFocus,
         tablet_manager::{TabletDescriptor, TabletSeatTrait},
@@ -686,6 +691,14 @@ impl AnvilState<UdevData> {
             InputEvent::TabletToolProximity { event, .. } => self.on_tablet_tool_proximity::<B>(dh, event),
             InputEvent::TabletToolTip { event, .. } => self.on_tablet_tool_tip::<B>(event),
             InputEvent::TabletToolButton { event, .. } => self.on_tablet_button::<B>(event),
+            InputEvent::GestureSwipeBegin { event, .. } => self.on_gesture_swipe_begin::<B>(event),
+            InputEvent::GestureSwipeUpdate { event, .. } => self.on_gesture_swipe_update::<B>(event),
+            InputEvent::GestureSwipeEnd { event, .. } => self.on_gesture_swipe_end::<B>(event),
+            InputEvent::GesturePinchBegin { event, .. } => self.on_gesture_pinch_begin::<B>(event),
+            InputEvent::GesturePinchUpdate { event, .. } => self.on_gesture_pinch_update::<B>(event),
+            InputEvent::GesturePinchEnd { event, .. } => self.on_gesture_pinch_end::<B>(event),
+            InputEvent::GestureHoldBegin { event, .. } => self.on_gesture_hold_begin::<B>(event),
+            InputEvent::GestureHoldEnd { event, .. } => self.on_gesture_hold_end::<B>(event),
             InputEvent::DeviceAdded { device } => {
                 if device.has_capability(DeviceCapability::TabletTool) {
                     self.seat
@@ -925,6 +938,108 @@ impl AnvilState<UdevData> {
                 evt.time_msec(),
             );
         }
+    }
+
+    fn on_gesture_swipe_begin<B: InputBackend>(&mut self, evt: B::GestureSwipeBeginEvent) {
+        let serial = SCOUNTER.next_serial();
+        let pointer = self.pointer.clone();
+        pointer.gesture_swipe_begin(
+            self,
+            &GestureSwipeBeginEvent {
+                serial,
+                time: evt.time_msec(),
+                fingers: evt.fingers(),
+            },
+        );
+    }
+
+    fn on_gesture_swipe_update<B: InputBackend>(&mut self, evt: B::GestureSwipeUpdateEvent) {
+        let pointer = self.pointer.clone();
+        pointer.gesture_swipe_update(
+            self,
+            &GestureSwipeUpdateEvent {
+                time: evt.time_msec(),
+                delta: evt.delta(),
+            },
+        );
+    }
+
+    fn on_gesture_swipe_end<B: InputBackend>(&mut self, evt: B::GestureSwipeEndEvent) {
+        let serial = SCOUNTER.next_serial();
+        let pointer = self.pointer.clone();
+        pointer.gesture_swipe_end(
+            self,
+            &GestureSwipeEndEvent {
+                serial,
+                time: evt.time_msec(),
+                cancelled: evt.cancelled(),
+            },
+        );
+    }
+
+    fn on_gesture_pinch_begin<B: InputBackend>(&mut self, evt: B::GesturePinchBeginEvent) {
+        let serial = SCOUNTER.next_serial();
+        let pointer = self.pointer.clone();
+        pointer.gesture_pinch_begin(
+            self,
+            &GesturePinchBeginEvent {
+                serial,
+                time: evt.time_msec(),
+                fingers: evt.fingers(),
+            },
+        );
+    }
+
+    fn on_gesture_pinch_update<B: InputBackend>(&mut self, evt: B::GesturePinchUpdateEvent) {
+        let pointer = self.pointer.clone();
+        pointer.gesture_pinch_update(
+            self,
+            &GesturePinchUpdateEvent {
+                time: evt.time_msec(),
+                delta: evt.delta(),
+                scale: evt.scale(),
+                rotation: evt.rotation(),
+            },
+        );
+    }
+
+    fn on_gesture_pinch_end<B: InputBackend>(&mut self, evt: B::GesturePinchEndEvent) {
+        let serial = SCOUNTER.next_serial();
+        let pointer = self.pointer.clone();
+        pointer.gesture_pinch_end(
+            self,
+            &GesturePinchEndEvent {
+                serial,
+                time: evt.time_msec(),
+                cancelled: evt.cancelled(),
+            },
+        );
+    }
+
+    fn on_gesture_hold_begin<B: InputBackend>(&mut self, evt: B::GestureHoldBeginEvent) {
+        let serial = SCOUNTER.next_serial();
+        let pointer = self.pointer.clone();
+        pointer.gesture_hold_begin(
+            self,
+            &GestureHoldBeginEvent {
+                serial,
+                time: evt.time_msec(),
+                fingers: evt.fingers(),
+            },
+        );
+    }
+
+    fn on_gesture_hold_end<B: InputBackend>(&mut self, evt: B::GestureHoldEndEvent) {
+        let serial = SCOUNTER.next_serial();
+        let pointer = self.pointer.clone();
+        pointer.gesture_hold_end(
+            self,
+            &GestureHoldEndEvent {
+                serial,
+                time: evt.time_msec(),
+                cancelled: evt.cancelled(),
+            },
+        );
     }
 
     fn clamp_coords(&self, pos: Point<f64, Logical>) -> Point<f64, Logical> {

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -13,7 +13,11 @@ use smithay::{
     desktop::{space::SpaceElement, utils::OutputPresentationFeedback, Window, WindowSurfaceType},
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-        pointer::{AxisFrame, ButtonEvent, MotionEvent, PointerTarget, RelativeMotionEvent},
+        pointer::{
+            AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+            GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+            GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
+        },
         Seat,
     },
     output::Output,
@@ -323,6 +327,126 @@ impl<Backend: crate::state::Backend> PointerTarget<AnvilState<Backend>> for Wind
                 WindowElement::X11(w) => PointerTarget::leave(w, seat, data, serial, time),
             };
             state.ptr_entered_window = false;
+        }
+    }
+    fn gesture_swipe_begin(
+        &self,
+        seat: &Seat<AnvilState<Backend>>,
+        data: &mut AnvilState<Backend>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        let state = self.decoration_state();
+        if !state.is_ssd || state.ptr_entered_window {
+            match self {
+                WindowElement::Wayland(w) => PointerTarget::gesture_swipe_begin(w, seat, data, event),
+                #[cfg(feature = "xwayland")]
+                WindowElement::X11(w) => PointerTarget::gesture_swipe_begin(w, seat, data, event),
+            }
+        }
+    }
+    fn gesture_swipe_update(
+        &self,
+        seat: &Seat<AnvilState<Backend>>,
+        data: &mut AnvilState<Backend>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        let state = self.decoration_state();
+        if !state.is_ssd || state.ptr_entered_window {
+            match self {
+                WindowElement::Wayland(w) => PointerTarget::gesture_swipe_update(w, seat, data, event),
+                #[cfg(feature = "xwayland")]
+                WindowElement::X11(w) => PointerTarget::gesture_swipe_update(w, seat, data, event),
+            }
+        }
+    }
+    fn gesture_swipe_end(
+        &self,
+        seat: &Seat<AnvilState<Backend>>,
+        data: &mut AnvilState<Backend>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        let state = self.decoration_state();
+        if !state.is_ssd || state.ptr_entered_window {
+            match self {
+                WindowElement::Wayland(w) => PointerTarget::gesture_swipe_end(w, seat, data, event),
+                #[cfg(feature = "xwayland")]
+                WindowElement::X11(w) => PointerTarget::gesture_swipe_end(w, seat, data, event),
+            }
+        }
+    }
+    fn gesture_pinch_begin(
+        &self,
+        seat: &Seat<AnvilState<Backend>>,
+        data: &mut AnvilState<Backend>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        let state = self.decoration_state();
+        if !state.is_ssd || state.ptr_entered_window {
+            match self {
+                WindowElement::Wayland(w) => PointerTarget::gesture_pinch_begin(w, seat, data, event),
+                #[cfg(feature = "xwayland")]
+                WindowElement::X11(w) => PointerTarget::gesture_pinch_begin(w, seat, data, event),
+            }
+        }
+    }
+    fn gesture_pinch_update(
+        &self,
+        seat: &Seat<AnvilState<Backend>>,
+        data: &mut AnvilState<Backend>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        let state = self.decoration_state();
+        if !state.is_ssd || state.ptr_entered_window {
+            match self {
+                WindowElement::Wayland(w) => PointerTarget::gesture_pinch_update(w, seat, data, event),
+                #[cfg(feature = "xwayland")]
+                WindowElement::X11(w) => PointerTarget::gesture_pinch_update(w, seat, data, event),
+            }
+        }
+    }
+    fn gesture_pinch_end(
+        &self,
+        seat: &Seat<AnvilState<Backend>>,
+        data: &mut AnvilState<Backend>,
+        event: &GesturePinchEndEvent,
+    ) {
+        let state = self.decoration_state();
+        if !state.is_ssd || state.ptr_entered_window {
+            match self {
+                WindowElement::Wayland(w) => PointerTarget::gesture_pinch_end(w, seat, data, event),
+                #[cfg(feature = "xwayland")]
+                WindowElement::X11(w) => PointerTarget::gesture_pinch_end(w, seat, data, event),
+            }
+        }
+    }
+    fn gesture_hold_begin(
+        &self,
+        seat: &Seat<AnvilState<Backend>>,
+        data: &mut AnvilState<Backend>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        let state = self.decoration_state();
+        if !state.is_ssd || state.ptr_entered_window {
+            match self {
+                WindowElement::Wayland(w) => PointerTarget::gesture_hold_begin(w, seat, data, event),
+                #[cfg(feature = "xwayland")]
+                WindowElement::X11(w) => PointerTarget::gesture_hold_begin(w, seat, data, event),
+            }
+        }
+    }
+    fn gesture_hold_end(
+        &self,
+        seat: &Seat<AnvilState<Backend>>,
+        data: &mut AnvilState<Backend>,
+        event: &GestureHoldEndEvent,
+    ) {
+        let state = self.decoration_state();
+        if !state.is_ssd || state.ptr_entered_window {
+            match self {
+                WindowElement::Wayland(w) => PointerTarget::gesture_hold_end(w, seat, data, event),
+                #[cfg(feature = "xwayland")]
+                WindowElement::X11(w) => PointerTarget::gesture_hold_end(w, seat, data, event),
+            }
         }
     }
 }

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -3,7 +3,9 @@ use std::cell::RefCell;
 use smithay::{
     desktop::space::SpaceElement,
     input::pointer::{
-        AxisFrame, ButtonEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
+        AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+        GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+        GestureSwipeUpdateEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
         PointerInnerHandle, RelativeMotionEvent,
     },
     reexports::wayland_protocols::xdg::shell::server::xdg_toplevel,
@@ -73,6 +75,78 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for MoveSurfaceG
         details: AxisFrame,
     ) {
         handle.axis(data, details)
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event);
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event);
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event);
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event);
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event);
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event);
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event);
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event);
     }
 
     fn start_data(&self) -> &PointerGrabStartData<AnvilState<BackendData>> {
@@ -356,6 +430,78 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
         details: AxisFrame,
     ) {
         handle.axis(data, details)
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event);
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event);
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event);
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event);
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event);
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event);
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event);
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event);
     }
 
     fn start_data(&self) -> &PointerGrabStartData<AnvilState<BackendData>> {

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -11,10 +11,11 @@ use smithay::{
         default_primary_scanout_output_compare, utils::select_dmabuf_feedback, RenderElementStates,
     },
     delegate_compositor, delegate_data_device, delegate_fractional_scale, delegate_input_method_manager,
-    delegate_keyboard_shortcuts_inhibit, delegate_layer_shell, delegate_output, delegate_presentation,
-    delegate_primary_selection, delegate_relative_pointer, delegate_seat, delegate_security_context,
-    delegate_shm, delegate_tablet_manager, delegate_text_input_manager, delegate_viewporter,
-    delegate_virtual_keyboard_manager, delegate_xdg_activation, delegate_xdg_decoration, delegate_xdg_shell,
+    delegate_keyboard_shortcuts_inhibit, delegate_layer_shell, delegate_output, delegate_pointer_gestures,
+    delegate_presentation, delegate_primary_selection, delegate_relative_pointer, delegate_seat,
+    delegate_security_context, delegate_shm, delegate_tablet_manager, delegate_text_input_manager,
+    delegate_viewporter, delegate_virtual_keyboard_manager, delegate_xdg_activation, delegate_xdg_decoration,
+    delegate_xdg_shell,
     desktop::{
         utils::{
             surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
@@ -53,6 +54,7 @@ use smithay::{
             KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
         },
         output::OutputManagerState,
+        pointer_gestures::PointerGesturesState,
         presentation::PresentationState,
         primary_selection::{set_primary_focus, PrimarySelectionHandler, PrimarySelectionState},
         relative_pointer::RelativePointerManagerState,
@@ -296,6 +298,8 @@ impl<BackendData: Backend> KeyboardShortcutsInhibitHandler for AnvilState<Backen
 delegate_keyboard_shortcuts_inhibit!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 delegate_virtual_keyboard_manager!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+
+delegate_pointer_gestures!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 delegate_relative_pointer!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
@@ -544,6 +548,9 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
         if BackendData::HAS_RELATIVE_MOTION {
             RelativePointerManagerState::new::<Self>(&dh);
         }
+        if BackendData::HAS_GESTURES {
+            PointerGesturesState::new::<Self>(&dh);
+        }
         SecurityContextState::new::<Self, _>(&dh, |client| {
             client
                 .get_data::<ClientState>()
@@ -756,6 +763,7 @@ pub fn take_presentation_feedback(
 
 pub trait Backend {
     const HAS_RELATIVE_MOTION: bool = false;
+    const HAS_GESTURES: bool = false;
     fn seat_name(&self) -> String;
     fn reset_buffers(&mut self, output: &Output);
     fn early_import(&mut self, surface: &WlSurface);

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -168,6 +168,7 @@ delegate_dmabuf!(AnvilState<UdevData>);
 
 impl Backend for UdevData {
     const HAS_RELATIVE_MOTION: bool = true;
+    const HAS_GESTURES: bool = true;
 
     fn seat_name(&self) -> String {
         self.session.seat()

--- a/smallvil/src/grabs/move_grab.rs
+++ b/smallvil/src/grabs/move_grab.rs
@@ -2,7 +2,9 @@ use crate::Smallvil;
 use smithay::{
     desktop::Window,
     input::pointer::{
-        AxisFrame, ButtonEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
+        AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+        GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+        GestureSwipeUpdateEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
         PointerInnerHandle, RelativeMotionEvent,
     },
     reexports::wayland_server::protocol::wl_surface::WlSurface,
@@ -67,6 +69,78 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
         details: AxisFrame,
     ) {
         handle.axis(data, details)
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event)
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event)
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event)
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event)
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event)
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event)
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event)
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event)
     }
 
     fn start_data(&self) -> &PointerGrabStartData<Smallvil> {

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -2,7 +2,9 @@ use crate::Smallvil;
 use smithay::{
     desktop::{Space, Window},
     input::pointer::{
-        AxisFrame, ButtonEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
+        AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+        GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+        GestureSwipeUpdateEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
         PointerInnerHandle, RelativeMotionEvent,
     },
     reexports::{
@@ -176,6 +178,78 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
         details: AxisFrame,
     ) {
         handle.axis(data, details)
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event)
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event)
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event)
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event)
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event)
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event)
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event)
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut Smallvil,
+        handle: &mut PointerInnerHandle<'_, Smallvil>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event)
     }
 
     fn start_data(&self) -> &PointerGrabStartData<Smallvil> {

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -221,6 +221,11 @@ pub trait GestureSwipeUpdateEvent<B: InputBackend>: Event<B> {
 
     /// Delta of center on the y axis from last begin/update.
     fn delta_y(&self) -> f64;
+
+    /// Delta between the last and new gesture center.
+    fn delta(&self) -> Point<f64, Logical> {
+        (self.delta_x(), self.delta_y()).into()
+    }
 }
 
 impl<B: InputBackend> GestureSwipeUpdateEvent<B> for UnusedEvent {
@@ -256,6 +261,11 @@ pub trait GesturePinchUpdateEvent<B: InputBackend>: Event<B> {
 
     /// Relative angle in degrees from last begin/update.
     fn rotation(&self) -> f64;
+
+    /// Delta between the last and new gesture center.
+    fn delta(&self) -> Point<f64, Logical> {
+        (self.delta_x(), self.delta_y()).into()
+    }
 }
 
 impl<B: InputBackend> GesturePinchUpdateEvent<B> for UnusedEvent {

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -3,7 +3,11 @@ use crate::{
     desktop::{utils::*, PopupManager},
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-        pointer::{AxisFrame, ButtonEvent, MotionEvent, PointerTarget, RelativeMotionEvent},
+        pointer::{
+            AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+            GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+            GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
+        },
         Seat, SeatHandler,
     },
     output::{Output, WeakOutput},
@@ -756,6 +760,54 @@ impl<D: SeatHandler + 'static> PointerTarget<D> for LayerSurface {
     fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {
         if let Some(surface) = self.0.focused_surface.lock().unwrap().take() {
             PointerTarget::<D>::leave(&surface, seat, data, serial, time)
+        }
+    }
+
+    fn gesture_swipe_begin(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeBeginEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_swipe_begin(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_swipe_update(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeUpdateEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_swipe_update(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_swipe_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeEndEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_swipe_end(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_pinch_begin(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchBeginEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_pinch_begin(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_pinch_update(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchUpdateEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_pinch_update(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_pinch_end(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchEndEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_pinch_end(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_hold_begin(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldBeginEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_hold_begin(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_hold_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldEndEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_hold_end(surface, seat, data, event)
         }
     }
 }

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -13,7 +13,9 @@ use crate::{
             ModifiersState,
         },
         pointer::{
-            AxisFrame, ButtonEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
+            AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+            GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+            GestureSwipeUpdateEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
             PointerInnerHandle, RelativeMotionEvent,
         },
         SeatHandler,
@@ -619,6 +621,78 @@ where
 
     fn axis(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, details: AxisFrame) {
         handle.axis(data, details);
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event);
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event);
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event);
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event);
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event);
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event);
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event);
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event);
     }
 
     fn start_data(&self) -> &PointerGrabStartData<D> {

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -3,7 +3,11 @@ use crate::{
     desktop::{space::RenderZindex, utils::*, PopupManager},
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-        pointer::{AxisFrame, ButtonEvent, MotionEvent, PointerTarget, RelativeMotionEvent},
+        pointer::{
+            AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+            GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+            GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
+        },
         Seat, SeatHandler,
     },
     output::Output,
@@ -321,6 +325,54 @@ impl<D: SeatHandler + 'static> PointerTarget<D> for Window {
     fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {
         if let Some(surface) = self.0.focused_surface.lock().unwrap().take() {
             PointerTarget::<D>::leave(&surface, seat, data, serial, time)
+        }
+    }
+
+    fn gesture_swipe_begin(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeBeginEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_swipe_begin(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_swipe_update(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeUpdateEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_swipe_update(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_swipe_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeEndEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_swipe_end(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_pinch_begin(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchBeginEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_pinch_begin(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_pinch_update(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchUpdateEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_pinch_update(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_pinch_end(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchEndEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_pinch_end(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_hold_begin(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldBeginEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_hold_begin(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_hold_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldEndEvent) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::gesture_hold_end(surface, seat, data, event)
         }
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -19,7 +19,10 @@
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
 //! # use smithay::backend::input::KeyState;
 //! # use smithay::input::{
-//! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent},
+//! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
+//! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
+//! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
+//! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
@@ -48,6 +51,14 @@
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
 //! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
+//! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
+//! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
+//! #   fn gesture_pinch_begin(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchBeginEvent) {}
+//! #   fn gesture_pinch_update(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchUpdateEvent) {}
+//! #   fn gesture_pinch_end(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchEndEvent) {}
+//! #   fn gesture_hold_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldBeginEvent) {}
+//! #   fn gesture_hold_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldEndEvent) {}
 //! # }
 //! # impl KeyboardTarget<State> for Target {
 //! #   fn enter(&self, seat: &Seat<State>, data: &mut State, keys: Vec<KeysymHandle<'_>>, serial: Serial) {}
@@ -296,7 +307,10 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
     /// # use smithay::backend::input::KeyState;
     /// # use smithay::input::{
-    /// #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent},
+    /// #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
+    /// #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
+    /// #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
+    /// #             GestureHoldBeginEvent, GestureHoldEndEvent},
     /// #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
     /// # };
     /// # use smithay::utils::{IsAlive, Serial};
@@ -313,6 +327,14 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
     /// #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
     /// #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+    /// #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
+    /// #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
+    /// #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
+    /// #   fn gesture_pinch_begin(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchBeginEvent) {}
+    /// #   fn gesture_pinch_update(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchUpdateEvent) {}
+    /// #   fn gesture_pinch_end(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchEndEvent) {}
+    /// #   fn gesture_hold_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldBeginEvent) {}
+    /// #   fn gesture_hold_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldEndEvent) {}
     /// # }
     /// # impl KeyboardTarget<State> for Target {
     /// #   fn enter(&self, seat: &Seat<State>, data: &mut State, keys: Vec<KeysymHandle<'_>>, serial: Serial) {}
@@ -394,7 +416,10 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// # use smithay::input::{Seat, SeatState, SeatHandler, keyboard::XkbConfig, pointer::CursorImageStatus};
     /// # use smithay::backend::input::KeyState;
     /// # use smithay::input::{
-    /// #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent},
+    /// #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
+    /// #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
+    /// #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
+    /// #             GestureHoldBeginEvent, GestureHoldEndEvent},
     /// #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
     /// # };
     /// # use smithay::utils::{IsAlive, Serial};
@@ -411,6 +436,14 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
     /// #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
     /// #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+    /// #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
+    /// #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
+    /// #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
+    /// #   fn gesture_pinch_begin(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchBeginEvent) {}
+    /// #   fn gesture_pinch_update(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchUpdateEvent) {}
+    /// #   fn gesture_pinch_end(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchEndEvent) {}
+    /// #   fn gesture_hold_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldBeginEvent) {}
+    /// #   fn gesture_hold_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldEndEvent) {}
     /// # }
     /// # impl KeyboardTarget<State> for Target {
     /// #   fn enter(&self, seat: &Seat<State>, data: &mut State, keys: Vec<KeysymHandle<'_>>, serial: Serial) {}

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -7,7 +7,11 @@ use crate::{
     utils::{Logical, Point},
 };
 
-use super::{AxisFrame, ButtonEvent, Focus, MotionEvent, PointerInnerHandle, RelativeMotionEvent};
+use super::{
+    AxisFrame, ButtonEvent, Focus, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+    GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+    GestureSwipeUpdateEvent, MotionEvent, PointerInnerHandle, RelativeMotionEvent,
+};
 
 /// A trait to implement a pointer grab
 ///
@@ -69,6 +73,94 @@ pub trait PointerGrab<D: SeatHandler>: Send {
     /// You generally will want to invoke `PointerInnerHandle::axis()` as part of your processing. If you
     /// don't, the rest of the compositor will behave as if the axis event never occurred.
     fn axis(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, details: AxisFrame);
+    /// A pointer of a given seat started a swipe gesture
+    ///
+    /// This method allows you attach additional behavior to a swipe gesture begin event, possibly altering it.
+    /// You generally will want to invoke `PointerInnerHandle::gesture_swipe_begin()` as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the event never occurred.
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeBeginEvent,
+    );
+    /// A pointer of a given seat updated a swipe gesture
+    ///
+    /// This method allows you attach additional behavior to a swipe gesture update event, possibly altering it.
+    /// You generally will want to invoke `PointerInnerHandle::gesture_swipe_update()` as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the event never occurred.
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeUpdateEvent,
+    );
+    /// A pointer of a given seat ended a swipe gesture
+    ///
+    /// This method allows you attach additional behavior to a swipe gesture end event, possibly altering it.
+    /// You generally will want to invoke `PointerInnerHandle::gesture_swipe_end()` as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the event never occurred.
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeEndEvent,
+    );
+    /// A pointer of a given seat started a pinch gesture
+    ///
+    /// This method allows you attach additional behavior to a pinch gesture begin event, possibly altering it.
+    /// You generally will want to invoke `PointerInnerHandle::gesture_pinch_begin()` as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the event never occurred.
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchBeginEvent,
+    );
+    /// A pointer of a given seat updated a pinch gesture
+    ///
+    /// This method allows you attach additional behavior to a pinch gesture update event, possibly altering it.
+    /// You generally will want to invoke `PointerInnerHandle::gesture_pinch_update()` as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the event never occurred.
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchUpdateEvent,
+    );
+    /// A pointer of a given seat ended a pinch gesture
+    ///
+    /// This method allows you attach additional behavior to a pinch gesture end event, possibly altering it.
+    /// You generally will want to invoke `PointerInnerHandle::gesture_pinch_end()` as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the event never occurred.
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchEndEvent,
+    );
+    /// A pointer of a given seat started a hold gesture
+    ///
+    /// This method allows you attach additional behavior to a hold gesture begin event, possibly altering it.
+    /// You generally will want to invoke `PointerInnerHandle::gesture_hold_begin()` as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the event never occurred.
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldBeginEvent,
+    );
+    /// A pointer of a given seat ended a hold gesture
+    ///
+    /// This method allows you attach additional behavior to a hold gesture end event, possibly altering it.
+    /// You generally will want to invoke `PointerInnerHandle::gesture_hold_end()` as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the event never occurred.
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldEndEvent,
+    );
     /// The data about the event that started the grab.
     fn start_data(&self) -> &GrabStartData<D>;
 }
@@ -168,6 +260,78 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
         handle.axis(data, details);
     }
 
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event);
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event);
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event);
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event);
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event);
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event);
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event);
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event);
+    }
+
     fn start_data(&self) -> &GrabStartData<D> {
         unreachable!()
     }
@@ -213,6 +377,78 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
 
     fn axis(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, details: AxisFrame) {
         handle.axis(data, details);
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event);
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event);
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event);
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event);
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event);
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event);
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event);
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event);
     }
 
     fn start_data(&self) -> &GrabStartData<D> {

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -37,6 +37,12 @@ pub struct PointerHandle<D: SeatHandler> {
     pub(crate) known_pointers: Arc<Mutex<Vec<wayland_server::protocol::wl_pointer::WlPointer>>>,
     #[cfg(feature = "wayland_frontend")]
     pub(crate) known_relative_pointers: Arc<Mutex<Vec<wayland_protocols::wp::relative_pointer::zv1::server::zwp_relative_pointer_v1::ZwpRelativePointerV1>>>,
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) known_swipe_gestures: Arc<Mutex<Vec<wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gesture_swipe_v1::ZwpPointerGestureSwipeV1>>>,
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) known_pinch_gestures: Arc<Mutex<Vec<wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gesture_pinch_v1::ZwpPointerGesturePinchV1>>>,
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) known_hold_gestures: Arc<Mutex<Vec<wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gesture_hold_v1::ZwpPointerGestureHoldV1>>>,
     pub(crate) span: tracing::Span,
 }
 
@@ -57,6 +63,9 @@ impl<D: SeatHandler> fmt::Debug for PointerHandle<D> {
             .field("last_enter", &self.last_enter)
             .field("known_pointers", &self.known_pointers)
             .field("known_relative_pointers", &self.known_relative_pointers)
+            .field("known_swipe_gestures", &self.known_swipe_gestures)
+            .field("known_pinch_gestures", &self.known_pinch_gestures)
+            .field("known_hold_gestures", &self.known_hold_gestures)
             .finish()
     }
 }
@@ -71,6 +80,12 @@ impl<D: SeatHandler> Clone for PointerHandle<D> {
             known_pointers: self.known_pointers.clone(),
             #[cfg(feature = "wayland_frontend")]
             known_relative_pointers: self.known_relative_pointers.clone(),
+            #[cfg(feature = "wayland_frontend")]
+            known_swipe_gestures: self.known_swipe_gestures.clone(),
+            #[cfg(feature = "wayland_frontend")]
+            known_pinch_gestures: self.known_pinch_gestures.clone(),
+            #[cfg(feature = "wayland_frontend")]
+            known_hold_gestures: self.known_hold_gestures.clone(),
             span: self.span.clone(),
         }
     }
@@ -111,6 +126,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
             known_pointers: Arc::new(Mutex::new(Vec::new())),
             #[cfg(feature = "wayland_frontend")]
             known_relative_pointers: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(feature = "wayland_frontend")]
+            known_swipe_gestures: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(feature = "wayland_frontend")]
+            known_pinch_gestures: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(feature = "wayland_frontend")]
+            known_hold_gestures: Arc::new(Mutex::new(Vec::new())),
             span: info_span!("input_pointer"),
         }
     }

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -112,6 +112,22 @@ where
     fn button(&self, seat: &Seat<D>, data: &mut D, event: &ButtonEvent);
     /// A pointer of a given seat scrolled on an axis
     fn axis(&self, seat: &Seat<D>, data: &mut D, frame: AxisFrame);
+    /// A pointer of a given seat started a swipe gesture
+    fn gesture_swipe_begin(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeBeginEvent);
+    /// A pointer of a given seat updated a swipe gesture
+    fn gesture_swipe_update(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeUpdateEvent);
+    /// A pointer of a given seat ended a swipe gesture
+    fn gesture_swipe_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeEndEvent);
+    /// A pointer of a given seat started a pinch gesture
+    fn gesture_pinch_begin(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchBeginEvent);
+    /// A pointer of a given seat updated a pinch gesture
+    fn gesture_pinch_update(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchUpdateEvent);
+    /// A pointer of a given seat ended a pinch gesture
+    fn gesture_pinch_end(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchEndEvent);
+    /// A pointer of a given seat started a hold gesture
+    fn gesture_hold_begin(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldBeginEvent);
+    /// A pointer of a given seat ended a hold gesture
+    fn gesture_hold_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldEndEvent);
     /// A pointer of a given seat left this handler
     fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32);
 }
@@ -259,6 +275,134 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
         });
     }
 
+    /// Notify about swipe gesture begin
+    ///
+    /// This will internally send the appropriate event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the relative pointer protocol.
+    #[instrument(level = "trace", parent = &self.span, skip(self, data))]
+    pub fn gesture_swipe_begin(&self, data: &mut D, event: &GestureSwipeBeginEvent) {
+        let seat = self.get_seat(data);
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(&seat, move |mut handle, grab| {
+                grab.gesture_swipe_begin(data, &mut handle, event);
+            });
+    }
+
+    /// Notify about swipe gesture update
+    ///
+    /// This will internally send the appropriate event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the relative pointer protocol.
+    #[instrument(level = "trace", parent = &self.span, skip(self, data))]
+    pub fn gesture_swipe_update(&self, data: &mut D, event: &GestureSwipeUpdateEvent) {
+        let seat = self.get_seat(data);
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(&seat, move |mut handle, grab| {
+                grab.gesture_swipe_update(data, &mut handle, event);
+            });
+    }
+
+    /// Notify about swipe gesture end
+    ///
+    /// This will internally send the appropriate event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the relative pointer protocol.
+    #[instrument(level = "trace", parent = &self.span, skip(self, data))]
+    pub fn gesture_swipe_end(&self, data: &mut D, event: &GestureSwipeEndEvent) {
+        let seat = self.get_seat(data);
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(&seat, move |mut handle, grab| {
+                grab.gesture_swipe_end(data, &mut handle, event);
+            });
+    }
+
+    /// Notify about pinch gesture begin
+    ///
+    /// This will internally send the appropriate event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the relative pointer protocol.
+    #[instrument(level = "trace", parent = &self.span, skip(self, data))]
+    pub fn gesture_pinch_begin(&self, data: &mut D, event: &GesturePinchBeginEvent) {
+        let seat = self.get_seat(data);
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(&seat, move |mut handle, grab| {
+                grab.gesture_pinch_begin(data, &mut handle, event);
+            });
+    }
+
+    /// Notify about pinch gesture update
+    ///
+    /// This will internally send the appropriate event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the relative pointer protocol.
+    #[instrument(level = "trace", parent = &self.span, skip(self, data))]
+    pub fn gesture_pinch_update(&self, data: &mut D, event: &GesturePinchUpdateEvent) {
+        let seat = self.get_seat(data);
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(&seat, move |mut handle, grab| {
+                grab.gesture_pinch_update(data, &mut handle, event);
+            });
+    }
+
+    /// Notify about pinch gesture end
+    ///
+    /// This will internally send the appropriate event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the relative pointer protocol.
+    #[instrument(level = "trace", parent = &self.span, skip(self, data))]
+    pub fn gesture_pinch_end(&self, data: &mut D, event: &GesturePinchEndEvent) {
+        let seat = self.get_seat(data);
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(&seat, move |mut handle, grab| {
+                grab.gesture_pinch_end(data, &mut handle, event);
+            });
+    }
+
+    /// Notify about hold gesture begin
+    ///
+    /// This will internally send the appropriate event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the relative pointer protocol.
+    #[instrument(level = "trace", parent = &self.span, skip(self, data))]
+    pub fn gesture_hold_begin(&self, data: &mut D, event: &GestureHoldBeginEvent) {
+        let seat = self.get_seat(data);
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(&seat, move |mut handle, grab| {
+                grab.gesture_hold_begin(data, &mut handle, event);
+            });
+    }
+
+    /// Notify about hold gesture end
+    ///
+    /// This will internally send the appropriate event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the relative pointer protocol.
+    #[instrument(level = "trace", parent = &self.span, skip(self, data))]
+    pub fn gesture_hold_end(&self, data: &mut D, event: &GestureHoldEndEvent) {
+        let seat = self.get_seat(data);
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(&seat, move |mut handle, grab| {
+                grab.gesture_hold_end(data, &mut handle, event);
+            });
+    }
+
     /// Access the current location of this pointer in the global space
     pub fn current_location(&self) -> Point<f64, Logical> {
         self.inner.lock().unwrap().location
@@ -393,6 +537,78 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
         if let Some((focused, _)) = self.inner.focus.as_mut() {
             focused.axis(self.seat, data, details);
         }
+    }
+
+    /// Notify about swipe gesture begin
+    ///
+    /// This will internally send the appropriate button event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the pointer gestures protocol.
+    pub fn gesture_swipe_begin(&mut self, data: &mut D, event: &GestureSwipeBeginEvent) {
+        self.inner.gesture_swipe_begin(data, self.seat, event);
+    }
+
+    /// Notify about swipe gesture update
+    ///
+    /// This will internally send the appropriate button event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the pointer gestures protocol.
+    pub fn gesture_swipe_update(&mut self, data: &mut D, event: &GestureSwipeUpdateEvent) {
+        self.inner.gesture_swipe_update(data, self.seat, event);
+    }
+
+    /// Notify about swipe gesture end
+    ///
+    /// This will internally send the appropriate button event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the pointer gestures protocol.
+    pub fn gesture_swipe_end(&mut self, data: &mut D, event: &GestureSwipeEndEvent) {
+        self.inner.gesture_swipe_end(data, self.seat, event);
+    }
+
+    /// Notify about pinch gesture begin
+    ///
+    /// This will internally send the appropriate button event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the pointer gestures protocol.
+    pub fn gesture_pinch_begin(&mut self, data: &mut D, event: &GesturePinchBeginEvent) {
+        self.inner.gesture_pinch_begin(data, self.seat, event);
+    }
+
+    /// Notify about pinch gesture update
+    ///
+    /// This will internally send the appropriate button event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the pointer gestures protocol.
+    pub fn gesture_pinch_update(&mut self, data: &mut D, event: &GesturePinchUpdateEvent) {
+        self.inner.gesture_pinch_update(data, self.seat, event);
+    }
+
+    /// Notify about pinch gesture end
+    ///
+    /// This will internally send the appropriate button event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the pointer gestures protocol.
+    pub fn gesture_pinch_end(&mut self, data: &mut D, event: &GesturePinchEndEvent) {
+        self.inner.gesture_pinch_end(data, self.seat, event);
+    }
+
+    /// Notify about hold gesture begin
+    ///
+    /// This will internally send the appropriate button event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the pointer gestures protocol.
+    pub fn gesture_hold_begin(&mut self, data: &mut D, event: &GestureHoldBeginEvent) {
+        self.inner.gesture_hold_begin(data, self.seat, event);
+    }
+
+    /// Notify about hold gesture end
+    ///
+    /// This will internally send the appropriate button event to the client
+    /// objects matching with the currently focused surface, if the client uses
+    /// the pointer gestures protocol.
+    pub fn gesture_hold_end(&mut self, data: &mut D, event: &GestureHoldEndEvent) {
+        self.inner.gesture_hold_end(data, self.seat, event);
     }
 }
 
@@ -529,6 +745,54 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
         }
     }
 
+    fn gesture_swipe_begin(&mut self, data: &mut D, seat: &Seat<D>, event: &GestureSwipeBeginEvent) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.gesture_swipe_begin(seat, data, event);
+        }
+    }
+
+    fn gesture_swipe_update(&mut self, data: &mut D, seat: &Seat<D>, event: &GestureSwipeUpdateEvent) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.gesture_swipe_update(seat, data, event);
+        }
+    }
+
+    fn gesture_swipe_end(&mut self, data: &mut D, seat: &Seat<D>, event: &GestureSwipeEndEvent) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.gesture_swipe_end(seat, data, event);
+        }
+    }
+
+    fn gesture_pinch_begin(&mut self, data: &mut D, seat: &Seat<D>, event: &GesturePinchBeginEvent) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.gesture_pinch_begin(seat, data, event);
+        }
+    }
+
+    fn gesture_pinch_update(&mut self, data: &mut D, seat: &Seat<D>, event: &GesturePinchUpdateEvent) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.gesture_pinch_update(seat, data, event);
+        }
+    }
+
+    fn gesture_pinch_end(&mut self, data: &mut D, seat: &Seat<D>, event: &GesturePinchEndEvent) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.gesture_pinch_end(seat, data, event);
+        }
+    }
+
+    fn gesture_hold_begin(&mut self, data: &mut D, seat: &Seat<D>, event: &GestureHoldBeginEvent) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.gesture_hold_begin(seat, data, event);
+        }
+    }
+
+    fn gesture_hold_end(&mut self, data: &mut D, seat: &Seat<D>, event: &GestureHoldEndEvent) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.gesture_hold_end(seat, data, event);
+        }
+    }
+
     fn with_grab<F>(&mut self, seat: &Seat<D>, f: F)
     where
         F: FnOnce(PointerInnerHandle<'_, D>, &mut dyn PointerGrab<D>),
@@ -637,6 +901,94 @@ pub struct AxisFrame {
     ///
     /// Only useful in conjunction of AxisSource::Finger events
     pub stop: (bool, bool),
+}
+
+/// Gesture swipe begin event
+#[derive(Debug, Clone)]
+pub struct GestureSwipeBeginEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+    /// Number of fingers of the event
+    pub fingers: u32,
+}
+
+/// Gesture swipe update event
+#[derive(Debug, Clone)]
+pub struct GestureSwipeUpdateEvent {
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+    /// Offset of the logical center of the gesture relative to the previous event
+    pub delta: Point<f64, Logical>,
+}
+
+/// Gesture swipe end event
+#[derive(Debug, Clone)]
+pub struct GestureSwipeEndEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+    /// Whether the gesture was cancelled
+    pub cancelled: bool,
+}
+
+/// Gesture pinch begin event
+#[derive(Debug, Clone)]
+pub struct GesturePinchBeginEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+    /// Number of fingers of the event
+    pub fingers: u32,
+}
+
+/// Gesture pinch update event
+#[derive(Debug, Clone)]
+pub struct GesturePinchUpdateEvent {
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+    /// Offset of the logical center of the gesture relative to the previous event
+    pub delta: Point<f64, Logical>,
+    /// Absolute scale compared to the begin event
+    pub scale: f64,
+    /// Relative angle in degrees clockwise compared to the previous event
+    pub rotation: f64,
+}
+
+/// Gesture pinch end event
+#[derive(Debug, Clone)]
+pub struct GesturePinchEndEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+    /// Whether the gesture was cancelled
+    pub cancelled: bool,
+}
+
+/// Gesture hold begin event
+#[derive(Debug, Clone)]
+pub struct GestureHoldBeginEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+    /// Number of fingers of the event
+    pub fingers: u32,
+}
+
+/// Gesture hold end event
+#[derive(Debug, Clone)]
+pub struct GestureHoldEndEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+    /// Whether the gesture was cancelled
+    pub cancelled: bool,
 }
 
 impl AxisFrame {

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -18,7 +18,9 @@ use wayland_server::{
 use crate::{
     input::{
         pointer::{
-            AxisFrame, ButtonEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
+            AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+            GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+            GestureSwipeUpdateEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
             PointerInnerHandle, RelativeMotionEvent,
         },
         Seat, SeatHandler,
@@ -251,6 +253,78 @@ where
     fn axis(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, details: AxisFrame) {
         // we just forward the axis events as is
         handle.axis(data, details);
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event);
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event);
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event);
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event);
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event);
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event);
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event);
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event);
     }
 
     fn start_data(&self) -> &PointerGrabStartData<D> {

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -17,7 +17,9 @@ use wayland_server::{
 
 use crate::input::{
     pointer::{
-        AxisFrame, ButtonEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
+        AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+        GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+        GestureSwipeUpdateEvent, GrabStartData as PointerGrabStartData, MotionEvent, PointerGrab,
         PointerInnerHandle, RelativeMotionEvent,
     },
     Seat, SeatHandler,
@@ -227,6 +229,78 @@ where
     fn axis(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, details: AxisFrame) {
         // we just forward the axis events as is
         handle.axis(data, details);
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event);
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event);
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event);
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event);
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event);
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event);
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event);
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut D,
+        handle: &mut PointerInnerHandle<'_, D>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event);
     }
 
     fn start_data(&self) -> &PointerGrabStartData<D> {

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -55,6 +55,7 @@ pub mod idle_inhibit;
 pub mod input_method;
 pub mod keyboard_shortcuts_inhibit;
 pub mod output;
+pub mod pointer_gestures;
 pub mod presentation;
 pub mod primary_selection;
 pub mod relative_pointer;

--- a/src/wayland/pointer_gestures.rs
+++ b/src/wayland/pointer_gestures.rs
@@ -1,0 +1,243 @@
+//! Utilities for pointer gestures support
+
+use wayland_protocols::wp::pointer_gestures::zv1::server::{
+    zwp_pointer_gesture_hold_v1::{self, ZwpPointerGestureHoldV1},
+    zwp_pointer_gesture_pinch_v1::{self, ZwpPointerGesturePinchV1},
+    zwp_pointer_gesture_swipe_v1::{self, ZwpPointerGestureSwipeV1},
+    zwp_pointer_gestures_v1::{self, ZwpPointerGesturesV1},
+};
+use wayland_server::{
+    backend::{ClientId, GlobalId, ObjectId},
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+};
+
+use crate::{
+    input::{pointer::PointerHandle, SeatHandler},
+    wayland::seat::PointerUserData,
+};
+
+const MANAGER_VERSION: u32 = 3;
+
+/// User data of ZwpPointerGesture*V1 objects
+#[derive(Debug)]
+pub struct PointerGestureUserData<D: SeatHandler> {
+    handle: Option<PointerHandle<D>>,
+}
+
+/// State of the pointer gestures
+#[derive(Debug)]
+pub struct PointerGesturesState {
+    global: GlobalId,
+}
+
+impl PointerGesturesState {
+    /// Register new [ZwpPointerGesturesV1] global
+    pub fn new<D>(display: &DisplayHandle) -> Self
+    where
+        D: GlobalDispatch<ZwpPointerGesturesV1, ()>,
+        D: Dispatch<ZwpPointerGesturesV1, ()>,
+        D: Dispatch<ZwpPointerGestureSwipeV1, PointerGestureUserData<D>>,
+        D: Dispatch<ZwpPointerGesturePinchV1, PointerGestureUserData<D>>,
+        D: Dispatch<ZwpPointerGestureHoldV1, PointerGestureUserData<D>>,
+        D: SeatHandler,
+        D: 'static,
+    {
+        let global = display.create_global::<D, ZwpPointerGesturesV1, _>(MANAGER_VERSION, ());
+
+        Self { global }
+    }
+
+    /// [ZwpPointerGesturesV1] GlobalId getter
+    pub fn global(&self) -> GlobalId {
+        self.global.clone()
+    }
+}
+
+impl<D> Dispatch<ZwpPointerGesturesV1, (), D> for PointerGesturesState
+where
+    D: Dispatch<ZwpPointerGesturesV1, ()>,
+    D: Dispatch<ZwpPointerGestureSwipeV1, PointerGestureUserData<D>>,
+    D: Dispatch<ZwpPointerGesturePinchV1, PointerGestureUserData<D>>,
+    D: Dispatch<ZwpPointerGestureHoldV1, PointerGestureUserData<D>>,
+    D: SeatHandler,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &wayland_server::Client,
+        _pointer_gestures: &ZwpPointerGesturesV1,
+        request: zwp_pointer_gestures_v1::Request,
+        _data: &(),
+        _dh: &DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            zwp_pointer_gestures_v1::Request::GetSwipeGesture { id, pointer } => {
+                let handle = &pointer.data::<PointerUserData<D>>().unwrap().handle;
+                let user_data = PointerGestureUserData {
+                    handle: handle.clone(),
+                };
+                let gesture = data_init.init(id, user_data);
+                if let Some(handle) = handle {
+                    handle.new_swipe_gesture(gesture);
+                }
+            }
+            zwp_pointer_gestures_v1::Request::GetPinchGesture { id, pointer } => {
+                let handle = &pointer.data::<PointerUserData<D>>().unwrap().handle;
+                let user_data = PointerGestureUserData {
+                    handle: handle.clone(),
+                };
+                let gesture = data_init.init(id, user_data);
+                if let Some(handle) = handle {
+                    handle.new_pinch_gesture(gesture);
+                }
+            }
+            zwp_pointer_gestures_v1::Request::GetHoldGesture { id, pointer } => {
+                let handle = &pointer.data::<PointerUserData<D>>().unwrap().handle;
+                let user_data = PointerGestureUserData {
+                    handle: handle.clone(),
+                };
+                let gesture = data_init.init(id, user_data);
+                if let Some(handle) = handle {
+                    handle.new_hold_gesture(gesture);
+                }
+            }
+            zwp_pointer_gestures_v1::Request::Release => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> GlobalDispatch<ZwpPointerGesturesV1, (), D> for PointerGesturesState
+where
+    D: GlobalDispatch<ZwpPointerGesturesV1, ()> + Dispatch<ZwpPointerGesturesV1, ()> + SeatHandler + 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _dh: &DisplayHandle,
+        _client: &Client,
+        resource: New<ZwpPointerGesturesV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(resource, ());
+    }
+}
+
+impl<D> Dispatch<ZwpPointerGestureSwipeV1, PointerGestureUserData<D>, D> for PointerGesturesState
+where
+    D: Dispatch<ZwpPointerGestureSwipeV1, PointerGestureUserData<D>>,
+    D: SeatHandler,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &wayland_server::Client,
+        _gesture: &ZwpPointerGestureSwipeV1,
+        request: zwp_pointer_gesture_swipe_v1::Request,
+        _data: &PointerGestureUserData<D>,
+        _dh: &DisplayHandle,
+        _data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            zwp_pointer_gesture_swipe_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+
+    fn destroyed(_state: &mut D, _: ClientId, object_id: ObjectId, data: &PointerGestureUserData<D>) {
+        if let Some(ref handle) = data.handle {
+            handle
+                .known_swipe_gestures
+                .lock()
+                .unwrap()
+                .retain(|p| p.id() != object_id);
+        }
+    }
+}
+
+impl<D> Dispatch<ZwpPointerGesturePinchV1, PointerGestureUserData<D>, D> for PointerGesturesState
+where
+    D: Dispatch<ZwpPointerGesturePinchV1, PointerGestureUserData<D>>,
+    D: SeatHandler,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &wayland_server::Client,
+        _gesture: &ZwpPointerGesturePinchV1,
+        request: zwp_pointer_gesture_pinch_v1::Request,
+        _data: &PointerGestureUserData<D>,
+        _dh: &DisplayHandle,
+        _data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            zwp_pointer_gesture_pinch_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+
+    fn destroyed(_state: &mut D, _: ClientId, object_id: ObjectId, data: &PointerGestureUserData<D>) {
+        if let Some(ref handle) = data.handle {
+            handle
+                .known_pinch_gestures
+                .lock()
+                .unwrap()
+                .retain(|p| p.id() != object_id);
+        }
+    }
+}
+
+impl<D> Dispatch<ZwpPointerGestureHoldV1, PointerGestureUserData<D>, D> for PointerGesturesState
+where
+    D: Dispatch<ZwpPointerGestureHoldV1, PointerGestureUserData<D>>,
+    D: SeatHandler,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &wayland_server::Client,
+        _gesture: &ZwpPointerGestureHoldV1,
+        request: zwp_pointer_gesture_hold_v1::Request,
+        _data: &PointerGestureUserData<D>,
+        _dh: &DisplayHandle,
+        _data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            zwp_pointer_gesture_hold_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+
+    fn destroyed(_state: &mut D, _: ClientId, object_id: ObjectId, data: &PointerGestureUserData<D>) {
+        if let Some(ref handle) = data.handle {
+            handle
+                .known_hold_gestures
+                .lock()
+                .unwrap()
+                .retain(|p| p.id() != object_id);
+        }
+    }
+}
+
+/// Macro to delegate implementation of the pointer gestures protocol
+#[macro_export]
+macro_rules! delegate_pointer_gestures {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gestures_v1::ZwpPointerGesturesV1: ()
+        ] => $crate::wayland::pointer_gestures::PointerGesturesState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gestures_v1::ZwpPointerGesturesV1: ()
+        ] => $crate::wayland::pointer_gestures::PointerGesturesState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gesture_swipe_v1::ZwpPointerGestureSwipeV1: $crate::wayland::pointer_gestures::PointerGestureUserData<Self>
+        ] => $crate::wayland::pointer_gestures::PointerGesturesState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gesture_pinch_v1::ZwpPointerGesturePinchV1: $crate::wayland::pointer_gestures::PointerGestureUserData<Self>
+        ] => $crate::wayland::pointer_gestures::PointerGesturesState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gesture_hold_v1::ZwpPointerGestureHoldV1: $crate::wayland::pointer_gestures::PointerGestureUserData<Self>
+        ] => $crate::wayland::pointer_gestures::PointerGesturesState);
+    };
+}

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -11,7 +11,10 @@
 //! use smithay::delegate_relative_pointer;
 //! # use smithay::backend::input::KeyState;
 //! # use smithay::input::{
-//! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent},
+//! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
+//! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
+//! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
+//! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
 //! #   Seat, SeatHandler, SeatState,
 //! # };
@@ -29,6 +32,14 @@
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
 //! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
+//! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
+//! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
+//! #   fn gesture_pinch_begin(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchBeginEvent) {}
+//! #   fn gesture_pinch_update(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchUpdateEvent) {}
+//! #   fn gesture_pinch_end(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchEndEvent) {}
+//! #   fn gesture_hold_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldBeginEvent) {}
+//! #   fn gesture_hold_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldEndEvent) {}
 //! # }
 //! # impl KeyboardTarget<State> for Target {
 //! #   fn enter(&self, seat: &Seat<State>, data: &mut State, keys: Vec<KeysymHandle<'_>>, serial: Serial) {}

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -1,6 +1,13 @@
 use std::{fmt, sync::Mutex};
 
-use wayland_protocols::wp::relative_pointer::zv1::server::zwp_relative_pointer_v1::ZwpRelativePointerV1;
+use wayland_protocols::wp::{
+    pointer_gestures::zv1::server::{
+        zwp_pointer_gesture_hold_v1::ZwpPointerGestureHoldV1,
+        zwp_pointer_gesture_pinch_v1::ZwpPointerGesturePinchV1,
+        zwp_pointer_gesture_swipe_v1::ZwpPointerGestureSwipeV1,
+    },
+    relative_pointer::zv1::server::zwp_relative_pointer_v1::ZwpRelativePointerV1,
+};
 use wayland_server::{
     backend::{ClientId, ObjectId},
     protocol::{
@@ -37,6 +44,21 @@ impl<D: SeatHandler> PointerHandle<D> {
     pub(crate) fn new_relative_pointer(&self, pointer: ZwpRelativePointerV1) {
         let mut guard = self.known_relative_pointers.lock().unwrap();
         guard.push(pointer);
+    }
+
+    pub(crate) fn new_swipe_gesture(&self, gesture: ZwpPointerGestureSwipeV1) {
+        let mut guard = self.known_swipe_gestures.lock().unwrap();
+        guard.push(gesture);
+    }
+
+    pub(crate) fn new_pinch_gesture(&self, gesture: ZwpPointerGesturePinchV1) {
+        let mut guard = self.known_pinch_gestures.lock().unwrap();
+        guard.push(gesture);
+    }
+
+    pub(crate) fn new_hold_gesture(&self, gesture: ZwpPointerGestureHoldV1) {
+        let mut guard = self.known_hold_gestures.lock().unwrap();
+        guard.push(gesture);
     }
 }
 

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -2,7 +2,11 @@ use crate::{
     backend::{input::KeyState, renderer::element::Id},
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-        pointer::{AxisFrame, ButtonEvent, MotionEvent, PointerTarget, RelativeMotionEvent},
+        pointer::{
+            AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+            GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+            GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
+        },
         Seat, SeatHandler,
     },
     utils::{user_data::UserDataMap, IsAlive, Logical, Rectangle, Serial, Size},
@@ -925,6 +929,54 @@ impl<D: SeatHandler + 'static> PointerTarget<D> for X11Surface {
     fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
             PointerTarget::leave(surface, seat, data, serial, time);
+        }
+    }
+
+    fn gesture_swipe_begin(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeBeginEvent) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            PointerTarget::gesture_swipe_begin(surface, seat, data, event);
+        }
+    }
+
+    fn gesture_swipe_update(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeUpdateEvent) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            PointerTarget::gesture_swipe_update(surface, seat, data, event);
+        }
+    }
+
+    fn gesture_swipe_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeEndEvent) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            PointerTarget::gesture_swipe_end(surface, seat, data, event);
+        }
+    }
+
+    fn gesture_pinch_begin(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchBeginEvent) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            PointerTarget::gesture_pinch_begin(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_pinch_update(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchUpdateEvent) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            PointerTarget::gesture_pinch_update(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_pinch_end(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchEndEvent) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            PointerTarget::gesture_pinch_end(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_hold_begin(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldBeginEvent) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            PointerTarget::gesture_hold_begin(surface, seat, data, event)
+        }
+    }
+
+    fn gesture_hold_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldEndEvent) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            PointerTarget::gesture_hold_end(surface, seat, data, event)
         }
     }
 }


### PR DESCRIPTION
Implements zwp_pointer_gestures_v1 and the entire Smithay support for it.

The Wayland gesture objects store whether they are currently active (i.e. between begin() and end()) on a given `WlSurface`. When receiving gesture update or end event, this field is checked, and if it doesn't match, then the gesture is cancelled. This way, gesture objects bound mid-gesture, or something equally weird happening, won't receive update() with no begin().

You could do something smarter, e.g. mutter will synthesize a gesture begin event if you move the pointer onto a surface mid-gesture, but doing this sounds quite more complex (need to track ongoing gestures on the pointer), and I don't think this usecase is very realistic (for this to happen you have to do something along move the pointer with a mouse while also making a gesture on the touchpad).

Anyway, here's a demo on my compositor, but it works in Anvil too, even on Xwayland windows.

https://github.com/Smithay/smithay/assets/1794388/29dae2c4-2dc9-48e3-b592-a357618b9f17

Here you can see the pinch zoom/rotate gesture visually in gtk4-demo, then the swipe gesture only in `WAYLAND_DEBUG` on the right, then the hold gesture by stopping the kinetic scrolling by putting a finger on the touchpad.

By default an Anvil build won't have the hold gestures, to enable them build with the `smithay/libinput_1_19` feature.