### PR TITLE
data_device: get clipboard selection instead of primary selection

### DIFF
--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -309,7 +309,7 @@ where
         .user_data()
         .get::<RefCell<SeatData<D::SelectionUserData>>>()
         .unwrap();
-    match seat_data.borrow().get_primary_selection() {
+    match seat_data.borrow().get_clipboard_selection() {
         None => Err(SelectionRequestError::NoSelection),
         Some(OfferReplySource::Client(source)) => {
             if !source.contains_mime_type(&mime_type) {


### PR DESCRIPTION
This appears to have been a copy/paste error, the primary selection accessor is in selection/primary selection,