### PR TITLE
Use `rustix` for `shm_open`/`shm_close` fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ libc = "0.2.103"
 libseat = { version = "0.2.1", optional = true, default_features = false }
 libloading = { version="0.8.0", optional = true }
 nix = { version = "0.27.0" }
-rustix = { version = "0.38.18", features = ["event", "fs", "mm", "net"] }
+rustix = { version = "0.38.18", features = ["event", "fs", "mm", "net", "shm"] }
 once_cell = "1.8.0"
 rand = "0.8.4"
 scopeguard = { version = "1.1.0", optional = true }


### PR DESCRIPTION
I didn't notice this use of `nix` earlier since it isn't used on either Linux or FreeBSD.