### PR TITLE
Use safe IO types in a couple more places

### DIFF
--- a/src/backend/drm/node/mod.rs
+++ b/src/backend/drm/node/mod.rs
@@ -8,7 +8,7 @@ use libc::dev_t;
 use std::{
     fmt::{self, Display, Formatter},
     io,
-    os::unix::io::{AsRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd},
     path::{Path, PathBuf},
 };
 
@@ -36,17 +36,12 @@ pub struct DrmNode {
 }
 
 impl DrmNode {
-    /// Creates a DRM node from a file descriptor.
+    /// Creates a DRM node from an open drm device.
     ///
     /// This function does not take ownership of the passed in file descriptor.
-    pub fn from_fd(fd: RawFd) -> Result<DrmNode, CreateDrmNodeError> {
-        let stat = fstat(fd).map_err(Into::<io::Error>::into)?;
+    pub fn from_file<A: AsFd>(file: A) -> Result<DrmNode, CreateDrmNodeError> {
+        let stat = fstat(file.as_fd().as_raw_fd()).map_err(Into::<io::Error>::into)?;
         DrmNode::from_stat(stat)
-    }
-
-    /// Creates a DRM node from an open drm device.
-    pub fn from_file<A: AsRawFd>(file: &A) -> Result<DrmNode, CreateDrmNodeError> {
-        DrmNode::from_fd(file.as_raw_fd())
     }
 
     /// Creates a DRM node from path.


### PR DESCRIPTION
This still leaves `XWaylandEvent::Ready` using a `RawFd`, which is awkward. Not sure exactly what the logic is there, and that field isn't used in anvil or cosmic-comp, but maybe ref-counting could be used? And `RawFd`s are used in `Session`/`LibSeatSession`, but it's not clear how to update that either.