### PR TITLE
Make `frame` a seperate method of `PointerTarget`/`PointerGrab`

### DIFF
--- a/anvil/src/focus.rs
+++ b/anvil/src/focus.rs
@@ -104,6 +104,13 @@ impl<BackendData: Backend> PointerTarget<AnvilState<BackendData>> for FocusTarge
             FocusTarget::Popup(p) => PointerTarget::axis(p.wl_surface(), seat, data, frame),
         }
     }
+    fn frame(&self, seat: &Seat<AnvilState<BackendData>>, data: &mut AnvilState<BackendData>) {
+        match self {
+            FocusTarget::Window(w) => PointerTarget::frame(w, seat, data),
+            FocusTarget::LayerSurface(l) => PointerTarget::frame(l, seat, data),
+            FocusTarget::Popup(p) => PointerTarget::frame(p.wl_surface(), seat, data),
+        }
+    }
     fn leave(
         &self,
         seat: &Seat<AnvilState<BackendData>>,

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -418,6 +418,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             }
             let pointer = self.pointer.clone();
             pointer.axis(self, frame);
+            pointer.frame(self);
         }
     }
 }
@@ -537,6 +538,7 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
                 time: evt.time_msec(),
             },
         );
+        pointer.frame(self);
     }
 }
 
@@ -574,6 +576,7 @@ impl AnvilState<UdevData> {
                                 time: 0,
                             },
                         );
+                        pointer.frame(self);
                     }
                 }
                 KeyAction::ScaleUp => {
@@ -611,6 +614,7 @@ impl AnvilState<UdevData> {
                                 time: 0,
                             },
                         );
+                        pointer.frame(self);
                         self.backend_data.reset_buffers(&output);
                     }
                 }
@@ -649,6 +653,7 @@ impl AnvilState<UdevData> {
                                 time: 0,
                             },
                         );
+                        pointer.frame(self);
                         self.backend_data.reset_buffers(&output);
                     }
                 }
@@ -777,6 +782,7 @@ impl AnvilState<UdevData> {
 
         // If pointer is locked, only emit relative motion
         if pointer_locked {
+            pointer.frame(self);
             return;
         }
 
@@ -792,10 +798,12 @@ impl AnvilState<UdevData> {
         if pointer_confined {
             if let Some((surface, surface_loc)) = &under {
                 if new_under.as_ref().and_then(|(under, _)| under.wl_surface()) != surface.wl_surface() {
+                    pointer.frame(self);
                     return;
                 }
                 if let Some(region) = confine_region {
                     if !region.contains(pointer_location.to_i32_round() - *surface_loc) {
+                        pointer.frame(self);
                         return;
                     }
                 }
@@ -811,6 +819,7 @@ impl AnvilState<UdevData> {
                 time: evt.time_msec(),
             },
         );
+        pointer.frame(self);
 
         // If pointer is now in a constraint region, activate it
         // TODO Anywhere else pointer is moved needs to do this
@@ -866,6 +875,7 @@ impl AnvilState<UdevData> {
                 time: evt.time_msec(),
             },
         );
+        pointer.frame(self);
     }
 
     fn on_tablet_tool_axis<B: InputBackend>(&mut self, evt: B::TabletToolAxisEvent) {
@@ -923,6 +933,8 @@ impl AnvilState<UdevData> {
                     evt.time_msec(),
                 );
             }
+
+            pointer.frame(self);
         }
     }
 
@@ -959,6 +971,7 @@ impl AnvilState<UdevData> {
                     time: 0,
                 },
             );
+            pointer.frame(self);
 
             if let (Some(under), Some(tablet), Some(tool)) = (
                 under.and_then(|(f, loc)| f.wl_surface().map(|s| (s, loc))),

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -302,6 +302,16 @@ impl<Backend: crate::state::Backend> PointerTarget<AnvilState<Backend>> for Wind
             }
         }
     }
+    fn frame(&self, seat: &Seat<AnvilState<Backend>>, data: &mut AnvilState<Backend>) {
+        let state = self.decoration_state();
+        if !state.is_ssd || state.ptr_entered_window {
+            match self {
+                WindowElement::Wayland(w) => PointerTarget::frame(w, seat, data),
+                #[cfg(feature = "xwayland")]
+                WindowElement::X11(w) => PointerTarget::frame(w, seat, data),
+            }
+        }
+    }
     fn leave(
         &self,
         seat: &Seat<AnvilState<Backend>>,

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -77,6 +77,14 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for MoveSurfaceG
         handle.axis(data, details)
     }
 
+    fn frame(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+    ) {
+        handle.frame(data);
+    }
+
     fn gesture_swipe_begin(
         &mut self,
         data: &mut AnvilState<BackendData>,
@@ -430,6 +438,14 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
         details: AxisFrame,
     ) {
         handle.axis(data, details)
+    }
+
+    fn frame(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
+    ) {
+        handle.frame(data);
     }
 
     fn gesture_swipe_begin(

--- a/smallvil/src/grabs/move_grab.rs
+++ b/smallvil/src/grabs/move_grab.rs
@@ -71,6 +71,10 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
         handle.axis(data, details)
     }
 
+    fn frame(&mut self, data: &mut Smallvil, handle: &mut PointerInnerHandle<'_, Smallvil>) {
+        handle.frame(data);
+    }
+
     fn gesture_swipe_begin(
         &mut self,
         data: &mut Smallvil,

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -180,6 +180,10 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
         handle.axis(data, details)
     }
 
+    fn frame(&mut self, data: &mut Smallvil, handle: &mut PointerInnerHandle<'_, Smallvil>) {
+        handle.frame(data);
+    }
+
     fn gesture_swipe_begin(
         &mut self,
         data: &mut Smallvil,

--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -52,6 +52,7 @@ impl Smallvil {
                         time: event.time_msec(),
                     },
                 );
+                pointer.frame(self);
             }
             InputEvent::PointerButton { event, .. } => {
                 let pointer = self.seat.get_pointer().unwrap();
@@ -92,6 +93,7 @@ impl Smallvil {
                         time: event.time_msec(),
                     },
                 );
+                pointer.frame(self);
             }
             InputEvent::PointerAxis { event, .. } => {
                 let source = event.source();
@@ -128,7 +130,9 @@ impl Smallvil {
                     }
                 }
 
-                self.seat.get_pointer().unwrap().axis(self, frame);
+                let pointer = self.seat.get_pointer().unwrap();
+                pointer.axis(self, frame);
+                pointer.frame(self);
             }
             _ => {}
         }

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -757,6 +757,11 @@ impl<D: SeatHandler + 'static> PointerTarget<D> for LayerSurface {
             PointerTarget::<D>::axis(surface, seat, data, frame)
         }
     }
+    fn frame(&self, seat: &Seat<D>, data: &mut D) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::frame(surface, seat, data)
+        }
+    }
     fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {
         if let Some(surface) = self.0.focused_surface.lock().unwrap().take() {
             PointerTarget::<D>::leave(&surface, seat, data, serial, time)

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -623,6 +623,10 @@ where
         handle.axis(data, details);
     }
 
+    fn frame(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>) {
+        handle.frame(data);
+    }
+
     fn gesture_swipe_begin(
         &mut self,
         data: &mut D,

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -297,7 +297,7 @@ impl<D: SeatHandler + 'static> PointerTarget<D> for Window {
                     PointerTarget::<D>::leave(&old_surface, seat, data, event.serial, event.time);
                     PointerTarget::<D>::enter(&surface, seat, data, &new_event);
                 } else {
-                    PointerTarget::<D>::motion(&surface, seat, data, &new_event)
+                    PointerTarget::<D>::motion(&surface, seat, data, &new_event);
                 }
             } else {
                 PointerTarget::<D>::enter(&surface, seat, data, &new_event)
@@ -320,6 +320,11 @@ impl<D: SeatHandler + 'static> PointerTarget<D> for Window {
     fn axis(&self, seat: &Seat<D>, data: &mut D, frame: AxisFrame) {
         if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
             PointerTarget::<D>::axis(surface, seat, data, frame)
+        }
+    }
+    fn frame(&self, seat: &Seat<D>, data: &mut D) {
+        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
+            PointerTarget::<D>::frame(surface, seat, data)
         }
     }
     fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -50,6 +50,7 @@
 //! #   fn relative_motion(&self, seat: &Seat<State>, data: &mut State, event: &RelativeMotionEvent) {}
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
 //! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
 //! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
 //! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
@@ -326,6 +327,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #   fn relative_motion(&self, seat: &Seat<State>, data: &mut State, event: &RelativeMotionEvent) {}
     /// #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
     /// #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
+    /// #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
     /// #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
     /// #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
     /// #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
@@ -435,6 +437,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #   fn relative_motion(&self, seat: &Seat<State>, data: &mut State, event: &RelativeMotionEvent) {}
     /// #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
     /// #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
+    /// #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
     /// #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
     /// #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
     /// #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -73,6 +73,10 @@ pub trait PointerGrab<D: SeatHandler>: Send {
     /// You generally will want to invoke `PointerInnerHandle::axis()` as part of your processing. If you
     /// don't, the rest of the compositor will behave as if the axis event never occurred.
     fn axis(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, details: AxisFrame);
+    /// End of a pointer frame
+    ///
+    /// A frame groups associated events. This terminates the frame.
+    fn frame(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>);
     /// A pointer of a given seat started a swipe gesture
     ///
     /// This method allows you attach additional behavior to a swipe gesture begin event, possibly altering it.
@@ -260,6 +264,10 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
         handle.axis(data, details);
     }
 
+    fn frame(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>) {
+        handle.frame(data);
+    }
+
     fn gesture_swipe_begin(
         &mut self,
         data: &mut D,
@@ -377,6 +385,10 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
 
     fn axis(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, details: AxisFrame) {
         handle.axis(data, details);
+    }
+
+    fn frame(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>) {
+        handle.frame(data);
     }
 
     fn gesture_swipe_begin(

--- a/src/wayland/data_device/dnd_grab.rs
+++ b/src/wayland/data_device/dnd_grab.rs
@@ -255,6 +255,10 @@ where
         handle.axis(data, details);
     }
 
+    fn frame(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>) {
+        handle.frame(data);
+    }
+
     fn gesture_swipe_begin(
         &mut self,
         data: &mut D,

--- a/src/wayland/data_device/server_dnd_grab.rs
+++ b/src/wayland/data_device/server_dnd_grab.rs
@@ -231,6 +231,10 @@ where
         handle.axis(data, details);
     }
 
+    fn frame(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>) {
+        handle.frame(data);
+    }
+
     fn gesture_swipe_begin(
         &mut self,
         data: &mut D,

--- a/src/wayland/pointer_gestures.rs
+++ b/src/wayland/pointer_gestures.rs
@@ -43,6 +43,7 @@
 //! #   fn relative_motion(&self, seat: &Seat<State>, data: &mut State, event: &RelativeMotionEvent) {}
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
 //! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
 //! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
 //! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -31,6 +31,7 @@
 //! #   fn relative_motion(&self, seat: &Seat<State>, data: &mut State, event: &RelativeMotionEvent) {}
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
 //! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
 //! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
 //! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -156,9 +156,6 @@ where
         }
         for_each_focused_pointers(seat, self, |ptr| {
             ptr.enter(serial.into(), self, event.location.x, event.location.y);
-            if ptr.version() >= 5 {
-                ptr.frame();
-            }
         })
     }
     fn leave(&self, seat: &Seat<D>, _data: &mut D, serial: Serial, time: u32) {
@@ -188,9 +185,7 @@ where
         });
         for_each_focused_pointers(seat, self, |ptr| {
             ptr.leave(serial.into(), self);
-            if ptr.version() >= 5 {
-                ptr.frame();
-            }
+            ptr.frame();
         });
         if let Some(pointer) = seat.get_pointer() {
             *pointer.last_enter.lock().unwrap() = None;
@@ -204,9 +199,6 @@ where
     fn motion(&self, seat: &Seat<D>, _data: &mut D, event: &MotionEvent) {
         for_each_focused_pointers(seat, self, |ptr| {
             ptr.motion(event.time, event.location.x, event.location.y);
-            if ptr.version() >= 5 {
-                ptr.frame();
-            }
         })
     }
     fn relative_motion(&self, seat: &Seat<D>, _data: &mut D, event: &RelativeMotionEvent) {
@@ -226,9 +218,6 @@ where
     fn button(&self, seat: &Seat<D>, _data: &mut D, event: &ButtonEvent) {
         for_each_focused_pointers(seat, self, |ptr| {
             ptr.button(event.serial.into(), event.time, event.button, event.state.into());
-            if ptr.version() >= 5 {
-                ptr.frame();
-            }
         })
     }
     fn axis(&self, seat: &Seat<D>, _data: &mut D, details: AxisFrame) {
@@ -273,11 +262,15 @@ where
             if details.axis.1 != 0.0 {
                 ptr.axis(details.time, WlAxis::VerticalScroll, details.axis.1);
             }
+        })
+    }
+
+    fn frame(&self, seat: &Seat<D>, _data: &mut D) {
+        for_each_focused_pointers(seat, self, |ptr| {
             if ptr.version() >= 5 {
-                // frame
                 ptr.frame();
             }
-        })
+        });
     }
 
     fn gesture_swipe_begin(&self, seat: &Seat<D>, _data: &mut D, event: &GestureSwipeBeginEvent) {

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -926,6 +926,12 @@ impl<D: SeatHandler + 'static> PointerTarget<D> for X11Surface {
         }
     }
 
+    fn frame(&self, seat: &Seat<D>, data: &mut D) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            PointerTarget::frame(surface, seat, data);
+        }
+    }
+
     fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
             PointerTarget::leave(surface, seat, data, serial, time);

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -236,6 +236,7 @@ fn handle_event(
                     time,
                 },
             );
+            ptr.frame(state);
         }
         WlcsEvent::PointerMoveRelative { delta, .. } => {
             let pointer_location = state.pointer.current_location() + delta;
@@ -261,15 +262,16 @@ fn handle_event(
                     delta_unaccel: delta,
                     utime,
                 },
-            )
+            );
+            ptr.frame(state);
         }
         WlcsEvent::PointerButtonDown { button_id, .. } => {
             let serial = SCOUNTER.next_serial();
-            let pointer = state.seat.get_pointer().unwrap();
-            if !pointer.is_grabbed() {
+            let ptr = state.seat.get_pointer().unwrap();
+            if !ptr.is_grabbed() {
                 let under = state
                     .space
-                    .element_under(pointer.current_location())
+                    .element_under(ptr.current_location())
                     .map(|(w, _)| w.clone());
                 if let Some(window) = under.as_ref() {
                     state.space.raise_element(window, true);
@@ -281,7 +283,7 @@ fn handle_event(
                     .set_focus(state, under.map(Into::into), serial);
             }
             let time = Duration::from(state.clock.now()).as_millis() as u32;
-            pointer.button(
+            ptr.button(
                 state,
                 &ButtonEvent {
                     button: button_id as u32,
@@ -290,11 +292,13 @@ fn handle_event(
                     time,
                 },
             );
+            ptr.frame(state);
         }
         WlcsEvent::PointerButtonUp { button_id, .. } => {
             let serial = SCOUNTER.next_serial();
             let time = Duration::from(state.clock.now()).as_millis() as u32;
-            state.seat.get_pointer().unwrap().button(
+            let ptr = state.seat.get_pointer().unwrap();
+            ptr.button(
                 state,
                 &ButtonEvent {
                     button: button_id as u32,
@@ -303,6 +307,7 @@ fn handle_event(
                     time,
                 },
             );
+            ptr.frame(state);
         }
         WlcsEvent::PointerRemoved { .. } => {}
         // touch inputs


### PR DESCRIPTION
Input handling in compositors will have to emit this appropriatly. But then other methods don't have to map perfectly to frames.

Meant to address https://github.com/Smithay/smithay/issues/1126.