### PR TITLE
wayland: fix presentation time refresh

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -1148,7 +1148,7 @@ impl AnvilState<UdevData> {
                         clock,
                         output
                             .current_mode()
-                            .map(|mode| mode.refresh as u32)
+                            .map(|mode| Duration::from_secs_f64(1_000f64 / mode.refresh as f64))
                             .unwrap_or_default(),
                         seq as u64,
                         flags,

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -391,7 +391,7 @@ pub fn run_winit() {
                             time,
                             output
                                 .current_mode()
-                                .map(|mode| mode.refresh as u32)
+                                .map(|mode| Duration::from_secs_f64(1_000f64 / mode.refresh as f64))
                                 .unwrap_or_default(),
                             0,
                             wp_presentation_feedback::Kind::Vsync,

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -442,7 +442,7 @@ pub fn run_x11() {
                             time,
                             output
                                 .current_mode()
-                                .map(|mode| mode.refresh as u32)
+                                .map(|mode| Duration::from_secs_f64(1_000f64 / mode.refresh as f64))
                                 .unwrap_or_default(),
                             0,
                             wp_presentation_feedback::Kind::Vsync,

--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -331,11 +331,12 @@ impl SurfacePresentationFeedback {
         output: &Output,
         clk_id: u32,
         time: impl Into<Duration>,
-        refresh: u32,
+        refresh: impl Into<Duration>,
         seq: u64,
         flags: wp_presentation_feedback::Kind,
     ) {
         let time = time.into();
+        let refresh = refresh.into();
 
         for callback in self.callbacks.drain(..) {
             if callback.clk_id() == clk_id {
@@ -392,7 +393,7 @@ impl OutputPresentationFeedback {
     pub fn presented<T, Kind>(
         &mut self,
         time: T,
-        refresh: u32,
+        refresh: impl Into<Duration>,
         seq: u64,
         flags: wp_presentation_feedback::Kind,
     ) where
@@ -400,6 +401,7 @@ impl OutputPresentationFeedback {
         Kind: crate::utils::NonNegativeClockSource,
     {
         let time = time.into();
+        let refresh = refresh.into();
         let clk_id = Kind::id() as u32;
         if let Some(output) = self.output.upgrade() {
             for mut callback in self.callbacks.drain(..) {

--- a/src/wayland/presentation/mod.rs
+++ b/src/wayland/presentation/mod.rs
@@ -63,7 +63,7 @@
 //! // ... send frame callbacks and present frame
 //!
 //! # let time = Duration::ZERO;
-//! # let refresh = 60_000;
+//! # let refresh = Duration::from_secs_f64(1_000f64 / 60_000f64);
 //! # let seq = 0;
 //! for feedback in presentation_feedbacks {
 //!     feedback.presented(&output, time, refresh, seq, wp_presentation_feedback::Kind::Vsync);
@@ -206,7 +206,7 @@ impl PresentationFeedbackCallback {
         self,
         output: &Output,
         time: impl Into<Duration>,
-        refresh: u32,
+        refresh: impl Into<Duration>,
         seq: u64,
         flags: wp_presentation_feedback::Kind,
     ) {
@@ -236,6 +236,7 @@ impl PresentationFeedbackCallback {
         let tv_sec_hi = (time.as_secs() >> 32) as u32;
         let tv_sec_lo = (time.as_secs() & 0xFFFFFFFF) as u32;
         let tv_nsec = time.subsec_nanos();
+        let refresh = refresh.into().as_nanos() as u32;
         let seq_hi = (seq >> 32) as u32;
         let seq_lo = (seq & 0xFFFFFFFF) as u32;
 


### PR DESCRIPTION
The refresh represents the time till the next vblank relative to the timestamp and not the mode refresh