### PR TITLE
Improve DummyRenderer for DrmCompositor usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ scan_fmt = { version = "0.2.3", default-features = false }
 encoding_rs = { version = "0.8.33", optional = true }
 profiling = "1.0"
 smallvec = "1.11"
+pixman = { git = "https://github.com/cmeissl/pixman-rs.git", version = "0.1.0", features = ["drm-fourcc"] }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::too_many_arguments)]
 
-
-
 use smithay::{
     backend::renderer::{
         element::{

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -1,13 +1,15 @@
 #![allow(clippy::too_many_arguments)]
 
+
+
 use smithay::{
     backend::renderer::{
         element::{
+            memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
             surface::WaylandSurfaceRenderElement,
-            texture::{TextureBuffer, TextureRenderElement},
             AsRenderElements, Kind,
         },
-        ImportAll, Renderer, Texture,
+        ImportAll, ImportMem, Renderer, Texture,
     },
     input::pointer::CursorImageStatus,
     render_elements,
@@ -26,50 +28,49 @@ use smithay::{
 pub static CLEAR_COLOR: [f32; 4] = [0.8, 0.8, 0.9, 1.0];
 pub static CLEAR_COLOR_FULLSCREEN: [f32; 4] = [0.0, 0.0, 0.0, 0.0];
 
-pub struct PointerElement<T: Texture> {
-    texture: Option<TextureBuffer<T>>,
+pub struct PointerElement {
+    buffer: Option<MemoryRenderBuffer>,
     status: CursorImageStatus,
 }
 
-impl<T: Texture> Default for PointerElement<T> {
+impl Default for PointerElement {
     fn default() -> Self {
         Self {
-            texture: Default::default(),
+            buffer: Default::default(),
             status: CursorImageStatus::default_named(),
         }
     }
 }
 
-impl<T: Texture> PointerElement<T> {
+impl PointerElement {
     pub fn set_status(&mut self, status: CursorImageStatus) {
         self.status = status;
     }
 
-    pub fn set_texture(&mut self, texture: TextureBuffer<T>) {
-        self.texture = Some(texture);
+    pub fn set_buffer(&mut self, buffer: MemoryRenderBuffer) {
+        self.buffer = Some(buffer);
     }
 }
 
 render_elements! {
-    pub PointerRenderElement<R> where
-        R: ImportAll;
+    pub PointerRenderElement<R> where R: ImportAll + ImportMem;
     Surface=WaylandSurfaceRenderElement<R>,
-    Texture=TextureRenderElement<<R as Renderer>::TextureId>,
+    Memory=MemoryRenderBufferRenderElement<R>,
 }
 
 impl<R: Renderer> std::fmt::Debug for PointerRenderElement<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Surface(arg0) => f.debug_tuple("Surface").field(arg0).finish(),
-            Self::Texture(arg0) => f.debug_tuple("Texture").field(arg0).finish(),
+            Self::Memory(arg0) => f.debug_tuple("Memory").field(arg0).finish(),
             Self::_GenericCatcher(arg0) => f.debug_tuple("_GenericCatcher").field(arg0).finish(),
         }
     }
 }
 
-impl<T: Texture + Clone + 'static, R> AsRenderElements<R> for PointerElement<T>
+impl<T: Texture + 'static, R> AsRenderElements<R> for PointerElement
 where
-    R: Renderer<TextureId = T> + ImportAll,
+    R: Renderer<TextureId = T> + ImportAll + ImportMem,
 {
     type RenderElement = PointerRenderElement<R>;
     fn render_elements<E>(
@@ -86,18 +87,20 @@ where
             CursorImageStatus::Hidden => vec![],
             // Always render `Default` for a named shape.
             CursorImageStatus::Named(_) => {
-                if let Some(texture) = self.texture.as_ref() {
-                    vec![
-                        PointerRenderElement::<R>::from(TextureRenderElement::from_texture_buffer(
+                if let Some(buffer) = self.buffer.as_ref() {
+                    vec![PointerRenderElement::<R>::from(
+                        MemoryRenderBufferRenderElement::from_buffer(
+                            renderer,
                             location.to_f64(),
-                            texture,
+                            buffer,
                             None,
                             None,
                             None,
                             Kind::Cursor,
-                        ))
-                        .into(),
-                    ]
+                        )
+                        .expect("Lost system pointer buffer"),
+                    )
+                    .into()]
                 } else {
                     vec![]
                 }

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -20,7 +20,7 @@ use smithay::{
         renderer::{
             damage::{Error as OutputDamageTrackerError, OutputDamageTracker},
             element::AsRenderElements,
-            gles::{GlesRenderer, GlesTexture},
+            gles::GlesRenderer,
             ImportDma, ImportMemWl,
         },
         winit::{self, WinitEvent, WinitGraphicsBackend},
@@ -209,7 +209,7 @@ pub fn run_winit() {
 
     info!("Initialization completed, starting the main loop.");
 
-    let mut pointer_element = PointerElement::<GlesTexture>::default();
+    let mut pointer_element = PointerElement::default();
 
     while state.running.load(Ordering::SeqCst) {
         let status = winit.dispatch_new_events(|event| match event {

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -200,6 +200,7 @@ impl<B: Buffer> From<UnderlyingStorage> for ScanoutBuffer<B> {
     fn from(storage: UnderlyingStorage) -> Self {
         match storage {
             UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer),
+            UnderlyingStorage::Memory(_) => todo!(),
         }
     }
 }
@@ -284,6 +285,7 @@ impl From<&UnderlyingStorage> for ElementFramebufferCacheBuffer {
     fn from(storage: &UnderlyingStorage) -> Self {
         match storage {
             UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer.downgrade()),
+            UnderlyingStorage::Memory(_) => todo!(),
         }
     }
 }
@@ -760,6 +762,7 @@ impl<'a, B: Buffer> From<&'a UnderlyingStorage> for ExportBuffer<'a, B> {
     fn from(storage: &'a UnderlyingStorage) -> Self {
         match storage {
             UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer),
+            UnderlyingStorage::Memory(_) => todo!(),
         }
     }
 }
@@ -3764,6 +3767,7 @@ fn apply_underlying_storage_transform(
                 element_transform
             }
         }
+        UnderlyingStorage::Memory(_) => element_transform,
     }
 }
 

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -226,7 +226,7 @@ use crate::{
     utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
 };
 
-use super::{Element, Id, Kind, RenderElement};
+use super::{Element, Id, Kind, RenderElement, UnderlyingStorage};
 
 #[derive(Debug)]
 struct MemoryRenderBufferInner {
@@ -693,5 +693,15 @@ where
         };
 
         frame.render_texture_from_to(texture, src, dst, damage, transform, self.alpha)
+    }
+
+    fn underlying_storage(&self, _renderer: &mut R) -> Option<UnderlyingStorage> {
+        let buf = self.buffer.inner.borrow();
+        Some(UnderlyingStorage::Memory((
+            buf.mem.as_ptr(),
+            buf.format,
+            buf.size.w as usize,
+            buf.size.h as usize,
+        )))
     }
 }

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -21,6 +21,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use drm_fourcc::DrmFourcc;
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::{backend::ObjectId, Resource};
 
@@ -100,6 +101,8 @@ pub enum UnderlyingStorage {
     /// A wayland buffer
     #[cfg(feature = "wayland_frontend")]
     Wayland(Buffer),
+    /// A memory backed buffer
+    Memory((*const u8, DrmFourcc, usize, usize)),
 }
 
 /// Defines the (optional) reason why a [`Element`] was selected for

--- a/src/backend/renderer/test.rs
+++ b/src/backend/renderer/test.rs
@@ -129,7 +129,9 @@ impl super::ImportMemWl for DummyRenderer {
         });
 
         match ret {
-            Ok((width, height)) => Ok(DummyTexture { width, height }),
+            Ok((width, height)) => Ok(DummyTexture {
+                size: Size::<u32, Buffer>::from((width, height)),
+            }),
             Err(e) => Err(DummyRendererError::BufferAccessError(e)),
         }
     }
@@ -222,17 +224,16 @@ impl Frame for DummyFrame {
 
 #[derive(Clone, Debug)]
 pub struct DummyTexture {
-    width: u32,
-    height: u32,
+    size: Size<u32, Buffer>,
 }
 
 impl Texture for DummyTexture {
     fn width(&self) -> u32 {
-        self.width
+        self.size.w
     }
 
     fn height(&self) -> u32 {
-        self.height
+        self.size.h
     }
 
     fn format(&self) -> Option<Fourcc> {

--- a/src/backend/renderer/test.rs
+++ b/src/backend/renderer/test.rs
@@ -16,7 +16,8 @@ use crate::{
     backend::{
         allocator::{dmabuf::Dmabuf, Fourcc},
         renderer::{
-            sync::SyncPoint, DebugFlags, Frame, ImportDma, ImportMem, Renderer, Texture, TextureFilter,
+            sync::SyncPoint, DebugFlags, ExportMem, Frame, ImportDma, ImportMem, Renderer, Texture,
+            TextureFilter,
         },
         SwapBuffersError,
     },
@@ -177,6 +178,65 @@ impl ImportEgl for DummyRenderer {
 #[cfg(feature = "wayland_frontend")]
 impl ImportDmaWl for DummyRenderer {}
 
+#[allow(dead_code)]
+#[derive(Debug)]
+enum Target {
+    Framebuffer,
+    Texture { txtr: DummyTexture },
+}
+
+#[derive(Debug)]
+pub struct DummyTextureMapping {}
+
+impl Texture for DummyTextureMapping {
+    fn width(&self) -> u32 {
+        todo!()
+    }
+
+    fn height(&self) -> u32 {
+        todo!()
+    }
+
+    fn format(&self) -> Option<Fourcc> {
+        todo!()
+    }
+}
+
+impl TextureMapping for DummyTextureMapping {
+    fn flipped(&self) -> bool {
+        true
+    }
+}
+
+impl ExportMem for DummyRenderer {
+    type TextureMapping = DummyTextureMapping;
+
+    fn copy_framebuffer(
+        &mut self,
+        _region: Rectangle<i32, Buffer>,
+        _format: Fourcc,
+    ) -> Result<Self::TextureMapping, <Self as Renderer>::Error> {
+        todo!()
+    }
+
+    fn copy_texture(
+        &mut self,
+        _texture: &Self::TextureId,
+        _region: Rectangle<i32, Buffer>,
+        _format: Fourcc,
+    ) -> Result<Self::TextureMapping, Self::Error> {
+        todo!()
+    }
+
+    fn map_texture<'a>(
+        &mut self,
+        _texture_mapping: &'a Self::TextureMapping,
+    ) -> Result<&'a [u8], <Self as Renderer>::Error> {
+        todo!()
+    }
+}
+
+/// Frame implementation for DummyRenderer
 #[derive(Debug)]
 pub struct DummyFrame {}
 


### PR DESCRIPTION
The Anvil WLCS implementation relies on using GPU rendering. For compositors that do not utilize this form of rendering and only rely on `DrmCompositor` this is non-optimal. Not only does it mean that new code needs to be written and never actually used in the real compositor, but less of the compositor is being tested.

In order to utilize DrmCompositor for WLCS however, some more of DummyRenderer needs to be implemented. This is the start of that work.

For example usage, see: https://gitlab.freedesktop.org/bwidawsk/sudbury/-/commits/wlcs