### PR TITLE
Revert "popups: Emit a wl_pointer.leave when destroyed"

### DIFF
--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -58,7 +58,7 @@
 //! to change the cursor icon.
 
 pub(crate) mod keyboard;
-pub(crate) mod pointer;
+mod pointer;
 mod touch;
 
 use std::{fmt, sync::Arc};

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -76,7 +76,7 @@ impl<D: SeatHandler> PointerHandle<D> {
 /// WlSurface role of a cursor image icon
 pub const CURSOR_IMAGE_ROLE: &str = "cursor_image";
 
-pub fn for_each_focused_pointers<D: SeatHandler + 'static>(
+fn for_each_focused_pointers<D: SeatHandler + 'static>(
     seat: &Seat<D>,
     surface: &WlSurface,
     mut f: impl FnMut(WlPointer),

--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -2,9 +2,9 @@ use std::sync::atomic::Ordering;
 
 use crate::{
     input::SeatHandler,
-    utils::{Serial, SERIAL_COUNTER},
+    utils::Serial,
     wayland::{
-        compositor, seat,
+        compositor,
         shell::xdg::{SurfaceCachedState, XdgPopupSurfaceData, XdgPositionerUserData},
     },
 };
@@ -35,18 +35,6 @@ where
             xdg_popup::Request::Destroy => {
                 if let Some(surface_data) = data.xdg_surface.data::<XdgSurfaceUserData>() {
                     surface_data.has_active_role.store(false, Ordering::Release);
-
-                    // If a pointer has focus (entered the popup's surface), protocol states that a
-                    // leave event must be generated before the next enter.
-                    let seat_state = state.seat_state();
-                    for seat in &seat_state.seats {
-                        seat::pointer::for_each_focused_pointers(seat, &surface_data.wl_surface, |ptr| {
-                            ptr.leave(SERIAL_COUNTER.next_serial().into(), &surface_data.wl_surface);
-                            if ptr.version() >= 5 {
-                                ptr.frame()
-                            }
-                        });
-                    }
                 }
             }
             xdg_popup::Request::Grab { seat, serial } => {


### PR DESCRIPTION
This reverts commit f1cd2dc813c85f96c08d9c2b1630901aa9789f07.

After that commit, dismissing any right click menu or tooltip in GTK 4 causes the app to ignore pointer events until it's refocused, in both Anvil and niri. Not sure who is wrong. Reverting for now.

cc @bwidawsk 