### PR TITLE
allow to specify a kind for an element

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -5,7 +5,7 @@ use smithay::{
         element::{
             surface::WaylandSurfaceRenderElement,
             texture::{TextureBuffer, TextureRenderElement},
-            AsRenderElements,
+            AsRenderElements, Kind,
         },
         ImportAll, Renderer, Texture,
     },
@@ -93,6 +93,7 @@ where
                             None,
                             None,
                             None,
+                            Kind::Cursor,
                         ))
                         .into(),
                     ]
@@ -103,7 +104,12 @@ where
             CursorImageStatus::Surface(surface) => {
                 let elements: Vec<PointerRenderElement<R>> =
                     smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
-                        renderer, surface, location, scale, alpha,
+                        renderer,
+                        surface,
+                        location,
+                        scale,
+                        alpha,
+                        Kind::Cursor,
                     );
                 elements.into_iter().map(E::from).collect()
             }

--- a/anvil/src/shell/ssd.rs
+++ b/anvil/src/shell/ssd.rs
@@ -2,7 +2,7 @@ use smithay::{
     backend::renderer::{
         element::{
             solid::{SolidColorBuffer, SolidColorRenderElement},
-            AsRenderElements,
+            AsRenderElements, Kind,
         },
         Renderer,
     },
@@ -184,6 +184,7 @@ impl<R: Renderer> AsRenderElements<R> for HeaderBar {
                 location + (header_end_offset - button_offset).to_physical_precise_round(scale),
                 scale,
                 alpha,
+                Kind::Unspecified,
             )
             .into(),
             SolidColorRenderElement::from_buffer(
@@ -191,9 +192,11 @@ impl<R: Renderer> AsRenderElements<R> for HeaderBar {
                 location + (header_end_offset - button_offset.upscale(2)).to_physical_precise_round(scale),
                 scale,
                 alpha,
+                Kind::Unspecified,
             )
             .into(),
-            SolidColorRenderElement::from_buffer(&self.background, location, scale, alpha).into(),
+            SolidColorRenderElement::from_buffer(&self.background, location, scale, alpha, Kind::Unspecified)
+                .into(),
         ]
     }
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -4,7 +4,10 @@ use smithay::{
     backend::{
         input::{InputEvent, KeyboardKeyEvent},
         renderer::{
-            element::surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
+            element::{
+                surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
+                Kind,
+            },
             gles::GlesRenderer,
             utils::{draw_render_elements, on_commit_buffer_handler},
             Frame, Renderer,
@@ -195,7 +198,14 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
             .toplevel_surfaces()
             .iter()
             .flat_map(|surface| {
-                render_elements_from_surface_tree(backend.renderer(), surface.wl_surface(), (0, 0), 1.0, 1.0)
+                render_elements_from_surface_tree(
+                    backend.renderer(),
+                    surface.wl_surface(),
+                    (0, 0),
+                    1.0,
+                    1.0,
+                    Kind::Unspecified,
+                )
             })
             .collect::<Vec<WaylandSurfaceRenderElement<GlesRenderer>>>();
 

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -149,7 +149,7 @@ use crate::{
             buffer_y_inverted,
             damage::{Error as OutputDamageTrackerError, OutputDamageTracker},
             element::{
-                Element, Id, RenderElement, RenderElementPresentationState, RenderElementState,
+                Element, Id, Kind, RenderElement, RenderElementPresentationState, RenderElementState,
                 RenderElementStates, RenderingReason, UnderlyingStorage,
             },
             sync::SyncPoint,
@@ -2816,6 +2816,15 @@ where
         if frame_state.is_assigned(plane_info.handle) {
             trace!(
                 "skipping element {:?} on cursor {:?}, plane already has element assigned",
+                element.id(),
+                plane_info.handle
+            );
+            return None;
+        }
+
+        if element.kind() != Kind::Cursor {
+            trace!(
+                "skipping element {:?} on cursor {:?}, element kind not cursor",
                 element.id(),
                 plane_info.handle
             );

--- a/src/backend/renderer/damage.rs
+++ b/src/backend/renderer/damage.rs
@@ -137,7 +137,10 @@
 //!         allocator::Fourcc,
 //!         renderer::{
 //!             damage::OutputDamageTracker,
-//!             element::memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement}
+//!             element::{
+//!                 Kind,
+//!                 memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
+//!             }
 //!         },
 //!     },
 //!     utils::{Point, Transform},
@@ -175,7 +178,7 @@
 //!     // Create a render element from the buffer
 //!     let location = Point::from((100.0, 100.0));
 //!     let render_element =
-//!         MemoryRenderBufferRenderElement::from_buffer(&mut renderer, location, &memory_buffer, None, None, None)
+//!         MemoryRenderBufferRenderElement::from_buffer(&mut renderer, location, &memory_buffer, None, None, None, Kind::Unspecified)
 //!         .expect("Failed to upload memory to gpu");
 //!
 //!     // Render the output

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -135,7 +135,10 @@
 //!         allocator::Fourcc,
 //!         renderer::{
 //!             damage::OutputDamageTracker,
-//!             element::memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
+//!             element::{
+//!                 Kind,
+//!                 memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
+//!             },
 //!         },
 //!     },
 //!     utils::{Point, Rectangle, Size, Transform},
@@ -192,7 +195,7 @@
 //!
 //!     // Create a render element from the buffer
 //!     let location = Point::from((100.0, 100.0));
-//!     let render_element = MemoryRenderBufferRenderElement::from_buffer(&mut renderer, location, &buffer, None, None, None)
+//!     let render_element = MemoryRenderBufferRenderElement::from_buffer(&mut renderer, location, &buffer, None, None, None, Kind::Unspecified)
 //!         .expect("Failed to upload from memory to gpu");
 //!
 //!     // Render the element(s)
@@ -223,7 +226,7 @@ use crate::{
     utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
 };
 
-use super::{Element, Id, RenderElement};
+use super::{Element, Id, Kind, RenderElement};
 
 #[derive(Debug)]
 struct MemoryRenderBufferInner {
@@ -491,6 +494,7 @@ pub struct MemoryRenderBufferRenderElement<R: Renderer> {
     src: Option<Rectangle<f64, Logical>>,
     size: Option<Size<i32, Logical>>,
     renderer_type: PhantomData<R>,
+    kind: Kind,
 }
 
 impl<R: Renderer> MemoryRenderBufferRenderElement<R> {
@@ -503,6 +507,7 @@ impl<R: Renderer> MemoryRenderBufferRenderElement<R> {
         alpha: Option<f32>,
         src: Option<Rectangle<f64, Logical>>,
         size: Option<Size<i32, Logical>>,
+        kind: Kind,
     ) -> Result<Self, <R as Renderer>::Error>
     where
         R: ImportMem,
@@ -516,6 +521,7 @@ impl<R: Renderer> MemoryRenderBufferRenderElement<R> {
             src,
             size,
             renderer_type: PhantomData,
+            kind,
         })
     }
 
@@ -658,6 +664,10 @@ impl<R: Renderer> Element for MemoryRenderBufferRenderElement<R> {
 
     fn alpha(&self) -> f32 {
         self.alpha
+    }
+
+    fn kind(&self) -> Kind {
+        self.kind
     }
 }
 

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -317,6 +317,22 @@ impl RenderElementStates {
     }
 }
 
+/// Defines the kind of an [`Element`]
+///
+/// This can give the backend a hint about how to handle the element
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum Kind {
+    /// The element represents a cursor
+    ///
+    /// An element representing a cursor is expected to change infrequently.
+    /// Not marking a cursor element as `Cursor` may result in lower performance and increased power usage.
+    /// In contrast, marking elements that change frequently as `Cursor` can degrade performance significantly.
+    Cursor,
+    /// The element kind is unspecified
+    #[default]
+    Unspecified,
+}
+
 /// A single element
 pub trait Element {
     /// Get the unique id of this element
@@ -355,6 +371,10 @@ pub trait Element {
     /// already encoded alpha in it's underlying representation.
     fn alpha(&self) -> f32 {
         1.0
+    }
+    /// Returns the [`Kind`] for this element
+    fn kind(&self) -> Kind {
+        Kind::default()
     }
 }
 
@@ -435,6 +455,10 @@ where
 
     fn alpha(&self) -> f32 {
         (*self).alpha()
+    }
+
+    fn kind(&self) -> Kind {
+        (*self).kind()
     }
 }
 
@@ -711,6 +735,19 @@ macro_rules! render_elements_internal {
                         #[$meta]
                     )*
                     Self::$body(x) => $crate::render_elements_internal!(@call alpha; x)
+                ),*,
+                Self::_GenericCatcher(_) => unreachable!(),
+            }
+        }
+
+        fn kind(&self) -> $crate::backend::renderer::element::Kind {
+            match self {
+                $(
+                    #[allow(unused_doc_comments)]
+                    $(
+                        #[$meta]
+                    )*
+                    Self::$body(x) => $crate::render_elements_internal!(@call kind; x)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -1411,6 +1448,10 @@ where
 
     fn alpha(&self) -> f32 {
         self.0.alpha()
+    }
+
+    fn kind(&self) -> Kind {
+        self.0.kind()
     }
 }
 

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -151,7 +151,10 @@
 //!         allocator::Fourcc,
 //!         renderer::{
 //!             damage::OutputDamageTracker,
-//!             element::texture::{TextureBuffer, TextureRenderElement},
+//!             element::{
+//!                 Kind,
+//!                 texture::{TextureBuffer, TextureRenderElement},
+//!             },
 //!         },
 //!     },
 //!     utils::{Point, Transform},
@@ -182,7 +185,7 @@
 //!     // Create a render element from the buffer
 //!     let location = Point::from((100.0, 100.0));
 //!     let render_element =
-//!         TextureRenderElement::from_texture_buffer(location, &texture_buffer, None, None, None);
+//!         TextureRenderElement::from_texture_buffer(location, &texture_buffer, None, None, None, Kind::Unspecified);
 //!
 //!     // Render the element(s)
 //!     damage_tracker
@@ -307,7 +310,10 @@
 //!         allocator::Fourcc,
 //!         renderer::{
 //!             damage::OutputDamageTracker,
-//!             element::texture::{TextureRenderBuffer, TextureRenderElement},
+//!             element::{
+//!                 Kind,
+//!                 texture::{TextureRenderBuffer, TextureRenderElement},
+//!             },
 //!         },
 //!     },
 //!     utils::{Point, Rectangle, Size, Transform},
@@ -382,6 +388,7 @@
 //!         None,
 //!         None,
 //!         None,
+//!         Kind::Unspecified,
 //!     );
 //!
 //!     // Render the element(s)
@@ -406,7 +413,7 @@ use crate::{
     utils::{Buffer, Coordinate, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
 };
 
-use super::{CommitCounter, Element, Id, RenderElement};
+use super::{CommitCounter, Element, Id, Kind, RenderElement};
 
 /// A single texture buffer
 #[derive(Debug, Clone)]
@@ -622,6 +629,7 @@ pub struct TextureRenderElement<T> {
     size: Option<Size<i32, Logical>>,
     opaque_regions: Option<Vec<Rectangle<i32, Logical>>>,
     snapshot: DamageSnapshot<i32, Buffer>,
+    kind: Kind,
 }
 
 impl<T: Texture> TextureRenderElement<T> {
@@ -643,6 +651,7 @@ impl<T: Texture + Clone> TextureRenderElement<T> {
         alpha: Option<f32>,
         src: Option<Rectangle<f64, Logical>>,
         size: Option<Size<i32, Logical>>,
+        kind: Kind,
     ) -> Self {
         TextureRenderElement::from_texture_with_damage(
             buffer.id.clone(),
@@ -656,6 +665,7 @@ impl<T: Texture + Clone> TextureRenderElement<T> {
             size,
             buffer.opaque_regions.clone(),
             buffer.damage_tracker.lock().unwrap().snapshot(),
+            kind,
         )
     }
 
@@ -666,6 +676,7 @@ impl<T: Texture + Clone> TextureRenderElement<T> {
         alpha: Option<f32>,
         src: Option<Rectangle<f64, Logical>>,
         size: Option<Size<i32, Logical>>,
+        kind: Kind,
     ) -> Self {
         TextureRenderElement::from_static_texture(
             buffer.id.clone(),
@@ -678,6 +689,7 @@ impl<T: Texture + Clone> TextureRenderElement<T> {
             src,
             size,
             buffer.opaque_regions.clone(),
+            kind,
         )
     }
 }
@@ -698,6 +710,7 @@ impl<T: Texture> TextureRenderElement<T> {
         size: Option<Size<i32, Logical>>,
         opaque_regions: Option<Vec<Rectangle<i32, Buffer>>>,
         snapshot: DamageSnapshot<i32, Buffer>,
+        kind: Kind,
     ) -> Self {
         let opaque_regions = opaque_regions.map(|regions| {
             regions
@@ -717,6 +730,7 @@ impl<T: Texture> TextureRenderElement<T> {
             size,
             opaque_regions,
             snapshot,
+            kind,
         }
     }
 
@@ -734,6 +748,7 @@ impl<T: Texture> TextureRenderElement<T> {
         src: Option<Rectangle<f64, Logical>>,
         size: Option<Size<i32, Logical>>,
         opaque_regions: Option<Vec<Rectangle<i32, Buffer>>>,
+        kind: Kind,
     ) -> Self {
         TextureRenderElement::from_texture_with_damage(
             id,
@@ -747,6 +762,7 @@ impl<T: Texture> TextureRenderElement<T> {
             size,
             opaque_regions,
             DamageSnapshot::empty(),
+            kind,
         )
     }
 
@@ -867,6 +883,10 @@ where
 
     fn alpha(&self) -> f32 {
         self.alpha
+    }
+
+    fn kind(&self) -> Kind {
+        self.kind
     }
 }
 

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     backend::renderer::{
-        element::{AsRenderElements, Element, Id, RenderElement, UnderlyingStorage},
+        element::{AsRenderElements, Element, Id, Kind, RenderElement, UnderlyingStorage},
         Renderer,
     },
     utils::{Buffer, Physical, Point, Rectangle, Scale},
@@ -87,6 +87,10 @@ impl<E: Element> Element for RescaleRenderElement<E> {
 
     fn alpha(&self) -> f32 {
         self.element.alpha()
+    }
+
+    fn kind(&self) -> Kind {
+        self.element.kind()
     }
 }
 
@@ -266,6 +270,10 @@ impl<E: Element> Element for CropRenderElement<E> {
     fn alpha(&self) -> f32 {
         self.element.alpha()
     }
+
+    fn kind(&self) -> Kind {
+        self.element.kind()
+    }
 }
 
 impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for CropRenderElement<E> {
@@ -361,6 +369,10 @@ impl<E: Element> Element for RelocateRenderElement<E> {
 
     fn alpha(&self) -> f32 {
         self.element.alpha()
+    }
+
+    fn kind(&self) -> Kind {
+        self.element.kind()
     }
 }
 

--- a/src/backend/renderer/gles/element.rs
+++ b/src/backend/renderer/gles/element.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     backend::renderer::{
-        element::{Element, Id, RenderElement, UnderlyingStorage},
+        element::{Element, Id, Kind, RenderElement, UnderlyingStorage},
         utils::CommitCounter,
     },
     utils::{Buffer, Logical, Physical, Rectangle, Scale, Transform},
@@ -20,6 +20,7 @@ pub struct PixelShaderElement {
     opaque_regions: Vec<Rectangle<i32, Logical>>,
     alpha: f32,
     additional_uniforms: Vec<Uniform<'static>>,
+    kind: Kind,
 }
 
 impl PixelShaderElement {
@@ -31,6 +32,7 @@ impl PixelShaderElement {
         opaque_regions: Option<Vec<Rectangle<i32, Logical>>>,
         alpha: f32,
         additional_uniforms: Vec<Uniform<'_>>,
+        kind: Kind,
     ) -> Self {
         PixelShaderElement {
             shader,
@@ -40,6 +42,7 @@ impl PixelShaderElement {
             opaque_regions: opaque_regions.unwrap_or_default(),
             alpha,
             additional_uniforms: additional_uniforms.into_iter().map(|u| u.into_owned()).collect(),
+            kind,
         }
     }
 
@@ -95,6 +98,10 @@ impl Element for PixelShaderElement {
 
     fn alpha(&self) -> f32 {
         1.0
+    }
+
+    fn kind(&self) -> Kind {
+        self.kind
     }
 }
 

--- a/src/desktop/space/element/wayland.rs
+++ b/src/desktop/space/element/wayland.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::renderer::Renderer,
+    backend::renderer::{element::Kind, Renderer},
     desktop::space::*,
     utils::{Physical, Point, Scale},
 };
@@ -47,6 +47,7 @@ where
             location,
             scale,
             alpha,
+            Kind::Unspecified,
         )
     }
 }

--- a/src/desktop/space/wayland/layer.rs
+++ b/src/desktop/space/wayland/layer.rs
@@ -2,7 +2,7 @@ use crate::{
     backend::renderer::{
         element::{
             surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
-            AsRenderElements,
+            AsRenderElements, Kind,
         },
         ImportAll, Renderer,
     },
@@ -41,13 +41,19 @@ where
                     location + offset,
                     scale,
                     alpha,
+                    Kind::Unspecified,
                 )
             });
 
         render_elements.extend(popup_render_elements);
 
         render_elements.extend(render_elements_from_surface_tree(
-            renderer, surface, location, scale, alpha,
+            renderer,
+            surface,
+            location,
+            scale,
+            alpha,
+            Kind::Unspecified,
         ));
 
         render_elements

--- a/src/desktop/space/wayland/window.rs
+++ b/src/desktop/space/wayland/window.rs
@@ -2,7 +2,7 @@ use crate::{
     backend::renderer::{
         element::{
             surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
-            AsRenderElements,
+            AsRenderElements, Kind,
         },
         ImportAll, Renderer,
     },
@@ -123,13 +123,19 @@ where
                     location + offset,
                     scale,
                     alpha,
+                    Kind::Unspecified,
                 )
             });
 
         render_elements.extend(popup_render_elements);
 
         render_elements.extend(render_elements_from_surface_tree(
-            renderer, surface, location, scale, alpha,
+            renderer,
+            surface,
+            location,
+            scale,
+            alpha,
+            Kind::Unspecified,
         ));
 
         render_elements

--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -3,7 +3,10 @@ use wayland_server::protocol::wl_surface::WlSurface;
 use super::*;
 use crate::{
     backend::renderer::{
-        element::surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
+        element::{
+            surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
+            Kind,
+        },
         ImportAll, Renderer,
     },
     desktop::{space::SpaceElement, utils::under_from_surface_tree, WindowSurfaceType},
@@ -115,6 +118,6 @@ where
         let Some(surface) = state.wl_surface.as_ref() else {
             return Vec::new();
         };
-        render_elements_from_surface_tree(renderer, surface, location, scale, alpha)
+        render_elements_from_surface_tree(renderer, surface, location, scale, alpha, Kind::Unspecified)
     }
 }


### PR DESCRIPTION
this can give the backend a hint about how to handle the element.
for now the only supported use-case is to not accidentally assign non cursor content to the cursor plane

In the future this could be extended to reflect `wp_content_type`.

Only a Draft to discuss alternatives.

## Alternatives

### Scan-out priority

One alternative would be to introduce some kind of `ScanoutPriority` which could be used to limit the planes
an element can or should be placed on. But this is way more complex, not only for implementation, but also from
the design perspective. Maybe the two things could be considered orthogonal? The `ScanoutPriority` could look roughly like this:

```rs
pub enum ScanoutPriority {
  Undesired,
  Undefined,
  Priorize(usize)
}
```

### Seperate paramter

Another alternative I considered is to explicitly pass the cursor element(s) to `DrmCompositor::render_frame`.
But this not only breaks the current API, it also turned out to create a mess with multiple backends.