### PR TITLE
drm leasing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ downcast-rs = "1.2.0"
 drm-fourcc = "^2.2.0"
 drm = { version = "0.10.0", optional = true }
 drm-ffi = { version = "0.6.0", optional = true }
-
 gbm = { version = "0.13.0", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.12", optional = true }
 input = { version = "0.8.2", default-features = false, features=["libinput_1_14"], optional = true }

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -52,7 +52,7 @@ use smithay::{
         vulkan::{version::Version, Instance, PhysicalDevice},
         SwapBuffersError,
     },
-    delegate_dmabuf,
+    delegate_dmabuf, delegate_drm_lease,
     desktop::{
         space::{Space, SurfaceTree},
         utils::OutputPresentationFeedback,
@@ -67,8 +67,8 @@ use smithay::{
         },
         drm::{
             self,
-            control::{connector, crtc, ModeTypeFlags},
-            Device,
+            control::{connector, crtc, Device, ModeTypeFlags},
+            Device as _,
         },
         input::Libinput,
         nix::fcntl::OFlag,
@@ -83,6 +83,9 @@ use smithay::{
         compositor,
         dmabuf::{
             DmabufFeedback, DmabufFeedbackBuilder, DmabufGlobal, DmabufHandler, DmabufState, ImportError,
+        },
+        drm_lease::{
+            DrmLease, DrmLeaseBuilder, DrmLeaseHandler, DrmLeaseRequest, DrmLeaseState, LeaseRejected,
         },
         input_method::{InputMethodHandle, InputMethodSeat},
     },
@@ -287,8 +290,12 @@ pub fn run_udev() {
                 libinput_context.suspend();
                 info!("pausing session");
 
-                for backend in data.state.backend_data.backends.values() {
+                for backend in data.state.backend_data.backends.values_mut() {
                     backend.drm.pause();
+                    backend.active_leases.clear();
+                    if let Some(lease_global) = backend.leasing_global.as_mut() {
+                        lease_global.suspend();
+                    }
                 }
             }
             SessionEvent::ActivateSession => {
@@ -305,6 +312,9 @@ pub fn run_udev() {
                     .map(|(handle, backend)| (*handle, backend))
                 {
                     backend.drm.activate();
+                    if let Some(lease_global) = backend.leasing_global.as_mut() {
+                        lease_global.resume::<AnvilState<UdevData>>();
+                    }
                     for surface in backend.surfaces.values_mut() {
                         if let Err(err) = surface.compositor.surface().reset_state() {
                             warn!("Failed to reset drm surface state: {}", err);
@@ -508,6 +518,64 @@ pub fn run_udev() {
     }
 }
 
+impl DrmLeaseHandler for AnvilState<UdevData> {
+    fn drm_lease_state(&mut self, node: DrmNode) -> &mut DrmLeaseState {
+        self.backend_data
+            .backends
+            .get_mut(&node)
+            .unwrap()
+            .leasing_global
+            .as_mut()
+            .unwrap()
+    }
+
+    fn lease_request(
+        &mut self,
+        node: DrmNode,
+        request: DrmLeaseRequest,
+    ) -> Result<DrmLeaseBuilder, LeaseRejected> {
+        let backend = self
+            .backend_data
+            .backends
+            .get(&node)
+            .ok_or(LeaseRejected::default())?;
+
+        let mut builder = DrmLeaseBuilder::new(&backend.drm);
+        for conn in request.connectors {
+            if let Some((_, crtc)) = backend
+                .non_desktop_connectors
+                .iter()
+                .find(|(handle, _)| *handle == conn)
+            {
+                builder.add_connector(conn);
+                builder.add_crtc(*crtc);
+                let planes = backend.drm.planes(crtc).map_err(LeaseRejected::with_cause)?;
+                builder.add_plane(planes.primary.handle);
+                if let Some(cursor) = planes.cursor {
+                    builder.add_plane(cursor.handle);
+                }
+            } else {
+                tracing::warn!(?conn, "Lease requested for desktop connector, denying request");
+                return Err(LeaseRejected::default());
+            }
+        }
+
+        Ok(builder)
+    }
+
+    fn new_active_lease(&mut self, node: DrmNode, lease: DrmLease) {
+        let backend = self.backend_data.backends.get_mut(&node).unwrap();
+        backend.active_leases.push(lease);
+    }
+
+    fn lease_destroyed(&mut self, node: DrmNode, lease: u32) {
+        let backend = self.backend_data.backends.get_mut(&node).unwrap();
+        backend.active_leases.retain(|l| l.id() != lease);
+    }
+}
+
+delegate_drm_lease!(AnvilState<UdevData>);
+
 pub type RenderSurface = GbmBufferedSurface<GbmAllocator<DrmDeviceFd>, Option<OutputPresentationFeedback>>;
 
 pub type GbmDrmCompositor = DrmCompositor<
@@ -690,6 +758,9 @@ impl Drop for SurfaceData {
 
 struct BackendData {
     surfaces: HashMap<crtc::Handle, SurfaceData>,
+    non_desktop_connectors: Vec<(connector::Handle, crtc::Handle)>,
+    leasing_global: Option<DrmLeaseState>,
+    active_leases: Vec<DrmLease>,
     gbm: GbmDevice<DrmDeviceFd>,
     drm: DrmDevice,
     drm_scanner: DrmScanner,
@@ -825,8 +896,17 @@ impl AnvilState<UdevData> {
                 gbm,
                 drm,
                 drm_scanner: DrmScanner::new(),
+                non_desktop_connectors: Vec::new(),
                 render_node,
                 surfaces: HashMap::new(),
+                leasing_global: DrmLeaseState::new::<AnvilState<UdevData>>(&self.display_handle, &node)
+                    .map_err(|err| {
+                        // TODO replace with inspect_err, once stable
+                        warn!(?err, "Failed to initialize drm lease global for: {}", node);
+                        err
+                    })
+                    .ok(),
+                active_leases: Vec::new(),
             },
         );
 
@@ -849,181 +929,216 @@ impl AnvilState<UdevData> {
             .unwrap();
         let render_formats = renderer.as_mut().egl_context().dmabuf_render_formats().clone();
 
-        info!(
-            ?crtc,
-            "Trying to setup connector {:?}-{}",
-            connector.interface(),
-            connector.interface_id(),
-        );
-
-        let mode_id = connector
-            .modes()
-            .iter()
-            .position(|mode| mode.mode_type().contains(ModeTypeFlags::PREFERRED))
-            .unwrap_or(0);
-
-        let drm_mode = connector.modes()[mode_id];
-        let wl_mode = WlMode::from(drm_mode);
-
-        let surface = match device.drm.create_surface(crtc, drm_mode, &[connector.handle()]) {
-            Ok(surface) => surface,
-            Err(err) => {
-                warn!("Failed to create drm surface: {}", err);
-                return;
-            }
-        };
-
         let output_name = format!("{}-{}", connector.interface().as_str(), connector.interface_id());
+        info!(?crtc, "Trying to setup connector {}", output_name,);
+
+        let non_desktop = device
+            .drm
+            .get_properties(connector.handle())
+            .ok()
+            .and_then(|props| {
+                let (info, value) = props
+                    .into_iter()
+                    .filter_map(|(handle, value)| {
+                        let info = device.drm.get_property(handle).ok()?;
+
+                        Some((info, value))
+                    })
+                    .find(|(info, _)| info.name().to_str() == Ok("non-desktop"))?;
+
+                info.value_type().convert_value(value).as_boolean()
+            })
+            .unwrap_or(false);
 
         let (make, model) = EdidInfo::for_connector(&device.drm, connector.handle())
             .map(|info| (info.manufacturer, info.model))
             .unwrap_or_else(|| ("Unknown".into(), "Unknown".into()));
 
-        let (phys_w, phys_h) = connector.size().unwrap_or((0, 0));
-        let output = Output::new(
-            output_name,
-            PhysicalProperties {
-                size: (phys_w as i32, phys_h as i32).into(),
-                subpixel: Subpixel::Unknown,
-                make,
-                model,
-            },
-        );
-        let global = output.create_global::<AnvilState<UdevData>>(&self.display_handle);
-
-        let x = self
-            .space
-            .outputs()
-            .fold(0, |acc, o| acc + self.space.output_geometry(o).unwrap().size.w);
-        let position = (x, 0).into();
-
-        output.set_preferred(wl_mode);
-        output.change_current_state(Some(wl_mode), None, None, Some(position));
-        self.space.map_output(&output, position);
-
-        output.user_data().insert_if_missing(|| UdevOutputId {
-            crtc,
-            device_id: node,
-        });
-
-        #[cfg(feature = "debug")]
-        let fps_element = self.backend_data.fps_texture.clone().map(FpsElement::new);
-
-        let allocator = GbmAllocator::new(
-            device.gbm.clone(),
-            GbmBufferFlags::RENDERING | GbmBufferFlags::SCANOUT,
-        );
-
-        let color_formats = if std::env::var("ANVIL_DISABLE_10BIT").is_ok() {
-            SUPPORTED_FORMATS_8BIT_ONLY
-        } else {
-            SUPPORTED_FORMATS
-        };
-
-        let compositor = if std::env::var("ANVIL_DISABLE_DRM_COMPOSITOR").is_ok() {
-            let gbm_surface = match GbmBufferedSurface::new(surface, allocator, color_formats, render_formats)
-            {
-                Ok(renderer) => renderer,
-                Err(err) => {
-                    warn!("Failed to create rendering surface: {}", err);
-                    return;
-                }
-            };
-            SurfaceComposition::Surface {
-                surface: gbm_surface,
-                damage_tracker: OutputDamageTracker::from_output(&output),
-                debug_flags: self.backend_data.debug_flags,
+        if non_desktop {
+            info!("Connector {} is non-desktop, setting up for leasing", output_name);
+            device.non_desktop_connectors.push((connector.handle(), crtc));
+            if let Some(lease_state) = device.leasing_global.as_mut() {
+                lease_state.add_connector::<AnvilState<UdevData>>(
+                    connector.handle(),
+                    output_name,
+                    format!("{} {}", make, model),
+                );
             }
         } else {
-            let driver = match device.drm.get_driver() {
-                Ok(driver) => driver,
+            let mode_id = connector
+                .modes()
+                .iter()
+                .position(|mode| mode.mode_type().contains(ModeTypeFlags::PREFERRED))
+                .unwrap_or(0);
+
+            let drm_mode = connector.modes()[mode_id];
+            let wl_mode = WlMode::from(drm_mode);
+
+            let surface = match device.drm.create_surface(crtc, drm_mode, &[connector.handle()]) {
+                Ok(surface) => surface,
                 Err(err) => {
-                    warn!("Failed to query drm driver: {}", err);
+                    warn!("Failed to create drm surface: {}", err);
                     return;
                 }
             };
 
-            let mut planes = surface.planes().clone();
+            let (phys_w, phys_h) = connector.size().unwrap_or((0, 0));
+            let output = Output::new(
+                output_name,
+                PhysicalProperties {
+                    size: (phys_w as i32, phys_h as i32).into(),
+                    subpixel: Subpixel::Unknown,
+                    make,
+                    model,
+                },
+            );
+            let global = output.create_global::<AnvilState<UdevData>>(&self.display_handle);
 
-            // Using an overlay plane on a nvidia card breaks
-            if driver.name().to_string_lossy().to_lowercase().contains("nvidia")
-                || driver
-                    .description()
-                    .to_string_lossy()
-                    .to_lowercase()
-                    .contains("nvidia")
-            {
-                planes.overlay = vec![];
-            }
+            let x = self
+                .space
+                .outputs()
+                .fold(0, |acc, o| acc + self.space.output_geometry(o).unwrap().size.w);
+            let position = (x, 0).into();
 
-            let mut compositor = match DrmCompositor::new(
-                &output,
-                surface,
-                Some(planes),
-                allocator,
+            output.set_preferred(wl_mode);
+            output.change_current_state(Some(wl_mode), None, None, Some(position));
+            self.space.map_output(&output, position);
+
+            output.user_data().insert_if_missing(|| UdevOutputId {
+                crtc,
+                device_id: node,
+            });
+
+            #[cfg(feature = "debug")]
+            let fps_element = self.backend_data.fps_texture.clone().map(FpsElement::new);
+
+            let allocator = GbmAllocator::new(
                 device.gbm.clone(),
-                color_formats,
-                render_formats,
-                device.drm.cursor_size(),
-                Some(device.gbm.clone()),
-            ) {
-                Ok(compositor) => compositor,
-                Err(err) => {
-                    warn!("Failed to create drm compositor: {}", err);
-                    return;
-                }
+                GbmBufferFlags::RENDERING | GbmBufferFlags::SCANOUT,
+            );
+
+            let color_formats = if std::env::var("ANVIL_DISABLE_10BIT").is_ok() {
+                SUPPORTED_FORMATS_8BIT_ONLY
+            } else {
+                SUPPORTED_FORMATS
             };
-            compositor.set_debug_flags(self.backend_data.debug_flags);
-            SurfaceComposition::Compositor(compositor)
-        };
 
-        let dmabuf_feedback = get_surface_dmabuf_feedback(
-            self.backend_data.primary_gpu,
-            device.render_node,
-            &mut self.backend_data.gpus,
-            &compositor,
-        );
+            let compositor = if std::env::var("ANVIL_DISABLE_DRM_COMPOSITOR").is_ok() {
+                let gbm_surface =
+                    match GbmBufferedSurface::new(surface, allocator, color_formats, render_formats) {
+                        Ok(renderer) => renderer,
+                        Err(err) => {
+                            warn!("Failed to create rendering surface: {}", err);
+                            return;
+                        }
+                    };
+                SurfaceComposition::Surface {
+                    surface: gbm_surface,
+                    damage_tracker: OutputDamageTracker::from_output(&output),
+                    debug_flags: self.backend_data.debug_flags,
+                }
+            } else {
+                let driver = match device.drm.get_driver() {
+                    Ok(driver) => driver,
+                    Err(err) => {
+                        warn!("Failed to query drm driver: {}", err);
+                        return;
+                    }
+                };
 
-        let surface = SurfaceData {
-            dh: self.display_handle.clone(),
-            device_id: node,
-            render_node: device.render_node,
-            global: Some(global),
-            compositor,
-            #[cfg(feature = "debug")]
-            fps: fps_ticker::Fps::default(),
-            #[cfg(feature = "debug")]
-            fps_element,
-            dmabuf_feedback,
-        };
+                let mut planes = surface.planes().clone();
 
-        device.surfaces.insert(crtc, surface);
+                // Using an overlay plane on a nvidia card breaks
+                if driver.name().to_string_lossy().to_lowercase().contains("nvidia")
+                    || driver
+                        .description()
+                        .to_string_lossy()
+                        .to_lowercase()
+                        .contains("nvidia")
+                {
+                    planes.overlay = vec![];
+                }
 
-        self.schedule_initial_render(node, crtc, self.handle.clone());
+                let mut compositor = match DrmCompositor::new(
+                    &output,
+                    surface,
+                    Some(planes),
+                    allocator,
+                    device.gbm.clone(),
+                    color_formats,
+                    render_formats,
+                    device.drm.cursor_size(),
+                    Some(device.gbm.clone()),
+                ) {
+                    Ok(compositor) => compositor,
+                    Err(err) => {
+                        warn!("Failed to create drm compositor: {}", err);
+                        return;
+                    }
+                };
+                compositor.set_debug_flags(self.backend_data.debug_flags);
+                SurfaceComposition::Compositor(compositor)
+            };
+
+            let dmabuf_feedback = get_surface_dmabuf_feedback(
+                self.backend_data.primary_gpu,
+                device.render_node,
+                &mut self.backend_data.gpus,
+                &compositor,
+            );
+
+            let surface = SurfaceData {
+                dh: self.display_handle.clone(),
+                device_id: node,
+                render_node: device.render_node,
+                global: Some(global),
+                compositor,
+                #[cfg(feature = "debug")]
+                fps: fps_ticker::Fps::default(),
+                #[cfg(feature = "debug")]
+                fps_element,
+                dmabuf_feedback,
+            };
+
+            device.surfaces.insert(crtc, surface);
+
+            self.schedule_initial_render(node, crtc, self.handle.clone());
+        }
     }
 
-    fn connector_disconnected(&mut self, node: DrmNode, _connector: connector::Info, crtc: crtc::Handle) {
+    fn connector_disconnected(&mut self, node: DrmNode, connector: connector::Info, crtc: crtc::Handle) {
         let device = if let Some(device) = self.backend_data.backends.get_mut(&node) {
             device
         } else {
             return;
         };
 
-        device.surfaces.remove(&crtc);
+        if let Some(pos) = device
+            .non_desktop_connectors
+            .iter()
+            .position(|(handle, _)| *handle == connector.handle())
+        {
+            let _ = device.non_desktop_connectors.remove(pos);
+            if let Some(leasing_state) = device.leasing_global.as_mut() {
+                leasing_state.withdraw_connector(connector.handle());
+            }
+        } else {
+            device.surfaces.remove(&crtc);
 
-        let output = self
-            .space
-            .outputs()
-            .find(|o| {
-                o.user_data()
-                    .get::<UdevOutputId>()
-                    .map(|id| id.device_id == node && id.crtc == crtc)
-                    .unwrap_or(false)
-            })
-            .cloned();
+            let output = self
+                .space
+                .outputs()
+                .find(|o| {
+                    o.user_data()
+                        .get::<UdevOutputId>()
+                        .map(|id| id.device_id == node && id.crtc == crtc)
+                        .unwrap_or(false)
+                })
+                .cloned();
 
-        if let Some(output) = output {
-            self.space.unmap_output(&output);
+            if let Some(output) = output {
+                self.space.unmap_output(&output);
+            }
         }
     }
 
@@ -1076,7 +1191,11 @@ impl AnvilState<UdevData> {
         debug!("Surfaces dropped");
 
         // drop the backends on this side
-        if let Some(backend_data) = self.backend_data.backends.remove(&node) {
+        if let Some(mut backend_data) = self.backend_data.backends.remove(&node) {
+            if let Some(mut leasing_global) = backend_data.leasing_global.take() {
+                leasing_global.disable_global::<AnvilState<UdevData>>();
+            }
+
             self.backend_data
                 .gpus
                 .as_mut()

--- a/src/wayland/drm_lease/mod.rs
+++ b/src/wayland/drm_lease/mod.rs
@@ -1,0 +1,1007 @@
+//! DRM Lease protocol
+//!
+//! This module provides helpers to handle the wp_drm_lease_v1 protocol,
+//! which allows clients to lease DRM resources from the compositor.
+//!
+//! This is in particular useful for VR applications, that would like to take over
+//! a directly attached VR display from the DRM device otherwise controlled by the compositor.
+//! In theory however any sorts of DRM resources can be lend out to less privileged clients via this protocol.
+//!
+//! ## How to use
+//!
+//! To setup the drm_lease global, you will need to first provide the `DrmNode` you want to lease resources from.
+//! You can usually get that from your [`DrmDevice`](crate::backend::drm::DrmDevice). Once the global is up,
+//! you can advertise connectors as available through [`DrmLeaseState::add_connector`].
+//! Should a connector become unavailable or is used by the compositor, you may remove it again using [`DrmLeaseState::withdraw_connector`].
+//!
+//! Any client requests will be issued through [`DrmStateHandler::lease_request`], which
+//! allows you to add additional needed DRM resources to the lease and accept or decline the request.
+//!
+//! ```no_run
+//! # use smithay::delegate_drm_lease;
+//! # use smithay::wayland::drm_lease::*;
+//! # use smithay::backend::drm::{DrmDevice, DrmNode};
+//!
+//! pub struct State {
+//!     drm_lease_state: DrmLeaseState,
+//!     active_leases: Vec<DrmLease>,
+//! }
+//!
+//! # impl State {
+//! #     fn get_device_for_node(&self, node: &DrmNode) -> &DrmDevice { todo!() }
+//! # }
+//!
+//! impl DrmLeaseHandler for State {
+//!   fn drm_lease_state(&mut self, node: DrmNode) -> &mut DrmLeaseState { &mut self.drm_lease_state }
+//!   fn lease_request(&mut self, node: DrmNode, request: DrmLeaseRequest) -> Result<DrmLeaseBuilder, LeaseRejected> {
+//!      let device = self.get_device_for_node(&node);
+//!      let mut builder = DrmLeaseBuilder::new(device);
+//!      for connector in request.connectors {
+//!         builder.add_connector(connector);
+//! #       let some_free_crtc = todo!();
+//! #       let primary_plane_for_connector = todo!();
+//!         builder.add_crtc(some_free_crtc);
+//!         builder.add_plane(primary_plane_for_connector);
+//!      }
+//!      Ok(builder)
+//!   }
+//!   fn new_active_lease(&mut self, node: DrmNode, lease: DrmLease) { self.active_leases.push(lease); }
+//!   fn lease_destroyed(&mut self, node: DrmNode, lease_id: u32) { self.active_leases.retain(|l| l.id() != lease_id); }
+//! }
+//!
+//! delegate_drm_lease!(State);
+//!
+//! # let mut display = wayland_server::Display::<State>::new().unwrap();
+//! # let display_handle = display.handle();
+//! # let drm_device: DrmDevice = todo!();
+//! let mut drm_lease_state = DrmLeaseState::new::<State>(
+//!     &display.handle(),
+//!     &DrmNode::from_file(
+//!         drm_device.device_fd()
+//!     ).unwrap()
+//! ).unwrap();
+//!
+//! // Add some connectors
+//! # let some_connector = todo!();
+//! drm_lease_state.add_connector::<State>(some_connector, "Unknown".into(), "Unknown".into());
+//!
+//! let state = State {
+//!    drm_lease_state,
+//!    active_leases: Vec::new(),
+//! };
+//!
+//! // Rest of the compositor goes here
+//! ```
+
+use std::{
+    collections::HashSet,
+    fmt,
+    num::NonZeroU32,
+    os::unix::{
+        io::{FromRawFd, OwnedFd},
+        prelude::AsFd,
+    },
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, Weak,
+    },
+};
+
+use drm::{
+    control::{connector, crtc, plane, Device, OFlag, RawResourceHandle},
+    SystemError,
+};
+use wayland_protocols::wp::drm_lease::v1::server::*;
+use wayland_server::backend::GlobalId;
+use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource};
+
+use crate::backend::drm::{DrmDevice, DrmDeviceFd, DrmNode, NodeType};
+
+/// Delegate type for a drm_lease global
+#[derive(Debug)]
+pub struct DrmLeaseState {
+    node: DrmNode,
+    dh: DisplayHandle,
+    global: Option<GlobalId>,
+    connectors: Vec<DrmLeaseConnector>,
+    known_lease_devices: Vec<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1>,
+    active_leases: Vec<DrmLeaseRef>,
+}
+
+#[derive(Debug)]
+struct DrmLeaseConnector {
+    name: String,
+    description: String,
+    node: DrmNode,
+    handle: connector::Handle,
+    enabled: bool,
+    known_instances: Vec<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1>,
+}
+
+/// Data attached to wp_drm_lease_request_v1 objects
+#[derive(Debug)]
+pub struct DrmLeaseRequestData {
+    node: DrmNode,
+    connectors: Mutex<Vec<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1>>,
+}
+
+/// DRM lease request containing a set of requested connectors
+#[derive(Debug)]
+pub struct DrmLeaseRequest {
+    /// requested connectors
+    pub connectors: Vec<connector::Handle>,
+}
+
+/// Builder struct to collect DRM resources to be leased
+#[derive(Debug)]
+pub struct DrmLeaseBuilder {
+    drm: DrmDeviceFd,
+    planes: HashSet<plane::Handle>,
+    connectors: HashSet<connector::Handle>,
+    crtcs: HashSet<crtc::Handle>,
+}
+
+impl DrmLeaseBuilder {
+    /// Create a new builder from a DRM Device
+    pub fn new(drm: &DrmDevice) -> DrmLeaseBuilder {
+        DrmLeaseBuilder {
+            drm: drm.device_fd().clone(),
+            planes: HashSet::new(),
+            connectors: HashSet::new(),
+            crtcs: HashSet::new(),
+        }
+    }
+
+    /// Add a CRTC to the to be leased resources
+    pub fn add_crtc(&mut self, crtc: crtc::Handle) {
+        self.crtcs.insert(crtc);
+    }
+
+    /// Add a connector to the to be leased resources
+    pub fn add_connector(&mut self, conn: connector::Handle) {
+        self.connectors.insert(conn);
+    }
+
+    /// Add a plane to the to be leased resources
+    pub fn add_plane(&mut self, plane: plane::Handle) {
+        self.planes.insert(plane);
+    }
+
+    fn build(self) -> Result<DrmLease, SystemError> {
+        let objects: Vec<RawResourceHandle> = self
+            .planes
+            .iter()
+            .cloned()
+            .map(Into::into)
+            .chain(self.connectors.iter().cloned().map(Into::into))
+            .chain(self.crtcs.iter().cloned().map(Into::into))
+            .collect();
+        let (id, fd) = self.drm.create_lease(&objects, OFlag::O_CLOEXEC)?;
+
+        Ok(DrmLease {
+            drm: self.drm.clone(),
+            planes: self.planes,
+            connectors: self.connectors,
+            crtcs: self.crtcs,
+            lease_id: id,
+            obj: Arc::new(Mutex::new(None)),
+            fd: Arc::new(Mutex::new(Some(fd))),
+            revoked: Arc::new(AtomicBool::new(false)),
+        })
+    }
+}
+
+/// Active DRM Lease
+///
+/// Dropping will revoke the lease
+#[derive(Debug, Clone)]
+pub struct DrmLease {
+    drm: DrmDeviceFd,
+    planes: HashSet<plane::Handle>,
+    connectors: HashSet<connector::Handle>,
+    crtcs: HashSet<crtc::Handle>,
+    lease_id: NonZeroU32,
+    obj: Arc<Mutex<Option<wp_drm_lease_v1::WpDrmLeaseV1>>>,
+    fd: Arc<Mutex<Option<OwnedFd>>>,
+    revoked: Arc<AtomicBool>,
+}
+
+impl DrmLease {
+    /// CRTCs being leased
+    pub fn crtcs(&self) -> impl Iterator<Item = &crtc::Handle> {
+        self.crtcs.iter()
+    }
+    /// Connectors being leased
+    pub fn connectors(&self) -> impl Iterator<Item = &connector::Handle> {
+        self.connectors.iter()
+    }
+    /// Planes being leased
+    pub fn planes(&self) -> impl Iterator<Item = &plane::Handle> {
+        self.planes.iter()
+    }
+    /// Lease Id
+    pub fn id(&self) -> u32 {
+        self.lease_id.get()
+    }
+
+    fn set_obj(&self, obj: wp_drm_lease_v1::WpDrmLeaseV1) {
+        *self.obj.lock().unwrap() = Some(obj);
+    }
+    fn take_fd(&mut self) -> Option<OwnedFd> {
+        self.fd.lock().unwrap().take()
+    }
+}
+
+#[derive(Debug)]
+struct DrmLeaseRef {
+    drm: DrmDeviceFd,
+    obj: Weak<Mutex<Option<wp_drm_lease_v1::WpDrmLeaseV1>>>,
+    lease_id: NonZeroU32,
+    revoked: Arc<AtomicBool>,
+    connectors: HashSet<connector::Handle>,
+}
+
+impl Drop for DrmLease {
+    fn drop(&mut self) {
+        if let Some(obj) = &self.obj.lock().unwrap().take() {
+            obj.finished();
+        }
+        if !self.revoked.swap(true, Ordering::SeqCst) {
+            tracing::info!(?self.lease_id, "Revoking lease");
+            if let Err(err) = self.drm.revoke_lease(self.lease_id) {
+                tracing::warn!(?err, "Error revoking lease");
+            };
+        }
+    }
+}
+
+impl DrmLeaseRef {
+    fn force_close(&self) {
+        if let Some(obj) = Weak::upgrade(&self.obj).and_then(|obj| obj.lock().unwrap().take()) {
+            obj.finished();
+        }
+        if !self.revoked.swap(true, Ordering::SeqCst) {
+            tracing::info!(?self.lease_id, "Revoking lease");
+            if let Err(err) = self.drm.revoke_lease(self.lease_id) {
+                tracing::warn!(?err, "Error revoking lease");
+            };
+        }
+    }
+}
+
+/// Data attached to wp_drm_lease_v1 objects
+#[derive(Debug)]
+pub struct DrmLeaseData {
+    id: u32,
+    node: DrmNode,
+}
+
+/// DRM lease was rejected by the compositor.
+#[derive(Debug, Default)]
+pub struct LeaseRejected(Option<Box<dyn std::error::Error + 'static>>);
+
+impl fmt::Display for LeaseRejected {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            Some(reason) => f.write_fmt(format_args!("Lease rejected, reason: {}", &**reason)),
+            None => f.write_str("Lease rejected"),
+        }
+    }
+}
+
+impl std::error::Error for LeaseRejected {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.as_deref()
+    }
+}
+
+impl LeaseRejected {
+    /// Wrap any error type in a `LeaseRejected` error to be returned from [`DrmLeaseHandler::lease_requested`].
+    pub fn with_cause<T: std::error::Error + 'static>(err: T) -> Self {
+        LeaseRejected(Some(Box::new(err)))
+    }
+}
+
+/// Handler trait for drm leasing from the compositor.
+pub trait DrmLeaseHandler:
+    GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+    + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, Self>
+    + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, Self>
+    + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, Self>
+    + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, Self>
+    + 'static
+{
+    /// Returns a mutable reference to the [`DrmLeaseState`] delegate type
+    fn drm_lease_state(&mut self, node: DrmNode) -> &mut DrmLeaseState;
+    /// A client has issued a new request.
+    ///
+    /// The request only contains connectors and the compositor is lease any resources it may seem fit.
+    /// It is recommended however to lease the requested connectors and any resources necessary to drive them
+    /// (free CRTCs per connector and at least their primary plane) or reject the request.
+    ///
+    /// To reject the request return `Err(LeaseRejected::default())`, otherwise return a [`DrmLeaseBuilder`] with all the resources added.
+    fn lease_request(
+        &mut self,
+        node: DrmNode,
+        request: DrmLeaseRequest,
+    ) -> Result<DrmLeaseBuilder, LeaseRejected>;
+    /// A new DRM lease is active. Dropping the provided [`DrmLease`] will revoke the lease.
+    fn new_active_lease(&mut self, node: DrmNode, lease: DrmLease);
+    /// A DRM lease was destroyed, the previously given [`DrmLease`] should be cleaned up, if not revoked already.
+    fn lease_destroyed(&mut self, node: DrmNode, lease_id: u32);
+}
+
+/// Data attached to a wp_drm_lease_device_v1 global
+pub struct DrmLeaseDeviceGlobalData {
+    filter: Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>,
+    path: PathBuf,
+    node: DrmNode,
+}
+
+impl fmt::Debug for DrmLeaseDeviceGlobalData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DrmLeaseDeviceGlobalData")
+            .field("path", &self.path)
+            .field("node", &self.node)
+            .finish()
+    }
+}
+
+/// Errors thrown by the DRM lease global
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+pub enum Error {
+    /// Unable to figure out the path of the drm device used
+    #[error("Unable to get modesetting node for drm device")]
+    UnableToGetPath,
+    /// Unable to get a new file descriptor for the drm device used
+    #[error("Unable to get file descriptor for drm device")]
+    UnableToGetFd,
+    /// Unable to open a new file descriptor for the drm device used
+    #[error("Unable to open new file descriptor for drm device")]
+    UnableToOpenNode(#[source] nix::Error),
+    /// Unable to drop DRM Master on a new file descriptor
+    #[error("Unable to drop master status on file descriptor for drm device")]
+    UnableToDropMaster(#[source] nix::errno::Errno),
+}
+
+fn get_non_master_fd<P: AsRef<Path>>(path: P) -> Result<OwnedFd, Error> {
+    let fd = nix::fcntl::open(
+        path.as_ref(),
+        OFlag::O_RDWR | OFlag::O_CLOEXEC,
+        nix::sys::stat::Mode::empty(),
+    )
+    .map_err(Error::UnableToOpenNode)?;
+
+    // check if the fd has master
+    if drm_ffi::get_client(fd, 0)
+        .map(|client| client.auth == 1)
+        .unwrap_or(false)
+    {
+        drm_ffi::auth::release_master(fd).map_err(Error::UnableToDropMaster)?;
+    }
+
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+impl DrmLeaseState {
+    /// Create a new DRM lease global for a given [`DrmNode`].
+    pub fn new<D>(display: &DisplayHandle, drm_node: &DrmNode) -> Result<DrmLeaseState, Error>
+    where
+        D: DrmLeaseHandler
+            + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+            + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+            + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+            + 'static,
+    {
+        Self::new_with_filter::<D, _>(display, drm_node, |_| true)
+    }
+
+    /// Create a new DRM lease global for a given [`DrmNode`] and a filter.
+    ///
+    /// Filters can be used to limit visibility of a global to certain clients.
+    pub fn new_with_filter<D, F>(
+        display: &DisplayHandle,
+        drm_node: &DrmNode,
+        filter: F,
+    ) -> Result<DrmLeaseState, Error>
+    where
+        D: DrmLeaseHandler
+            + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+            + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+            + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+            + 'static,
+        F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
+    {
+        let path = drm_node
+            .dev_path_with_type(NodeType::Primary)
+            .ok_or(Error::UnableToGetPath)?;
+
+        // test once if we can get a non-master fd before initializing the global
+        let _ = get_non_master_fd(&path)?;
+
+        let data = DrmLeaseDeviceGlobalData {
+            filter: Box::new(filter),
+            path,
+            node: *drm_node,
+        };
+
+        let global = display.create_global::<D, wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, _>(1, data);
+
+        Ok(DrmLeaseState {
+            node: *drm_node,
+            dh: display.clone(),
+            global: Some(global),
+            connectors: Vec::new(),
+            known_lease_devices: Vec::new(),
+            active_leases: Vec::new(),
+        })
+    }
+
+    /// Add a connector, that is free to be leased to clients.
+    pub fn add_connector<D>(&mut self, connector: connector::Handle, name: String, description: String)
+    where
+        D: DrmLeaseHandler
+            + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+            + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+            + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+            + 'static,
+    {
+        if self.connectors.iter().any(|conn| conn.handle == connector) {
+            return;
+        }
+
+        let mut instances = Vec::new();
+        for instance in &self.known_lease_devices {
+            if let Ok(client) = self.dh.get_client(instance.id()) {
+                if let Ok(lease_connector) = client
+                    .create_resource::<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, _, D>(
+                        &self.dh, 1, self.node,
+                    )
+                {
+                    instance.connector(&lease_connector);
+                    lease_connector.name(name.clone());
+                    lease_connector.description(description.clone());
+                    lease_connector.connector_id(connector.into());
+                    instances.push(lease_connector);
+                    instance.done();
+                }
+            }
+        }
+
+        self.connectors.push(DrmLeaseConnector {
+            name,
+            description,
+            node: self.node,
+            handle: connector,
+            enabled: true,
+            known_instances: instances,
+        });
+    }
+
+    /// Withdraw a connector from the set of connectors available for leasing
+    pub fn withdraw_connector(&mut self, connector: connector::Handle) {
+        let mut clients = HashSet::new();
+        if let Some(pos) = self.connectors.iter().position(|conn| conn.handle == connector) {
+            let lease_connector = self.connectors.remove(pos);
+            for instance in &lease_connector.known_instances {
+                instance.withdrawn();
+                if let Some(client) = instance.client() {
+                    clients.insert(client.id());
+                }
+            }
+        }
+        for instance in &self.known_lease_devices {
+            if let Some(client) = instance.client() {
+                if clients.contains(&client.id()) {
+                    instance.done();
+                }
+            }
+        }
+
+        self.active_leases
+            .retain(|lease| !lease.connectors.contains(&connector));
+    }
+
+    /// Suspend all connectors temporarily (e.g. upon loosing DRM master as the session becomes inactive)
+    pub fn suspend(&mut self) {
+        self.suspend_internal(None);
+    }
+
+    fn suspend_internal(&mut self, connectors: Option<&HashSet<connector::Handle>>) {
+        let mut clients = HashSet::new();
+        for connector in self.connectors.iter_mut().filter(|c| {
+            connectors
+                .map(|filter| filter.contains(&c.handle))
+                .unwrap_or(true)
+        }) {
+            for instance in connector.known_instances.drain(..) {
+                instance.withdrawn();
+                if let Some(client) = instance.client() {
+                    clients.insert(client.id());
+                }
+            }
+            connector.enabled = false;
+        }
+        for (instance, client) in self
+            .known_lease_devices
+            .iter()
+            .flat_map(|instance| instance.client().map(|client| (instance, client)))
+        {
+            if clients.contains(&client.id()) {
+                instance.done();
+            }
+        }
+    }
+
+    /// Resume all connectors temporarily (e.g. upon gaining DRM master as the session becomes active)
+    pub fn resume<D>(&mut self)
+    where
+        D: DrmLeaseHandler
+            + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+            + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+            + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+            + 'static,
+    {
+        self.resume_internal::<D>(None);
+    }
+
+    fn resume_internal<D>(&mut self, connectors: Option<&HashSet<connector::Handle>>)
+    where
+        D: DrmLeaseHandler
+            + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+            + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+            + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+            + 'static,
+    {
+        for (instance, client) in self
+            .known_lease_devices
+            .iter()
+            .flat_map(|instance| instance.client().map(|client| (instance, client)))
+        {
+            let mut once = false;
+            for connector in self.connectors.iter_mut().filter(|c| {
+                connectors
+                    .map(|filter| filter.contains(&c.handle))
+                    .unwrap_or(true)
+            }) {
+                if let Some(lease_connector) = connector.new_instance::<D>(&self.dh, &client) {
+                    instance.connector(&lease_connector);
+                    connector.send_info(&lease_connector);
+                    once = true;
+                }
+            }
+            if once {
+                instance.done();
+            }
+        }
+        for connector in self.connectors.iter_mut().filter(|c| {
+            connectors
+                .map(|filter| filter.contains(&c.handle))
+                .unwrap_or(true)
+        }) {
+            connector.enabled = true;
+        }
+    }
+
+    fn remove_lease<D>(&mut self, id: u32) -> Option<DrmLeaseRef>
+    where
+        D: DrmLeaseHandler
+            + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+            + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+            + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+            + 'static,
+    {
+        let lease_ref = {
+            if let Some(pos) = self
+                .active_leases
+                .iter()
+                .position(|lease| lease.lease_id.get() == id)
+            {
+                let lease = self.active_leases.remove(pos);
+                self.resume_internal::<D>(Some(&lease.connectors));
+                lease
+            } else {
+                return None;
+            }
+        };
+        lease_ref.force_close();
+        Some(lease_ref)
+    }
+
+    /// [`DrmNode`] belonging to this DRM lease global
+    pub fn node(&self) -> DrmNode {
+        self.node
+    }
+
+    /// Disable the global, it will no longer be advertised to new clients
+    pub fn disable_global<D>(&mut self)
+    where
+        D: DrmLeaseHandler
+            + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+            + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+            + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+            + 'static,
+    {
+        if let Some(global) = self.global.take() {
+            self.dh.disable_global::<D>(global);
+        }
+    }
+}
+
+impl Drop for DrmLeaseState {
+    fn drop(&mut self) {
+        // End all leases
+        self.active_leases.clear();
+
+        // withdraw all connectors
+        for connector in &self.connectors {
+            for instance in &connector.known_instances {
+                instance.withdrawn();
+            }
+        }
+
+        // end all devices
+        for device in &*self.known_lease_devices {
+            device.released();
+        }
+    }
+}
+
+impl DrmLeaseConnector {
+    fn new_instance<D>(
+        &mut self,
+        dh: &DisplayHandle,
+        client: &Client,
+    ) -> Option<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1>
+    where
+        D: DrmLeaseHandler
+            + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+            + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+            + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+            + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+            + 'static,
+    {
+        if let Ok(lease_connector) =
+            client.create_resource::<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, _, D>(dh, 1, self.node)
+        {
+            self.known_instances.push(lease_connector.clone());
+
+            Some(lease_connector)
+        } else {
+            None
+        }
+    }
+
+    fn send_info(&self, connector: &wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1) {
+        connector.name(self.name.clone());
+        connector.description(self.description.clone());
+        connector.connector_id(self.handle.into());
+        connector.done();
+    }
+}
+
+impl<D> GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData, D>
+    for DrmLeaseState
+where
+    D: DrmLeaseHandler
+        + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+        + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+        + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+        + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+        + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+        + 'static,
+{
+    fn bind(
+        state: &mut D,
+        dh: &DisplayHandle,
+        client: &Client,
+        resource: New<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1>,
+        global_data: &DrmLeaseDeviceGlobalData,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        let drm_lease_state = state.drm_lease_state(global_data.node);
+        let wp_drm_lease_device = data_init.init(resource, global_data.node);
+
+        let Ok(fd) = get_non_master_fd(&global_data.path) else {
+            // nothing we can do
+            wp_drm_lease_device.released();
+            return;
+        };
+
+        wp_drm_lease_device.drm_fd(fd.as_fd());
+        for connector in drm_lease_state.connectors.iter_mut().filter(|c| c.enabled) {
+            if let Some(id) = connector.new_instance::<D>(dh, client) {
+                wp_drm_lease_device.connector(&id);
+                connector.send_info(&id);
+            }
+        }
+        wp_drm_lease_device.done();
+
+        drm_lease_state.known_lease_devices.push(wp_drm_lease_device);
+    }
+
+    fn can_view(client: Client, global_data: &DrmLeaseDeviceGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+impl<D> Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D> for DrmLeaseState
+where
+    D: DrmLeaseHandler
+        + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+        + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+        + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+        + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+        + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+        + 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        resource: &wp_drm_lease_device_v1::WpDrmLeaseDeviceV1,
+        request: <wp_drm_lease_device_v1::WpDrmLeaseDeviceV1 as Resource>::Request,
+        data: &DrmNode,
+        _dhandle: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            wp_drm_lease_device_v1::Request::CreateLeaseRequest { id } => {
+                data_init.init(
+                    id,
+                    DrmLeaseRequestData {
+                        node: *data,
+                        connectors: Mutex::new(Vec::new()),
+                    },
+                );
+            }
+            wp_drm_lease_device_v1::Request::Release => {
+                let drm_lease_state = state.drm_lease_state(*data);
+                drm_lease_state
+                    .known_lease_devices
+                    .retain(|device| device != resource);
+                resource.released();
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<D> Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D> for DrmLeaseState
+where
+    D: DrmLeaseHandler
+        + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+        + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+        + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+        + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+        + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+        + 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &Client,
+        _resource: &wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1,
+        _request: <wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1 as Resource>::Request,
+        _data: &DrmNode,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+    }
+
+    fn destroyed(
+        state: &mut D,
+        _client: wayland_server::backend::ClientId,
+        resource: &wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1,
+        data: &DrmNode,
+    ) {
+        let drm_lease_state = state.drm_lease_state(*data);
+        drm_lease_state.connectors.iter_mut().for_each(|connector| {
+            connector.known_instances.retain(|obj| obj != resource);
+        });
+    }
+}
+
+impl<D> Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D> for DrmLeaseState
+where
+    D: DrmLeaseHandler
+        + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+        + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+        + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+        + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+        + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+        + 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        resource: &wp_drm_lease_request_v1::WpDrmLeaseRequestV1,
+        request: <wp_drm_lease_request_v1::WpDrmLeaseRequestV1 as Resource>::Request,
+        data: &DrmLeaseRequestData,
+        _dhandle: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            wp_drm_lease_request_v1::Request::RequestConnector { connector } => {
+                data.connectors.lock().unwrap().push(connector);
+            }
+            wp_drm_lease_request_v1::Request::Submit { id } => {
+                let drm_lease_state = state.drm_lease_state(data.node);
+
+                let mut connector_handles = Vec::new();
+                for connector in &*data.connectors.lock().unwrap() {
+                    if let Some(conn) = drm_lease_state
+                        .connectors
+                        .iter()
+                        .find(|conn| conn.known_instances.iter().any(|obj| obj == connector))
+                    {
+                        if connector_handles.iter().any(|handle| handle == &conn.handle) {
+                            resource.post_error(
+                                wp_drm_lease_request_v1::Error::DuplicateConnector,
+                                format!("Duplicate connector: {}", conn.name),
+                            );
+                            return;
+                        } else {
+                            connector_handles.push(conn.handle);
+                        }
+                    } else {
+                        resource.post_error(
+                            wp_drm_lease_request_v1::Error::WrongDevice,
+                            "Requested lease for wrong device",
+                        );
+                        return;
+                    }
+                }
+
+                if connector_handles.is_empty() {
+                    resource.post_error(
+                        wp_drm_lease_request_v1::Error::EmptyLease,
+                        "Lease doesn't contain any connectors",
+                    );
+                }
+
+                match state.lease_request(
+                    data.node,
+                    DrmLeaseRequest {
+                        connectors: connector_handles,
+                    },
+                ) {
+                    Ok(builder) => match builder.build() {
+                        Ok(mut lease) => {
+                            let lease_obj = data_init.init(
+                                id,
+                                DrmLeaseData {
+                                    id: lease.lease_id.get(),
+                                    node: data.node,
+                                },
+                            );
+                            lease.set_obj(lease_obj.clone());
+                            let fd = lease.take_fd().unwrap();
+                            lease_obj.lease_fd(fd.as_fd());
+
+                            let lease_ref = DrmLeaseRef {
+                                drm: lease.drm.clone(),
+                                obj: Arc::downgrade(&lease.obj),
+                                lease_id: lease.lease_id,
+                                connectors: lease.connectors.clone(),
+                                revoked: lease.revoked.clone(),
+                            };
+
+                            let drm_lease_state = state.drm_lease_state(data.node);
+                            drm_lease_state.suspend_internal(Some(&lease.connectors));
+                            drm_lease_state.active_leases.push(lease_ref);
+
+                            state.new_active_lease(data.node, lease);
+                        }
+                        Err(err) => {
+                            tracing::error!(?err, "Failed to create lease");
+                            let lease_obj = data_init.init(
+                                id,
+                                DrmLeaseData {
+                                    id: 0,
+                                    node: data.node,
+                                },
+                            );
+                            lease_obj.finished();
+                        }
+                    },
+                    Err(err) => {
+                        tracing::debug!(?err, "Compositor denied lease request");
+                        let lease_obj = data_init.init(
+                            id,
+                            DrmLeaseData {
+                                id: 0,
+                                node: data.node,
+                            },
+                        );
+                        lease_obj.finished();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<D> Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D> for DrmLeaseState
+where
+    D: DrmLeaseHandler
+        + GlobalDispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmLeaseDeviceGlobalData>
+        + Dispatch<wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1, DrmNode, D>
+        + Dispatch<wp_drm_lease_device_v1::WpDrmLeaseDeviceV1, DrmNode, D>
+        + Dispatch<wp_drm_lease_request_v1::WpDrmLeaseRequestV1, DrmLeaseRequestData, D>
+        + Dispatch<wp_drm_lease_v1::WpDrmLeaseV1, DrmLeaseData, D>
+        + 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &Client,
+        _resource: &wp_drm_lease_v1::WpDrmLeaseV1,
+        _request: <wp_drm_lease_v1::WpDrmLeaseV1 as Resource>::Request,
+        _data: &DrmLeaseData,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+    }
+
+    fn destroyed(
+        state: &mut D,
+        _client: wayland_server::backend::ClientId,
+        _resource: &wp_drm_lease_v1::WpDrmLeaseV1,
+        data: &DrmLeaseData,
+    ) {
+        let drm_lease_state = state.drm_lease_state(data.node);
+        if let Some(lease_ref) = drm_lease_state.remove_lease::<D>(data.id) {
+            state.lease_destroyed(data.node, lease_ref.lease_id.get());
+        }
+    }
+}
+
+/// Macro to delegate implementation of the drm-lease protocol to [`DrmLeaseState`].
+///
+/// You must also implement [`DrmLeaseHandler`] to use this.
+#[macro_export]
+macro_rules! delegate_drm_lease {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        type __WpDrmLeaseDeviceV1 =
+            $crate::reexports::wayland_protocols::wp::drm_lease::v1::server::wp_drm_lease_device_v1::WpDrmLeaseDeviceV1;
+        type __WpDrmLeaseConnectorV1 =
+            $crate::reexports::wayland_protocols::wp::drm_lease::v1::server::wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1;
+        type __WpDrmLeaseRequestV1 =
+            $crate::reexports::wayland_protocols::wp::drm_lease::v1::server::wp_drm_lease_request_v1::WpDrmLeaseRequestV1;
+        type __WpDrmLeaseV1 =
+            $crate::reexports::wayland_protocols::wp::drm_lease::v1::server::wp_drm_lease_v1::WpDrmLeaseV1;
+
+        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            __WpDrmLeaseDeviceV1: $crate::wayland::drm_lease::DrmLeaseDeviceGlobalData
+        ] => $crate::wayland::drm_lease::DrmLeaseState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            __WpDrmLeaseConnectorV1: $crate::backend::drm::DrmNode
+        ] => $crate::wayland::drm_lease::DrmLeaseState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            __WpDrmLeaseDeviceV1: $crate::backend::drm::DrmNode
+        ] => $crate::wayland::drm_lease::DrmLeaseState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            __WpDrmLeaseRequestV1: $crate::wayland::drm_lease::DrmLeaseRequestData
+        ] => $crate::wayland::drm_lease::DrmLeaseState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            __WpDrmLeaseV1: $crate::wayland::drm_lease::DrmLeaseData
+        ] => $crate::wayland::drm_lease::DrmLeaseState);
+
+    };
+}

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -50,6 +50,8 @@ pub mod compositor;
 pub mod content_type;
 pub mod data_device;
 pub mod dmabuf;
+#[cfg(feature = "backend_drm")]
+pub mod drm_lease;
 pub mod fractional_scale;
 pub mod idle_inhibit;
 pub mod input_method;


### PR DESCRIPTION
TODO:

- [x] Do a drm-rs release
- [x] Make the handler withdraw/re-annouce successfully leased/released connectors internally, so downstream doesn't need to track and call `withdraw_connector` and `add_connector` respectively.
- [x] Add suspend/resume to temporarily revoke all leases/advertised connectors while session is inactive / master was lost
- [x] Implement in anvil
- [x] Actually test the damn thing