### PR TITLE
Feature/egl context priority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,8 +354,11 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-registry-
 
       - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        # nightly changed no_coverage to coverage(off) which breaks the build
+        # see: https://github.com/rust-lang/rust/pull/114656
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2023-06-17
           components: llvm-tools-preview
 
       - name: grcov cache

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -34,7 +34,7 @@ use smithay::{
             compositor::DrmCompositor, CreateDrmNodeError, DrmDevice, DrmDeviceFd, DrmError, DrmEvent,
             DrmEventMetadata, DrmNode, DrmSurface, GbmBufferedSurface, NodeType,
         },
-        egl::{self, EGLDevice, EGLDisplay},
+        egl::{self, context::ContextPriority, EGLDevice, EGLDisplay},
         libinput::{LibinputInputBackend, LibinputSessionInterface},
         renderer::{
             damage::{Error as OutputDamageTrackerError, OutputDamageTracker},
@@ -228,7 +228,7 @@ pub fn run_udev() {
     };
     info!("Using {} as primary gpu.", primary_gpu);
 
-    let gpus = GpuManager::new(GbmGlesBackend::default()).unwrap();
+    let gpus = GpuManager::new(GbmGlesBackend::with_context_priority(ContextPriority::High)).unwrap();
 
     let data = UdevData {
         dh: display.handle(),

--- a/build.rs
+++ b/build.rs
@@ -45,6 +45,7 @@ fn gl_generate() {
                 "EGL_KHR_swap_buffers_with_damage",
                 "EGL_KHR_fence_sync",
                 "EGL_ANDROID_native_fence_sync",
+                "EGL_IMG_context_priority",
             ],
         )
         .write_bindings(gl_generator::GlobalGenerator, &mut file)


### PR DESCRIPTION
This PR adds support for egl context priority using the [EGL_IMG_context_priority](https://registry.khronos.org/EGL/extensions/IMG/EGL_IMG_context_priority.txt) egl extension.

It also changes the multigpu code to request a high priority context by default.