### PR TITLE
Make output_update() public

### DIFF
--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -26,7 +26,7 @@ mod output;
 mod utils;
 
 #[cfg(feature = "wayland_frontend")]
-mod wayland;
+pub(crate) mod wayland;
 
 pub use self::element::*;
 use self::output::*;

--- a/src/desktop/space/wayland/mod.rs
+++ b/src/desktop/space/wayland/mod.rs
@@ -27,9 +27,13 @@ fn output_surfaces(o: &Output) -> RefMut<'_, HashSet<WlWeak<WlSurface>>> {
     surfaces
 }
 
+/// Updates the output overlap for a surface tree.
+///
+/// Surfaces in the tree will receive output enter and leave events as necessary according to their
+/// computed overlap.
 #[instrument(level = "trace", skip(output), fields(output = output.name()))]
 #[profiling::function]
-fn output_update(output: &Output, output_overlap: Option<Rectangle<i32, Logical>>, surface: &WlSurface) {
+pub fn output_update(output: &Output, output_overlap: Option<Rectangle<i32, Logical>>, surface: &WlSurface) {
     let mut surface_list = output_surfaces(output);
 
     with_surface_tree_downward(

--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -59,20 +59,11 @@ impl SpaceElement for X11Surface {
             state.borrow_mut().output_overlap.retain(|weak, _| weak != output);
         }
 
-        let mut surface_list = output_surfaces(output);
         let state = self.state.lock().unwrap();
         let Some(surface) = state.wl_surface.as_ref() else {
             return;
         };
-        with_surface_tree_downward(
-            surface,
-            (),
-            |_, _, _| TraversalAction::DoChildren(()),
-            |wl_surface, _, _| {
-                output_leave(output, &mut surface_list, wl_surface);
-            },
-            |_, _, _| true,
-        );
+        output_update(output, None, surface);
     }
 
     fn refresh(&self) {
@@ -85,7 +76,7 @@ impl SpaceElement for X11Surface {
         };
         for (weak, overlap) in wo_state.output_overlap.iter() {
             if let Some(output) = weak.upgrade() {
-                output_update(&output, *overlap, surface);
+                output_update(&output, Some(*overlap), surface);
             }
         }
     }

--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -20,6 +20,8 @@ use std::{cell::RefCell, sync::Mutex, time::Duration};
 use wayland_protocols::wp::presentation_time::server::wp_presentation_feedback;
 use wayland_server::protocol::wl_surface;
 
+pub use super::super::space::wayland::output_update;
+
 impl RendererSurfaceState {
     fn contains_point<P: Into<Point<f64, Logical>>>(&self, attrs: &SurfaceAttributes, point: P) -> bool {
         let point = point.into();


### PR DESCRIPTION
It's useful for compositors to manage output overlap for non-Window surfaces, e.g. pointer and DnD surfaces.

I put it in `desktop/wayland/utils` as there's nothing Space-specific about it.

Example use scenario: https://github.com/YaLTeR/niri/commit/01906b190318a5e12feeb0dfa20a602a8561809f