### PR TITLE
Fix: toggle decorations in anvil

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -683,9 +683,11 @@ impl AnvilState<UdevData> {
                 }
 
                 action => match action {
-                    KeyAction::None | KeyAction::Quit | KeyAction::Run(_) | KeyAction::TogglePreview => {
-                        self.process_common_key_action(action)
-                    }
+                    KeyAction::None
+                    | KeyAction::Quit
+                    | KeyAction::Run(_)
+                    | KeyAction::TogglePreview
+                    | KeyAction::ToggleDecorations => self.process_common_key_action(action),
 
                     _ => unreachable!(),
                 },


### PR DESCRIPTION
Fixes that toggling decorations may reach `unreachable!()` and thus panic `anvil`.