### PR TITLE
drm: Query syncobj for supports_fencing

### DIFF
--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -3,6 +3,7 @@ use std::os::unix::io::AsFd;
 use std::sync::Arc;
 
 use drm::control::{connector, crtc, plane, Mode};
+use drm::{Device, DriverCapability};
 use gbm::BufferObject;
 
 use crate::backend::allocator::dmabuf::{AsDmabuf, Dmabuf};
@@ -13,7 +14,7 @@ use crate::backend::drm::gbm::{framebuffer_from_bo, GbmFramebuffer};
 use crate::backend::drm::{plane_has_property, DrmError, DrmSurface};
 use crate::backend::renderer::sync::SyncPoint;
 use crate::backend::SwapBuffersError;
-use crate::utils::{Physical, Point, Rectangle, Transform};
+use crate::utils::{DevPath, Physical, Point, Rectangle, Transform};
 
 use tracing::{debug, error, info_span, instrument, trace, warn};
 
@@ -71,8 +72,18 @@ where
             match Self::new_internal(drm.clone(), allocator, renderer_formats.clone(), *format) {
                 Ok((current_fb, swapchain, is_opaque)) => {
                     drop(_guard);
-                    let supports_fencing =
-                        !drm.is_legacy() && plane_has_property(&*drm, drm.plane(), "IN_FENCE_FD")?;
+                    let supports_fencing = !drm.is_legacy()
+                        && drm
+                            .get_driver_capability(DriverCapability::SyncObj)
+                            .map(|val| val != 0)
+                            .map_err(|err| {
+                                Error::DrmError(DrmError::Access {
+                                    errmsg: "Failed to query driver capability",
+                                    dev: drm.dev_path(),
+                                    source: err,
+                                })
+                            })?
+                        && plane_has_property(&*drm, drm.plane(), "IN_FENCE_FD")?;
 
                     return Ok(GbmBufferedSurface {
                         current_fb,


### PR DESCRIPTION
Fixes the nvidia 545-beta driver, which can now apparently export/import fences, but not on the drm-side.