### PR TITLE
Change `PointerHandle.motion` and friends to take relative coords

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -26,7 +26,7 @@ use smithay::{
         wayland_protocols::xdg::decoration::zv1::server::zxdg_toplevel_decoration_v1,
         wayland_server::{protocol::wl_pointer, DisplayHandle},
     },
-    utils::{Logical, Point, Serial, Transform, SERIAL_COUNTER as SCOUNTER},
+    utils::{Logical, Point, RelativePoint, Serial, Transform, SERIAL_COUNTER as SCOUNTER},
     wayland::{
         compositor::with_states,
         input_method::InputMethodSeat,
@@ -348,7 +348,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         }
     }
 
-    pub fn surface_under(&self, pos: Point<f64, Logical>) -> Option<(FocusTarget, Point<i32, Logical>)> {
+    pub fn focused_surface(&self, pos: Point<f64, Logical>) -> Option<RelativePoint<FocusTarget>> {
         let output = self.space.outputs().find(|o| {
             let geometry = self.space.output_geometry(o).unwrap();
             geometry.contains(pos.to_i32_round())
@@ -356,29 +356,46 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         let output_geo = self.space.output_geometry(output).unwrap();
         let layers = layer_map_for_output(output);
 
-        let mut under = None;
+        let mut focus: Option<RelativePoint<FocusTarget>> = None;
         if let Some(window) = output
             .user_data()
             .get::<FullscreenSurface>()
             .and_then(|f| f.get())
         {
-            under = Some((window.into(), output_geo.loc));
+            focus = Some(RelativePoint::on_focused_surface(
+                pos,
+                window.into(),
+                output_geo.loc,
+            ));
         } else if let Some(layer) = layers
             .layer_under(WlrLayer::Overlay, pos)
             .or_else(|| layers.layer_under(WlrLayer::Top, pos))
         {
             let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-            under = Some((layer.clone().into(), output_geo.loc + layer_loc))
+            focus = Some(RelativePoint::on_focused_surface(
+                pos,
+                layer.clone().into(),
+                output_geo.loc + layer_loc,
+            ));
         } else if let Some((window, location)) = self.space.element_under(pos) {
-            under = Some((window.clone().into(), location));
+            focus = Some(RelativePoint::on_focused_surface(
+                pos,
+                window.clone().into(),
+                location,
+            ));
         } else if let Some(layer) = layers
             .layer_under(WlrLayer::Bottom, pos)
             .or_else(|| layers.layer_under(WlrLayer::Background, pos))
         {
             let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-            under = Some((layer.clone().into(), output_geo.loc + layer_loc));
+            focus = Some(RelativePoint::on_focused_surface(
+                pos,
+                layer.clone().into(),
+                output_geo.loc + layer_loc,
+            ));
         };
-        under
+
+        focus
     }
 
     fn on_pointer_axis<B: InputBackend>(&mut self, _dh: &DisplayHandle, evt: B::PointerAxisEvent) {
@@ -525,10 +542,11 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
         let serial = SCOUNTER.next_serial();
 
         let pointer = self.pointer.clone();
-        let under = self.surface_under(pos);
+        let focus = self.focused_surface(pos);
+
         pointer.motion(
             self,
-            under,
+            focus,
             &MotionEvent {
                 location: pos,
                 serial,
@@ -563,10 +581,10 @@ impl AnvilState<UdevData> {
                         let y = geometry.size.h as f64 / 2.0;
                         let location = (x, y).into();
                         let pointer = self.pointer.clone();
-                        let under = self.surface_under(location);
+                        let focus = self.focused_surface(location);
                         pointer.motion(
                             self,
-                            under,
+                            focus,
                             &MotionEvent {
                                 location,
                                 serial: SCOUNTER.next_serial(),
@@ -601,10 +619,10 @@ impl AnvilState<UdevData> {
 
                         crate::shell::fixup_positions(&mut self.space, pointer_location);
                         let pointer = self.pointer.clone();
-                        let under = self.surface_under(pointer_location);
+                        let focus = self.focused_surface(pointer_location);
                         pointer.motion(
                             self,
-                            under,
+                            focus,
                             &MotionEvent {
                                 location: pointer_location,
                                 serial: SCOUNTER.next_serial(),
@@ -640,10 +658,10 @@ impl AnvilState<UdevData> {
 
                         crate::shell::fixup_positions(&mut self.space, pointer_location);
                         let pointer = self.pointer.clone();
-                        let under = self.surface_under(pointer_location);
+                        let focus = self.focused_surface(pointer_location);
                         pointer.motion(
                             self,
-                            under,
+                            focus,
                             &MotionEvent {
                                 location: pointer_location,
                                 serial: SCOUNTER.next_serial(),
@@ -736,21 +754,22 @@ impl AnvilState<UdevData> {
         let serial = SCOUNTER.next_serial();
 
         let pointer = self.pointer.clone();
-        let under = self.surface_under(pointer_location);
+        let focus = self.focused_surface(pointer_location);
 
         let mut pointer_locked = false;
         let mut pointer_confined = false;
         let mut confine_region = None;
-        if let Some((surface, surface_loc)) = under
+        if let Some((surface, loc)) = focus
             .as_ref()
-            .and_then(|(target, l)| Some((target.wl_surface()?, l)))
+            .and_then(|focused| Some((focused.surface.wl_surface()?, focused.loc)))
         {
             with_pointer_constraint(&surface, &pointer, |constraint| match constraint {
                 Some(constraint) if constraint.is_active() => {
                     // Constraint does not apply if not within region
-                    if !constraint.region().map_or(true, |x| {
-                        x.contains(pointer_location.to_i32_round() - *surface_loc)
-                    }) {
+                    if !constraint
+                        .region()
+                        .map_or(true, |x| x.contains(loc.to_i32_round()))
+                    {
                         return;
                     }
                     match &*constraint {
@@ -769,7 +788,7 @@ impl AnvilState<UdevData> {
 
         pointer.relative_motion(
             self,
-            under.clone(),
+            focus.clone(),
             &RelativeMotionEvent {
                 delta: evt.delta(),
                 delta_unaccel: evt.delta_unaccel(),
@@ -789,17 +808,17 @@ impl AnvilState<UdevData> {
         // this event is never generated by winit
         pointer_location = self.clamp_coords(pointer_location);
 
-        let new_under = self.surface_under(pointer_location);
+        let new_focus = self.focused_surface(pointer_location);
 
         // If confined, don't move pointer if it would go outside surface or region
         if pointer_confined {
-            if let Some((surface, surface_loc)) = &under {
-                if new_under.as_ref().and_then(|(under, _)| under.wl_surface()) != surface.wl_surface() {
+            if let Some(focused) = &focus {
+                if new_focus.as_ref().and_then(|nf| nf.surface.wl_surface()) != focused.surface.wl_surface() {
                     pointer.frame(self);
                     return;
                 }
                 if let Some(region) = confine_region {
-                    if !region.contains(pointer_location.to_i32_round() - *surface_loc) {
+                    if !region.contains(focused.loc.to_i32_round()) {
                         pointer.frame(self);
                         return;
                     }
@@ -809,7 +828,7 @@ impl AnvilState<UdevData> {
 
         pointer.motion(
             self,
-            under,
+            focus,
             &MotionEvent {
                 location: pointer_location,
                 serial,
@@ -820,12 +839,12 @@ impl AnvilState<UdevData> {
 
         // If pointer is now in a constraint region, activate it
         // TODO Anywhere else pointer is moved needs to do this
-        if let Some((under, surface_location)) =
-            new_under.and_then(|(target, loc)| Some((target.wl_surface()?, loc)))
+        if let Some((under, loc)) =
+            new_focus.and_then(|focused| Some((focused.surface.wl_surface()?, focused.loc)))
         {
             with_pointer_constraint(&under, &pointer, |constraint| match constraint {
                 Some(constraint) if !constraint.is_active() => {
-                    let point = pointer_location.to_i32_round() - surface_location;
+                    let point = loc.to_i32_round();
                     if constraint.region().map_or(true, |region| region.contains(point)) {
                         constraint.activate();
                     }
@@ -861,11 +880,11 @@ impl AnvilState<UdevData> {
         pointer_location = self.clamp_coords(pointer_location);
 
         let pointer = self.pointer.clone();
-        let under = self.surface_under(pointer_location);
+        let focus = self.focused_surface(pointer_location);
 
         pointer.motion(
             self,
-            under,
+            focus,
             &MotionEvent {
                 location: pointer_location,
                 serial,
@@ -888,13 +907,13 @@ impl AnvilState<UdevData> {
             let pointer_location = evt.position_transformed(rect.size) + rect.loc.to_f64();
 
             let pointer = self.pointer.clone();
-            let under = self.surface_under(pointer_location);
+            let focus = self.focused_surface(pointer_location);
             let tablet = tablet_seat.get_tablet(&TabletDescriptor::from(&evt.device()));
             let tool = tablet_seat.get_tool(&evt.tool());
 
             pointer.motion(
                 self,
-                under.clone(),
+                focus.clone(),
                 &MotionEvent {
                     location: pointer_location,
                     serial: SCOUNTER.next_serial(),
@@ -924,7 +943,11 @@ impl AnvilState<UdevData> {
 
                 tool.motion(
                     pointer_location,
-                    under.and_then(|(f, loc)| f.wl_surface().map(|s| (s, loc))),
+                    focus.and_then(|f| {
+                        f.surface
+                            .wl_surface()
+                            .map(|surface| RelativePoint { surface, loc: f.loc })
+                    }),
                     &tablet,
                     SCOUNTER.next_serial(),
                     evt.time_msec(),
@@ -955,13 +978,13 @@ impl AnvilState<UdevData> {
             let pointer_location = evt.position_transformed(rect.size) + rect.loc.to_f64();
 
             let pointer = self.pointer.clone();
-            let under = self.surface_under(pointer_location);
+            let focus = self.focused_surface(pointer_location);
             let tablet = tablet_seat.get_tablet(&TabletDescriptor::from(&evt.device()));
             let tool = tablet_seat.get_tool(&tool);
 
             pointer.motion(
                 self,
-                under.clone(),
+                focus.clone(),
                 &MotionEvent {
                     location: pointer_location,
                     serial: SCOUNTER.next_serial(),
@@ -970,15 +993,19 @@ impl AnvilState<UdevData> {
             );
             pointer.frame(self);
 
-            if let (Some(under), Some(tablet), Some(tool)) = (
-                under.and_then(|(f, loc)| f.wl_surface().map(|s| (s, loc))),
+            if let (Some(focus), Some(tablet), Some(tool)) = (
+                focus.and_then(|f| {
+                    f.surface
+                        .wl_surface()
+                        .map(|surface| RelativePoint { surface, loc: f.loc })
+                }),
                 tablet,
                 tool,
             ) {
                 match evt.state() {
                     ProximityState::In => tool.proximity_in(
                         pointer_location,
-                        under,
+                        focus,
                         &tablet,
                         SCOUNTER.next_serial(),
                         evt.time_msec(),

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -548,7 +548,7 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
             self,
             focus,
             &MotionEvent {
-                location: pos,
+                global_location: pos,
                 serial,
                 time: evt.time_msec(),
             },
@@ -586,7 +586,7 @@ impl AnvilState<UdevData> {
                             self,
                             focus,
                             &MotionEvent {
-                                location,
+                                global_location: location,
                                 serial: SCOUNTER.next_serial(),
                                 time: 0,
                             },
@@ -624,7 +624,7 @@ impl AnvilState<UdevData> {
                             self,
                             focus,
                             &MotionEvent {
-                                location: pointer_location,
+                                global_location: pointer_location,
                                 serial: SCOUNTER.next_serial(),
                                 time: 0,
                             },
@@ -663,7 +663,7 @@ impl AnvilState<UdevData> {
                             self,
                             focus,
                             &MotionEvent {
-                                location: pointer_location,
+                                global_location: pointer_location,
                                 serial: SCOUNTER.next_serial(),
                                 time: 0,
                             },
@@ -830,7 +830,7 @@ impl AnvilState<UdevData> {
             self,
             focus,
             &MotionEvent {
-                location: pointer_location,
+                global_location: pointer_location,
                 serial,
                 time: evt.time_msec(),
             },
@@ -886,7 +886,7 @@ impl AnvilState<UdevData> {
             self,
             focus,
             &MotionEvent {
-                location: pointer_location,
+                global_location: pointer_location,
                 serial,
                 time: evt.time_msec(),
             },
@@ -915,7 +915,7 @@ impl AnvilState<UdevData> {
                 self,
                 focus.clone(),
                 &MotionEvent {
-                    location: pointer_location,
+                    global_location: pointer_location,
                     serial: SCOUNTER.next_serial(),
                     time: 0,
                 },
@@ -986,7 +986,7 @@ impl AnvilState<UdevData> {
                 self,
                 focus.clone(),
                 &MotionEvent {
-                    location: pointer_location,
+                    global_location: pointer_location,
                     serial: SCOUNTER.next_serial(),
                     time: 0,
                 },

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -195,12 +195,12 @@ impl<Backend: crate::state::Backend> PointerTarget<AnvilState<Backend>> for Wind
     fn enter(&self, seat: &Seat<AnvilState<Backend>>, data: &mut AnvilState<Backend>, event: &MotionEvent) {
         let mut state = self.decoration_state();
         if state.is_ssd {
-            if event.location.y < HEADER_BAR_HEIGHT as f64 {
-                state.header_bar.pointer_enter(event.location);
+            if event.global_location.y < HEADER_BAR_HEIGHT as f64 {
+                state.header_bar.pointer_enter(event.global_location);
             } else {
                 state.header_bar.pointer_leave();
                 let mut event = event.clone();
-                event.location.y -= HEADER_BAR_HEIGHT as f64;
+                event.global_location.y -= HEADER_BAR_HEIGHT as f64;
                 match self {
                     WindowElement::Wayland(w) => PointerTarget::enter(w, seat, data, &event),
                     #[cfg(feature = "xwayland")]
@@ -220,7 +220,7 @@ impl<Backend: crate::state::Backend> PointerTarget<AnvilState<Backend>> for Wind
     fn motion(&self, seat: &Seat<AnvilState<Backend>>, data: &mut AnvilState<Backend>, event: &MotionEvent) {
         let mut state = self.decoration_state();
         if state.is_ssd {
-            if event.location.y < HEADER_BAR_HEIGHT as f64 {
+            if event.global_location.y < HEADER_BAR_HEIGHT as f64 {
                 match self {
                     WindowElement::Wayland(w) => {
                         PointerTarget::leave(w, seat, data, event.serial, event.time)
@@ -229,11 +229,11 @@ impl<Backend: crate::state::Backend> PointerTarget<AnvilState<Backend>> for Wind
                     WindowElement::X11(w) => PointerTarget::leave(w, seat, data, event.serial, event.time),
                 };
                 state.ptr_entered_window = false;
-                state.header_bar.pointer_enter(event.location);
+                state.header_bar.pointer_enter(event.global_location);
             } else {
                 state.header_bar.pointer_leave();
                 let mut event = event.clone();
-                event.location.y -= HEADER_BAR_HEIGHT as f64;
+                event.global_location.y -= HEADER_BAR_HEIGHT as f64;
                 if state.ptr_entered_window {
                     match self {
                         WindowElement::Wayland(w) => PointerTarget::motion(w, seat, data, &event),

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -9,7 +9,7 @@ use smithay::{
         PointerInnerHandle, RelativeMotionEvent,
     },
     reexports::wayland_protocols::xdg::shell::server::xdg_toplevel,
-    utils::{IsAlive, Logical, Point, Serial, Size},
+    utils::{IsAlive, Logical, Point, RelativePoint, Serial, Size},
     wayland::{compositor::with_states, shell::xdg::SurfaceCachedState},
 };
 #[cfg(feature = "xwayland")]
@@ -32,7 +32,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for MoveSurfaceG
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        _focus: Option<(FocusTarget, Point<i32, Logical>)>,
+        _focus: Option<RelativePoint<FocusTarget>>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -49,7 +49,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for MoveSurfaceG
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        focus: Option<(FocusTarget, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<FocusTarget>>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);
@@ -246,7 +246,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        _focus: Option<(FocusTarget, Point<i32, Logical>)>,
+        _focus: Option<RelativePoint<FocusTarget>>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -331,7 +331,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        focus: Option<(FocusTarget, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<FocusTarget>>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -38,7 +38,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for MoveSurfaceG
         // While the grab is active, no client has pointer focus
         handle.motion(data, None, event);
 
-        let delta = event.location - self.start_data.location;
+        let delta = event.global_location - self.start_data.location;
         let new_location = self.initial_window_location.to_f64() + delta;
 
         data.space
@@ -258,7 +258,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
             return;
         }
 
-        let (mut dx, mut dy) = (event.location - self.start_data.location).into();
+        let (mut dx, mut dy) = (event.global_location - self.start_data.location).into();
 
         let mut new_window_width = self.initial_window_size.w;
         let mut new_window_height = self.initial_window_size.h;

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -112,7 +112,7 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
                 .focus
                 .as_ref()
                 .unwrap()
-                .0
+                .surface
                 .same_client_as(&surface.wl_surface().id())
         {
             return;
@@ -404,7 +404,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 .focus
                 .as_ref()
                 .unwrap()
-                .0
+                .surface
                 .same_client_as(&surface.wl_surface().id())
         {
             return;

--- a/smallvil/src/grabs/move_grab.rs
+++ b/smallvil/src/grabs/move_grab.rs
@@ -8,7 +8,7 @@ use smithay::{
         PointerInnerHandle, RelativeMotionEvent,
     },
     reexports::wayland_server::protocol::wl_surface::WlSurface,
-    utils::{Logical, Point},
+    utils::{Logical, Point, RelativePoint},
 };
 
 pub struct MoveSurfaceGrab {
@@ -22,7 +22,7 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
         &mut self,
         data: &mut Smallvil,
         handle: &mut PointerInnerHandle<'_, Smallvil>,
-        _focus: Option<(WlSurface, Point<i32, Logical>)>,
+        _focus: Option<RelativePoint<WlSurface>>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -38,7 +38,7 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
         &mut self,
         data: &mut Smallvil,
         handle: &mut PointerInnerHandle<'_, Smallvil>,
-        focus: Option<(WlSurface, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<WlSurface>>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);

--- a/smallvil/src/grabs/move_grab.rs
+++ b/smallvil/src/grabs/move_grab.rs
@@ -28,7 +28,7 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
         // While the grab is active, no client has pointer focus
         handle.motion(data, None, event);
 
-        let delta = event.location - self.start_data.location;
+        let delta = event.global_location - self.start_data.location;
         let new_location = self.initial_window_location.to_f64() + delta;
         data.space
             .map_element(self.window.clone(), new_location.to_i32_round(), true);

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -82,7 +82,7 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
         // While the grab is active, no client has pointer focus
         handle.motion(data, None, event);
 
-        let mut delta = event.location - self.start_data.location;
+        let mut delta = event.global_location - self.start_data.location;
 
         let mut new_window_width = self.initial_rect.size.w;
         let mut new_window_height = self.initial_rect.size.h;

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -10,7 +10,7 @@ use smithay::{
     reexports::{
         wayland_protocols::xdg::shell::server::xdg_toplevel, wayland_server::protocol::wl_surface::WlSurface,
     },
-    utils::{Logical, Point, Rectangle, Size},
+    utils::{Logical, Point, Rectangle, RelativePoint, Size},
     wayland::{compositor, shell::xdg::SurfaceCachedState},
 };
 use std::cell::RefCell;
@@ -76,7 +76,7 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
         &mut self,
         data: &mut Smallvil,
         handle: &mut PointerInnerHandle<'_, Smallvil>,
-        _focus: Option<(WlSurface, Point<i32, Logical>)>,
+        _focus: Option<RelativePoint<WlSurface>>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -132,7 +132,7 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
         &mut self,
         data: &mut Smallvil,
         handle: &mut PointerInnerHandle<'_, Smallvil>,
-        focus: Option<(WlSurface, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<WlSurface>>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);

--- a/smallvil/src/handlers/xdg_shell.rs
+++ b/smallvil/src/handlers/xdg_shell.rs
@@ -142,9 +142,9 @@ fn check_grab(
 
     let start_data = pointer.grab_start_data()?;
 
-    let (focus, _) = start_data.focus.as_ref()?;
+    let focused = start_data.focus.as_ref()?;
     // If the focus was for a different surface, ignore the request.
-    if !focus.id().same_client_as(&surface.id()) {
+    if !focused.surface.id().same_client_as(&surface.id()) {
         return None;
     }
 

--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -52,7 +52,7 @@ impl Smallvil {
                     self,
                     focus,
                     &MotionEvent {
-                        location: pos,
+                        global_location: pos,
                         serial,
                         time: event.time_msec(),
                     },

--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -8,6 +8,7 @@ use smithay::{
         pointer::{AxisFrame, ButtonEvent, MotionEvent},
     },
     reexports::wayland_server::protocol::wl_surface::WlSurface,
+    utils::RelativePoint,
     utils::SERIAL_COUNTER,
 };
 
@@ -41,11 +42,15 @@ impl Smallvil {
 
                 let pointer = self.seat.get_pointer().unwrap();
 
-                let under = self.surface_under(pos);
+                let focus = if let Some((surface, sloc)) = self.surface_under(pos) {
+                    Some(RelativePoint::on_focused_surface(pos, surface, sloc))
+                } else {
+                    None
+                };
 
                 pointer.motion(
                     self,
-                    under,
+                    focus,
                     &MotionEvent {
                         location: pos,
                         serial,

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -724,9 +724,9 @@ impl LayerSurface {
 
 impl<D: SeatHandler + 'static> PointerTarget<D> for LayerSurface {
     fn enter(&self, seat: &Seat<D>, data: &mut D, event: &MotionEvent) {
-        if let Some((surface, loc)) = self.surface_under(event.location, WindowSurfaceType::ALL) {
+        if let Some((surface, loc)) = self.surface_under(event.global_location, WindowSurfaceType::ALL) {
             let mut new_event = event.clone();
-            new_event.location -= loc.to_f64();
+            new_event.global_location -= loc.to_f64();
             if let Some(old_surface) = self.0.focused_surface.lock().unwrap().replace(surface.clone()) {
                 if old_surface != surface {
                     PointerTarget::<D>::leave(&old_surface, seat, data, event.serial, event.time);

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         SeatHandler,
     },
-    utils::{DeadResource, IsAlive, Logical, Point, Serial},
+    utils::{DeadResource, IsAlive, RelativePoint, Serial},
     wayland::{compositor::get_role, seat::WaylandFocus, shell::xdg::XDG_POPUP_ROLE},
 };
 
@@ -303,7 +303,10 @@ where
                 // We set the focus to root as this will make
                 // sure the grab will stay alive until the
                 // toplevel is destroyed or the grab is unset
-                focus: Some((root.into(), (0, 0).into())),
+                focus: Some(RelativePoint {
+                    surface: root.into(),
+                    loc: (0f64, 0f64).into(),
+                }),
                 location: (0f64, 0f64).into(),
             },
         }
@@ -547,7 +550,7 @@ where
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &MotionEvent,
     ) {
         if self.popup_grab.has_ended() {
@@ -565,7 +568,7 @@ where
                     .current_grab()
                     .as_ref()
                     .and_then(|f2| f2.wl_surface())
-                    .map(|s| f1.0.same_client_as(&s.id()))
+                    .map(|s| f1.surface.same_client_as(&s.id()))
             })
             .unwrap_or(false)
         {
@@ -579,7 +582,7 @@ where
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);
@@ -605,7 +608,7 @@ where
                 .and_then(|f| {
                     self.popup_grab
                         .current_grab()
-                        .and_then(|f2| f.0.wl_surface().map(|s| f2.same_client_as(&s.id())))
+                        .and_then(|f2| f.surface.wl_surface().map(|s| f2.same_client_as(&s.id())))
                 })
                 .unwrap_or(false)
         {

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -289,9 +289,9 @@ impl Window {
 
 impl<D: SeatHandler + 'static> PointerTarget<D> for Window {
     fn enter(&self, seat: &Seat<D>, data: &mut D, event: &MotionEvent) {
-        if let Some((surface, loc)) = self.surface_under(event.location, WindowSurfaceType::ALL) {
+        if let Some((surface, loc)) = self.surface_under(event.global_location, WindowSurfaceType::ALL) {
             let mut new_event = event.clone();
-            new_event.location -= loc.to_f64();
+            new_event.global_location -= loc.to_f64();
             if let Some(old_surface) = self.0.focused_surface.lock().unwrap().replace(surface.clone()) {
                 if old_surface != surface {
                     PointerTarget::<D>::leave(&old_surface, seat, data, event.serial, event.time);

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use crate::{
     backend::input::ButtonState,
     input::SeatHandler,
-    utils::Serial,
     utils::{Logical, Point},
+    utils::{RelativePoint, Serial},
 };
 
 use super::{
@@ -46,7 +46,7 @@ pub trait PointerGrab<D: SeatHandler>: Send {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &MotionEvent,
     );
     /// Relative motion was reported
@@ -58,7 +58,7 @@ pub trait PointerGrab<D: SeatHandler>: Send {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &RelativeMotionEvent,
     );
     /// A button press was reported
@@ -171,10 +171,9 @@ pub trait PointerGrab<D: SeatHandler>: Send {
 
 /// Data about the event that started the grab.
 pub struct GrabStartData<D: SeatHandler> {
-    /// The focused surface and its location, if any, at the start of the grab.
-    ///
-    /// The location coordinates are in the global compositor space.
-    pub focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+    /// The focused surface and the pointer's relative location, if any, at the
+    /// start of the grab.
+    pub focus: Option<RelativePoint<D::PointerFocus>>,
     /// The button that initiated the grab.
     pub button: u32,
     /// The location of the click that initiated the grab, in the global compositor space.
@@ -226,7 +225,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &MotionEvent,
     ) {
         handle.motion(data, focus, event);
@@ -236,7 +235,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);
@@ -359,7 +358,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        _focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        _focus: Option<RelativePoint<D::PointerFocus>>,
         event: &MotionEvent,
     ) {
         handle.motion(data, self.start_data.focus.clone(), event);
@@ -369,7 +368,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -8,8 +8,8 @@ use std::{
 use crate::{
     backend::input::{Axis, AxisSource, ButtonState},
     input::{Seat, SeatHandler},
-    utils::Serial,
     utils::{IsAlive, Logical, Point},
+    utils::{RelativePoint, Serial},
 };
 
 mod cursor_image;
@@ -216,19 +216,13 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     /// You provide the new location of the pointer, in the form of:
     ///
     /// - The coordinates of the pointer in the global compositor space
-    /// - The surface on top of which the cursor is, and the coordinates of its
-    ///   origin in the global compositor space (or `None` of the pointer is not
-    ///   on top of a client surface).
+    /// - The surface the cursor is on top of, and the relative location of the
+    ///   cursor within that surface.
     ///
     /// This will internally take care of notifying the appropriate client objects
     /// of enter/motion/leave events.
-    #[instrument(level = "trace", parent = &self.span, skip(self, data, focus), fields(focus = ?focus.as_ref().map(|(_, loc)| ("...", loc))))]
-    pub fn motion(
-        &self,
-        data: &mut D,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
-        event: &MotionEvent,
-    ) {
+    #[instrument(level = "trace", parent = &self.span, skip(self, data, focus), fields(focus = ?focus.as_ref().map(|focus| ("...", focus.loc))))]
+    pub fn motion(&self, data: &mut D, focus: Option<RelativePoint<D::PointerFocus>>, event: &MotionEvent) {
         let mut inner = self.inner.lock().unwrap();
         inner.pending_focus = focus.clone();
         let seat = self.get_seat(data);
@@ -242,11 +236,11 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     /// This will internally send the appropriate button event to the client
     /// objects matching with the currently focused surface, if the client uses
     /// the relative pointer protocol.
-    #[instrument(level = "trace", parent = &self.span, skip(self, data, focus), fields(focus = ?focus.as_ref().map(|(_, loc)| ("...", loc))))]
+    #[instrument(level = "trace", parent = &self.span, skip(self, data, focus), fields(focus = ?focus.as_ref().map(|focus| ("...", focus.loc))))]
     pub fn relative_motion(
         &self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &RelativeMotionEvent,
     ) {
         let mut inner = self.inner.lock().unwrap();
@@ -435,7 +429,12 @@ where
 {
     /// Retrieve the current pointer focus
     pub fn current_focus(&self) -> Option<<D as SeatHandler>::PointerFocus> {
-        self.inner.lock().unwrap().focus.clone().map(|(focus, _)| focus)
+        self.inner
+            .lock()
+            .unwrap()
+            .focus
+            .clone()
+            .map(|focus| focus.surface)
     }
 }
 
@@ -479,7 +478,7 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     }
 
     /// Access the current focus of this pointer
-    pub fn current_focus(&self) -> Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)> {
+    pub fn current_focus(&self) -> Option<RelativePoint<D::PointerFocus>> {
         self.inner.focus.clone()
     }
 
@@ -501,16 +500,17 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     /// You provide the new location of the pointer, in the form of:
     ///
     /// - The coordinates of the pointer in the global compositor space
-    /// - The surface on top of which the cursor is, and the coordinates of its
-    ///   origin in the global compositor space (or `None` of the pointer is not
-    ///   on top of a client surface).
+    /// - The surface on top of which the cursor is, and the coordinates of the
+    ///   pointer relative to the surface.
+    ///
+    /// A value of None indicates that no surface is focused.
     ///
     /// This will internally take care of notifying the appropriate client objects
     /// of enter/motion/leave events.
     pub fn motion(
         &mut self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &MotionEvent,
     ) {
         self.inner.motion(data, self.seat, focus, event);
@@ -524,7 +524,7 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     pub fn relative_motion(
         &mut self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &RelativeMotionEvent,
     ) {
         self.inner.relative_motion(data, self.seat, focus, event);
@@ -535,8 +535,8 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     /// This will internally send the appropriate button event to the client
     /// objects matching with the currently focused surface.
     pub fn button(&mut self, data: &mut D, event: &ButtonEvent) {
-        if let Some((focused, _)) = self.inner.focus.as_mut() {
-            focused.button(self.seat, data, event);
+        if let Some(RelativePoint { surface, .. }) = self.inner.focus.as_mut() {
+            surface.button(self.seat, data, event);
         }
     }
 
@@ -545,8 +545,8 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     /// This will internally send the appropriate axis events to the client
     /// objects matching with the currently focused surface.
     pub fn axis(&mut self, data: &mut D, details: AxisFrame) {
-        if let Some((focused, _)) = self.inner.focus.as_mut() {
-            focused.axis(self.seat, data, details);
+        if let Some(RelativePoint { surface, .. }) = self.inner.focus.as_mut() {
+            surface.axis(self.seat, data, details);
         }
     }
 
@@ -555,8 +555,8 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     /// This will internally send the appropriate frame event to the client
     /// objects matching with the currently focused surface.
     pub fn frame(&mut self, data: &mut D) {
-        if let Some((focused, _)) = self.inner.focus.as_mut() {
-            focused.frame(self.seat, data);
+        if let Some(RelativePoint { surface, .. }) = self.inner.focus.as_mut() {
+            surface.frame(self.seat, data);
         }
     }
 
@@ -634,8 +634,8 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
 }
 
 pub(crate) struct PointerInternal<D: SeatHandler> {
-    pub(crate) focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
-    pending_focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+    pub(crate) focus: Option<RelativePoint<D::PointerFocus>>,
+    pending_focus: Option<RelativePoint<D::PointerFocus>>,
     location: Point<f64, Logical>,
     grab: GrabStatus<D>,
     pressed_buttons: Vec<u32>,
@@ -714,44 +714,43 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
         &mut self,
         data: &mut D,
         seat: &Seat<D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<RelativePoint<D::PointerFocus>>,
         event: &MotionEvent,
     ) {
         // do we leave a surface ?
         let mut leave = true;
         self.location = event.location;
-        if let Some((ref current_focus, _)) = self.focus {
-            if let Some((ref new_focus, _)) = focus {
-                if current_focus == new_focus {
+        if let Some(ref current_focus) = self.focus {
+            if let Some(ref new_focus) = focus {
+                if current_focus.surface == new_focus.surface {
                     leave = false;
                 }
             }
         }
         if leave {
-            if let Some((focused, _)) = self.focus.as_mut() {
-                focused.leave(seat, data, event.serial, event.time);
+            if let Some(focus) = self.focus.as_mut() {
+                focus.surface.leave(seat, data, event.serial, event.time);
             }
             self.focus = None;
             data.cursor_image(seat, CursorImageStatus::default_named());
         }
 
         // do we enter one ?
-        if let Some((surface, surface_location)) = focus {
+        if let Some(focus) = focus {
             let entered = self.focus.is_none();
             // in all cases, update the focus, the coordinates of the surface
             // might have changed
-            self.focus = Some((surface, surface_location));
+            self.focus = Some(focus.clone());
             let event = MotionEvent {
-                location: event.location - surface_location.to_f64(),
+                location: focus.loc.to_f64(),
                 serial: event.serial,
                 time: event.time,
             };
-            let (focused, _) = self.focus.as_mut().unwrap();
             if entered {
-                focused.enter(seat, data, &event);
+                focus.surface.enter(seat, data, &event);
             } else {
                 // we were on top of a surface and remained on it
-                focused.motion(seat, data, &event);
+                focus.surface.motion(seat, data, &event);
             }
         }
     }
@@ -760,59 +759,59 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
         &mut self,
         data: &mut D,
         seat: &Seat<D>,
-        _focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        _focus: Option<RelativePoint<D::PointerFocus>>,
         event: &RelativeMotionEvent,
     ) {
-        if let Some((focused, _)) = self.focus.as_mut() {
-            focused.relative_motion(seat, data, event);
+        if let Some(focus) = self.focus.as_mut() {
+            focus.surface.relative_motion(seat, data, event);
         }
     }
 
     fn gesture_swipe_begin(&mut self, data: &mut D, seat: &Seat<D>, event: &GestureSwipeBeginEvent) {
-        if let Some((focused, _)) = self.focus.as_mut() {
-            focused.gesture_swipe_begin(seat, data, event);
+        if let Some(focus) = self.focus.as_mut() {
+            focus.surface.gesture_swipe_begin(seat, data, event);
         }
     }
 
     fn gesture_swipe_update(&mut self, data: &mut D, seat: &Seat<D>, event: &GestureSwipeUpdateEvent) {
-        if let Some((focused, _)) = self.focus.as_mut() {
-            focused.gesture_swipe_update(seat, data, event);
+        if let Some(focus) = self.focus.as_mut() {
+            focus.surface.gesture_swipe_update(seat, data, event);
         }
     }
 
     fn gesture_swipe_end(&mut self, data: &mut D, seat: &Seat<D>, event: &GestureSwipeEndEvent) {
-        if let Some((focused, _)) = self.focus.as_mut() {
-            focused.gesture_swipe_end(seat, data, event);
+        if let Some(focus) = self.focus.as_mut() {
+            focus.surface.gesture_swipe_end(seat, data, event);
         }
     }
 
     fn gesture_pinch_begin(&mut self, data: &mut D, seat: &Seat<D>, event: &GesturePinchBeginEvent) {
-        if let Some((focused, _)) = self.focus.as_mut() {
-            focused.gesture_pinch_begin(seat, data, event);
+        if let Some(focus) = self.focus.as_mut() {
+            focus.surface.gesture_pinch_begin(seat, data, event);
         }
     }
 
     fn gesture_pinch_update(&mut self, data: &mut D, seat: &Seat<D>, event: &GesturePinchUpdateEvent) {
-        if let Some((focused, _)) = self.focus.as_mut() {
-            focused.gesture_pinch_update(seat, data, event);
+        if let Some(focus) = self.focus.as_mut() {
+            focus.surface.gesture_pinch_update(seat, data, event);
         }
     }
 
     fn gesture_pinch_end(&mut self, data: &mut D, seat: &Seat<D>, event: &GesturePinchEndEvent) {
-        if let Some((focused, _)) = self.focus.as_mut() {
-            focused.gesture_pinch_end(seat, data, event);
+        if let Some(focus) = self.focus.as_mut() {
+            focus.surface.gesture_pinch_end(seat, data, event);
         }
     }
 
     fn gesture_hold_begin(&mut self, data: &mut D, seat: &Seat<D>, event: &GestureHoldBeginEvent) {
-        if let Some((focused, _)) = self.focus.as_mut() {
-            focused.gesture_hold_begin(seat, data, event);
+        if let Some(focus) = self.focus.as_mut() {
+            focus.surface.gesture_hold_begin(seat, data, event);
         }
     }
 
     fn gesture_hold_end(&mut self, data: &mut D, seat: &Seat<D>, event: &GestureHoldEndEvent) {
-        if let Some((focused, _)) = self.focus.as_mut() {
-            focused.gesture_hold_end(seat, data, event);
+        if let Some(focus) = self.focus.as_mut() {
+            focus.surface.gesture_hold_end(seat, data, event);
         }
     }
 
@@ -825,8 +824,8 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
             GrabStatus::Borrowed => panic!("Accessed a pointer grab from within a pointer grab access."),
             GrabStatus::Active(_, ref mut handler) => {
                 // If this grab is associated with a surface that is no longer alive, discard it
-                if let Some((ref focus, _)) = handler.start_data().focus {
-                    if !focus.alive() {
+                if let Some(ref focus) = handler.start_data().focus {
+                    if !focus.surface.alive() {
                         self.grab = GrabStatus::None;
                         f(&mut PointerInnerHandle { inner: self, seat }, &mut DefaultGrab);
                         return;

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -683,7 +683,7 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
                 seat,
                 None,
                 &MotionEvent {
-                    location,
+                    global_location: location,
                     serial,
                     time: 0,
                 },
@@ -702,7 +702,7 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
                 seat,
                 focus,
                 &MotionEvent {
-                    location,
+                    global_location: location,
                     serial,
                     time,
                 },
@@ -719,7 +719,7 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
     ) {
         // do we leave a surface ?
         let mut leave = true;
-        self.location = event.location;
+        self.location = event.global_location;
         if let Some(ref current_focus) = self.focus {
             if let Some(ref new_focus) = focus {
                 if current_focus.surface == new_focus.surface {
@@ -742,7 +742,7 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
             // might have changed
             self.focus = Some(focus.clone());
             let event = MotionEvent {
-                location: focus.loc.to_f64(),
+                global_location: focus.loc.to_f64(),
                 serial: event.serial,
                 time: event.time,
             };
@@ -857,8 +857,8 @@ pub enum Focus {
 /// Pointer motion event
 #[derive(Debug, Clone)]
 pub struct MotionEvent {
-    /// Location of the pointer in compositor space
-    pub location: Point<f64, Logical>,
+    /// Location of the pointer in global compositor space
+    pub global_location: Point<f64, Logical>,
     /// Serial of the event
     pub serial: Serial,
     /// Timestamp of the event, with millisecond granularity

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -28,6 +28,9 @@ pub use serial::*;
 mod clock;
 pub use clock::*;
 
+mod relative_point;
+pub use relative_point::*;
+
 /// This resource is not managed by Smithay
 #[derive(Debug)]
 pub struct UnmanagedResource;

--- a/src/utils/relative_point.rs
+++ b/src/utils/relative_point.rs
@@ -21,11 +21,11 @@ impl<S: WaylandFocus> RelativePoint<S> {
     pub fn on_focused_surface(
         point: Point<f64, Logical>,
         focus: S,
-        focus_origin: Point<i32, Logical>,
+        focus_origin: impl Into<Point<i32, Logical>>,
     ) -> Self {
         Self {
             surface: focus,
-            loc: point - focus_origin.to_f64(),
+            loc: point - focus_origin.into().to_f64(),
         }
     }
 }

--- a/src/utils/relative_point.rs
+++ b/src/utils/relative_point.rs
@@ -1,0 +1,31 @@
+#[cfg(feature = "wayland_frontend")]
+use crate::wayland::seat::WaylandFocus;
+
+use super::{Logical, Point};
+
+/// Represents a point on a surface, relative to that surface's origin in
+/// global compositor space.
+#[derive(Debug, Clone)]
+pub struct RelativePoint<S> {
+    /// The surface that the pointer is over.
+    pub surface: S,
+    /// The relative location of the cursor within the surface.
+    pub loc: Point<f64, Logical>,
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl<S: WaylandFocus> RelativePoint<S> {
+    /// Calculates the relative position of a cursor on a target surface,
+    /// given a point and that  surface's origin coordinates, both in global
+    /// compositor space.
+    pub fn on_focused_surface(
+        point: Point<f64, Logical>,
+        focus: S,
+        focus_origin: Point<i32, Logical>,
+    ) -> Self {
+        Self {
+            surface: focus,
+            loc: point - focus_origin.to_f64(),
+        }
+    }
+}

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -155,7 +155,12 @@ where
             *pointer.last_enter.lock().unwrap() = Some(serial);
         }
         for_each_focused_pointers(seat, self, |ptr| {
-            ptr.enter(serial.into(), self, event.location.x, event.location.y);
+            ptr.enter(
+                serial.into(),
+                self,
+                event.global_location.x,
+                event.global_location.y,
+            );
         })
     }
     fn leave(&self, seat: &Seat<D>, _data: &mut D, serial: Serial, time: u32) {
@@ -200,7 +205,7 @@ where
     }
     fn motion(&self, seat: &Seat<D>, _data: &mut D, event: &MotionEvent) {
         for_each_focused_pointers(seat, self, |ptr| {
-            ptr.motion(event.time, event.location.x, event.location.y);
+            ptr.motion(event.time, event.global_location.x, event.global_location.y);
         })
     }
     fn relative_motion(&self, seat: &Seat<D>, _data: &mut D, event: &RelativeMotionEvent) {

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -457,7 +457,7 @@ where
                     .unwrap()
                     .focus
                     .as_ref()
-                    .map(|(focus, _)| focus.same_client_as(&pointer.id()))
+                    .map(|focused| focused.surface.same_client_as(&pointer.id()))
                     .unwrap_or(false)
                 {
                     return;

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -208,12 +208,12 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>, display_han
         WlcsEvent::NewPointer { .. } => {}
         WlcsEvent::PointerMoveAbsolute { location, .. } => {
             let serial = SCOUNTER.next_serial();
-            let under = state.surface_under(location);
+            let focus = state.focused_surface(location);
             let time = Duration::from(state.clock.now()).as_millis() as u32;
             let ptr = state.pointer.clone();
             ptr.motion(
                 state,
-                under,
+                focus,
                 &MotionEvent {
                     location,
                     serial,
@@ -225,13 +225,13 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>, display_han
         WlcsEvent::PointerMoveRelative { delta, .. } => {
             let pointer_location = state.pointer.current_location() + delta;
             let serial = SCOUNTER.next_serial();
-            let under = state.surface_under(pointer_location);
+            let focus = state.focused_surface(pointer_location);
             let time = Duration::from(state.clock.now()).as_millis() as u32;
             let utime = Duration::from(state.clock.now()).as_micros() as u64;
             let ptr = state.pointer.clone();
             ptr.motion(
                 state,
-                under.clone(),
+                focus.clone(),
                 &MotionEvent {
                     location: pointer_location,
                     serial,
@@ -240,7 +240,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>, display_han
             );
             ptr.relative_motion(
                 state,
-                under,
+                focus,
                 &RelativeMotionEvent {
                     delta,
                     delta_unaccel: delta,

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -215,7 +215,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>, display_han
                 state,
                 focus,
                 &MotionEvent {
-                    location,
+                    global_location: location,
                     serial,
                     time,
                 },
@@ -233,7 +233,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>, display_han
                 state,
                 focus.clone(),
                 &MotionEvent {
-                    location: pointer_location,
+                    global_location: pointer_location,
                     serial,
                     time,
                 },


### PR DESCRIPTION
The existing API is helpful in that it makes it harder to mess up the math, but it's not flexible enough to support having different windows with different scaling factors. That's relevant if, for example, you want to force a scale factor of 1 for Xwayland windows.

The existing API takes `Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>`, with the point being the surface origin, rather than the relative coordinates of the point on that surface. Then, internally, it converts into relative coordinates to generate the wayland event. A user familiar with wayland but not reading the documentation closely might think that the point should be the relative coords, not the surface origin (this happened to me).

Additionally, if you have different scale factors for different windows, it's impossible (or very difficult) to get the calculation right, since smithay is assuming that the coordinate space for the surface is the same as the global compositor space.