### PR TITLE
Make Relocate/Rescale/CropRenderElement fields public

### DIFF
--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -11,9 +11,9 @@ use crate::{
 /// A element that allows to re-scale another element
 #[derive(Debug)]
 pub struct RescaleRenderElement<E> {
-    element: E,
-    origin: Point<i32, Physical>,
-    scale: Scale<f64>,
+    pub element: E,
+    pub origin: Point<i32, Physical>,
+    pub scale: Scale<f64>,
 }
 
 impl<E: Element> RescaleRenderElement<E> {
@@ -113,9 +113,9 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RescaleRenderElement
 /// A element that allows to crop another element
 #[derive(Debug)]
 pub struct CropRenderElement<E> {
-    element: E,
-    src: Rectangle<f64, Buffer>,
-    crop_rect: Rectangle<i32, Physical>,
+    pub element: E,
+    pub src: Rectangle<f64, Buffer>,
+    pub crop_rect: Rectangle<i32, Physical>,
 }
 
 impl<E: Element> CropRenderElement<E> {
@@ -304,9 +304,9 @@ pub enum Relocate {
 /// A element that allows to offset the location of an existing element
 #[derive(Debug)]
 pub struct RelocateRenderElement<E> {
-    element: E,
-    relocate: Relocate,
-    location: Point<i32, Physical>,
+    pub element: E,
+    pub relocate: Relocate,
+    pub location: Point<i32, Physical>,
 }
 
 impl<E: Element> RelocateRenderElement<E> {


### PR DESCRIPTION
This patch changes the visibility of render element helpers to allow modifying existing transforms instead of having to rely on excessive nesting.

---

Haven't added docs yet because I'm curious if this is desired and if the implementation is appropriate. I think for scale/transform element there aren't any major drawbacks, but cropping's constructor does a little more than just store the rect.

My usecase for this is to move a texture in the later stages of my rendering pipeline:

```rust
                    texture.0.element.location.x += self.quickswitch_offset as i32;
                    texture.0.crop_rect.loc.x += self.quickswitch_offset as i32;
```