### PR TITLE
xdg-activation: Add client_id to token data

### DIFF
--- a/src/wayland/xdg_activation/dispatch.rs
+++ b/src/wayland/xdg_activation/dispatch.rs
@@ -87,7 +87,7 @@ where
 {
     fn request(
         state: &mut D,
-        _: &Client,
+        client: &Client,
         token: &xdg_activation_token_v1::XdgActivationTokenV1,
         request: xdg_activation_token_v1::Request,
         data: &ActivationTokenData,
@@ -146,6 +146,7 @@ where
                     let mut guard = data.build.lock().unwrap();
 
                     XdgActivationTokenData::new(
+                        client.id(),
                         guard.serial.take(),
                         guard.app_id.take(),
                         guard.surface.take(),

--- a/src/wayland/xdg_activation/mod.rs
+++ b/src/wayland/xdg_activation/mod.rs
@@ -53,7 +53,7 @@ use std::{
 
 use wayland_protocols::xdg::activation::v1::server::xdg_activation_v1;
 use wayland_server::{
-    backend::GlobalId,
+    backend::{ClientId, GlobalId},
     protocol::{wl_seat::WlSeat, wl_surface::WlSurface},
     Dispatch, DisplayHandle, GlobalDispatch,
 };
@@ -103,6 +103,8 @@ impl From<XdgActivationToken> for String {
 
 #[derive(Debug, Clone)]
 pub struct XdgActivationTokenData {
+    /// Client that requested the token
+    pub client_id: ClientId,
     /// Provides information about the seat and serial event that requested the token.
     ///
     /// The serial can come from an input or focus event.
@@ -129,6 +131,7 @@ pub struct XdgActivationTokenData {
 
 impl XdgActivationTokenData {
     fn new(
+        client_id: ClientId,
         serial: Option<(Serial, WlSeat)>,
         app_id: Option<String>,
         surface: Option<WlSurface>,
@@ -136,6 +139,7 @@ impl XdgActivationTokenData {
         (
             XdgActivationToken::new(),
             XdgActivationTokenData {
+                client_id,
                 serial,
                 app_id,
                 surface,


### PR DESCRIPTION
Makes it easier to special case certain (e.g. privileged) clients, as surface and seat (which could otherwise be used to get the client) are optional.