### PR TITLE
dmabuf: Store single modifier, instead of storing per-plane

### DIFF
--- a/src/backend/allocator/dumb.rs
+++ b/src/backend/allocator/dumb.rs
@@ -97,8 +97,13 @@ impl AsDmabuf for DumbBuffer {
     #[profiling::function]
     fn export(&self) -> Result<Dmabuf, Self::Error> {
         let fd = self.fd.buffer_to_prime_fd(self.handle.handle(), 0)?;
-        let mut builder = Dmabuf::builder(self.size(), self.format.code, DmabufFlags::empty());
-        builder.add_plane(fd, 0, 0, self.handle.pitch(), Modifier::Linear);
+        let mut builder = Dmabuf::builder(
+            self.size(),
+            self.format.code,
+            self.format.modifier,
+            DmabufFlags::empty(),
+        );
+        builder.add_plane(fd, 0, 0, self.handle.pitch());
         builder.build().ok_or(rustix::io::Errno::INVAL.into())
     }
 }

--- a/src/backend/allocator/gbm.rs
+++ b/src/backend/allocator/gbm.rs
@@ -163,7 +163,6 @@ impl<T> AsDmabuf for GbmBuffer<T> {
                 idx as u32,
                 self.offset(idx)?,
                 self.stride_for_plane(idx)?,
-                self.modifier()?,
             );
         }
 

--- a/src/backend/allocator/vulkan/mod.rs
+++ b/src/backend/allocator/vulkan/mod.rs
@@ -436,7 +436,12 @@ impl AsDmabuf for VulkanImage {
             .memory(self.inner.memory);
 
         let fd = unsafe { self.khr_external_memory_fd.get_memory_fd(&create_info) }?;
-        let mut builder = Dmabuf::builder(self.size(), self.format().code, DmabufFlags::empty());
+        let mut builder = Dmabuf::builder(
+            self.size(),
+            self.format().code,
+            self.format().modifier,
+            DmabufFlags::empty(),
+        );
 
         for idx in 0..self.format_plane_count {
             // get_image_subresource_layout only gets the layout of one memory plane. This mask specifies
@@ -458,7 +463,6 @@ impl AsDmabuf for VulkanImage {
                 idx,
                 layout.offset as u32,
                 layout.row_pitch as u32,
-                self.format().modifier,
             );
         }
 

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -611,6 +611,7 @@ impl EGLDisplay {
         let mut dma = Dmabuf::builder(
             size,
             Fourcc::try_from(format as u32).expect("Unknown format"),
+            Modifier::from(modifier),
             if y_inverted {
                 DmabufFlags::Y_INVERT
             } else {
@@ -625,7 +626,6 @@ impl EGLDisplay {
                 i as u32,
                 offsets[i as usize] as u32,
                 strides[i as usize] as u32,
-                Modifier::from(modifier),
             );
         }
         dma.build().ok_or(Error::DmabufExportFailed(EGLError::BadAlloc))


### PR DESCRIPTION
Version 5 of the protocol requires an error if planes do not all have the same modifier: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/224.

Separate modifiers per-plane is apparently a historical artifact that isn't actually supported in drm in the kernel. So it makes sense to remove it from the `Dmabuf` abstraction in Smithay. The `Buffer` implementation already used just the modifier for the first plane.

This has the logic to produce an error when version 5 of the protocol is exposed, but still creates the global with version 4 until wayland-protocols is updated.