### PR TITLE
get_dmabuf_formats: Always allow implict modifiers

### DIFF
--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -862,16 +862,7 @@ fn get_dmabuf_formats(
             }
         };
 
-        if num == 0 {
-            texture_formats.insert(DrmFormat {
-                code: fourcc,
-                modifier: Modifier::Invalid,
-            });
-            render_formats.insert(DrmFormat {
-                code: fourcc,
-                modifier: Modifier::Invalid,
-            });
-        } else {
+        if num != 0 {
             let mut mods: Vec<u64> = Vec::with_capacity(num as usize);
             let mut external: Vec<ffi::egl::types::EGLBoolean> = Vec::with_capacity(num as usize);
 
@@ -902,6 +893,15 @@ fn get_dmabuf_formats(
                 }
             }
         }
+
+        texture_formats.insert(DrmFormat {
+            code: fourcc,
+            modifier: Modifier::Invalid,
+        });
+        render_formats.insert(DrmFormat {
+            code: fourcc,
+            modifier: Modifier::Invalid,
+        });
     }
 
     trace!("Supported dmabuf import formats: {:?}", texture_formats);


### PR DESCRIPTION
https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt

My interpretation is that `DRM_FORMAT_MOD_INVALID` is always supported to indicate "effective format modifier is implementation-defined". And is not listed by `eglQueryDmaBufModifiersEXT`.

So import with implicit modifiers was broken, if the EGL driver supported modifiers.

This seems to fix AMDVLK on cosmic-comp, which still uses `wl_drm`.