### PR TITLE
utils/clock: Use `rustix`, without `unsafe`; infallible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ libc = "0.2.103"
 libseat = { version = "0.2.1", optional = true, default_features = false }
 libloading = { version="0.8.0", optional = true }
 nix = { version = "0.27.0" }
-rustix = { version = "0.38.18", features = ["event", "fs", "mm", "net", "shm"] }
+rustix = { version = "0.38.18", features = ["event", "fs", "mm", "net", "shm", "time"] }
 once_cell = "1.8.0"
 rand = "0.8.4"
 scopeguard = { version = "1.1.0", optional = true }

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -512,7 +512,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
     ) -> AnvilState<BackendData> {
         let dh = display.handle();
 
-        let clock = Clock::new().expect("failed to initialize clock");
+        let clock = Clock::new();
 
         // init wayland clients
         let socket_name = if listen_on_socket {

--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -404,7 +404,7 @@ impl OutputPresentationFeedback {
     {
         let time = time.into();
         let refresh = refresh.into();
-        let clk_id = Kind::id() as u32;
+        let clk_id = Kind::ID as u32;
         if let Some(output) = self.output.upgrade() {
             for mut callback in self.callbacks.drain(..) {
                 callback.presented(&output, clk_id, time, refresh, seq, flags);


### PR DESCRIPTION
Rustix's `lock_gettime` does not return an error, and notes it is infallible, while `clock_gettime_dynamic` can handle some additional clocks that may result in an error.

I don't think the clock helper in Smithay needs to handle any of those, so returning a `Result` in `new` is unneeded.

This also uses an associated const for `ClockSource::ID`, so the clock id doesn't need to be stored a runtime when it's already expressed in the type. Const generics would be suitable, but don't work with enums yet.