### PR TITLE
Fix order of pointer axis events within frame

### DIFF
--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -226,13 +226,6 @@ where
     }
     fn axis(&self, seat: &Seat<D>, _data: &mut D, details: AxisFrame) {
         for_each_focused_pointers(seat, self, |ptr| {
-            // axis
-            if details.axis.0 != 0.0 {
-                ptr.axis(details.time, WlAxis::HorizontalScroll, details.axis.0);
-            }
-            if details.axis.1 != 0.0 {
-                ptr.axis(details.time, WlAxis::VerticalScroll, details.axis.1);
-            }
             if ptr.version() >= 5 {
                 // axis source
                 if let Some(source) = details.source {
@@ -265,6 +258,15 @@ where
                 if details.stop.1 {
                     ptr.axis_stop(details.time, WlAxis::VerticalScroll);
                 }
+            }
+            // axis
+            if details.axis.0 != 0.0 {
+                ptr.axis(details.time, WlAxis::HorizontalScroll, details.axis.0);
+            }
+            if details.axis.1 != 0.0 {
+                ptr.axis(details.time, WlAxis::VerticalScroll, details.axis.1);
+            }
+            if ptr.version() >= 5 {
                 // frame
                 ptr.frame();
             }


### PR DESCRIPTION
The protocol states "each axis_discrete event is always followed by exactly one axis event with the same axis number within the same wl_pointer.frame", while "The order of wl_pointer.axis_discrete and wl_pointer.axis_source is not guaranteed."

Which suggests `axis_discrete` should occur before `axis`.

This should correctly match the protocol spec, and other compositors.