### PR TITLE
Make `smithay::desktop::Window` support XWayland windows

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -108,7 +108,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 for element in self.space.elements() {
                     #[allow(irrefutable_let_patterns)]
                     if let WindowElement::Wayland(window) = element {
-                        let toplevel = window.toplevel();
+                        let toplevel = window.toplevel().unwrap();
                         let mode_changed = toplevel.with_pending_state(|state| {
                             if let Some(current_mode) = state.decoration_mode {
                                 let new_mode =

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -311,7 +311,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
 
         match &self.window {
             WindowElement::Wayland(w) => {
-                let xdg = w.toplevel();
+                let xdg = w.toplevel().unwrap();
                 xdg.with_pending_state(|state| {
                     state.states.set(xdg_toplevel::State::Resizing);
                     state.size = Some(self.last_window_size);
@@ -355,7 +355,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
 
             match &self.window {
                 WindowElement::Wayland(w) => {
-                    let xdg = w.toplevel();
+                    let xdg = w.toplevel().unwrap();
                     xdg.with_pending_state(|state| {
                         state.states.unset(xdg_toplevel::State::Resizing);
                         state.size = Some(self.last_window_size);

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -242,7 +242,7 @@ fn ensure_initial_configure(surface: &WlSurface, space: &Space<WindowElement>, p
                     .initial_configure_sent
             });
             if !initial_configure_sent {
-                toplevel.toplevel().send_configure();
+                toplevel.toplevel().unwrap().send_configure();
             }
         }
 
@@ -347,7 +347,7 @@ fn place_new_window(
     // set the initial toplevel bounds
     #[allow(irrefutable_let_patterns)]
     if let WindowElement::Wayland(window) = window {
-        window.toplevel().with_pending_state(|state| {
+        window.toplevel().unwrap().with_pending_state(|state| {
             state.bounds = Some(output_geometry.size);
         });
     }

--- a/anvil/src/shell/ssd.rs
+++ b/anvil/src/shell/ssd.rs
@@ -63,7 +63,7 @@ impl HeaderBar {
         match self.pointer_loc.as_ref() {
             Some(loc) if loc.x >= (self.width - BUTTON_WIDTH) as f64 => {
                 match window {
-                    WindowElement::Wayland(w) => w.toplevel().send_close(),
+                    WindowElement::Wayland(w) => w.toplevel().unwrap().send_close(),
                     #[cfg(feature = "xwayland")]
                     WindowElement::X11(w) => {
                         let _ = w.close();
@@ -72,7 +72,7 @@ impl HeaderBar {
             }
             Some(loc) if loc.x >= (self.width - (BUTTON_WIDTH * 2)) as f64 => {
                 match window {
-                    WindowElement::Wayland(w) => state.maximize_request(w.toplevel().clone()),
+                    WindowElement::Wayland(w) => state.maximize_request(w.toplevel().unwrap().clone()),
                     #[cfg(feature = "xwayland")]
                     WindowElement::X11(w) => {
                         let surface = w.clone();
@@ -86,7 +86,7 @@ impl HeaderBar {
                 match window {
                     WindowElement::Wayland(w) => {
                         let seat = seat.clone();
-                        let toplevel = w.toplevel().clone();
+                        let toplevel = w.toplevel().unwrap().clone();
                         state
                             .handle
                             .insert_idle(move |data| data.state.move_request_xdg(&toplevel, &seat, serial));

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -46,7 +46,7 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
         // Do not send a configure here, the initial configure
         // of a xdg_surface has to be sent during the commit if
         // the surface is not already configured
-        let window = WindowElement::Wayland(Window::new(surface));
+        let window = WindowElement::Wayland(Window::new_wayland_window(surface));
         place_new_window(&mut self.space, self.pointer.current_location(), &window, true);
     }
 

--- a/smallvil/src/handlers/compositor.rs
+++ b/smallvil/src/handlers/compositor.rs
@@ -33,7 +33,11 @@ impl CompositorHandler for Smallvil {
             while let Some(parent) = get_parent(&root) {
                 root = parent;
             }
-            if let Some(window) = self.space.elements().find(|w| w.toplevel().wl_surface() == &root) {
+            if let Some(window) = self
+                .space
+                .elements()
+                .find(|w| w.toplevel().unwrap().wl_surface() == &root)
+            {
                 window.on_commit();
             }
         };

--- a/smallvil/src/handlers/xdg_shell.rs
+++ b/smallvil/src/handlers/xdg_shell.rs
@@ -33,7 +33,7 @@ impl XdgShellHandler for Smallvil {
     }
 
     fn new_toplevel(&mut self, surface: ToplevelSurface) {
-        let window = Window::new(surface);
+        let window = Window::new_wayland_window(surface);
         self.space.map_element(window, (0, 0), false);
     }
 
@@ -65,7 +65,7 @@ impl XdgShellHandler for Smallvil {
             let window = self
                 .space
                 .elements()
-                .find(|w| w.toplevel().wl_surface() == wl_surface)
+                .find(|w| w.toplevel().unwrap().wl_surface() == wl_surface)
                 .unwrap()
                 .clone();
             let initial_window_location = self.space.element_location(&window).unwrap();
@@ -97,7 +97,7 @@ impl XdgShellHandler for Smallvil {
             let window = self
                 .space
                 .elements()
-                .find(|w| w.toplevel().wl_surface() == wl_surface)
+                .find(|w| w.toplevel().unwrap().wl_surface() == wl_surface)
                 .unwrap()
                 .clone();
             let initial_window_location = self.space.element_location(&window).unwrap();
@@ -156,7 +156,7 @@ pub fn handle_commit(popups: &mut PopupManager, space: &Space<Window>, surface: 
     // Handle toplevel commits.
     if let Some(window) = space
         .elements()
-        .find(|w| w.toplevel().wl_surface() == surface)
+        .find(|w| w.toplevel().unwrap().wl_surface() == surface)
         .cloned()
     {
         let initial_configure_sent = with_states(surface, |states| {
@@ -170,7 +170,7 @@ pub fn handle_commit(popups: &mut PopupManager, space: &Space<Window>, surface: 
         });
 
         if !initial_configure_sent {
-            window.toplevel().send_configure();
+            window.toplevel().unwrap().send_configure();
         }
     }
 

--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -71,14 +71,18 @@ impl Smallvil {
                         .map(|(w, l)| (w.clone(), l))
                     {
                         self.space.raise_element(&window, true);
-                        keyboard.set_focus(self, Some(window.toplevel().wl_surface().clone()), serial);
+                        keyboard.set_focus(
+                            self,
+                            Some(window.toplevel().unwrap().wl_surface().clone()),
+                            serial,
+                        );
                         self.space.elements().for_each(|window| {
-                            window.toplevel().send_pending_configure();
+                            window.toplevel().unwrap().send_pending_configure();
                         });
                     } else {
                         self.space.elements().for_each(|window| {
                             window.set_activated(false);
-                            window.toplevel().send_pending_configure();
+                            window.toplevel().unwrap().send_pending_configure();
                         });
                         keyboard.set_focus(self, Option::<WlSurface>::None, serial);
                     }

--- a/src/desktop/space/wayland/window.rs
+++ b/src/desktop/space/wayland/window.rs
@@ -9,6 +9,7 @@ use crate::{
     desktop::{space::SpaceElement, PopupManager, Window, WindowSurfaceType},
     output::Output,
     utils::{Logical, Physical, Point, Rectangle, Scale},
+    wayland::seat::WaylandFocus,
 };
 
 use super::{output_update, WindowOutputUserData};
@@ -55,26 +56,28 @@ impl SpaceElement for Window {
             state.borrow_mut().output_overlap.retain(|weak, _| weak != output);
         }
 
-        let surface = self.toplevel().wl_surface();
-        output_update(output, None, surface);
-        for (popup, _) in PopupManager::popups_for_surface(surface) {
-            output_update(output, None, popup.wl_surface());
+        if let Some(surface) = &self.wl_surface() {
+            output_update(output, None, surface);
+            for (popup, _) in PopupManager::popups_for_surface(surface) {
+                output_update(output, None, popup.wl_surface());
+            }
         }
     }
 
     #[profiling::function]
     fn refresh(&self) {
-        self.user_data().insert_if_missing(WindowOutputUserData::default);
-        let state = self.user_data().get::<WindowOutputUserData>().unwrap().borrow();
+        if let Some(surface) = &self.wl_surface() {
+            self.user_data().insert_if_missing(WindowOutputUserData::default);
+            let state = self.user_data().get::<WindowOutputUserData>().unwrap().borrow();
 
-        let surface = self.toplevel().wl_surface();
-        for (weak, overlap) in state.output_overlap.iter() {
-            if let Some(output) = weak.upgrade() {
-                output_update(&output, Some(*overlap), surface);
-                for (popup, location) in PopupManager::popups_for_surface(surface) {
-                    let mut overlap = *overlap;
-                    overlap.loc -= location;
-                    output_update(&output, Some(overlap), popup.wl_surface());
+            for (weak, overlap) in state.output_overlap.iter() {
+                if let Some(output) = weak.upgrade() {
+                    output_update(&output, Some(*overlap), surface);
+                    for (popup, location) in PopupManager::popups_for_surface(surface) {
+                        let mut overlap = *overlap;
+                        overlap.loc -= location;
+                        output_update(&output, Some(overlap), popup.wl_surface());
+                    }
                 }
             }
         }
@@ -96,34 +99,35 @@ where
         scale: Scale<f64>,
         alpha: f32,
     ) -> Vec<C> {
-        let surface = self.toplevel().wl_surface();
-
         let mut render_elements: Vec<C> = Vec::new();
-        let popup_render_elements =
-            PopupManager::popups_for_surface(surface).flat_map(|(popup, popup_offset)| {
-                let offset = (self.geometry().loc + popup_offset - popup.geometry().loc)
-                    .to_physical_precise_round(scale);
 
-                render_elements_from_surface_tree(
-                    renderer,
-                    popup.wl_surface(),
-                    location + offset,
-                    scale,
-                    alpha,
-                    Kind::Unspecified,
-                )
-            });
+        if let Some(surface) = &self.wl_surface() {
+            let popup_render_elements =
+                PopupManager::popups_for_surface(surface).flat_map(|(popup, popup_offset)| {
+                    let offset = (self.geometry().loc + popup_offset - popup.geometry().loc)
+                        .to_physical_precise_round(scale);
 
-        render_elements.extend(popup_render_elements);
+                    render_elements_from_surface_tree(
+                        renderer,
+                        popup.wl_surface(),
+                        location + offset,
+                        scale,
+                        alpha,
+                        Kind::Unspecified,
+                    )
+                });
 
-        render_elements.extend(render_elements_from_surface_tree(
-            renderer,
-            surface,
-            location,
-            scale,
-            alpha,
-            Kind::Unspecified,
-        ));
+            render_elements.extend(popup_render_elements);
+
+            render_elements.extend(render_elements_from_surface_tree(
+                renderer,
+                surface,
+                location,
+                scale,
+                alpha,
+                Kind::Unspecified,
+            ));
+        }
 
         render_elements
     }

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -415,7 +415,7 @@ impl Window {
     /// Returns a [`UserDataMap`] to allow associating arbitrary data with this window.
     pub fn user_data(&self) -> &UserDataMap {
         match &self.0.surface {
-            WindowSurface::Wayland((_, data)) => &data,
+            WindowSurface::Wayland((_, data)) => data,
             #[cfg(feature = "xwayland")]
             WindowSurface::X11(s) => s.user_data(),
         }

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "xwayland")]
+use crate::xwayland::X11Surface;
 use crate::{
     backend::input::KeyState,
     desktop::{space::RenderZindex, utils::*, PopupManager},
@@ -18,7 +20,6 @@ use crate::{
         seat::WaylandFocus,
         shell::xdg::{SurfaceCachedState, ToplevelSurface},
     },
-    xwayland::X11Surface,
 };
 use std::{
     hash::{Hash, Hasher},
@@ -401,7 +402,8 @@ impl Window {
     pub fn toplevel(&self) -> Option<&ToplevelSurface> {
         match &self.0.surface {
             WindowSurface::Wayland((s, _)) => Some(s),
-            _ => None,
+            #[cfg(feature = "xwayland")]
+            WindowSurface::X11(_) => None,
         }
     }
 
@@ -414,6 +416,7 @@ impl Window {
     pub fn user_data(&self) -> &UserDataMap {
         match &self.0.surface {
             WindowSurface::Wayland((_, data)) => &data,
+            #[cfg(feature = "xwayland")]
             WindowSurface::X11(s) => s.user_data(),
         }
     }


### PR DESCRIPTION
As mentioned in https://github.com/Smithay/smithay/issues/1202, `Window` is supposed to abstract over both Xdg toplevels and X11 surfaces. So now I have done it.
There is a breaking API change - `Window::toplevel()` now returns an `Option`. And the `new()` function will be deprecated, replaced by `new_wayland_window()` and `new_x11_window()`.
Fixes are applied to Smallvil and Anvil to make them compile and work. But to take full advantage of this PR, Anvil may need major refactor in the future.