### PR TITLE
Start global serial counter at 1

### DIFF
--- a/src/utils/serial.rs
+++ b/src/utils/serial.rs
@@ -71,7 +71,9 @@ pub struct SerialCounter {
 impl SerialCounter {
     /// Retrieve the next serial from the counter
     pub fn next_serial(&self) -> Serial {
-        let _ = self.serial.compare_exchange(0, 1, Ordering::AcqRel, Ordering::SeqCst);
+        let _ = self
+            .serial
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::SeqCst);
         Serial(self.serial.fetch_add(1, Ordering::AcqRel))
     }
 }
@@ -122,7 +124,7 @@ mod tests {
         let serial2 = counter.next_serial();
 
         assert!(serial1 == u32::MAX.into());
-        assert!(serial2 == 0.into());
+        assert!(serial2 == 1.into());
 
         assert!(serial1 < serial2);
     }

--- a/src/utils/serial.rs
+++ b/src/utils/serial.rs
@@ -71,6 +71,7 @@ pub struct SerialCounter {
 impl SerialCounter {
     /// Retrieve the next serial from the counter
     pub fn next_serial(&self) -> Serial {
+        let _ = self.serial.compare_exchange(0, 1, Ordering::AcqRel, Ordering::SeqCst);
         Serial(self.serial.fetch_add(1, Ordering::AcqRel))
     }
 }

--- a/src/utils/serial.rs
+++ b/src/utils/serial.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 ///
 /// Is is also used internally by some parts of Smithay.
 pub static SERIAL_COUNTER: SerialCounter = SerialCounter {
-    serial: AtomicU32::new(0),
+    serial: AtomicU32::new(1),
 };
 
 /// A serial type, whose comparison takes into account the wrapping-around behavior of the


### PR DESCRIPTION
Qt apps don't acknowledge the xdg_surface configure event when the serial number is 0, therefore, no toplevel appears.

This bug never happens on most compositors because the serial number 0 is used for other things, and by the time a configure event comes, the number is already incremented.

The minimal example suffers from this bug because it's so minimal, and unfortunately serial number 0 is used for the first configure event.