### PR TITLE
wayland(dmabuf): ImportNotifier for asynchronous buffer import

### DIFF
--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -39,7 +39,7 @@ use smithay::{
     wayland::{
         compositor,
         dmabuf::{
-            DmabufFeedback, DmabufFeedbackBuilder, DmabufGlobal, DmabufHandler, DmabufState, ImportError,
+            DmabufFeedback, DmabufFeedbackBuilder, DmabufGlobal, DmabufHandler, DmabufState, ImportNotifier,
         },
     },
 };
@@ -64,13 +64,16 @@ impl DmabufHandler for AnvilState<WinitData> {
         &mut self.backend_data.dmabuf_state.0
     }
 
-    fn dmabuf_imported(&mut self, _global: &DmabufGlobal, dmabuf: Dmabuf) -> Result<(), ImportError> {
-        self.backend_data
+    fn dmabuf_imported(&mut self, _global: &DmabufGlobal, dmabuf: Dmabuf, notifier: ImportNotifier) {
+        if self
+            .backend_data
             .backend
             .renderer()
             .import_dmabuf(&dmabuf, None)
-            .map(|_| ())
-            .map_err(|_| ImportError::Failed)
+            .is_err()
+        {
+            notifier.failed();
+        }
     }
 }
 delegate_dmabuf!(AnvilState<WinitData>);

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -44,7 +44,7 @@ use smithay::{
     wayland::{
         compositor,
         dmabuf::{
-            DmabufFeedback, DmabufFeedbackBuilder, DmabufGlobal, DmabufHandler, DmabufState, ImportError,
+            DmabufFeedback, DmabufFeedbackBuilder, DmabufGlobal, DmabufHandler, DmabufState, ImportNotifier,
         },
     },
 };
@@ -73,12 +73,10 @@ impl DmabufHandler for AnvilState<X11Data> {
         &mut self.backend_data.dmabuf_state
     }
 
-    fn dmabuf_imported(&mut self, _global: &DmabufGlobal, dmabuf: Dmabuf) -> Result<(), ImportError> {
-        self.backend_data
-            .renderer
-            .import_dmabuf(&dmabuf, None)
-            .map(|_| ())
-            .map_err(|_| ImportError::Failed)
+    fn dmabuf_imported(&mut self, _global: &DmabufGlobal, dmabuf: Dmabuf, notifier: ImportNotifier) {
+        if self.backend_data.renderer.import_dmabuf(&dmabuf, None).is_err() {
+            notifier.failed();
+        }
     }
 }
 delegate_dmabuf!(AnvilState<X11Data>);

--- a/src/wayland/dmabuf/dispatch.rs
+++ b/src/wayland/dmabuf/dispatch.rs
@@ -1,7 +1,5 @@
 use std::sync::{atomic::AtomicBool, Mutex};
 
-use tracing::error;
-
 use wayland_protocols::wp::linux_dmabuf::zv1::server::{
     zwp_linux_buffer_params_v1, zwp_linux_dmabuf_feedback_v1, zwp_linux_dmabuf_v1,
 };
@@ -16,7 +14,7 @@ use crate::{
 
 use super::{
     DmabufData, DmabufFeedbackData, DmabufGlobal, DmabufGlobalData, DmabufHandler, DmabufParamsData,
-    DmabufState, ImportError, Modifier, SurfaceDmabufFeedbackState,
+    DmabufState, Import, ImportNotifier, Modifier, SurfaceDmabufFeedbackState,
 };
 
 impl<D> Dispatch<wl_buffer::WlBuffer, Dmabuf, D> for DmabufState
@@ -224,7 +222,7 @@ where
 {
     fn request(
         state: &mut D,
-        client: &Client,
+        _client: &Client,
         params: &zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1,
         request: zwp_linux_buffer_params_v1::Request,
         data: &DmabufParamsData,
@@ -285,33 +283,15 @@ where
                 // create_dmabuf performs an implicit ensure_unused function call.
                 if let Some(dmabuf) = data.create_dmabuf(params, width, height, format, flags) {
                     if state.dmabuf_state().globals.get(&data.id).is_some() {
-                        match state.dmabuf_imported(&DmabufGlobal { id: data.id }, dmabuf.clone()) {
-                            Ok(_) => {
-                                match client.create_resource::<wl_buffer::WlBuffer, Dmabuf, D>(dh, 1, dmabuf)
-                                {
-                                    Ok(buffer) => {
-                                        params.created(&buffer);
-                                    }
+                        let notifier = ImportNotifier {
+                            inner: params.clone(),
+                            display: dh.clone(),
+                            dmabuf: dmabuf.clone(),
+                            import: Import::Falliable,
+                            drop_ignore: false,
+                        };
 
-                                    Err(_) => {
-                                        error!("failed to create protocol object for \"create\" request");
-                                        // Failed to import since the buffer protocol object could not be created.
-                                        params.failed();
-                                    }
-                                }
-                            }
-
-                            Err(ImportError::InvalidFormat) => {
-                                params.post_error(
-                                    zwp_linux_buffer_params_v1::Error::InvalidFormat,
-                                    "format and plane combination are not valid",
-                                );
-                            }
-
-                            Err(ImportError::Failed) => {
-                                params.failed();
-                            }
-                        }
+                        state.dmabuf_imported(&DmabufGlobal { id: data.id }, dmabuf, notifier);
                     } else {
                         // If the dmabuf global was destroyed, we cannot import any buffers.
                         params.failed();
@@ -330,28 +310,18 @@ where
                 // create_dmabuf performs an implicit ensure_unused function call.
                 if let Some(dmabuf) = data.create_dmabuf(params, width, height, format, flags) {
                     if state.dmabuf_state().globals.get(&data.id).is_some() {
-                        match state.dmabuf_imported(&DmabufGlobal { id: data.id }, dmabuf.clone()) {
-                            Ok(_) => {
-                                // Import was successful, initialize the dmabuf data
-                                data_init.init(buffer_id, dmabuf);
-                            }
+                        // The buffer isn't technically valid during data_init, but the client is not allowed to use the buffer until ready.
+                        let buffer = data_init.init(buffer_id, dmabuf.clone());
 
-                            Err(ImportError::InvalidFormat) => {
-                                params.post_error(
-                                    zwp_linux_buffer_params_v1::Error::InvalidFormat,
-                                    "format and plane combination are not valid",
-                                );
-                            }
+                        let notifier = ImportNotifier {
+                            inner: params.clone(),
+                            display: dh.clone(),
+                            dmabuf: dmabuf.clone(),
+                            import: Import::Infallible(buffer),
+                            drop_ignore: false,
+                        };
 
-                            Err(ImportError::Failed) => {
-                                // Buffer import failed. The protocol documentation heavily implies killing the
-                                // client is the right thing to do here.
-                                params.post_error(
-                                    zwp_linux_buffer_params_v1::Error::InvalidWlBuffer,
-                                    "buffer import failed",
-                                );
-                            }
-                        }
+                        state.dmabuf_imported(&DmabufGlobal { id: data.id }, dmabuf, notifier);
                     } else {
                         // Buffer import failed. The protocol documentation heavily implies killing the
                         // client is the right thing to do here.

--- a/src/wayland/dmabuf/dispatch.rs
+++ b/src/wayland/dmabuf/dispatch.rs
@@ -283,14 +283,12 @@ where
                 // create_dmabuf performs an implicit ensure_unused function call.
                 if let Some(dmabuf) = data.create_dmabuf(params, width, height, format, flags) {
                     if state.dmabuf_state().globals.get(&data.id).is_some() {
-                        let notifier = ImportNotifier {
-                            inner: params.clone(),
-                            display: dh.clone(),
-                            dmabuf: dmabuf.clone(),
-                            import: Import::Falliable,
-                            drop_ignore: false,
-                        };
-
+                        let notifier = ImportNotifier::new(
+                            params.clone(),
+                            dh.clone(),
+                            dmabuf.clone(),
+                            Import::Falliable,
+                        );
                         state.dmabuf_imported(&DmabufGlobal { id: data.id }, dmabuf, notifier);
                     } else {
                         // If the dmabuf global was destroyed, we cannot import any buffers.
@@ -312,15 +310,12 @@ where
                     if state.dmabuf_state().globals.get(&data.id).is_some() {
                         // The buffer isn't technically valid during data_init, but the client is not allowed to use the buffer until ready.
                         let buffer = data_init.init(buffer_id, dmabuf.clone());
-
-                        let notifier = ImportNotifier {
-                            inner: params.clone(),
-                            display: dh.clone(),
-                            dmabuf: dmabuf.clone(),
-                            import: Import::Infallible(buffer),
-                            drop_ignore: false,
-                        };
-
+                        let notifier = ImportNotifier::new(
+                            params.clone(),
+                            dh.clone(),
+                            dmabuf.clone(),
+                            Import::Infallible(buffer),
+                        );
                         state.dmabuf_imported(&DmabufGlobal { id: data.id }, dmabuf, notifier);
                     } else {
                         // Buffer import failed. The protocol documentation heavily implies killing the

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -955,6 +955,16 @@ impl ImportNotifier {
         }
         self.drop_ignore = true;
     }
+
+    fn new(params: ZwpLinuxBufferParamsV1, display: DisplayHandle, dmabuf: Dmabuf, import: Import) -> Self {
+        Self {
+            inner: params,
+            display,
+            dmabuf,
+            import,
+            drop_ignore: false,
+        }
+    }
 }
 
 impl Drop for ImportNotifier {


### PR DESCRIPTION
This pull request adds the ImportNotifier type, which allows dmabuf import results to be delayed until processed at a later time. In my case this would be after being handled through a channel but can be extended to allow creating an importing thread.

Resolves #699

A quick test by smalling alacritty in smallvil shows this appears to work correctly.