### PR TITLE
Remove unnecessary rebind of `processor`

### DIFF
--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -72,8 +72,7 @@ impl WindowElement {
             #[cfg(feature = "xwayland")]
             WindowElement::X11(w) => {
                 if let Some(surface) = w.wl_surface() {
-                    let mut processor = processor;
-                    with_surfaces_surface_tree(&surface, &mut processor);
+                    with_surfaces_surface_tree(&surface, processor);
                 }
             }
         }


### PR DESCRIPTION
GIMP is tested, which works fine.

This is necessary in previous versions but not now, as API has changed.