### PR TITLE
gbm: fix legacy dmabuf export

### DIFF
--- a/src/backend/allocator/gbm.rs
+++ b/src/backend/allocator/gbm.rs
@@ -203,7 +203,6 @@ impl<T> AsDmabuf for GbmBuffer<T> {
                 idx as u32,
                 self.offset(idx)?,
                 self.stride_for_plane(idx)?,
-                self.modifier()?,
             );
         }
         Ok(builder.build().unwrap())


### PR DESCRIPTION
#1266 removed the modifier argument of `add_plane`, but missed one usage in the legacy gbm path