### PR TITLE
Dependencies updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ wayland-sys = { version = "0.31", optional = true }
 wayland-backend = { version = "0.3.0", optional = true }
 winit = { version = "0.28.0", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
 x11rb = { version = "0.12.0", optional = true }
-xkbcommon = { version = "0.5.0", features = ["wayland"]}
+xkbcommon = { version = "0.6.0", features = ["wayland"]}
 scan_fmt = { version = "0.2.3", default-features = false }
 encoding = { version = "0.2.33", optional = true }
 profiling = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ drm-ffi = { version = "0.6.0", optional = true }
 gbm = { version = "0.13.0", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.12", optional = true }
 input = { version = "0.8.2", default-features = false, features=["libinput_1_14"], optional = true }
-indexmap = "1.9"
+indexmap = "2.0"
 lazy_static = "1"
 libc = "0.2.103"
 libseat = { version = "0.2.1", optional = true, default_features = false }
@@ -60,7 +60,7 @@ wayland-server = { version = "0.31.0", optional = true }
 wayland-sys = { version = "0.31", optional = true }
 wayland-backend = { version = "0.3.0", optional = true }
 winit = { version = "0.28.0", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
-x11rb = { version = "0.11.1", optional = true }
+x11rb = { version = "0.12.0", optional = true }
 xkbcommon = { version = "0.5.0", features = ["wayland"]}
 scan_fmt = { version = "0.2.3", default-features = false }
 encoding = { version = "0.2.33", optional = true }
@@ -69,7 +69,7 @@ smallvec = "1.11"
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
-criterion = { version = "0.4" }
+criterion = { version = "0.5" }
 image = "0.24"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ appendlist = "1.4"
 # Intentionally pick a commit from "0.37-stable" branch since additions for 0.37.1 are used
 ash = { version = "0.37.1", optional = true }
 bitflags = "2.2.1"
-calloop = "0.11.0"
+calloop = "0.12.1"
 cgmath = "0.18.0"
 downcast-rs = "1.2.0"
 drm-fourcc = "^2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ appendlist = "1.4"
 # Intentionally pick a commit from "0.37-stable" branch since additions for 0.37.1 are used
 ash = { version = "0.37.1", optional = true }
 bitflags = "2.2.1"
-calloop = "0.12.1"
+calloop = "0.12.2"
 cgmath = "0.18.0"
 downcast-rs = "1.2.0"
 drm-fourcc = "^2.2.0"

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -18,7 +18,7 @@ xcursor = {version = "0.3.3", optional = true}
 xkbcommon = "0.5.0"
 renderdoc = {version = "0.11.0", optional = true}
 smithay-drm-extras = {path = "../smithay-drm-extras", optional = true}
-puffin_http = { version = "0.9", optional = true }
+puffin_http = { version = "0.13", optional = true }
 profiling = { version = "1.0" }
 
 [dependencies.smithay]
@@ -30,7 +30,7 @@ path = ".."
 default-features = false
 features = ["composite"]
 optional = true
-version = "0.11.1"
+version = "0.12.0"
 
 [build-dependencies]
 gl_generator = "0.14"

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -15,7 +15,7 @@ tracing = { version = "0.1.37", features = ["max_level_trace", "release_max_leve
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 thiserror = "1"
 xcursor = {version = "0.3.3", optional = true}
-xkbcommon = "0.5.0"
+xkbcommon = "0.6.0"
 renderdoc = {version = "0.11.0", optional = true}
 smithay-drm-extras = {path = "../smithay-drm-extras", optional = true}
 puffin_http = { version = "0.13", optional = true }

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -1177,33 +1177,32 @@ enum KeyAction {
 }
 
 fn process_keyboard_shortcut(modifiers: ModifiersState, keysym: Keysym) -> Option<KeyAction> {
-    if modifiers.ctrl && modifiers.alt && keysym == xkb::KEY_BackSpace
-        || modifiers.logo && keysym == xkb::KEY_q
+    if modifiers.ctrl && modifiers.alt && keysym == Keysym::BackSpace || modifiers.logo && keysym == Keysym::q
     {
         // ctrl+alt+backspace = quit
         // logo + q = quit
         Some(KeyAction::Quit)
-    } else if (xkb::KEY_XF86Switch_VT_1..=xkb::KEY_XF86Switch_VT_12).contains(&keysym) {
+    } else if (xkb::KEY_XF86Switch_VT_1..=xkb::KEY_XF86Switch_VT_12).contains(&keysym.raw()) {
         // VTSwitch
         Some(KeyAction::VtSwitch(
-            (keysym - xkb::KEY_XF86Switch_VT_1 + 1) as i32,
+            (keysym.raw() - xkb::KEY_XF86Switch_VT_1 + 1) as i32,
         ))
-    } else if modifiers.logo && keysym == xkb::KEY_Return {
+    } else if modifiers.logo && keysym == Keysym::Return {
         // run terminal
         Some(KeyAction::Run("weston-terminal".into()))
-    } else if modifiers.logo && (xkb::KEY_1..=xkb::KEY_9).contains(&keysym) {
-        Some(KeyAction::Screen((keysym - xkb::KEY_1) as usize))
-    } else if modifiers.logo && modifiers.shift && keysym == xkb::KEY_M {
+    } else if modifiers.logo && (xkb::KEY_1..=xkb::KEY_9).contains(&keysym.raw()) {
+        Some(KeyAction::Screen((keysym.raw() - xkb::KEY_1) as usize))
+    } else if modifiers.logo && modifiers.shift && keysym == Keysym::M {
         Some(KeyAction::ScaleDown)
-    } else if modifiers.logo && modifiers.shift && keysym == xkb::KEY_P {
+    } else if modifiers.logo && modifiers.shift && keysym == Keysym::P {
         Some(KeyAction::ScaleUp)
-    } else if modifiers.logo && modifiers.shift && keysym == xkb::KEY_W {
+    } else if modifiers.logo && modifiers.shift && keysym == Keysym::W {
         Some(KeyAction::TogglePreview)
-    } else if modifiers.logo && modifiers.shift && keysym == xkb::KEY_R {
+    } else if modifiers.logo && modifiers.shift && keysym == Keysym::R {
         Some(KeyAction::RotateOutput)
-    } else if modifiers.logo && modifiers.shift && keysym == xkb::KEY_T {
+    } else if modifiers.logo && modifiers.shift && keysym == Keysym::T {
         Some(KeyAction::ToggleTint)
-    } else if modifiers.logo && modifiers.shift && keysym == xkb::KEY_D {
+    } else if modifiers.logo && modifiers.shift && keysym == Keysym::D {
         Some(KeyAction::ToggleDecorations)
     } else {
         None

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -24,7 +24,7 @@ use smithay::{
         PopupManager, Space,
     },
     input::{
-        keyboard::XkbConfig,
+        keyboard::{Keysym, XkbConfig},
         pointer::{CursorImageStatus, PointerHandle},
         Seat, SeatHandler, SeatState,
     },
@@ -146,7 +146,7 @@ pub struct AnvilState<BackendData: Backend + 'static> {
     pub dnd_icon: Option<WlSurface>,
 
     // input-related fields
-    pub suppressed_keys: Vec<u32>,
+    pub suppressed_keys: Vec<Keysym>,
     pub cursor_status: Arc<Mutex<CursorImageStatus>>,
     pub seat_name: String,
     pub seat: Seat<AnvilState<BackendData>>,

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -529,7 +529,10 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                 Generic::new(display, Interest::READ, Mode::Level),
                 |_, display, data| {
                     profiling::scope!("dispatch_clients");
-                    display.dispatch_clients(&mut data.state).unwrap();
+                    // Safety: we don't drop the display
+                    unsafe {
+                        display.get_mut().dispatch_clients(&mut data.state).unwrap();
+                    }
                     Ok(PostAction::Continue)
                 },
             )

--- a/examples/buffer_test.rs
+++ b/examples/buffer_test.rs
@@ -159,7 +159,7 @@ fn open_device(path: &str) -> DrmDeviceFd {
     let file = File::options()
         .read(true)
         .write(true)
-        .open(&path)
+        .open(path)
         .expect("Failed to open device node");
     DrmDeviceFd::new(DeviceFd::from(Into::<OwnedFd>::into(file)))
 }

--- a/smallvil/src/state.rs
+++ b/smallvil/src/state.rs
@@ -131,7 +131,10 @@ impl Smallvil {
             .insert_source(
                 Generic::new(display, Interest::READ, Mode::Level),
                 |_, display, state| {
-                    display.dispatch_clients(&mut state.state).unwrap();
+                    // Safety: we don't drop the display
+                    unsafe {
+                        display.get_mut().dispatch_clients(&mut state.state).unwrap();
+                    }
                     Ok(PostAction::Continue)
                 },
             )

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -511,12 +511,15 @@ impl EventSource for DrmDeviceNotifier {
 
     fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
         self.token = Some(factory.token());
-        poll.register(
-            self.internal.as_fd(),
-            Interest::READ,
-            calloop::Mode::Level,
-            self.token.unwrap(),
-        )
+        // Safety: the FD cannot be closed without removing the DrmDeviceNotifier from the event loop
+        unsafe {
+            poll.register(
+                self.internal.as_fd(),
+                Interest::READ,
+                calloop::Mode::Level,
+                self.token.unwrap(),
+            )
+        }
     }
 
     fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -769,7 +769,8 @@ impl EventSource for LibinputInputBackend {
 
     fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
         self.token = Some(factory.token());
-        poll.register(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap())
+        // Safety: the FD cannot be closed without removing the LibinputInputBackend from the event loop
+        unsafe { poll.register(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap()) }
     }
 
     fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {

--- a/src/backend/session/libseat.rs
+++ b/src/backend/session/libseat.rs
@@ -243,12 +243,15 @@ impl EventSource for LibSeatSessionNotifier {
 
         self.token = Some(factory.token());
         let mut seat = self.internal.seat.borrow_mut();
-        poll.register(
-            seat.get_fd().unwrap(),
-            calloop::Interest::READ,
-            calloop::Mode::Level,
-            self.token.unwrap(),
-        )
+        // Safety: the seat fd cannot be close without removing the LibSeatSessionNotifier from the event loop
+        unsafe {
+            poll.register(
+                seat.get_fd().unwrap(),
+                calloop::Interest::READ,
+                calloop::Mode::Level,
+                self.token.unwrap(),
+            )
+        }
     }
 
     fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -192,7 +192,8 @@ impl EventSource for UdevBackend {
 
     fn register(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {
         self.token = Some(factory.token());
-        poll.register(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap())
+        // Safety: the fd is owned by the UdevBackend and cannot be closed before it is removed from the event loop
+        unsafe { poll.register(self.as_fd(), Interest::READ, Mode::Level, self.token.unwrap()) }
     }
 
     fn reregister(&mut self, poll: &mut Poll, factory: &mut TokenFactory) -> calloop::Result<()> {

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -149,7 +149,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for WlSurface {
             kbd.enter(
                 serial.into(),
                 self,
-                serialize_pressed_keys(keys.iter().map(|h| h.raw_code() - 8).collect()),
+                serialize_pressed_keys(keys.iter().map(|h| h.raw_code().raw() - 8).collect()),
             )
         });
         let text_input = seat.text_input();
@@ -173,7 +173,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for WlSurface {
         time: u32,
     ) {
         for_each_focused_kbds(seat, self, |kbd| {
-            kbd.key(serial.into(), time, key.raw_code() - 8, state.into())
+            kbd.key(serial.into(), time, key.raw_code().raw() - 8, state.into())
         })
     }
 

--- a/src/wayland/socket.rs
+++ b/src/wayland/socket.rs
@@ -88,7 +88,7 @@ impl ListeningSocketSource {
 
     /// Returns the name of the listening socket.
     pub fn socket_name(&self) -> &OsStr {
-        self.socket.file.socket_name().unwrap()
+        self.socket.get_ref().socket_name().unwrap()
     }
 }
 

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -282,7 +282,8 @@ where
             Generic::<_, io::Error>::new(child_stdout, Interest::READ, Mode::Level),
             move |_, child_stdout, _| {
                 // the closure must be called exactly one time, this cannot panic
-                xwayland_ready(&loop_inner, child_stdout);
+                // Safety: xwayland_ready will not close the child_stdout
+                xwayland_ready(&loop_inner, unsafe { child_stdout.get_mut() });
                 Ok(calloop::PostAction::Remove)
             },
         )

--- a/wlcs_anvil/Cargo.toml
+++ b/wlcs_anvil/Cargo.toml
@@ -12,8 +12,8 @@ crate-type = ["cdylib"]
 [dependencies]
 smithay = { path = "..", default-features=false, features=["wayland_frontend", "backend_egl", "use_system_lib"] }
 anvil = { path = "../anvil", default-features=false }
-wayland-sys = { version = "0.30.1", features = ["client", "server"] }
+wayland-sys = { version = "0.31.0", features = ["client", "server"] }
 libc = "0.2"
-memoffset = "0.6"
+memoffset = "0.9"
 cgmath = "0.18"
-nix = "0.24"
+nix = "0.27"

--- a/wlcs_anvil/src/renderer.rs
+++ b/wlcs_anvil/src/renderer.rs
@@ -100,7 +100,7 @@ impl ImportMemWl for DummyRenderer {
                 for w in 0..width {
                     let idx = (offset + w + h * stride) as usize;
                     assert!(idx < len);
-                    x |= unsafe { ptr::read(ptr.offset(idx as isize)) };
+                    x |= unsafe { ptr::read(ptr.add(idx)) };
                 }
             }
 


### PR DESCRIPTION
PR composed of 4 commits:

- Update of calloop to 0.12.1, which required adding a few unsafe block with associated safety comments
- Trivial update of several dependencies
- Update of xkbcommon to 0.6.0, which now uses concrete types to represent `Keycode` and `Keysym`, this found a small bug in the input/keyboard logic, where the `+ 8` offset was forgotten
- Minor clippy fixes