### PR TITLE
Accept `F` instead of `&mut F` in `with_surfaces_surface_tree` again

### DIFF
--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -149,7 +149,7 @@ where
 type SurfacePrimaryScanoutOutput = Mutex<PrimaryScanoutOutput>;
 
 /// Run a closure on all surfaces of a surface tree
-pub fn with_surfaces_surface_tree<F>(surface: &wl_surface::WlSurface, processor: &mut F)
+pub fn with_surfaces_surface_tree<F>(surface: &wl_surface::WlSurface, mut processor: F)
 where
     F: FnMut(&wl_surface::WlSurface, &SurfaceData),
 {


### PR DESCRIPTION
https://github.com/Smithay/smithay/pull/1177 changed this. But it isn't actually needed for the other changes there, since there's a blanket implementation of `FnMut` for `&mut` references to types implementing `FnMut`.

So this is more general, and helpful for simply passing a closure to the function, etc.