### PR TITLE
Simplify the CI a bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,33 +143,54 @@ jobs:
       - name: Check
         run: cargo check --features "test_all_features"
 
+  smithay-check-features:
+    needs:
+      - format
+      - clippy-check
+
+    env:
+      RUSTFLAGS: "-D warnings"
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Get date for registry cache
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Cargo registry cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ steps.date.outputs.date }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: System dependencies
+        run: sudo apt-get update; sudo apt-get install -y libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev
+
+      - name: Downgrade log
+        run: cargo update -p log --precise 0.4.14
+
+      - name: Test features
+        env:
+          RUST_BACKTRACE: full
+        run: cargo hack check --each-feature --no-dev-deps
+
   smithay-tests:
     needs:
       - format
       - clippy-check
-    strategy:
-      fail-fast: false
-      matrix:
-        features:
-        - ''
-        - backend_winit
-        - backend_drm
-        - backend_gbm
-        - backend_egl
-        - backend_libinput
-        - backend_udev
-        - backend_session
-        - backend_session_libseat
-        - backend_vulkan
-        - backend_x11
-        - desktop
-        - renderer_gl
-        - renderer_glow
-        - renderer_multi
-        - wayland_frontend
-        - xwayland
-        - default
-        - test_all_features
 
     env:
       RUSTFLAGS: "-D warnings"
@@ -202,18 +223,16 @@ jobs:
       - name: Downgrade log
         run: cargo update -p log --precise 0.4.14
       
-      - name: Test features
+      - name: Run tests
         env:
           RUST_BACKTRACE: full
-        run: cargo test --no-default-features --features "${{ matrix.features }}"
+        run: cargo test --features "test_all_features"
 
-  smallvil:
+  smallvil-check:
     needs:
       - format
       - clippy-check
       - smithay-tests
-    strategy:
-      fail-fast: false
 
     env:
       RUSTFLAGS: "-D warnings"
@@ -249,24 +268,13 @@ jobs:
       - name: Test smallvil
         env:
           RUST_BACKTRACE: full
-        run: cargo test --manifest-path "./smallvil/Cargo.toml"
+        run: cargo check --manifest-path "./smallvil/Cargo.toml"
 
-  anvil-tests:
+  anvil-check-features:
     needs:
       - format
       - clippy-check
       - smithay-tests
-    strategy:
-      fail-fast: false
-      matrix:
-        features:
-        - ''
-        - egl
-        - winit
-        - udev
-        - x11
-        - default
-        - test_all_features
 
     env:
       RUSTFLAGS: "-D warnings"
@@ -293,6 +301,9 @@ jobs:
       - name: Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev
       
@@ -302,14 +313,14 @@ jobs:
       - name: Test features
         env:
           RUST_BACKTRACE: full
-        run: cargo test --manifest-path "./anvil/Cargo.toml" --no-default-features --features "${{ matrix.features }}"
+        run: cargo hack check --each-feature --manifest-path "./anvil/Cargo.toml"
 
   anvil-wlcs:
     needs:
       - format
       - clippy-check
       - smithay-tests
-      - anvil-tests
+      - anvil-check-features
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,7 @@ jobs:
 
     runs-on: ubuntu-22.04
     needs:
-      - clippy-check
-      - format
+      - smithay-check-features
 
     steps:
       - name: Checkout sources
@@ -108,8 +107,7 @@ jobs:
 
     runs-on: ubuntu-22.04
     needs:
-      - clippy-check
-      - format
+      - smithay-check-features
 
     steps:
       - name: Checkout sources
@@ -140,9 +138,6 @@ jobs:
         run: cargo check --features "test_all_features"
 
   smithay-check-features:
-    needs:
-      - format
-      - clippy-check
 
     env:
       RUSTFLAGS: "-D warnings"
@@ -182,8 +177,7 @@ jobs:
 
   smithay-tests:
     needs:
-      - format
-      - clippy-check
+      - smithay-check-features
 
     env:
       RUSTFLAGS: "-D warnings"
@@ -220,9 +214,7 @@ jobs:
 
   smallvil-check:
     needs:
-      - format
-      - clippy-check
-      - smithay-tests
+      - smithay-check-features
 
     env:
       RUSTFLAGS: "-D warnings"
@@ -259,9 +251,7 @@ jobs:
 
   anvil-check-features:
     needs:
-      - format
-      - clippy-check
-      - smithay-tests
+      - smithay-check-features
 
     env:
       RUSTFLAGS: "-D warnings"
@@ -301,9 +291,6 @@ jobs:
 
   anvil-wlcs:
     needs:
-      - format
-      - clippy-check
-      - smithay-tests
       - anvil-check-features
 
     strategy:
@@ -400,7 +387,7 @@ jobs:
     name: Documentation on Github Pages
     runs-on: ubuntu-22.04
     needs:
-      - smithay-tests
+      - smithay-check-features
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,6 @@ jobs:
         run: cargo cache clean-unref
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev
-      - name: Downgrade log
-        run: cargo update -p log --precise 0.4.14
       - name: Clippy Smithay
         run: cargo clippy --features "test_all_features" -- -D warnings
       - name: Clippy Anvil
@@ -101,8 +99,6 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-registry-
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev
-      - name: Downgrade log
-        run: cargo update -p log --precise 0.4.14
       - name: Check
         run: cargo check --features "test_all_features"
 
@@ -179,9 +175,6 @@ jobs:
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev
 
-      - name: Downgrade log
-        run: cargo update -p log --precise 0.4.14
-
       - name: Test features
         env:
           RUST_BACKTRACE: full
@@ -219,9 +212,6 @@ jobs:
       
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev
-
-      - name: Downgrade log
-        run: cargo update -p log --precise 0.4.14
       
       - name: Run tests
         env:
@@ -261,9 +251,6 @@ jobs:
 
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libxkbcommon-dev libegl1-mesa-dev libwayland-dev
-      
-      - name: Downgrade log
-        run: cargo update -p log --precise 0.4.14
       
       - name: Test smallvil
         env:
@@ -306,9 +293,6 @@ jobs:
 
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev
-      
-      - name: Downgrade log
-        run: cargo update -p log --precise 0.4.14
       
       - name: Test features
         env:
@@ -393,9 +377,6 @@ jobs:
       - name: Build WLCS
         run: ./compile_wlcs.sh
 
-      - name: Downgrade log
-        run: cargo update -p log --precise 0.4.14
-
       - name: Build anvil WLCS plugin
         env:
           RUST_BACKTRACE: full
@@ -447,9 +428,6 @@ jobs:
 
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev
-      
-      - name: Downgrade log
-        run: cargo update -p log --precise 0.4.14
       
       - name: Build Documentation
         env: 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Test features
         env:
           RUST_BACKTRACE: full
-        run: cargo hack check --each-feature --manifest-path "./anvil/Cargo.toml"
+        run: cargo hack check --each-feature --manifest-path "./anvil/Cargo.toml" --exclude-features profile-with-puffin,profile-with-tracy,profile-with-tracy-mem
 
   anvil-wlcs:
     needs:


### PR DESCRIPTION
A few changes to hopefully simplify the CI and reduce its running time:

- Use `cargo check` instead of `cargo test` when there is no test to run anyway
- Use `cargo hack` to check features individually instead of creating a huge matrix of jobs
  - Should save on runtime overall for no longer having a huge list of containers to run and being rate-limited by github
  - Makes the CI result less clogged to read
  - This will automatically pick up new features if / when they are added
- Stop downgrading `log`, this was done to workaround an issue with slog but we don't use it anymore so that should no longer be needed.