### PR TITLE
xwm: Fix reordering

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -214,15 +214,15 @@ enum StackingDirection {
 impl StackingDirection {
     fn pos_comparator(&self, pos: usize, last_pos: usize) -> bool {
         match self {
-            Self::Downwards => last_pos > pos,
-            Self::Upwards => last_pos < pos,
+            Self::Downwards => last_pos < pos,
+            Self::Upwards => last_pos > pos,
         }
     }
 
     fn stack_mode(&self) -> StackMode {
         match self {
-            Self::Downwards => StackMode::ABOVE,
-            Self::Upwards => StackMode::BELOW,
+            Self::Downwards => StackMode::BELOW,
+            Self::Upwards => StackMode::ABOVE,
         }
     }
 }


### PR DESCRIPTION
This was unfortunately reversed in https://github.com/Smithay/smithay/pull/1024, which wasn't obvious due to the refactoring that PR was doing.