### PR TITLE
Update winit to 0.29.2 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,7 +419,7 @@ jobs:
       - name: Build Documentation
         env: 
           RUSTDOCFLAGS: --cfg=docsrs
-        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.10.6 -p drm -p gbm -p input -p nix:0.27.1 -p udev:0.8.0 -p wayland-server -p wayland-backend -p wayland-protocols:0.31.0 -p winit -p x11rb
+        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop -p drm -p gbm -p input -p nix:0.27.1 -p udev:0.8.0 -p wayland-server -p wayland-backend -p wayland-protocols:0.31.0 -p winit -p x11rb
         
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ wayland-protocols-misc = { version = "0.2.0", features = ["server"], optional = 
 wayland-server = { version = "0.31.0", optional = true }
 wayland-sys = { version = "0.31", optional = true }
 wayland-backend = { version = "0.3.0", optional = true }
-winit = { version = "0.28.0", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
+winit = { version = "0.29.2", default-features = false, features = ["wayland", "wayland-dlopen", "x11", "rwh_06"], optional = true }
 x11rb = { version = "0.12.0", optional = true }
 xkbcommon = { version = "0.7.0", features = ["wayland"]}
 scan_fmt = { version = "0.2.3", default-features = false }

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -19,10 +19,7 @@ use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 #[cfg(feature = "backend_winit")]
 use wayland_egl as wegl;
 #[cfg(feature = "backend_winit")]
-use winit::{
-    platform::{wayland::WindowExtWayland, x11::WindowExtX11},
-    window::Window as WinitWindow,
-};
+use winit::window::Window as WinitWindow;
 
 #[cfg(feature = "backend_gbm")]
 use gbm::{AsRaw, Device as GbmDevice};
@@ -165,52 +162,58 @@ impl<A: AsFd + Send + 'static> EGLNativeDisplay for GbmDevice<A> {
 #[cfg(feature = "backend_winit")]
 impl EGLNativeDisplay for Arc<WinitWindow> {
     fn supported_platforms(&self) -> Vec<EGLPlatform<'_>> {
-        if let Some(display) = self.wayland_display() {
-            vec![
-                // see: https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_platform_wayland.txt
-                egl_platform!(PLATFORM_WAYLAND_KHR, display, &["EGL_KHR_platform_wayland"]),
-                // see: https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_platform_wayland.txt
-                egl_platform!(PLATFORM_WAYLAND_EXT, display, &["EGL_EXT_platform_wayland"]),
-                // see: https://raw.githubusercontent.com/google/angle/main/extensions/EGL_ANGLE_platform_angle.txt
-                egl_platform!(
-                    PLATFORM_ANGLE_ANGLE,
-                    display,
-                    &[
-                        "EGL_ANGLE_platform_angle",
-                        "EGL_ANGLE_platform_angle_vulkan",
-                        "EGL_EXT_platform_wayland",
-                    ],
-                    vec![
-                        ffi::egl::PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE,
-                        ffi::egl::PLATFORM_WAYLAND_EXT as _,
-                        ffi::egl::PLATFORM_ANGLE_TYPE_ANGLE,
-                        ffi::egl::PLATFORM_ANGLE_TYPE_VULKAN_ANGLE,
-                        ffi::egl::NONE as ffi::EGLint
-                    ]
-                ),
-            ]
-        } else if let Some(display) = self.xlib_display() {
-            vec![
-                // see: https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_platform_x11.txt
-                egl_platform!(PLATFORM_X11_KHR, display, &["EGL_KHR_platform_x11"]),
-                // see: https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_platform_x11.txt
-                egl_platform!(PLATFORM_X11_EXT, display, &["EGL_EXT_platform_x11"]),
-                // see: https://raw.githubusercontent.com/google/angle/main/extensions/EGL_ANGLE_platform_angle.txt
-                egl_platform!(
-                    PLATFORM_ANGLE_ANGLE,
-                    display,
-                    &["EGL_ANGLE_platform_angle", "EGL_ANGLE_platform_angle_vulkan"],
-                    vec![
-                        ffi::egl::PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE,
-                        ffi::egl::PLATFORM_X11_EXT as _,
-                        ffi::egl::PLATFORM_ANGLE_TYPE_ANGLE,
-                        ffi::egl::PLATFORM_ANGLE_TYPE_VULKAN_ANGLE,
-                        ffi::egl::NONE as ffi::EGLint
-                    ]
-                ),
-            ]
-        } else {
-            unreachable!("No backends for winit other then Wayland and X11 are supported")
+        use winit::raw_window_handle::{self, HasDisplayHandle};
+
+        match self.display_handle().map(|handle| handle.as_raw()) {
+            Ok(raw_window_handle::RawDisplayHandle::Xlib(handle)) => {
+                let display = handle.display.unwrap().as_ptr();
+                vec![
+                    // see: https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_platform_x11.txt
+                    egl_platform!(PLATFORM_X11_KHR, display, &["EGL_KHR_platform_x11"]),
+                    // see: https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_platform_x11.txt
+                    egl_platform!(PLATFORM_X11_EXT, display, &["EGL_EXT_platform_x11"]),
+                    // see: https://raw.githubusercontent.com/google/angle/main/extensions/EGL_ANGLE_platform_angle.txt
+                    egl_platform!(
+                        PLATFORM_ANGLE_ANGLE,
+                        display,
+                        &["EGL_ANGLE_platform_angle", "EGL_ANGLE_platform_angle_vulkan"],
+                        vec![
+                            ffi::egl::PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE,
+                            ffi::egl::PLATFORM_X11_EXT as _,
+                            ffi::egl::PLATFORM_ANGLE_TYPE_ANGLE,
+                            ffi::egl::PLATFORM_ANGLE_TYPE_VULKAN_ANGLE,
+                            ffi::egl::NONE as ffi::EGLint
+                        ]
+                    ),
+                ]
+            }
+            Ok(raw_window_handle::RawDisplayHandle::Wayland(handle)) => {
+                let display = handle.display.as_ptr();
+                vec![
+                    // see: https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_platform_wayland.txt
+                    egl_platform!(PLATFORM_WAYLAND_KHR, display, &["EGL_KHR_platform_wayland"]),
+                    // see: https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_platform_wayland.txt
+                    egl_platform!(PLATFORM_WAYLAND_EXT, display, &["EGL_EXT_platform_wayland"]),
+                    // see: https://raw.githubusercontent.com/google/angle/main/extensions/EGL_ANGLE_platform_angle.txt
+                    egl_platform!(
+                        PLATFORM_ANGLE_ANGLE,
+                        display,
+                        &[
+                            "EGL_ANGLE_platform_angle",
+                            "EGL_ANGLE_platform_angle_vulkan",
+                            "EGL_EXT_platform_wayland",
+                        ],
+                        vec![
+                            ffi::egl::PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE,
+                            ffi::egl::PLATFORM_WAYLAND_EXT as _,
+                            ffi::egl::PLATFORM_ANGLE_TYPE_ANGLE,
+                            ffi::egl::PLATFORM_ANGLE_TYPE_VULKAN_ANGLE,
+                            ffi::egl::NONE as ffi::EGLint
+                        ]
+                    ),
+                ]
+            }
+            _ => unreachable!("No backends for winit other then Wayland and X11 are supported"),
         }
     }
 }

--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -1,7 +1,7 @@
-use std::{cell::RefCell, path::PathBuf, rc::Rc};
+use std::path::PathBuf;
 
 use winit::{
-    dpi::LogicalPosition,
+    dpi::PhysicalPosition,
     event::{ElementState, MouseButton as WinitMouseButton, MouseScrollDelta},
 };
 
@@ -11,8 +11,6 @@ use crate::backend::input::{
     PointerMotionAbsoluteEvent, TouchCancelEvent, TouchDownEvent, TouchEvent, TouchMotionEvent, TouchSlot,
     TouchUpEvent, UnusedEvent,
 };
-
-use super::WindowSize;
 
 /// Marker used to define the `InputBackend` types for the winit backend.
 #[derive(Debug)]
@@ -83,9 +81,9 @@ impl KeyboardKeyEvent<WinitInput> for WinitKeyboardInputEvent {
 /// Winit-Backend internal event wrapping `winit`'s types into a [`PointerMotionAbsoluteEvent`]
 #[derive(Debug, Clone)]
 pub struct WinitMouseMovedEvent {
-    pub(crate) size: Rc<RefCell<WindowSize>>,
     pub(crate) time: u64,
-    pub(crate) logical_position: LogicalPosition<f64>,
+    pub(crate) position: RelativePosition,
+    pub(crate) global_position: PhysicalPosition<f64>,
 }
 
 impl Event<WinitInput> for WinitMouseMovedEvent {
@@ -100,27 +98,20 @@ impl Event<WinitInput> for WinitMouseMovedEvent {
 
 impl PointerMotionAbsoluteEvent<WinitInput> for WinitMouseMovedEvent {}
 impl AbsolutePositionEvent<WinitInput> for WinitMouseMovedEvent {
-    // TODO: maybe use {Logical, Physical}Position from winit?
     fn x(&self) -> f64 {
-        let wsize = self.size.borrow();
-        self.logical_position.x * wsize.scale_factor
+        self.global_position.x
     }
 
     fn y(&self) -> f64 {
-        let wsize = self.size.borrow();
-        self.logical_position.y * wsize.scale_factor
+        self.global_position.y
     }
 
     fn x_transformed(&self, width: i32) -> f64 {
-        let wsize = self.size.borrow();
-        let w_width = wsize.logical_size().w;
-        f64::max(self.logical_position.x * width as f64 / w_width, 0.0)
+        f64::max(self.position.x * width as f64, 0.0)
     }
 
     fn y_transformed(&self, height: i32) -> f64 {
-        let wsize = self.size.borrow();
-        let w_height = wsize.logical_size().h;
-        f64::max(self.logical_position.y * height as f64 / w_height, 0.0)
+        f64::max(self.position.y * height as f64, 0.0)
     }
 }
 
@@ -191,6 +182,8 @@ impl PointerButtonEvent<WinitInput> for WinitMouseInputEvent {
             WinitMouseButton::Left => 0x110,
             WinitMouseButton::Right => 0x111,
             WinitMouseButton::Middle => 0x112,
+            WinitMouseButton::Forward => 0x115,
+            WinitMouseButton::Back => 0x116,
             WinitMouseButton::Other(b) => {
                 if self.is_x11 {
                     input::xorg_mouse_to_libinput(b as u32)
@@ -209,9 +202,9 @@ impl PointerButtonEvent<WinitInput> for WinitMouseInputEvent {
 /// Winit-Backend internal event wrapping `winit`'s types into a [`TouchDownEvent`]
 #[derive(Debug, Clone)]
 pub struct WinitTouchStartedEvent {
-    pub(crate) size: Rc<RefCell<WindowSize>>,
     pub(crate) time: u64,
-    pub(crate) location: LogicalPosition<f64>,
+    pub(crate) position: RelativePosition,
+    pub(crate) global_position: PhysicalPosition<f64>,
     pub(crate) id: u64,
 }
 
@@ -235,34 +228,28 @@ impl TouchEvent<WinitInput> for WinitTouchStartedEvent {
 
 impl AbsolutePositionEvent<WinitInput> for WinitTouchStartedEvent {
     fn x(&self) -> f64 {
-        let wsize = self.size.borrow();
-        self.location.x * wsize.scale_factor
+        self.global_position.x
     }
 
     fn y(&self) -> f64 {
-        let wsize = self.size.borrow();
-        self.location.y * wsize.scale_factor
+        self.global_position.y
     }
 
     fn x_transformed(&self, width: i32) -> f64 {
-        let wsize = self.size.borrow();
-        let w_width = wsize.logical_size().w;
-        f64::max(self.location.x * width as f64 / w_width, 0.0)
+        f64::max(self.position.x * width as f64, 0.0)
     }
 
     fn y_transformed(&self, height: i32) -> f64 {
-        let wsize = self.size.borrow();
-        let w_height = wsize.logical_size().h;
-        f64::max(self.location.y * height as f64 / w_height, 0.0)
+        f64::max(self.position.y * height as f64, 0.0)
     }
 }
 
 /// Winit-Backend internal event wrapping `winit`'s types into a [`TouchMotionEvent`]
 #[derive(Debug, Clone)]
 pub struct WinitTouchMovedEvent {
-    pub(crate) size: Rc<RefCell<WindowSize>>,
     pub(crate) time: u64,
-    pub(crate) location: LogicalPosition<f64>,
+    pub(crate) position: RelativePosition,
+    pub(crate) global_position: PhysicalPosition<f64>,
     pub(crate) id: u64,
 }
 
@@ -286,25 +273,19 @@ impl TouchEvent<WinitInput> for WinitTouchMovedEvent {
 
 impl AbsolutePositionEvent<WinitInput> for WinitTouchMovedEvent {
     fn x(&self) -> f64 {
-        let wsize = self.size.borrow();
-        self.location.x * wsize.scale_factor
+        self.global_position.x
     }
 
     fn y(&self) -> f64 {
-        let wsize = self.size.borrow();
-        self.location.y * wsize.scale_factor
+        self.global_position.y
     }
 
     fn x_transformed(&self, width: i32) -> f64 {
-        let wsize = self.size.borrow();
-        let w_width = wsize.logical_size().w;
-        f64::max(self.location.x * width as f64 / w_width, 0.0)
+        f64::max(self.position.x * width as f64, 0.0)
     }
 
     fn y_transformed(&self, height: i32) -> f64 {
-        let wsize = self.size.borrow();
-        let w_height = wsize.logical_size().h;
-        f64::max(self.location.y * height as f64 / w_height, 0.0)
+        f64::max(self.position.y * height as f64, 0.0)
     }
 }
 
@@ -373,6 +354,22 @@ impl From<ElementState> for ButtonState {
             ElementState::Pressed => ButtonState::Pressed,
             ElementState::Released => ButtonState::Released,
         }
+    }
+}
+
+/// Position relative to the source window, so each coordinate lays inside
+/// the range from [0;1].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct RelativePosition {
+    /// Position of the `x` relative to the window.
+    x: f64,
+    /// Position of the `y` relative to the window.
+    y: f64,
+}
+
+impl RelativePosition {
+    pub(crate) fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
     }
 }
 


### PR DESCRIPTION
Make better winit integration by providing a calloop's WaylandSource
for it. The winit backend now doesn't use vsync and utilizes frame
callbacks, when the user cooperates and asks for `redraw_requested`.

Fixes #146.