### PR TITLE
Use pixman renderer for DrmCompositor's pointer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ cc = { version = "1.0.79", optional = true }
 default = ["backend_drm", "backend_gbm", "backend_libinput", "backend_udev", "backend_session_libseat", "backend_x11", "backend_winit", "desktop", "renderer_gl", "renderer_multi", "xwayland", "wayland_frontend", "backend_vulkan"]
 backend_winit = ["winit", "backend_egl", "wayland-egl", "renderer_gl"]
 backend_x11 = ["x11rb", "x11rb/dri3", "x11rb/xfixes", "x11rb/present", "x11rb_event_source", "backend_gbm", "backend_drm", "backend_egl"]
-backend_drm = ["drm", "drm-ffi"]
+backend_drm = ["drm", "drm-ffi", "renderer_pixman"] # Pixman needed for DrmCompositor
 backend_gbm = ["gbm", "cc", "pkg-config"]
 backend_gbm_has_fd_for_plane = []
 backend_gbm_has_create_with_modifiers2 = []

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -3,11 +3,11 @@
 use smithay::{
     backend::renderer::{
         element::{
+            memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
             surface::WaylandSurfaceRenderElement,
-            texture::{TextureBuffer, TextureRenderElement},
             AsRenderElements, Kind,
         },
-        ImportAll, Renderer, Texture,
+        ImportAll, ImportMem, Renderer, Texture,
     },
     input::pointer::CursorImageStatus,
     render_elements,
@@ -26,50 +26,49 @@ use smithay::{
 pub static CLEAR_COLOR: [f32; 4] = [0.8, 0.8, 0.9, 1.0];
 pub static CLEAR_COLOR_FULLSCREEN: [f32; 4] = [0.0, 0.0, 0.0, 0.0];
 
-pub struct PointerElement<T: Texture> {
-    texture: Option<TextureBuffer<T>>,
+pub struct PointerElement {
+    buffer: Option<MemoryRenderBuffer>,
     status: CursorImageStatus,
 }
 
-impl<T: Texture> Default for PointerElement<T> {
+impl Default for PointerElement {
     fn default() -> Self {
         Self {
-            texture: Default::default(),
+            buffer: Default::default(),
             status: CursorImageStatus::default_named(),
         }
     }
 }
 
-impl<T: Texture> PointerElement<T> {
+impl PointerElement {
     pub fn set_status(&mut self, status: CursorImageStatus) {
         self.status = status;
     }
 
-    pub fn set_texture(&mut self, texture: TextureBuffer<T>) {
-        self.texture = Some(texture);
+    pub fn set_buffer(&mut self, buffer: MemoryRenderBuffer) {
+        self.buffer = Some(buffer);
     }
 }
 
 render_elements! {
-    pub PointerRenderElement<R> where
-        R: ImportAll;
+    pub PointerRenderElement<R> where R: ImportAll + ImportMem;
     Surface=WaylandSurfaceRenderElement<R>,
-    Texture=TextureRenderElement<<R as Renderer>::TextureId>,
+    Memory=MemoryRenderBufferRenderElement<R>,
 }
 
 impl<R: Renderer> std::fmt::Debug for PointerRenderElement<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Surface(arg0) => f.debug_tuple("Surface").field(arg0).finish(),
-            Self::Texture(arg0) => f.debug_tuple("Texture").field(arg0).finish(),
+            Self::Memory(arg0) => f.debug_tuple("Memory").field(arg0).finish(),
             Self::_GenericCatcher(arg0) => f.debug_tuple("_GenericCatcher").field(arg0).finish(),
         }
     }
 }
 
-impl<T: Texture + Clone + 'static, R> AsRenderElements<R> for PointerElement<T>
+impl<T: Texture + 'static, R> AsRenderElements<R> for PointerElement
 where
-    R: Renderer<TextureId = T> + ImportAll,
+    R: Renderer<TextureId = T> + ImportAll + ImportMem,
 {
     type RenderElement = PointerRenderElement<R>;
     fn render_elements<E>(
@@ -86,18 +85,20 @@ where
             CursorImageStatus::Hidden => vec![],
             // Always render `Default` for a named shape.
             CursorImageStatus::Named(_) => {
-                if let Some(texture) = self.texture.as_ref() {
-                    vec![
-                        PointerRenderElement::<R>::from(TextureRenderElement::from_texture_buffer(
+                if let Some(buffer) = self.buffer.as_ref() {
+                    vec![PointerRenderElement::<R>::from(
+                        MemoryRenderBufferRenderElement::from_buffer(
+                            renderer,
                             location.to_f64(),
-                            texture,
+                            buffer,
                             None,
                             None,
                             None,
                             Kind::Cursor,
-                        ))
-                        .into(),
-                    ]
+                        )
+                        .expect("Lost system pointer buffer"),
+                    )
+                    .into()]
                 } else {
                     vec![]
                 }

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -20,7 +20,7 @@ use smithay::backend::drm::compositor::PrimaryPlaneElement;
 #[cfg(feature = "egl")]
 use smithay::backend::renderer::ImportEgl;
 #[cfg(feature = "debug")]
-use smithay::backend::renderer::ImportMem;
+use smithay::backend::renderer::{multigpu::MultiTexture, ImportMem};
 use smithay::{
     backend::{
         allocator::{
@@ -37,7 +37,7 @@ use smithay::{
         libinput::{LibinputInputBackend, LibinputSessionInterface},
         renderer::{
             damage::{Error as OutputDamageTrackerError, OutputDamageTracker},
-            element::{texture::TextureBuffer, AsRenderElements, RenderElement, RenderElementStates},
+            element::{memory::MemoryRenderBuffer, AsRenderElements, RenderElement, RenderElementStates},
             gles::{GlesRenderer, GlesTexture},
             multigpu::{gbm::GbmGlesBackend, GpuManager, MultiRenderer, MultiTexture},
             sync::SyncPoint,
@@ -124,8 +124,8 @@ pub struct UdevData {
     allocator: Option<Box<dyn Allocator<Buffer = Dmabuf, Error = AnyError>>>,
     gpus: GpuManager<GbmGlesBackend<GlesRenderer>>,
     backends: HashMap<DrmNode, BackendData>,
-    pointer_images: Vec<(xcursor::parser::Image, TextureBuffer<MultiTexture>)>,
-    pointer_element: PointerElement<MultiTexture>,
+    pointer_images: Vec<(xcursor::parser::Image, MemoryRenderBuffer)>,
+    pointer_element: PointerElement,
     #[cfg(feature = "debug")]
     fps_texture: Option<MultiTexture>,
     pointer_image: crate::cursor::Cursor,
@@ -1437,19 +1437,16 @@ impl AnvilState<UdevData> {
                 }
             })
             .unwrap_or_else(|| {
-                let texture = TextureBuffer::from_memory(
-                    &mut renderer,
+                let buffer = MemoryRenderBuffer::from_memory(
                     &frame.pixels_rgba,
                     Fourcc::Abgr8888,
                     (frame.width as i32, frame.height as i32),
-                    false,
                     1,
                     Transform::Normal,
                     None,
-                )
-                .expect("Failed to import cursor bitmap");
-                pointer_images.push((frame, texture.clone()));
-                texture
+                );
+                pointer_images.push((frame, buffer.clone()));
+                buffer
             });
 
         let output = if let Some(output) = self.space.outputs().find(|o| {
@@ -1573,8 +1570,8 @@ fn render_surface<'a, 'b>(
     space: &Space<WindowElement>,
     output: &Output,
     pointer_location: Point<f64, Logical>,
-    pointer_image: &TextureBuffer<MultiTexture>,
-    pointer_element: &mut PointerElement<MultiTexture>,
+    pointer_image: &MemoryRenderBuffer,
+    pointer_element: &mut PointerElement,
     dnd_icon: &Option<wl_surface::WlSurface>,
     cursor_status: &mut CursorImageStatus,
     clock: &Clock<Monotonic>,
@@ -1603,7 +1600,7 @@ fn render_surface<'a, 'b>(
         let cursor_pos_scaled = cursor_pos.to_physical(scale).to_i32_round();
 
         // set cursor
-        pointer_element.set_texture(pointer_image.clone());
+        pointer_element.set_buffer(pointer_image.clone());
 
         // draw the cursor as relevant
         {

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -20,7 +20,7 @@ use smithay::{
         renderer::{
             damage::{Error as OutputDamageTrackerError, OutputDamageTracker},
             element::AsRenderElements,
-            gles::{GlesRenderer, GlesTexture},
+            gles::GlesRenderer,
             ImportDma, ImportMemWl,
         },
         winit::{self, WinitEvent, WinitGraphicsBackend},
@@ -214,7 +214,7 @@ pub fn run_winit() {
 
     info!("Initialization completed, starting the main loop.");
 
-    let mut pointer_element = PointerElement::<GlesTexture>::default();
+    let mut pointer_element = PointerElement::default();
 
     while state.running.load(Ordering::SeqCst) {
         let status = winit.dispatch_new_events(|event| match event {

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -202,7 +202,7 @@ impl<B: Buffer> From<UnderlyingStorage> for ScanoutBuffer<B> {
     fn from(storage: UnderlyingStorage) -> Self {
         match storage {
             UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer),
-            UnderlyingStorage::Memory(_) => todo!(),
+            UnderlyingStorage::Memory { .. } => todo!(),
         }
     }
 }
@@ -287,7 +287,7 @@ impl From<&UnderlyingStorage> for ElementFramebufferCacheBuffer {
     fn from(storage: &UnderlyingStorage) -> Self {
         match storage {
             UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer.downgrade()),
-            UnderlyingStorage::Memory(_) => todo!(),
+            UnderlyingStorage::Memory { .. } => todo!(),
         }
     }
 }
@@ -764,7 +764,7 @@ impl<'a, B: Buffer> From<&'a UnderlyingStorage> for ExportBuffer<'a, B> {
     fn from(storage: &'a UnderlyingStorage) -> Self {
         match storage {
             UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer),
-            UnderlyingStorage::Memory(_) => todo!(),
+            UnderlyingStorage::Memory { .. } => todo!(),
         }
     }
 }
@@ -3806,7 +3806,7 @@ fn apply_underlying_storage_transform(
                 element_transform
             }
         }
-        UnderlyingStorage::Memory(_) => element_transform,
+        UnderlyingStorage::Memory { .. } => element_transform,
     }
 }
 

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -202,6 +202,7 @@ impl<B: Buffer> From<UnderlyingStorage> for ScanoutBuffer<B> {
     fn from(storage: UnderlyingStorage) -> Self {
         match storage {
             UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer),
+            UnderlyingStorage::Memory(_) => todo!(),
         }
     }
 }
@@ -286,6 +287,7 @@ impl From<&UnderlyingStorage> for ElementFramebufferCacheBuffer {
     fn from(storage: &UnderlyingStorage) -> Self {
         match storage {
             UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer.downgrade()),
+            UnderlyingStorage::Memory(_) => todo!(),
         }
     }
 }
@@ -762,6 +764,7 @@ impl<'a, B: Buffer> From<&'a UnderlyingStorage> for ExportBuffer<'a, B> {
     fn from(storage: &'a UnderlyingStorage) -> Self {
         match storage {
             UnderlyingStorage::Wayland(buffer) => Self::Wayland(buffer),
+            UnderlyingStorage::Memory(_) => todo!(),
         }
     }
 }
@@ -3803,6 +3806,7 @@ fn apply_underlying_storage_transform(
                 element_transform
             }
         }
+        UnderlyingStorage::Memory(_) => element_transform,
     }
 }
 

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -3093,7 +3093,7 @@ where
                         &cursor_texture,
                         src,
                         dst,
-                        element.damage_since(scale, None).as_slice(),
+                        &[Rectangle::from_loc_and_size((0,0), dst.size)],
                         element.transform(),
                         element.alpha(),
                     )?;

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -3093,7 +3093,7 @@ where
                         &cursor_texture,
                         src,
                         dst,
-                        &[Rectangle::from_loc_and_size((0,0), dst.size)],
+                        &[Rectangle::from_loc_and_size((0, 0), dst.size)],
                         element.transform(),
                         element.alpha(),
                     )?;

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -2834,7 +2834,30 @@ where
 
     #[allow(clippy::too_many_arguments)]
     #[instrument(level = "trace", skip_all)]
+    #[cfg(not(feature = "pixman_renderer"))]
+    fn try_assign_cursor_plane<R, E>(
+        &mut self,
+        _renderer: &mut R,
+        _element: &E,
+        _element_zindex: usize,
+        _element_geometry: Rectangle<i32, Physical>,
+        _scale: Scale<f64>,
+        _frame_state: &mut Frame<A, F>,
+        _output_damage: &mut Vec<Rectangle<i32, Physical>>,
+        _output_transform: Transform,
+        _output_geometry: Rectangle<i32, Physical>,
+    ) -> Option<PlaneAssignment>
+    where
+        R: Renderer,
+        E: RenderElement<R>,
+    {
+        None
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(level = "trace", skip_all)]
     #[profiling::function]
+    #[cfg(feature = "pixman_renderer")]
     fn try_assign_cursor_plane<R, E>(
         &mut self,
         renderer: &mut R,

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -226,7 +226,7 @@ use crate::{
     utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
 };
 
-use super::{Element, Id, Kind, RenderElement};
+use super::{Element, Id, Kind, RenderElement, UnderlyingStorage};
 
 #[derive(Debug)]
 struct MemoryRenderBufferInner {
@@ -693,5 +693,15 @@ where
         };
 
         frame.render_texture_from_to(texture, src, dst, damage, transform, self.alpha)
+    }
+
+    fn underlying_storage(&self, _renderer: &mut R) -> Option<UnderlyingStorage> {
+        let buf = self.buffer.inner.borrow();
+        Some(UnderlyingStorage::Memory((
+            buf.mem.as_ptr(),
+            buf.format,
+            buf.size.w as usize,
+            buf.size.h as usize,
+        )))
     }
 }

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -697,11 +697,11 @@ where
 
     fn underlying_storage(&self, _renderer: &mut R) -> Option<UnderlyingStorage> {
         let buf = self.buffer.inner.borrow();
-        Some(UnderlyingStorage::Memory((
-            buf.mem.as_ptr(),
-            buf.format,
-            buf.size.w as usize,
-            buf.size.h as usize,
-        )))
+        Some(UnderlyingStorage::Memory {
+            data: buf.mem.as_ptr(),
+            format: buf.format,
+            width: buf.size.w as usize,
+            height: buf.size.h as usize,
+        })
     }
 }

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -21,6 +21,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use drm_fourcc::DrmFourcc;
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::{backend::ObjectId, Resource};
 
@@ -100,6 +101,8 @@ pub enum UnderlyingStorage {
     /// A wayland buffer
     #[cfg(feature = "wayland_frontend")]
     Wayland(Buffer),
+    /// A memory backed buffer
+    Memory((*const u8, DrmFourcc, usize, usize)),
 }
 
 /// Defines the (optional) reason why a [`Element`] was selected for

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -102,7 +102,16 @@ pub enum UnderlyingStorage {
     #[cfg(feature = "wayland_frontend")]
     Wayland(Buffer),
     /// A memory backed buffer
-    Memory((*const u8, DrmFourcc, usize, usize)),
+    Memory {
+        /// Data of the underylying buffer
+        data: *const u8,
+        /// Format for the buffer
+        format: DrmFourcc,
+        /// Width of the buffer
+        width: usize,
+        /// Height of the buffer
+        height: usize,
+    },
 }
 
 /// Defines the (optional) reason why a [`Element`] was selected for


### PR DESCRIPTION
Primary motivation of this PR is to remove the dependency on `Offscreen` in the DrmCompositor.