### PR TITLE
drm: fix cursor buffer write error check

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -3076,7 +3076,12 @@ where
             }
         };
 
-        if let Err(err) = cursor_buffer.write(data) {
+        let Ok(res) = cursor_buffer.write(data) else {
+            info!("failed to write cursor buffer, device destroyed");
+            return None;
+        };
+
+        if let Err(err) = res {
             info!("failed to write cursor buffer; {}", err);
             return None;
         }


### PR DESCRIPTION
This should fix #1275 by recognizing `gbm_bo_write` failed, but only fixes number 3 as mentioned in  https://github.com/Smithay/smithay/issues/1275#issuecomment-1890473451