### PR TITLE
Add separate keymap for virtual keyboard

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -220,7 +220,7 @@ pub fn run_udev() {
     let primary_gpu = if let Ok(var) = std::env::var("ANVIL_DRM_DEVICE") {
         DrmNode::from_path(var).expect("Invalid drm device path")
     } else {
-        primary_gpu(&session.seat())
+        primary_gpu(session.seat())
             .unwrap()
             .and_then(|x| DrmNode::from_path(x).ok()?.node_with_type(NodeType::Render)?.ok())
             .unwrap_or_else(|| {

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -7,6 +7,7 @@ use xkbcommon::xkb::{self, Keymap, KEYMAP_FORMAT_TEXT_V1};
 
 use crate::utils::sealed_file::SealedFile;
 
+/// Keymap ID, uniquely identifying the keymap without requiring a full content hash.
 static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 /// Wraps an XKB keymap into a sealed file or stores as just a string for sending to WlKeyboard over an fd

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -560,7 +560,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     #[instrument(parent = &self.arc.span, skip(self, data, keymap))]
     pub(crate) fn change_keymap(&self, data: &mut D, keymap: &xkb::Keymap) {
         let mut keymap_file = self.arc.keymap.lock().unwrap();
-        keymap_file.change_keymap(&keymap);
+        keymap_file.change_keymap(keymap);
 
         let mods = self.arc.internal.lock().unwrap().mods_state;
         self.send_keymap(data, &keymap_file, mods);

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -571,10 +571,11 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         use wayland_server::{protocol::wl_keyboard::KeymapFormat, Resource};
 
         // Ignore request which do not change the keymap.
-        if keymap_file.id() == self.active_keymap {
+        let new_id = keymap_file.id();
+        if new_id == self.active_keymap {
             return;
         }
-        println!("SENDING NEW KEYMAP ({})", keymap_file.id());
+        self.active_keymap = new_id;
 
         let known_kbds = &self.arc.known_kbds;
         for kbd in &*known_kbds.lock().unwrap() {

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -3,10 +3,12 @@
 use crate::backend::input::KeyState;
 use crate::utils::{IsAlive, Serial, SERIAL_COUNTER};
 use std::collections::HashSet;
+#[cfg(feature = "wayland_frontend")]
+use std::sync::RwLock;
 use std::{
     default::Default,
     fmt, io,
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, Mutex},
 };
 use thiserror::Error;
 use tracing::{debug, error, info, info_span, instrument, trace};
@@ -194,6 +196,7 @@ pub(crate) struct KbdRc<D: SeatHandler> {
     #[cfg(feature = "wayland_frontend")]
     pub(crate) last_enter: Mutex<Option<Serial>>,
     pub(crate) span: tracing::Span,
+    #[cfg(feature = "wayland_frontend")]
     pub(crate) active_keymap: RwLock<usize>,
 }
 
@@ -546,6 +549,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
                 known_kbds: Mutex::new(Vec::new()),
                 #[cfg(feature = "wayland_frontend")]
                 last_enter: Mutex::new(None),
+                #[cfg(feature = "wayland_frontend")]
                 active_keymap: RwLock::new(active_keymap),
                 span,
             }),
@@ -954,6 +958,7 @@ impl<'a, D: SeatHandler + 'static> KeyboardInnerHandle<'a, D> {
         };
 
         // Ensure keymap is up to date.
+        #[cfg(feature = "wayland_frontend")]
         if let Some(keyboard_handle) = self.seat.get_keyboard() {
             let keymap_file = keyboard_handle.arc.keymap.lock().unwrap();
             let mods = keyboard_handle.arc.internal.lock().unwrap().mods_state;

--- a/src/wayland/virtual_keyboard/mod.rs
+++ b/src/wayland/virtual_keyboard/mod.rs
@@ -41,8 +41,6 @@
 //! ```
 //!
 
-use std::sync::atomic::AtomicBool;
-
 use wayland_protocols_misc::zwp_virtual_keyboard_v1::server::{
     zwp_virtual_keyboard_manager_v1::{self, ZwpVirtualKeyboardManagerV1},
     zwp_virtual_keyboard_v1::ZwpVirtualKeyboardV1,
@@ -157,7 +155,6 @@ where
                     VirtualKeyboardUserData {
                         handle: virtual_keyboard_handle.clone(),
                         seat: seat.clone(),
-                        has_keymap: AtomicBool::new(false),
                     },
                 );
 

--- a/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
+++ b/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
@@ -1,5 +1,4 @@
 use std::os::unix::io::OwnedFd;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     fmt,
     sync::{Arc, Mutex},
@@ -10,14 +9,14 @@ use wayland_protocols_misc::zwp_virtual_keyboard_v1::server::zwp_virtual_keyboar
 use wayland_protocols_misc::zwp_virtual_keyboard_v1::server::zwp_virtual_keyboard_v1::{
     self, ZwpVirtualKeyboardV1,
 };
-use wayland_server::Resource;
 use wayland_server::{
     backend::ClientId,
     protocol::wl_keyboard::{KeyState, KeymapFormat},
-    Client, DataInit, Dispatch, DisplayHandle,
+    Client, DataInit, Dispatch, DisplayHandle, Resource,
 };
 use xkbcommon::xkb;
 
+use crate::input::keyboard::KeymapFile;
 use crate::{
     input::{Seat, SeatHandler},
     utils::SERIAL_COUNTER,
@@ -29,7 +28,7 @@ use super::VirtualKeyboardManagerState;
 #[derive(Debug, Default)]
 pub(crate) struct VirtualKeyboard {
     instances: u8,
-    old_keymap: Option<String>,
+    keymap: Option<KeymapFile>,
 }
 
 /// Handle to a virtual keyboard instance
@@ -48,7 +47,6 @@ impl VirtualKeyboardHandle {
 /// User data of ZwpVirtualKeyboardV1 object
 pub struct VirtualKeyboardUserData<D: SeatHandler> {
     pub(super) handle: VirtualKeyboardHandle,
-    pub(crate) has_keymap: AtomicBool,
     pub(crate) seat: Seat<D>,
 }
 
@@ -78,15 +76,23 @@ where
     ) {
         match request {
             zwp_virtual_keyboard_v1::Request::Keymap { format, fd, size } => {
-                if update_keymap(data, format, fd, size as usize) {
-                    data.has_keymap.store(true, Ordering::Relaxed);
-                }
+                update_keymap(data, format, fd, size as usize);
             }
             zwp_virtual_keyboard_v1::Request::Key { time, key, state } => {
-                if !data.has_keymap.load(Ordering::Relaxed) {
-                    virtual_keyboard.post_error(NoKeymap, "`key` sent before keymap.")
-                }
+                // Ensure keymap was initialized.
+                let virtual_data = data.handle.inner.lock().unwrap();
+                let keymap = match &virtual_data.keymap {
+                    Some(keymap) => keymap,
+                    None => {
+                        virtual_keyboard.post_error(NoKeymap, "`key` sent before keymap.");
+                        return;
+                    }
+                };
+
+                // Ensure virtual keyboard's keymap is active.
                 let keyboard_handle = data.seat.get_keyboard().unwrap();
+                keyboard_handle.send_keymap(keymap);
+
                 let internal = keyboard_handle.arc.internal.lock().unwrap();
                 if let Some(focus) = internal.focus.as_ref().and_then(|f| f.0.wl_surface()) {
                     for_each_focused_kbds(&data.seat, &focus, |kbd| {
@@ -108,10 +114,20 @@ where
                 mods_locked,
                 group,
             } => {
-                if !data.has_keymap.load(Ordering::Relaxed) {
-                    virtual_keyboard.post_error(NoKeymap, "`modifiers` sent before keymap.")
-                }
+                // Ensure keymap was initialized.
+                let virtual_data = data.handle.inner.lock().unwrap();
+                let keymap = match &virtual_data.keymap {
+                    Some(keymap) => keymap,
+                    None => {
+                        virtual_keyboard.post_error(NoKeymap, "`modifiers` sent before keymap.");
+                        return;
+                    }
+                };
+
+                // Ensure virtual keyboard's keymap is active.
                 let keyboard_handle = data.seat.get_keyboard().unwrap();
+                keyboard_handle.send_keymap(keymap);
+
                 let internal = keyboard_handle.arc.internal.lock().unwrap();
                 if let Some(focus) = internal.focus.as_ref().and_then(|f| f.0.wl_surface()) {
                     for_each_focused_kbds(&data.seat, &focus, |kbd| {
@@ -136,45 +152,22 @@ where
         _state: &mut D,
         _client: ClientId,
         _virtual_keyboard: &ZwpVirtualKeyboardV1,
-        data: &VirtualKeyboardUserData<D>,
+        _data: &VirtualKeyboardUserData<D>,
     ) {
-        let mut inner = data.handle.inner.lock().unwrap();
-        inner.instances -= 1;
-        if inner.instances != 0 {
-            return;
-        }
-
-        let old_keymap = match &inner.old_keymap {
-            Some(old_keymap) => old_keymap,
-            None => return,
-        };
-
-        let keyboard_handle = data.seat.get_keyboard().unwrap();
-        let old_keymap = xkb::Keymap::new_from_string(
-            &xkb::Context::new(xkb::CONTEXT_NO_FLAGS),
-            old_keymap.to_string(),
-            xkb::KEYMAP_FORMAT_TEXT_V1,
-            xkb::KEYMAP_COMPILE_NO_FLAGS,
-        );
-
-        // Restore the old keymap.
-        if let Some(old_keymap) = old_keymap {
-            keyboard_handle.change_keymap(old_keymap);
-        }
     }
 }
 
 /// Handle the zwp_virtual_keyboard_v1::keymap request.
 ///
 /// The `true` returns when keymap was properly loaded.
-fn update_keymap<D>(data: &VirtualKeyboardUserData<D>, format: u32, fd: OwnedFd, size: usize) -> bool
+fn update_keymap<D>(data: &VirtualKeyboardUserData<D>, format: u32, fd: OwnedFd, size: usize)
 where
     D: SeatHandler + 'static,
 {
     // Only libxkbcommon compatible keymaps are supported.
     if format != KeymapFormat::XkbV1 as u32 {
         debug!("Unsupported keymap format: {format:?}");
-        return false;
+        return;
     }
 
     let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
@@ -191,24 +184,15 @@ where
         Ok(Some(new_keymap)) => new_keymap,
         Ok(None) => {
             debug!("Invalid libxkbcommon keymap");
-            return false;
+            return;
         }
         Err(err) => {
             debug!("Could not map the keymap: {err:?}");
-            return false;
+            return;
         }
     };
 
-    // Get old keymap to allow restoring to it later.
-    let keyboard_handle = data.seat.get_keyboard().unwrap();
-    let internal = keyboard_handle.arc.internal.lock().unwrap();
-    let old_keymap = internal.keymap.get_as_string(xkb::FORMAT_TEXT_V1);
-
-    if old_keymap != new_keymap.get_as_string(xkb::FORMAT_TEXT_V1) {
-        let mut inner = data.handle.inner.lock().unwrap();
-        inner.old_keymap = Some(old_keymap);
-        keyboard_handle.change_keymap(new_keymap);
-    }
-
-    true
+    // Store active virtual keyboard map.
+    let mut inner = data.handle.inner.lock().unwrap();
+    inner.keymap = Some(KeymapFile::new(&new_keymap));
 }


### PR DESCRIPTION
Smithay's virtual keyboard implementation previously stored a single keymap on the seat, updating it whenever either the real or virtual keyboard's keymap was changed. As a result the two keyboards could break each other by setting an incorrect keymap.

To allow both the seat's real keyboard and the virtual keyboard to function simultaneously, a separate keymap is stored for each and whenever an input event related to a keymap is handled, the keymap is updated.

Closes #1222.

---

I'm not actually sure if this is a valid approach or not and it's definitely possible that I've missed updating the keymap in some places, but this minimal fix has been confirmed to fix the issue for me.