### PR TITLE
Take `&self` in handle methods that took `&mut self`

### DIFF
--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -44,7 +44,7 @@ impl TouchHandle {
     ///
     /// The `position` parameter is in surface-local coordinates.
     pub fn down(
-        &mut self,
+        &self,
         serial: Serial,
         time: u32,
         surface: &WlSurface,

--- a/src/wayland/tablet_manager/tablet_seat.rs
+++ b/src/wayland/tablet_manager/tablet_seat.rs
@@ -86,7 +86,7 @@ impl TabletSeatHandle {
     }
 
     /// Add a callback to SetCursor event
-    pub fn on_cursor_surface<F>(&mut self, cb: F)
+    pub fn on_cursor_surface<F>(&self, cb: F)
     where
         F: FnMut(&TabletToolDescriptor, CursorImageStatus) + Send + 'static,
     {


### PR DESCRIPTION
Other methods take `&self`. It doesn't really make sense to take `&mut self` on reference counted types in general.