### PR TITLE
High res scrolling support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ drm-ffi = { version = "0.7.0", optional = true }
 errno = "0.3.5"
 gbm = { version = "0.14.0", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.12", optional = true }
-input = { version = "0.8.2", default-features = false, features=["libinput_1_14"], optional = true }
+input = { version = "0.8.2", default-features = false, features=["libinput_1_19"], optional = true }
 indexmap = "2.0"
 lazy_static = "1"
 libc = "0.2.103"
@@ -94,7 +94,6 @@ backend_udev = ["udev", "input/udev"]
 backend_vulkan = ["ash", "scopeguard"]
 backend_session_libseat = ["backend_session", "libseat"]
 desktop = []
-libinput_1_19 = ["input/libinput_1_19"]
 renderer_gl = ["gl_generator", "backend_egl"]
 renderer_glow = ["renderer_gl", "glow"]
 renderer_multi = ["backend_drm"]
@@ -104,7 +103,7 @@ use_bindgen = ["drm-ffi/use_bindgen", "gbm/use_bindgen", "input/gen"]
 wayland_frontend = ["wayland-server", "wayland-protocols", "wayland-protocols-wlr", "wayland-protocols-misc", "tempfile"]
 x11rb_event_source = ["x11rb"]
 xwayland = ["encoding_rs", "wayland_frontend", "x11rb/composite", "x11rb/xfixes", "x11rb_event_source", "scopeguard"]
-test_all_features = ["default", "use_system_lib", "renderer_glow", "libinput_1_19", "renderer_test"]
+test_all_features = ["default", "use_system_lib", "renderer_glow", "renderer_test"]
 
 [[example]]
 name = "minimal"

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -384,25 +384,25 @@ impl<BackendData: Backend> AnvilState<BackendData> {
     fn on_pointer_axis<B: InputBackend>(&mut self, _dh: &DisplayHandle, evt: B::PointerAxisEvent) {
         let horizontal_amount = evt
             .amount(input::Axis::Horizontal)
-            .unwrap_or_else(|| evt.amount_discrete(input::Axis::Horizontal).unwrap_or(0.0) * 3.0);
+            .unwrap_or_else(|| evt.amount_v120(input::Axis::Horizontal).unwrap_or(0.0) * 3.0 / 120.);
         let vertical_amount = evt
             .amount(input::Axis::Vertical)
-            .unwrap_or_else(|| evt.amount_discrete(input::Axis::Vertical).unwrap_or(0.0) * 3.0);
-        let horizontal_amount_discrete = evt.amount_discrete(input::Axis::Horizontal);
-        let vertical_amount_discrete = evt.amount_discrete(input::Axis::Vertical);
+            .unwrap_or_else(|| evt.amount_v120(input::Axis::Vertical).unwrap_or(0.0) * 3.0 / 120.);
+        let horizontal_amount_discrete = evt.amount_v120(input::Axis::Horizontal);
+        let vertical_amount_discrete = evt.amount_v120(input::Axis::Vertical);
 
         {
             let mut frame = AxisFrame::new(evt.time_msec()).source(evt.source());
             if horizontal_amount != 0.0 {
                 frame = frame.value(Axis::Horizontal, horizontal_amount);
                 if let Some(discrete) = horizontal_amount_discrete {
-                    frame = frame.discrete(Axis::Horizontal, discrete as i32);
+                    frame = frame.v120(Axis::Horizontal, discrete as i32);
                 }
             }
             if vertical_amount != 0.0 {
                 frame = frame.value(Axis::Vertical, vertical_amount);
                 if let Some(discrete) = vertical_amount_discrete {
-                    frame = frame.discrete(Axis::Vertical, discrete as i32);
+                    frame = frame.v120(Axis::Vertical, discrete as i32);
                 }
             }
             if evt.source() == AxisSource::Finger {

--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -100,24 +100,24 @@ impl Smallvil {
 
                 let horizontal_amount = event
                     .amount(Axis::Horizontal)
-                    .unwrap_or_else(|| event.amount_discrete(Axis::Horizontal).unwrap_or(0.0) * 3.0);
+                    .unwrap_or_else(|| event.amount_v120(Axis::Horizontal).unwrap_or(0.0) * 3.0 / 120.);
                 let vertical_amount = event
                     .amount(Axis::Vertical)
-                    .unwrap_or_else(|| event.amount_discrete(Axis::Vertical).unwrap_or(0.0) * 3.0);
-                let horizontal_amount_discrete = event.amount_discrete(Axis::Horizontal);
-                let vertical_amount_discrete = event.amount_discrete(Axis::Vertical);
+                    .unwrap_or_else(|| event.amount_v120(Axis::Vertical).unwrap_or(0.0) * 3.0 / 120.);
+                let horizontal_amount_discrete = event.amount_v120(Axis::Horizontal);
+                let vertical_amount_discrete = event.amount_v120(Axis::Vertical);
 
                 let mut frame = AxisFrame::new(event.time_msec()).source(source);
                 if horizontal_amount != 0.0 {
                     frame = frame.value(Axis::Horizontal, horizontal_amount);
                     if let Some(discrete) = horizontal_amount_discrete {
-                        frame = frame.discrete(Axis::Horizontal, discrete as i32);
+                        frame = frame.v120(Axis::Horizontal, discrete as i32);
                     }
                 }
                 if vertical_amount != 0.0 {
                     frame = frame.value(Axis::Vertical, vertical_amount);
                     if let Some(discrete) = vertical_amount_discrete {
-                        frame = frame.discrete(Axis::Vertical, discrete as i32);
+                        frame = frame.v120(Axis::Vertical, discrete as i32);
                     }
                 }
 

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -353,7 +353,7 @@ pub trait PointerAxisEvent<B: InputBackend>: Event<B> {
     /// Amount of scrolling in discrete steps on the given [`Axis`].
     ///
     /// Guaranteed to be `Some` when source returns either [`AxisSource::Wheel`] or [`AxisSource::WheelTilt`].
-    fn amount_discrete(&self, axis: Axis) -> Option<f64>;
+    fn amount_v120(&self, axis: Axis) -> Option<f64>;
 
     /// Source of the scroll event.
     fn source(&self) -> AxisSource;
@@ -364,7 +364,7 @@ impl<B: InputBackend> PointerAxisEvent<B> for UnusedEvent {
         match *self {}
     }
 
-    fn amount_discrete(&self, _axis: Axis) -> Option<f64> {
+    fn amount_v120(&self, _axis: Axis) -> Option<f64> {
         match *self {}
     }
 

--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -148,10 +148,11 @@ impl PointerAxisEvent<WinitInput> for WinitMouseWheelEvent {
         }
     }
 
-    fn amount_discrete(&self, axis: Axis) -> Option<f64> {
+    // TODO: Use high-res scroll where backend supports it
+    fn amount_v120(&self, axis: Axis) -> Option<f64> {
         match (axis, self.delta) {
-            (Axis::Horizontal, MouseScrollDelta::LineDelta(x, _)) => Some(x as f64),
-            (Axis::Vertical, MouseScrollDelta::LineDelta(_, y)) => Some(y as f64),
+            (Axis::Horizontal, MouseScrollDelta::LineDelta(x, _)) => Some(x as f64 * 120.),
+            (Axis::Vertical, MouseScrollDelta::LineDelta(_, y)) => Some(y as f64 * 120.),
             (_, MouseScrollDelta::PixelDelta(_)) => None,
         }
     }

--- a/src/backend/x11/input.rs
+++ b/src/backend/x11/input.rs
@@ -120,9 +120,9 @@ impl PointerAxisEvent<X11Input> for X11MouseWheelEvent {
         None
     }
 
-    fn amount_discrete(&self, axis: Axis) -> Option<f64> {
+    fn amount_v120(&self, axis: Axis) -> Option<f64> {
         if self.axis == axis {
-            Some(self.amount)
+            Some(self.amount * 120.)
         } else {
             Some(0.0)
         }

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -919,7 +919,7 @@ pub struct AxisFrame {
     /// Raw scroll value per axis of the event
     pub axis: (f64, f64),
     /// Discrete representation of scroll value per axis, if available
-    pub discrete: Option<(i32, i32)>,
+    pub v120: Option<(i32, i32)>,
     /// If the axis is considered having stoped movement
     ///
     /// Only useful in conjunction of AxisSource::Finger events
@@ -1021,7 +1021,7 @@ impl AxisFrame {
             source: None,
             time,
             axis: (0.0, 0.0),
-            discrete: None,
+            v120: None,
             stop: (false, false),
         }
     }
@@ -1043,14 +1043,14 @@ impl AxisFrame {
     /// This event is optional and gives the client additional information about
     /// the nature of the axis event. E.g. a scroll wheel might issue separate steps,
     /// while a touchpad may never issue this event as it has no steps.
-    pub fn discrete(mut self, axis: Axis, steps: i32) -> Self {
-        let discrete = self.discrete.get_or_insert_with(Default::default);
+    pub fn v120(mut self, axis: Axis, steps: i32) -> Self {
+        let v120 = self.v120.get_or_insert_with(Default::default);
         match axis {
             Axis::Horizontal => {
-                discrete.0 = steps;
+                v120.0 = steps;
             }
             Axis::Vertical => {
-                discrete.1 = steps;
+                v120.1 = steps;
             }
         };
         self

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -161,7 +161,7 @@ impl<D: SeatHandler + 'static> SeatState<D> {
     {
         let Seat { arc } = self.new_seat(name);
 
-        let global_id = display.create_global::<D, _, _>(7, SeatGlobalData { arc: arc.clone() });
+        let global_id = display.create_global::<D, _, _>(8, SeatGlobalData { arc: arc.clone() });
         arc.inner.lock().unwrap().global = Some(global_id);
 
         Seat { arc }


### PR DESCRIPTION
I've been thinking about how to handle high res scroll. Might as well hack together an initial implementation. Very WIP, but shows what is still needed here.

Testing things, it seems `PointerScrollWheelEvent` is emitted whenever a scroll is sent from the device, while `PointerAxisEvent` is only sent after accumulating change. So this impacts even clients not using the new protocol version, so they can get more precise scrolling from `wl_pointer::axis`.

In particular, this works in Firefox.

Issues:

* For clients not using the new protocol version, we need to accumulate `axis_value120` events into a `axis_discrete` event
  - Where can this be handed? Probably somewhere in Smithay and not the compositor?
    * Not obviously something libinput backend can deal with. Handle in `PointerTarget<D> for WlSurface` somehow?
* Instead of one `PointerAxisEvent` with an `AxisSource` enum, there are multiple `PointerScroll*` event types
  - Currently this only handles `PointerScrollWheelEvent`
  - `smithay::backend::input` currently models its API here on libinput. So do we want to remove our `AxisSource` and split `type PointerAxisEvent` into 3 types?
* Requires libinput 1.19
  - May be okay? Otherwise, have feature flag, and fallback to generating events from `PointerAxisEvent`
* Needs implementation for X11/winit backend. Ideally using high-res scroll when available.