### PR TITLE
Take `OwnedFd` instead of `RawFd` is `Session` methods

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -3,7 +3,6 @@ use std::ffi::OsString;
 use std::{
     collections::{hash_map::HashMap, HashSet},
     convert::TryInto,
-    os::unix::io::FromRawFd,
     path::Path,
     sync::{atomic::Ordering, Mutex},
     time::{Duration, Instant},
@@ -856,7 +855,7 @@ impl AnvilState<UdevData> {
             )
             .map_err(DeviceAddError::DeviceOpen)?;
 
-        let fd = DrmDeviceFd::new(unsafe { DeviceFd::from_raw_fd(fd) });
+        let fd = DrmDeviceFd::new(DeviceFd::from(fd));
 
         let (drm, notifier) = DrmDevice::new(fd.clone(), true).map_err(DeviceAddError::DrmDevice)?;
         let gbm = GbmDevice::new(fd).map_err(DeviceAddError::GbmDevice)?;

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -16,10 +16,7 @@ use std::{
     path::PathBuf,
 };
 #[cfg(feature = "backend_session")]
-use std::{
-    os::unix::io::{FromRawFd, IntoRawFd, OwnedFd},
-    path::Path,
-};
+use std::{os::unix::io::OwnedFd, path::Path};
 
 use calloop::{EventSource, Interest, Mode, Poll, PostAction, Readiness, Token, TokenFactory};
 
@@ -607,15 +604,13 @@ impl<S: Session> From<S> for LibinputSessionInterface<S> {
 impl<S: Session> libinput::LibinputInterface for LibinputSessionInterface<S> {
     fn open_restricted(&mut self, path: &Path, flags: i32) -> Result<OwnedFd, i32> {
         use nix::fcntl::OFlag;
-        let fd = self
-            .0
+        self.0
             .open(path, OFlag::from_bits_truncate(flags))
-            .map_err(|err| err.as_errno().unwrap_or(1 /*Use EPERM by default*/))?;
-        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+            .map_err(|err| err.as_errno().unwrap_or(1 /*Use EPERM by default*/))
     }
 
     fn close_restricted(&mut self, fd: OwnedFd) {
-        let _ = self.0.close(fd.into_raw_fd());
+        let _ = self.0.close(fd);
     }
 }
 

--- a/src/backend/session/mod.rs
+++ b/src/backend/session/mod.rs
@@ -29,7 +29,7 @@
 use nix::fcntl::OFlag;
 use std::{
     cell::RefCell,
-    os::unix::io::RawFd,
+    os::unix::io::OwnedFd,
     path::Path,
     rc::Rc,
     sync::{Arc, Mutex},
@@ -45,9 +45,9 @@ pub trait Session {
     /// Opens a device at the given `path` with the given flags.
     ///
     /// Returns a raw file descriptor
-    fn open(&mut self, path: &Path, flags: OFlag) -> Result<RawFd, Self::Error>;
+    fn open(&mut self, path: &Path, flags: OFlag) -> Result<OwnedFd, Self::Error>;
     /// Close a previously opened file descriptor
-    fn close(&mut self, fd: RawFd) -> Result<(), Self::Error>;
+    fn close(&mut self, fd: OwnedFd) -> Result<(), Self::Error>;
 
     /// Change the currently active virtual terminal
     fn change_vt(&mut self, vt: i32) -> Result<(), Self::Error>;
@@ -72,10 +72,10 @@ pub enum Event {
 impl Session for () {
     type Error = ();
 
-    fn open(&mut self, _path: &Path, _flags: OFlag) -> Result<RawFd, Self::Error> {
+    fn open(&mut self, _path: &Path, _flags: OFlag) -> Result<OwnedFd, Self::Error> {
         Err(())
     }
-    fn close(&mut self, _fd: RawFd) -> Result<(), Self::Error> {
+    fn close(&mut self, _fd: OwnedFd) -> Result<(), Self::Error> {
         Err(())
     }
 
@@ -94,11 +94,11 @@ impl Session for () {
 impl<S: Session> Session for Rc<RefCell<S>> {
     type Error = S::Error;
 
-    fn open(&mut self, path: &Path, flags: OFlag) -> Result<RawFd, Self::Error> {
+    fn open(&mut self, path: &Path, flags: OFlag) -> Result<OwnedFd, Self::Error> {
         self.borrow_mut().open(path, flags)
     }
 
-    fn close(&mut self, fd: RawFd) -> Result<(), Self::Error> {
+    fn close(&mut self, fd: OwnedFd) -> Result<(), Self::Error> {
         self.borrow_mut().close(fd)
     }
 
@@ -118,11 +118,11 @@ impl<S: Session> Session for Rc<RefCell<S>> {
 impl<S: Session> Session for Arc<Mutex<S>> {
     type Error = S::Error;
 
-    fn open(&mut self, path: &Path, flags: OFlag) -> Result<RawFd, Self::Error> {
+    fn open(&mut self, path: &Path, flags: OFlag) -> Result<OwnedFd, Self::Error> {
         self.lock().unwrap().open(path, flags)
     }
 
-    fn close(&mut self, fd: RawFd) -> Result<(), Self::Error> {
+    fn close(&mut self, fd: OwnedFd) -> Result<(), Self::Error> {
         self.lock().unwrap().close(fd)
     }
 


### PR DESCRIPTION
Using `OwnedFd` here should be safe. If `close` finds a `RawFd` that matches, either it is a file descriptor for that device, or this is some fd not opened through this API, and will close a device for which the fd was already freed.

Alternately, `Session` could have an associated type, defined as something like `libseat::Device`, and take that instead of `OwnedFd`. But implementing `libinput::LibinputInterface` requires just taking `OwnedFd`s, so this would mean simply moving the mapping from fds to devices/ids to `LibinputSessionInterface` instead.

I guess in https://github.com/PolyMeilex/libseat-rs/pull/4 I was assuming `libseat_close_device` would close the fd. As is, it isn't possible to use that API in libseat and actually close the fd without unsafe code. Maybe `Device` isn't necessary and it could just take the id to close the device. If the fd outlives the device being closed, I guess operations on it may fail? But it won't invalidate the fd, at least. So it's not a "safety" issue.