### PR TITLE
xdg-activation: Rework

### DIFF
--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -409,6 +409,14 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
         self.inner.lock().unwrap().location
     }
 
+    /// Access the [`Serial`] of the last `pointer_enter` event, if that focus is still active.
+    ///
+    /// In other words this will return `None` again, once a `pointer_leave` event occured.
+    #[cfg(feature = "wayland_frontend")]
+    pub fn last_enter(&self) -> Option<Serial> {
+        *self.last_enter.lock().unwrap()
+    }
+
     fn get_seat(&self, data: &mut D) -> Seat<D> {
         let seat_state = data.seat_state();
         seat_state

--- a/src/utils/serial.rs
+++ b/src/utils/serial.rs
@@ -48,6 +48,13 @@ impl From<Serial> for u32 {
     }
 }
 
+impl Serial {
+    /// Checks if a serial was generated after or is equal to another given serial
+    pub fn is_no_older_than(&self, other: &Serial) -> bool {
+        other <= self
+    }
+}
+
 /// A counter for generating serials, for use in the client protocol
 ///
 /// A global instance of this counter is available as the `SERIAL_COUNTER`

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -145,6 +145,7 @@ fn serialize_pressed_keys(keys: Vec<u32>) -> Vec<u8> {
 
 impl<D: SeatHandler + 'static> KeyboardTarget<D> for WlSurface {
     fn enter(&self, seat: &Seat<D>, state: &mut D, keys: Vec<KeysymHandle<'_>>, serial: Serial) {
+        *seat.get_keyboard().unwrap().arc.last_enter.lock().unwrap() = Some(serial);
         for_each_focused_kbds(seat, self, |kbd| {
             kbd.enter(
                 serial.into(),
@@ -171,6 +172,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for WlSurface {
     }
 
     fn leave(&self, seat: &Seat<D>, state: &mut D, serial: Serial) {
+        *seat.get_keyboard().unwrap().arc.last_enter.lock().unwrap() = None;
         for_each_focused_kbds(seat, self, |kbd| kbd.leave(serial.into(), self));
         let text_input = seat.text_input();
         let input_method = seat.input_method();

--- a/src/wayland/xdg_activation/dispatch.rs
+++ b/src/wayland/xdg_activation/dispatch.rs
@@ -51,10 +51,7 @@ where
 
                 let activation_state = state.activation_state();
 
-                if let Some(token_data) = activation_state.pending_tokens.remove(&token) {
-                    activation_state
-                        .activation_requests
-                        .insert(token.clone(), (token_data.clone(), surface.clone()));
+                if let Some(token_data) = activation_state.known_tokens.get(&token).cloned() {
                     state.request_activation(token, token_data, surface);
                 }
             }
@@ -158,7 +155,7 @@ where
                 *data.token.lock().unwrap() = Some(activation_token.clone());
                 state
                     .activation_state()
-                    .pending_tokens
+                    .known_tokens
                     .insert(activation_token.clone(), token_data);
                 token.done(activation_token.to_string());
             }
@@ -170,21 +167,10 @@ where
     }
 
     fn destroyed(
-        state: &mut D,
+        _: &mut D,
         _: ClientId,
         _: &xdg_activation_token_v1::XdgActivationTokenV1,
-        data: &ActivationTokenData,
+        _: &ActivationTokenData,
     ) {
-        let guard = data.token.lock().unwrap();
-
-        if let Some(token) = &*guard {
-            let activation_state = state.activation_state();
-
-            activation_state.pending_tokens.remove(token);
-
-            if let Some((token_data, surface)) = activation_state.activation_requests.remove(token) {
-                state.destroy_activation(token.clone(), token_data, surface);
-            }
-        }
     }
 }

--- a/src/wayland/xdg_activation/dispatch.rs
+++ b/src/wayland/xdg_activation/dispatch.rs
@@ -152,11 +152,15 @@ where
                     )
                 };
 
+                let valid = state.token_created(activation_token.clone(), token_data.clone());
+
                 *data.token.lock().unwrap() = Some(activation_token.clone());
-                state
-                    .activation_state()
-                    .known_tokens
-                    .insert(activation_token.clone(), token_data);
+                if valid {
+                    state
+                        .activation_state()
+                        .known_tokens
+                        .insert(activation_token.clone(), token_data);
+                }
                 token.done(activation_token.to_string());
             }
 

--- a/src/wayland/xdg_activation/mod.rs
+++ b/src/wayland/xdg_activation/mod.rs
@@ -172,6 +172,11 @@ impl XdgActivationState {
         }
     }
 
+    /// Access the data of a known token
+    pub fn data_for_token(&self, token: &XdgActivationToken) -> Option<&XdgActivationTokenData> {
+        self.known_tokens.get(token)
+    }
+
     /// Retain pending tokens
     ///
     /// You may want to remove super old tokens

--- a/src/wayland/xdg_activation/mod.rs
+++ b/src/wayland/xdg_activation/mod.rs
@@ -159,8 +159,7 @@ impl XdgActivationTokenData {
 #[derive(Debug)]
 pub struct XdgActivationState {
     global: GlobalId,
-    pending_tokens: HashMap<XdgActivationToken, XdgActivationTokenData>,
-    activation_requests: HashMap<XdgActivationToken, (XdgActivationTokenData, WlSurface)>,
+    known_tokens: HashMap<XdgActivationToken, XdgActivationTokenData>,
 }
 
 impl XdgActivationState {
@@ -178,46 +177,26 @@ impl XdgActivationState {
 
         XdgActivationState {
             global,
-            pending_tokens: HashMap::new(),
-            activation_requests: HashMap::new(),
+            known_tokens: HashMap::new(),
         }
-    }
-
-    /// Get current activation requests
-    ///
-    /// HashMap contains token data and target surface.
-    pub fn requests(&self) -> &HashMap<XdgActivationToken, (XdgActivationTokenData, WlSurface)> {
-        &self.activation_requests
-    }
-
-    /// Remove and return the activation request
-    ///
-    /// If you consider a request to be unwanted you can use this method to
-    /// discard it and don't track it any futher.
-    pub fn remove_request(
-        &mut self,
-        token: &XdgActivationToken,
-    ) -> Option<(XdgActivationTokenData, WlSurface)> {
-        self.activation_requests.remove(token)
-    }
-
-    /// Retain activation requests
-    pub fn retain_requests<F>(&mut self, mut f: F)
-    where
-        F: FnMut(&XdgActivationToken, &(XdgActivationTokenData, WlSurface)) -> bool,
-    {
-        self.activation_requests.retain(|k, v| f(k, v))
     }
 
     /// Retain pending tokens
     ///
     /// You may want to remove super old tokens
     /// that were never turned into activation request for some reason
-    pub fn retain_pending_tokens<F>(&mut self, mut f: F)
+    pub fn retain_tokens<F>(&mut self, mut f: F)
     where
         F: FnMut(&XdgActivationToken, &XdgActivationTokenData) -> bool,
     {
-        self.pending_tokens.retain(|k, v| f(k, v))
+        self.known_tokens.retain(|k, v| f(k, v))
+    }
+
+    /// Removes an activation token from the internal storage.
+    ///
+    /// Returns `true` if the token was found and subsequently removed.
+    pub fn remove_token(&mut self, token: &XdgActivationToken) -> bool {
+        self.known_tokens.remove(token).is_some()
     }
 
     /// Returns the xdg activation global.
@@ -236,22 +215,9 @@ pub trait XdgActivationHandler {
     /// The compositor may know which client requested this by checking the token data and may decide whether
     /// or not to follow through with the activation if it's considered unwanted.
     ///
-    /// If a request is unwanted, you can discard the request using [`XdgActivationState::remove_request`] to
-    /// ignore any future requests.
+    /// The token remains in the pool and might be used to issue other requests
+    /// until the compositor decides to remove it using [`XdgActivationState::remove_token`] or [`XdgActivationState::retain_tokens`].
     fn request_activation(
-        &mut self,
-        token: XdgActivationToken,
-        token_data: XdgActivationTokenData,
-        surface: WlSurface,
-    );
-
-    /// The activation token was destroyed.
-    ///
-    /// The compositor may cancel any activation requests coming from the token.
-    ///
-    /// For example if your compositor blinks or highlights a window when it requests activation then the
-    /// animation should stop when this function is called.
-    fn destroy_activation(
         &mut self,
         token: XdgActivationToken,
         token_data: XdgActivationTokenData,

--- a/src/wayland/xdg_activation/mod.rs
+++ b/src/wayland/xdg_activation/mod.rs
@@ -59,7 +59,7 @@
 use std::{
     collections::HashMap,
     ops,
-    sync::{atomic::AtomicBool, Mutex},
+    sync::{atomic::AtomicBool, Arc, Mutex},
     time::Instant,
 };
 
@@ -72,7 +72,7 @@ use wayland_server::{
 
 use rand::distributions::{Alphanumeric, DistString};
 
-use crate::utils::Serial;
+use crate::utils::{user_data::UserDataMap, Serial};
 
 mod dispatch;
 
@@ -135,6 +135,8 @@ pub struct XdgActivationTokenData {
     /// You can use this do ignore tokens based on time.
     /// For example you coould ignore all tokens older that 5s.
     pub timestamp: Instant,
+    /// Additional user data attached
+    pub user_data: Arc<UserDataMap>,
 }
 
 impl XdgActivationTokenData {
@@ -150,6 +152,7 @@ impl XdgActivationTokenData {
                 app_id,
                 surface,
                 timestamp: Instant::now(),
+                user_data: Arc::new(UserDataMap::new()),
             },
         )
     }
@@ -214,6 +217,8 @@ pub trait XdgActivationHandler {
     ///
     /// If the token isn't considered valid, it can be immediately untracked by returning `false`.
     /// The default implementation considers every token valid and will always return `true`.
+    ///
+    /// This method may also be used to attach user_data to the token.
     fn token_created(&mut self, token: XdgActivationToken, data: XdgActivationTokenData) -> bool {
         let _ = (token, data);
         true

--- a/src/wayland/xdg_activation/mod.rs
+++ b/src/wayland/xdg_activation/mod.rs
@@ -28,19 +28,7 @@
 //!     ) {
 //!         if token_data.timestamp.elapsed().as_secs() < 10 {
 //!             // Request surface activation
-//!         } else{
-//!             // Discard the request
-//!             self.activation_state.remove_request(&token);
 //!         }
-//!     }
-//!
-//!     fn destroy_activation(
-//!         &mut self,
-//!         token: XdgActivationToken,
-//!         token_data: XdgActivationTokenData,
-//!         surface: WlSurface
-//!     ) {
-//!         // The request is cancelled
 //!     }
 //! }
 //!

--- a/src/wayland/xdg_activation/mod.rs
+++ b/src/wayland/xdg_activation/mod.rs
@@ -210,6 +210,15 @@ pub trait XdgActivationHandler {
     /// Returns the activation state.
     fn activation_state(&mut self) -> &mut XdgActivationState;
 
+    /// A client has created a new token.
+    ///
+    /// If the token isn't considered valid, it can be immediately untracked by returning `false`.
+    /// The default implementation considers every token valid and will always return `true`.
+    fn token_created(&mut self, token: XdgActivationToken, data: XdgActivationTokenData) -> bool {
+        let _ = (token, data);
+        true
+    }
+
     /// A client has requested surface activation.
     ///
     /// The compositor may know which client requested this by checking the token data and may decide whether

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -155,6 +155,7 @@ mod atoms {
             _NET_WM_WINDOW_TYPE_UTILITY,
             _NET_WM_STATE_MODAL,
             _MOTIF_WM_HINTS,
+            _NET_STARTUP_ID,
 
             // server -> client
             WM_S0,


### PR DESCRIPTION
Best reviewed commit-by-commit.

- d116691 - drops tracking pending vs requested tokens. The whole destruction logic was flawed, as the clients don't have to cooperate. The first client generating the token may destroy the wayland object as soon as it has received the token string. The wayland request explicitly states, that the token stays valid.
- 4931081- notifies downstream when a new token is created. In this commit this is only used to immediately discard tokens downstream may consider invalid.
- 568dda9 - Adds user-data to the token data. This could also be done by downstream manually, given that the token implements `Hash`. But we already have a `HashMap` inside the `ActivationState` anyway. (optional)
- 6359bc5 - Updates module docs
- 52d7d94 - Adds a helper to check if a serial is not older than another one (optional, just better named than simply relying on `PartialOrd`)
- 0331432 - Makes the last enter serials of pointer/keyboard accessible to properly test for focus when clients generate a new activation token
- 0a93ee5 - Updates anvil's implementation of the protocol
- 7573458 - Adds reading X11 clients `_NET_STARTUP_ID`, which is the same as an activation token set at startup, so that downstream can implement this for e.g. Xwayland clients started by a wayland launcher. Anvil does not make use of this, as it focuses all new windows anyway and doesn't care about startup.