### PR TITLE
‘vils: Fix axis_stop event delivery

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -400,16 +400,20 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 if let Some(discrete) = horizontal_amount_discrete {
                     frame = frame.discrete(Axis::Horizontal, discrete as i32);
                 }
-            } else if evt.source() == AxisSource::Finger {
-                frame = frame.stop(Axis::Horizontal);
             }
             if vertical_amount != 0.0 {
                 frame = frame.value(Axis::Vertical, vertical_amount);
                 if let Some(discrete) = vertical_amount_discrete {
                     frame = frame.discrete(Axis::Vertical, discrete as i32);
                 }
-            } else if evt.source() == AxisSource::Finger {
-                frame = frame.stop(Axis::Vertical);
+            }
+            if evt.source() == AxisSource::Finger {
+                if evt.amount(Axis::Horizontal) == Some(0.0) {
+                    frame = frame.stop(Axis::Horizontal);
+                }
+                if evt.amount(Axis::Vertical) == Some(0.0) {
+                    frame = frame.stop(Axis::Vertical);
+                }
             }
             let pointer = self.pointer.clone();
             pointer.axis(self, frame);

--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -111,16 +111,21 @@ impl Smallvil {
                     if let Some(discrete) = horizontal_amount_discrete {
                         frame = frame.discrete(Axis::Horizontal, discrete as i32);
                     }
-                } else if source == AxisSource::Finger {
-                    frame = frame.stop(Axis::Horizontal);
                 }
                 if vertical_amount != 0.0 {
                     frame = frame.value(Axis::Vertical, vertical_amount);
                     if let Some(discrete) = vertical_amount_discrete {
                         frame = frame.discrete(Axis::Vertical, discrete as i32);
                     }
-                } else if source == AxisSource::Finger {
-                    frame = frame.stop(Axis::Vertical);
+                }
+
+                if source == AxisSource::Finger {
+                    if event.amount(Axis::Horizontal) == Some(0.0) {
+                        frame = frame.stop(Axis::Horizontal);
+                    }
+                    if event.amount(Axis::Vertical) == Some(0.0) {
+                        frame = frame.stop(Axis::Vertical);
+                    }
                 }
 
                 self.seat.get_pointer().unwrap().axis(self, frame);


### PR DESCRIPTION
It's only supposed to be sent when there actually is a zero in the event, not when the value is missing.

This notably fixes non-diagonal scrolling in winit and alacritty.