### PR TITLE
Make XdgShellHandler::reposition_request mandatory

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -66,6 +66,10 @@ impl XdgShellHandler for App {
     fn grab(&mut self, _surface: PopupSurface, _seat: wl_seat::WlSeat, _serial: Serial) {
         // Handle popup grab here
     }
+
+    fn reposition_request(&mut self, _surface: PopupSurface, _positioner: PositionerState, _token: u32) {
+        // Handle popup reposition here
+    }
 }
 
 impl SelectionHandler for App {

--- a/src/wayland/shell/xdg/decoration.rs
+++ b/src/wayland/shell/xdg/decoration.rs
@@ -42,6 +42,12 @@
 //!     #     seat: wl_seat::WlSeat,
 //!     #     serial: Serial,
 //!     # ) { unimplemented!() }
+//!     # fn reposition_request(
+//!     #     &mut self,
+//!     #     surface: PopupSurface,
+//!     #     positioner: PositionerState,
+//!     #     token: u32,
+//!     # ) { unimplemented!() }
 //!     // ...
 //! }
 //! impl XdgDecorationHandler for State {

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -65,6 +65,14 @@
 //!     ) {
 //!         // ...
 //!     }
+//!     fn reposition_request(
+//!         &mut self,
+//!         surface: PopupSurface,
+//!         positioner: PositionerState,
+//!         token: u32,
+//!     ) {
+//!         // ...
+//!     }
 //! }
 //! delegate_xdg_shell!(State);
 //!

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -930,8 +930,10 @@ pub trait XdgShellHandler {
     /// A surface has acknowledged a configure serial.
     fn ack_configure(&mut self, surface: wl_surface::WlSurface, configure: Configure) {}
 
-    /// A client requested a reposition, providing a new
-    /// positioner, of a popup.
+    /// A client requested a reposition, providing a new positioner for a popup.
+    ///
+    /// To confirm the new popup position, `PopupSurface::send_repositioned` must be
+    /// called on the provided surface with the token.
     ///
     /// ## Arguments
     ///
@@ -944,7 +946,7 @@ pub trait XdgShellHandler {
     ///     The new popup position will not take effect until the corresponding configure event
     ///     is acknowledged by the client. See xdg_popup.repositioned for details.
     ///     The token itself is opaque, and has no other special meaning.
-    fn reposition_request(&mut self, surface: PopupSurface, positioner: PositionerState, token: u32) {}
+    fn reposition_request(&mut self, surface: PopupSurface, positioner: PositionerState, token: u32);
 
     /// A toplevel surface was destroyed.
     fn toplevel_destroyed(&mut self, surface: ToplevelSurface) {}


### PR DESCRIPTION
When running a GTK4 application which tries to reposition a popup surface, it will wait for a commit to confirm the repositioning and halt all rendering.

To avoid compositors accidentally skipping the implementation of this function, it should be clearly indicated that this is mandatory. The documentation was also expanded to reinforce this point.