### PR TITLE
Take a global filter function in `InputMethodManagerState::new`

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -563,7 +563,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
         let presentation_state = PresentationState::new::<Self>(&dh, clock.id() as u32);
         let fractional_scale_manager_state = FractionalScaleManagerState::new::<Self>(&dh);
         TextInputManagerState::new::<Self>(&dh);
-        InputMethodManagerState::new::<Self>(&dh);
+        InputMethodManagerState::new::<Self, _>(&dh, |_client| true);
         VirtualKeyboardManagerState::new::<Self, _>(&dh, |_client| true);
         // Expose global only if backend supports relative motion events
         if BackendData::HAS_RELATIVE_MOTION {


### PR DESCRIPTION
I still wonder if there's a cleaner way to deal with global visibility, but don't have any suggestions at the moment.

KDE exposes the input method protocol only to the process it starts as an IME. This is definitely a protocol that one may want to restrict.