### PR TITLE
session_lock: Add accessor for `ExtSessionLockV1` to `SessionLocker`

### DIFF
--- a/src/wayland/session_lock/mod.rs
+++ b/src/wayland/session_lock/mod.rs
@@ -208,6 +208,11 @@ impl SessionLocker {
         }
     }
 
+    /// Get the underlying [`ExtSessionLockV1`]
+    pub fn ext_session_lock(&self) -> &ExtSessionLockV1 {
+        self.lock.as_ref().unwrap()
+    }
+
     /// Notify the client that the session lock was successful.
     pub fn lock(mut self) {
         if let Some(lock) = self.lock.take() {


### PR DESCRIPTION
The compositor can store this, and test if the object is still valid with `DisplayHandle::get_client`. This way the compositor can allow another session lock to be created if the previous client crashed and failed to unlock.

Maybe there could be a better API to help with this, but I'm not sure how.

https://github.com/pop-os/cosmic-comp/pull/205 demonstrates how this can be handled.