### PR TITLE
Implement `Eq` and `Hash` for `PopupSurface`

### DIFF
--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1478,6 +1478,15 @@ impl std::cmp::PartialEq for PopupSurface {
     }
 }
 
+impl std::cmp::Eq for PopupSurface {}
+
+impl std::hash::Hash for PopupSurface {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // self.alive().hash(state);
+        self.wl_surface.hash(state);
+    }
+}
+
 impl PopupSurface {
     /// Is the toplevel surface referred by this handle still alive?
     pub fn alive(&self) -> bool {


### PR DESCRIPTION
Does what it says on the tin. This allows `PopupSurface` to be used in `HashMap`s, should compositors wish to associate custom state with a popup.

Closes #1199.