### PR TITLE
wayland/compositor: add wl_compositor@v6 constructor

### DIFF
--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -65,14 +65,15 @@ impl WindowElement {
 
     pub fn with_surfaces<F>(&self, processor: F)
     where
-        F: FnMut(&WlSurface, &WlSurfaceData) + Copy,
+        F: FnMut(&WlSurface, &WlSurfaceData),
     {
         match self {
             WindowElement::Wayland(w) => w.with_surfaces(processor),
             #[cfg(feature = "xwayland")]
             WindowElement::X11(w) => {
                 if let Some(surface) = w.wl_surface() {
-                    with_surfaces_surface_tree(&surface, processor);
+                    let mut processor = processor;
+                    with_surfaces_surface_tree(&surface, &mut processor);
                 }
             }
         }

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -703,16 +703,16 @@ impl LayerSurface {
     }
 
     /// Run a closure on all surfaces in this layer (including it's popups, if [`PopupManager`] is used)
-    pub fn with_surfaces<F>(&self, processor: F)
+    pub fn with_surfaces<F>(&self, mut processor: F)
     where
-        F: FnMut(&WlSurface, &SurfaceData) + Copy,
+        F: FnMut(&WlSurface, &SurfaceData),
     {
         let surface = self.0.surface.wl_surface();
 
-        with_surfaces_surface_tree(surface, processor);
+        with_surfaces_surface_tree(surface, &mut processor);
         for (popup, _) in PopupManager::popups_for_surface(surface) {
             let surface = popup.wl_surface();
-            with_surfaces_surface_tree(surface, processor);
+            with_surfaces_surface_tree(surface, &mut processor);
         }
     }
 

--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -149,7 +149,7 @@ where
 type SurfacePrimaryScanoutOutput = Mutex<PrimaryScanoutOutput>;
 
 /// Run a closure on all surfaces of a surface tree
-pub fn with_surfaces_surface_tree<F>(surface: &wl_surface::WlSurface, mut processor: F)
+pub fn with_surfaces_surface_tree<F>(surface: &wl_surface::WlSurface, processor: &mut F)
 where
     F: FnMut(&wl_surface::WlSurface, &SurfaceData),
 {

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -224,15 +224,15 @@ impl Window {
     }
 
     /// Run a closure on all surfaces in this window (including it's popups, if [`PopupManager`] is used)
-    pub fn with_surfaces<F>(&self, processor: F)
+    pub fn with_surfaces<F>(&self, mut processor: F)
     where
-        F: FnMut(&wl_surface::WlSurface, &SurfaceData) + Copy,
+        F: FnMut(&wl_surface::WlSurface, &SurfaceData),
     {
         let surface = self.0.toplevel.wl_surface();
-        with_surfaces_surface_tree(surface, processor);
+        with_surfaces_surface_tree(surface, &mut processor);
         for (popup, _) in PopupManager::popups_for_surface(surface) {
             let surface = popup.wl_surface();
-            with_surfaces_surface_tree(surface, processor);
+            with_surfaces_surface_tree(surface, &mut processor);
         }
     }
 

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -390,7 +390,7 @@ where
     D: 'static,
 {
     fn request(
-        _state: &mut D,
+        state: &mut D,
         _client: &wayland_server::Client,
         subcompositor: &WlSubcompositor,
         request: wl_subcompositor::Request,
@@ -416,6 +416,8 @@ where
                 super::with_states(&surface, |states| {
                     states.data_map.insert_if_missing_threadsafe(SubsurfaceState::new)
                 });
+
+                state.new_subsurface(&surface, &parent);
             }
             wl_subcompositor::Request::Destroy => {}
             _ => unreachable!(),

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -110,14 +110,16 @@ mod handlers;
 mod transaction;
 mod tree;
 
+use std::cell::RefCell;
 use std::{any::Any, sync::Mutex};
 
 pub use self::cache::{Cacheable, MultiCache};
 pub use self::handlers::{RegionUserData, SubsurfaceCachedState, SubsurfaceUserData, SurfaceUserData};
 use self::transaction::TransactionQueue;
 pub use self::transaction::{Blocker, BlockerState};
-use self::tree::PrivateSurfaceData;
 pub use self::tree::{AlreadyHasRole, TraversalAction};
+use self::tree::{PrivateSurfaceData, SuggestedSurfaceState};
+use crate::utils::Transform;
 use crate::utils::{user_data::UserDataMap, Buffer, Logical, Point, Rectangle};
 use wayland_server::backend::GlobalId;
 use wayland_server::protocol::wl_compositor::WlCompositor;
@@ -399,6 +401,32 @@ where
     PrivateSurfaceData::with_states(surface, f)
 }
 
+/// Send the `scale` and `transform` preferences for the given surface when it supports them.
+///
+/// The new state is only send when it differs from the already cached one on the calling thread.
+pub fn send_surface_state(surface: &WlSurface, data: &SurfaceData, scale: i32, transform: Transform) {
+    if surface.version() < 6 {
+        return;
+    }
+
+    // NOTE we insert default for checks below to work properly.
+    let mut storage = data
+        .data_map
+        .get_or_insert(|| RefCell::new(SuggestedSurfaceState::default()))
+        .borrow_mut();
+
+    if storage.scale != scale {
+        surface.preferred_buffer_scale(scale);
+        storage.scale = scale;
+    }
+
+    let transform = transform.into();
+    if storage.transform != transform {
+        surface.preferred_buffer_transform(transform);
+        storage.transform = transform;
+    }
+}
+
 /// Retrieve the metadata associated with a `wl_region`
 ///
 /// If the region is not managed by the `CompositorGlobal` that provided this token, this
@@ -564,18 +592,40 @@ impl CompositorClientState {
     }
 }
 
-#[doc(hidden)]
 impl CompositorState {
-    /// Create new [`wl_compositor`](wayland_server::protocol::wl_compositor)
-    /// and [`wl_subcompositor`](wayland_server::protocol::wl_subcompositor) globals.
+    /// Create new [`wl_compositor`] version 5 and [`wl_subcompositor`] globals.
     ///
     /// It returns the two global handles, in case you wish to remove these globals from
     /// the event loop in the future.
+    ///
+    /// [`wl_compositor`]: wayland_server::protocol::wl_compositor
+    /// [`wl_subcompositor`]: wayland_server::protocol::wl_subcompositor
     pub fn new<D>(display: &DisplayHandle) -> Self
     where
         D: GlobalDispatch<WlCompositor, ()> + GlobalDispatch<WlSubcompositor, ()> + 'static,
     {
-        let compositor = display.create_global::<D, WlCompositor, ()>(5, ());
+        Self::new_with_version::<D>(display, 5)
+    }
+
+    /// The same as [`new`], but binds at least version 6 of [`wl_compositor`].
+    ///
+    /// This means that for clients to scale and apply transformation with
+    /// non-default values [`send_surface_state`] must be used.
+    ///
+    /// [`new`]: Self::new
+    /// [`wl_compositor`]: wayland_server::protocol::wl_compositor
+    pub fn new_v6<D>(display: &DisplayHandle) -> Self
+    where
+        D: GlobalDispatch<WlCompositor, ()> + GlobalDispatch<WlSubcompositor, ()> + 'static,
+    {
+        Self::new_with_version::<D>(display, 6)
+    }
+
+    fn new_with_version<D>(display: &DisplayHandle, version: u32) -> Self
+    where
+        D: GlobalDispatch<WlCompositor, ()> + GlobalDispatch<WlSubcompositor, ()> + 'static,
+    {
+        let compositor = display.create_global::<D, WlCompositor, ()>(version, ());
         let subcompositor = display.create_global::<D, WlSubcompositor, ()>(1, ());
 
         CompositorState {

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -545,6 +545,20 @@ pub trait CompositorHandler {
         let _ = surface;
     }
 
+    /// New subsurface handler.
+    ///
+    /// This handler can be used to run extra logic when subsurface is getting created. This
+    /// is an addition to [`new_surface`], which will be run for the subsurface surface anyway.
+    ///
+    /// When your compositor knows beforehand where it'll position subsurfaces it can send
+    /// [`send_surface_state`] to them.
+    ///
+    /// [`new_surface`]: Self::new_surface
+    fn new_subsurface(&mut self, surface: &WlSurface, parent: &WlSurface) {
+        let _ = surface;
+        let _ = parent;
+    }
+
     /// Surface commit handler
     ///
     /// This is called when any changed state from a commit actually becomes visible.

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -11,7 +11,11 @@ use std::{
     fmt,
     sync::{atomic::Ordering, Arc, Mutex},
 };
-use wayland_server::{backend::ObjectId, protocol::wl_surface::WlSurface, DisplayHandle, Resource};
+use wayland_server::{
+    backend::ObjectId,
+    protocol::{wl_output::Transform, wl_surface::WlSurface},
+    DisplayHandle, Resource,
+};
 
 type CommitHook = dyn Fn(&mut dyn Any, &DisplayHandle, &WlSurface) + Send + Sync;
 type DestructionHook = dyn Fn(&mut dyn Any, &SurfaceData) + Send;
@@ -503,6 +507,24 @@ impl PrivateSurfaceData {
                 true
             }
             TraversalAction::Break => false,
+        }
+    }
+}
+
+/// The latest surface state suggest by wl_compositor `v6` events.
+#[derive(Debug)]
+pub struct SuggestedSurfaceState {
+    /// Latest scale sent via `wl_surface::preferred_buffer_scale`.
+    pub scale: i32,
+    /// Latest transform sent via `wl_surface::preferred_buffer_transform`.
+    pub transform: Transform,
+}
+
+impl Default for SuggestedSurfaceState {
+    fn default() -> Self {
+        Self {
+            scale: 1,
+            transform: Transform::Normal,
         }
     }
 }


### PR DESCRIPTION
`wl_compositor@v6` requires special handling in downstream compositors, so smithay can't provide it unconditionally, thus allow setting a version for `wl_compositor` when creating a global.

--

This is probably not really a good solution, Alternative could be to have a separate constructor which builds _at least_ v6.