### PR TITLE
Add `restore_focus` argument to `PointerInnerHandle::unset_grab`

### DIFF
--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -64,7 +64,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for MoveSurfaceG
         handle.button(data, event);
         if handle.current_pressed().is_empty() {
             // No more buttons are pressed, release the grab.
-            handle.unset_grab(data, event.serial, event.time);
+            handle.unset_grab(data, event.serial, event.time, true);
         }
     }
 
@@ -254,7 +254,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
 
         // It is impossible to get `min_size` and `max_size` of dead toplevel, so we return early.
         if !self.window.alive() {
-            handle.unset_grab(data, event.serial, event.time);
+            handle.unset_grab(data, event.serial, event.time, true);
             return;
         }
 
@@ -346,7 +346,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
         handle.button(data, event);
         if handle.current_pressed().is_empty() {
             // No more buttons are pressed, release the grab.
-            handle.unset_grab(data, event.serial, event.time);
+            handle.unset_grab(data, event.serial, event.time, true);
 
             // If toplevel is dead, we can't resize it, so we return early.
             if !self.window.alive() {

--- a/smallvil/src/grabs/move_grab.rs
+++ b/smallvil/src/grabs/move_grab.rs
@@ -58,7 +58,7 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
 
         if !handle.current_pressed().contains(&BTN_LEFT) {
             // No more buttons are pressed, release the grab.
-            handle.unset_grab(data, event.serial, event.time);
+            handle.unset_grab(data, event.serial, event.time, true);
         }
     }
 

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -152,7 +152,7 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
 
         if !handle.current_pressed().contains(&BTN_LEFT) {
             // No more buttons are pressed, release the grab.
-            handle.unset_grab(data, event.serial, event.time);
+            handle.unset_grab(data, event.serial, event.time, true);
 
             let xdg = self.window.toplevel();
             xdg.with_pending_state(|state| {

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -551,7 +551,7 @@ where
         event: &MotionEvent,
     ) {
         if self.popup_grab.has_ended() {
-            handle.unset_grab(data, event.serial, event.time);
+            handle.unset_grab(data, event.serial, event.time, true);
             self.popup_grab.unset_keyboard_grab(data, event.serial);
             return;
         }
@@ -591,7 +591,7 @@ where
         let state = event.state;
 
         if self.popup_grab.has_ended() {
-            handle.unset_grab(data, serial, time);
+            handle.unset_grab(data, serial, time, true);
             handle.button(data, event);
             self.popup_grab.unset_keyboard_grab(data, serial);
             return;
@@ -610,7 +610,7 @@ where
                 .unwrap_or(false)
         {
             let _ = self.popup_grab.ungrab(PopupUngrabStrategy::All);
-            handle.unset_grab(data, serial, time);
+            handle.unset_grab(data, serial, time, true);
             handle.button(data, event);
             self.popup_grab.unset_keyboard_grab(data, serial);
             return;

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -379,7 +379,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
         handle.button(data, event);
         if handle.current_pressed().is_empty() {
             // no more buttons are pressed, release the grab
-            handle.unset_grab(data, event.serial, event.time);
+            handle.unset_grab(data, event.serial, event.time, false);
         }
     }
 

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -229,8 +229,8 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
         let mut inner = self.inner.lock().unwrap();
         inner.pending_focus = focus.clone();
         let seat = self.get_seat(data);
-        inner.with_grab(&seat, move |mut handle, grab| {
-            grab.motion(data, &mut handle, focus, event);
+        inner.with_grab(&seat, |handle, grab| {
+            grab.motion(data, handle, focus, event);
         });
     }
 
@@ -249,8 +249,8 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
         let mut inner = self.inner.lock().unwrap();
         inner.pending_focus = focus.clone();
         let seat = self.get_seat(data);
-        inner.with_grab(&seat, move |mut handle, grab| {
-            grab.relative_motion(data, &mut handle, focus, event);
+        inner.with_grab(&seat, |handle, grab| {
+            grab.relative_motion(data, handle, focus, event);
         });
     }
 
@@ -270,8 +270,8 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
             }
         }
         let seat = self.get_seat(data);
-        inner.with_grab(&seat, |mut handle, grab| {
-            grab.button(data, &mut handle, event);
+        inner.with_grab(&seat, |handle, grab| {
+            grab.button(data, handle, event);
         });
     }
 
@@ -281,8 +281,8 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn axis(&self, data: &mut D, details: AxisFrame) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |mut handle, grab| {
-            grab.axis(data, &mut handle, details);
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.axis(data, handle, details);
         });
     }
 
@@ -292,8 +292,8 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn frame(&self, data: &mut D) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |mut handle, grab| {
-            grab.frame(data, &mut handle);
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.frame(data, handle);
         });
     }
 
@@ -305,12 +305,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_swipe_begin(&self, data: &mut D, event: &GestureSwipeBeginEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(&seat, move |mut handle, grab| {
-                grab.gesture_swipe_begin(data, &mut handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_swipe_begin(data, handle, event);
+        });
     }
 
     /// Notify about swipe gesture update
@@ -321,12 +318,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_swipe_update(&self, data: &mut D, event: &GestureSwipeUpdateEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(&seat, move |mut handle, grab| {
-                grab.gesture_swipe_update(data, &mut handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_swipe_update(data, handle, event);
+        });
     }
 
     /// Notify about swipe gesture end
@@ -337,12 +331,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_swipe_end(&self, data: &mut D, event: &GestureSwipeEndEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(&seat, move |mut handle, grab| {
-                grab.gesture_swipe_end(data, &mut handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_swipe_end(data, handle, event);
+        });
     }
 
     /// Notify about pinch gesture begin
@@ -353,12 +344,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_pinch_begin(&self, data: &mut D, event: &GesturePinchBeginEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(&seat, move |mut handle, grab| {
-                grab.gesture_pinch_begin(data, &mut handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_pinch_begin(data, handle, event);
+        });
     }
 
     /// Notify about pinch gesture update
@@ -369,12 +357,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_pinch_update(&self, data: &mut D, event: &GesturePinchUpdateEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(&seat, move |mut handle, grab| {
-                grab.gesture_pinch_update(data, &mut handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_pinch_update(data, handle, event);
+        });
     }
 
     /// Notify about pinch gesture end
@@ -385,12 +370,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_pinch_end(&self, data: &mut D, event: &GesturePinchEndEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(&seat, move |mut handle, grab| {
-                grab.gesture_pinch_end(data, &mut handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_pinch_end(data, handle, event);
+        });
     }
 
     /// Notify about hold gesture begin
@@ -401,12 +383,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_hold_begin(&self, data: &mut D, event: &GestureHoldBeginEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(&seat, move |mut handle, grab| {
-                grab.gesture_hold_begin(data, &mut handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_hold_begin(data, handle, event);
+        });
     }
 
     /// Notify about hold gesture end
@@ -417,12 +396,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_hold_end(&self, data: &mut D, event: &GestureHoldEndEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(&seat, move |mut handle, grab| {
-                grab.gesture_hold_end(data, &mut handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_hold_end(data, handle, event);
+        });
     }
 
     /// Access the current location of this pointer in the global space
@@ -827,9 +803,9 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
 
     fn with_grab<F>(&mut self, seat: &Seat<D>, f: F)
     where
-        F: FnOnce(PointerInnerHandle<'_, D>, &mut dyn PointerGrab<D>),
+        F: FnOnce(&mut PointerInnerHandle<'_, D>, &mut dyn PointerGrab<D>),
     {
-        let mut grab = ::std::mem::replace(&mut self.grab, GrabStatus::Borrowed);
+        let mut grab = std::mem::replace(&mut self.grab, GrabStatus::Borrowed);
         match grab {
             GrabStatus::Borrowed => panic!("Accessed a pointer grab from within a pointer grab access."),
             GrabStatus::Active(_, ref mut handler) => {
@@ -837,14 +813,14 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
                 if let Some((ref focus, _)) = handler.start_data().focus {
                     if !focus.alive() {
                         self.grab = GrabStatus::None;
-                        f(PointerInnerHandle { inner: self, seat }, &mut DefaultGrab);
+                        f(&mut PointerInnerHandle { inner: self, seat }, &mut DefaultGrab);
                         return;
                     }
                 }
-                f(PointerInnerHandle { inner: self, seat }, &mut **handler);
+                f(&mut PointerInnerHandle { inner: self, seat }, &mut **handler);
             }
             GrabStatus::None => {
-                f(PointerInnerHandle { inner: self, seat }, &mut DefaultGrab);
+                f(&mut PointerInnerHandle { inner: self, seat }, &mut DefaultGrab);
             }
         }
 

--- a/src/wayland/selection/data_device/dnd_grab.rs
+++ b/src/wayland/selection/data_device/dnd_grab.rs
@@ -245,7 +245,7 @@ where
                     }
                 }
             }
-            handle.unset_grab(data, event.serial, event.time);
+            handle.unset_grab(data, event.serial, event.time, true);
         }
     }
 

--- a/src/wayland/selection/data_device/server_dnd_grab.rs
+++ b/src/wayland/selection/data_device/server_dnd_grab.rs
@@ -224,7 +224,7 @@ where
                     }
                 }
             }
-            handle.unset_grab(data, serial, time);
+            handle.unset_grab(data, serial, time, true);
         }
     }
 


### PR DESCRIPTION
Used in `ClickGrab` to prevent `motion` events from occurring with every `button` event. Otherwise, behavior should be unchanged. This matches the argument taken by `KeyboardInnerHandle::unset_grab`.
    
This seems like the simplest solution. It would also be possible to add a method to the `PointerGrab` trait indicating if focus should be restored, but that's complicated since `unset_grab` can't access the
grab when it's `Borrowed`, so it would have to add a bool to `GrabStatus::Borrowed`, etc.
    
This still doesn't send a `frame`, but since this takes a serial and a time, it probably will be sent along with other pointer events, and hopefully part of a `frame`. The Wayland spec isn't all that specific
about when things can/should be part of a `frame`...
    
Calling `motion` is also incorrect with pointer constraints, but grabs other than `ClickGrab` generally shouldn't exist while a constraint is active. It would be good to enforce that some way.

The first commit here is a change I had as part of an attempt at a different approach, which turned out more complicated; but this part seemed a bit neater.

Fixes https://github.com/Smithay/smithay/issues/1148.