### PR TITLE
xdg-activation: Allow the compositor to create tokens

### DIFF
--- a/src/wayland/xdg_activation/dispatch.rs
+++ b/src/wayland/xdg_activation/dispatch.rs
@@ -146,7 +146,7 @@ where
                     let mut guard = data.build.lock().unwrap();
 
                     XdgActivationTokenData::new(
-                        client.id(),
+                        Some(client.id()),
                         guard.serial.take(),
                         guard.app_id.take(),
                         guard.surface.take(),

--- a/src/wayland/xdg_activation/mod.rs
+++ b/src/wayland/xdg_activation/mod.rs
@@ -104,7 +104,7 @@ impl From<XdgActivationToken> for String {
 #[derive(Debug, Clone)]
 pub struct XdgActivationTokenData {
     /// Client that requested the token
-    pub client_id: ClientId,
+    pub client_id: Option<ClientId>,
     /// Provides information about the seat and serial event that requested the token.
     ///
     /// The serial can come from an input or focus event.
@@ -131,7 +131,7 @@ pub struct XdgActivationTokenData {
 
 impl XdgActivationTokenData {
     fn new(
-        client_id: ClientId,
+        client_id: Option<ClientId>,
         serial: Option<(Serial, WlSeat)>,
         app_id: Option<String>,
         surface: Option<WlSurface>,
@@ -174,6 +174,19 @@ impl XdgActivationState {
             global,
             known_tokens: HashMap::new(),
         }
+    }
+
+    /// Create a token without any client association, e.g. for spawning processes from the compositor.
+    ///
+    /// This will not invoke [`XdgActivationHandler::created_token`] like client-created tokens,
+    /// instead use the return arguments to handle any initialization of the data you might need and to copy the token.
+    pub fn create_external_token(
+        &mut self,
+        app_id: impl Into<Option<String>>,
+    ) -> (&XdgActivationToken, &XdgActivationTokenData) {
+        let (token, data) = XdgActivationTokenData::new(None, None, app_id.into(), None);
+        self.known_tokens.insert(token.clone(), data);
+        self.known_tokens.get_key_value(&token).unwrap()
     }
 
     /// Access the data of a known token


### PR DESCRIPTION
This is useful for compositor that spawn processes on their own, e.g. from key-bindings.