### PR TITLE
Take two on delegate macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [workspace]
 members = [
     "smithay-drm-extras",
+    "smithay-macros",
     "smallvil",
     "anvil",
     "wlcs_anvil"
@@ -69,6 +70,7 @@ profiling = "1.0"
 smallvec = "1.11"
 pixman = { version = "0.1.0", features = ["drm-fourcc"], optional = true }
 
+smithay-macros = { path = "./smithay-macros" }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -168,7 +168,7 @@ pub struct AnvilState<BackendData: Backend + 'static> {
     pub show_window_preview: bool,
 }
 
-delegate_compositor!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_compositor!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> DataDeviceHandler for AnvilState<BackendData> {
     fn data_device_state(&self) -> &DataDeviceState {
@@ -189,9 +189,9 @@ impl<BackendData: Backend> ServerDndGrabHandler for AnvilState<BackendData> {
         unreachable!("Anvil doesn't do server-side grabs");
     }
 }
-delegate_data_device!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_data_device!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
-delegate_output!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_output!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> SelectionHandler for AnvilState<BackendData> {
     type SelectionUserData = ();
@@ -227,7 +227,7 @@ impl<BackendData: Backend> PrimarySelectionHandler for AnvilState<BackendData> {
         &self.primary_selection_state
     }
 }
-delegate_primary_selection!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_primary_selection!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> DataControlHandler for AnvilState<BackendData> {
     fn data_control_state(&self) -> &DataControlState {
@@ -235,14 +235,14 @@ impl<BackendData: Backend> DataControlHandler for AnvilState<BackendData> {
     }
 }
 
-delegate_data_control!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_data_control!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> ShmHandler for AnvilState<BackendData> {
     fn shm_state(&self) -> &ShmState {
         &self.shm_state
     }
 }
-delegate_shm!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_shm!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> SeatHandler for AnvilState<BackendData> {
     type KeyboardFocus = FocusTarget;
@@ -265,11 +265,11 @@ impl<BackendData: Backend> SeatHandler for AnvilState<BackendData> {
         *self.cursor_status.lock().unwrap() = image;
     }
 }
-delegate_seat!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_seat!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
-delegate_tablet_manager!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_tablet_manager!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
-delegate_text_input_manager!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_text_input_manager!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> InputMethodHandler for AnvilState<BackendData> {
     fn new_popup(&mut self, surface: PopupSurface) {
@@ -292,7 +292,7 @@ impl<BackendData: Backend> InputMethodHandler for AnvilState<BackendData> {
     }
 }
 
-delegate_input_method_manager!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_input_method_manager!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> KeyboardShortcutsInhibitHandler for AnvilState<BackendData> {
     fn keyboard_shortcuts_inhibit_state(&mut self) -> &mut KeyboardShortcutsInhibitState {
@@ -305,13 +305,13 @@ impl<BackendData: Backend> KeyboardShortcutsInhibitHandler for AnvilState<Backen
     }
 }
 
-delegate_keyboard_shortcuts_inhibit!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_keyboard_shortcuts_inhibit!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
-delegate_virtual_keyboard_manager!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_virtual_keyboard_manager!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
-delegate_pointer_gestures!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_pointer_gestures!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
-delegate_relative_pointer!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_relative_pointer!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> PointerConstraintsHandler for AnvilState<BackendData> {
     fn new_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>) {
@@ -323,9 +323,9 @@ impl<BackendData: Backend> PointerConstraintsHandler for AnvilState<BackendData>
         }
     }
 }
-delegate_pointer_constraints!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_pointer_constraints!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
-delegate_viewporter!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_viewporter!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> XdgActivationHandler for AnvilState<BackendData> {
     fn activation_state(&mut self) -> &mut XdgActivationState {
@@ -364,7 +364,7 @@ impl<BackendData: Backend> XdgActivationHandler for AnvilState<BackendData> {
         }
     }
 }
-delegate_xdg_activation!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_xdg_activation!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> XdgDecorationHandler for AnvilState<BackendData> {
     fn new_decoration(&mut self, toplevel: ToplevelSurface) {
@@ -416,11 +416,11 @@ impl<BackendData: Backend> XdgDecorationHandler for AnvilState<BackendData> {
         }
     }
 }
-delegate_xdg_decoration!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_xdg_decoration!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
-delegate_xdg_shell!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
-delegate_layer_shell!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
-delegate_presentation!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_xdg_shell!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_layer_shell!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_presentation!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> FractionalScaleHandler for AnvilState<BackendData> {
     fn new_fractional_scale(
@@ -469,7 +469,7 @@ impl<BackendData: Backend> FractionalScaleHandler for AnvilState<BackendData> {
         });
     }
 }
-delegate_fractional_scale!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_fractional_scale!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend + 'static> SecurityContextHandler for AnvilState<BackendData> {
     fn context_created(&mut self, source: SecurityContextListenerSource, security_context: SecurityContext) {
@@ -489,7 +489,7 @@ impl<BackendData: Backend + 'static> SecurityContextHandler for AnvilState<Backe
             .expect("Failed to init wayland socket source");
     }
 }
-delegate_security_context!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_security_context!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 #[cfg(feature = "xwayland")]
 impl<BackendData: Backend + 'static> XWaylandKeyboardGrabHandler for AnvilState<BackendData> {
@@ -502,7 +502,7 @@ impl<BackendData: Backend + 'static> XWaylandKeyboardGrabHandler for AnvilState<
     }
 }
 #[cfg(feature = "xwayland")]
-delegate_xwayland_keyboard_grab!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+delegate_xwayland_keyboard_grab!(impl<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend + 'static> AnvilState<BackendData> {
     pub fn init(

--- a/smithay-macros/Cargo.toml
+++ b/smithay-macros/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-proc-macro-crate = "3"
 proc-macro2 = "1"
 quote = "1"
 

--- a/smithay-macros/Cargo.toml
+++ b/smithay-macros/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "smithay-macros"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro-crate = "3"
+proc-macro2 = "1"
+quote = "1"
+
+[dependencies.syn]
+version = "2"
+default-features = false
+features = ["parsing", "full", "proc-macro", "printing"]
+
+[dev-dependencies]
+smithay = { path = "../" }

--- a/smithay-macros/examples/simple.rs
+++ b/smithay-macros/examples/simple.rs
@@ -1,0 +1,49 @@
+use ::smithay::wayland::{buffer::BufferHandler, shm::ShmHandler};
+
+trait MarkerTrait {}
+
+struct State<T: MarkerTrait> {
+    _d: T,
+}
+
+impl<T: MarkerTrait> BufferHandler for State<T> {
+    fn buffer_destroyed(
+        &mut self,
+        _buffer: &smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer,
+    ) {
+        todo!()
+    }
+}
+
+impl<T: MarkerTrait> ShmHandler for State<T> {
+    fn shm_state(&self) -> &smithay::wayland::shm::ShmState {
+        todo!()
+    }
+}
+
+smithay_macros::delegate_bundle!(
+    impl<T: MarkerTrait + 'static> State<T> {},
+    Bundle {
+        dispatch_to: smithay::wayland::shm::ShmState,
+        globals: [Global {
+            interface: smithay::reexports::wayland_server::protocol::wl_shm::WlShm,
+            data: (),
+        }],
+        resources: [
+            Resource {
+                interface: smithay::reexports::wayland_server::protocol::wl_shm::WlShm,
+                data: (),
+            },
+            Resource {
+                interface: smithay::reexports::wayland_server::protocol::wl_shm_pool::WlShmPool,
+                data: smithay::wayland::shm::ShmPoolUserData,
+            },
+            Resource {
+                interface: smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer,
+                data: smithay::wayland::shm::ShmBufferUserData,
+            },
+        ],
+    },
+);
+
+fn main() {}

--- a/smithay-macros/src/bundle.rs
+++ b/smithay-macros/src/bundle.rs
@@ -1,0 +1,164 @@
+use proc_macro2::Span;
+use syn::{
+    braced, bracketed,
+    parse::{Parse, ParseBuffer, ParseStream},
+    Error, Ident, Result, Token, Type,
+};
+
+fn parse_array<F>(input: &ParseStream, mut cb: F) -> Result<()>
+where
+    F: FnMut(&ParseBuffer) -> Result<()>,
+{
+    let content;
+    let _bracket_token = bracketed!(content in input);
+
+    while !content.is_empty() {
+        cb(&content)?;
+        if content.is_empty() {
+            break;
+        }
+        let _punct: Token![,] = content.parse()?;
+    }
+
+    Ok(())
+}
+
+fn parse_fields<F>(input: &ParseStream, mut cb: F) -> Result<()>
+where
+    F: FnMut(&ParseBuffer) -> Result<()>,
+{
+    let content;
+    let _brace_token = braced!(content in input);
+
+    while !content.is_empty() {
+        cb(&content)?;
+        if content.is_empty() {
+            break;
+        }
+        let _punct: Token![,] = content.parse()?;
+    }
+
+    Ok(())
+}
+
+pub struct Global {
+    pub interface: Type,
+    pub data: Type,
+}
+
+impl Parse for Global {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let ident: Ident = input.parse()?;
+        if ident != "Global" {
+            return Err(Error::new(ident.span(), "expected `Bundle`"));
+        }
+
+        let (interface, data) = parse_interface_data(&input, ident.span())?;
+        Ok(Self { interface, data })
+    }
+}
+
+pub struct Resource {
+    pub interface: Type,
+    pub data: Type,
+}
+
+impl Parse for Resource {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let ident: Ident = input.parse()?;
+        if ident != "Resource" {
+            return Err(Error::new(ident.span(), "expected `Bundle`"));
+        }
+
+        let (interface, data) = parse_interface_data(&input, ident.span())?;
+        Ok(Self { interface, data })
+    }
+}
+
+fn parse_interface_data(input: &ParseStream, span: Span) -> Result<(Type, Type)> {
+    let mut interface = None;
+    let mut data = None;
+
+    parse_fields(input, |input| {
+        let member: Ident = input.parse()?;
+        let _colon_token: Token![:] = input.parse()?;
+
+        if member == "interface" {
+            interface = Some(input.parse()?);
+        } else if member == "data" {
+            data = Some(input.parse()?);
+        } else {
+            return Err(Error::new(
+                member.span(),
+                "Unexpected field, expected `interface, data`",
+            ));
+        }
+
+        Ok(())
+    })?;
+
+    let interface = interface.ok_or(Error::new(span, "Field `interface` not found"))?;
+    let data = data.ok_or(Error::new(span, "Field `data` not found"))?;
+
+    Ok((interface, data))
+}
+
+pub struct Bundle {
+    pub dispatch_to: Type,
+    pub globals: Vec<Global>,
+    pub resources: Vec<Resource>,
+}
+
+impl Parse for Bundle {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let ident: Ident = input.parse()?;
+
+        if ident != "Bundle" {
+            return Err(Error::new(ident.span(), "expected `Bundle`"));
+        }
+
+        let mut dispatch_to = None;
+        let mut globals = None;
+        let mut resources = None;
+
+        parse_fields(&input, |input| {
+            let member: Ident = input.parse()?;
+            let _colon_token: Token![:] = input.parse()?;
+
+            if member == "dispatch_to" {
+                dispatch_to = Some(input.parse()?);
+            } else if member == "globals" {
+                let mut elements = Vec::new();
+                parse_array(&input, |input| {
+                    elements.push(input.parse()?);
+                    Ok(())
+                })?;
+                globals = Some(elements);
+            } else if member == "resources" {
+                let mut elements = Vec::new();
+                parse_array(&input, |input| {
+                    elements.push(input.parse()?);
+                    Ok(())
+                })?;
+                resources = Some(elements);
+            } else {
+                return Err(Error::new(
+                    member.span(),
+                    "Unexpected field, expected `dispatch_to, globals, resources`",
+                ));
+            }
+
+            Ok(())
+        })?;
+
+        let dispatch_to = dispatch_to.ok_or(Error::new(ident.span(), "Field `dispatch_to` not found"))?;
+        let globals = globals.ok_or(Error::new(ident.span(), "Field `globals` not found"))?;
+        let resources = resources.ok_or(Error::new(ident.span(), "Field `resources` not found"))?;
+
+        Ok(Self {
+            dispatch_to,
+            globals,
+            resources,
+        })
+    }
+}

--- a/smithay-macros/src/bundle.rs
+++ b/smithay-macros/src/bundle.rs
@@ -50,7 +50,7 @@ impl Parse for Global {
     fn parse(input: ParseStream) -> Result<Self> {
         let ident: Ident = input.parse()?;
         if ident != "Global" {
-            return Err(Error::new(ident.span(), "expected `Bundle`"));
+            return Err(Error::new(ident.span(), "expected `Global`"));
         }
 
         let (interface, data) = parse_interface_data(&input, ident.span())?;
@@ -67,7 +67,7 @@ impl Parse for Resource {
     fn parse(input: ParseStream) -> Result<Self> {
         let ident: Ident = input.parse()?;
         if ident != "Resource" {
-            return Err(Error::new(ident.span(), "expected `Bundle`"));
+            return Err(Error::new(ident.span(), "expected `Resource`"));
         }
 
         let (interface, data) = parse_interface_data(&input, ident.span())?;

--- a/smithay-macros/src/delegate_dispatch.rs
+++ b/smithay-macros/src/delegate_dispatch.rs
@@ -1,0 +1,122 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+use crate::{
+    bundle::{Bundle, Global, Resource},
+    smithay,
+};
+
+pub(crate) fn delegate_module(
+    self_ty: &syn::Type,
+    generics: &syn::Generics,
+    module: &Bundle,
+) -> TokenStream2 {
+    let Bundle {
+        dispatch_to,
+        globals,
+        resources,
+        ..
+    } = module;
+
+    let globals = globals
+        .iter()
+        .map(|g| delegate_global_dispatch(self_ty, generics, dispatch_to, g));
+    let resources = resources
+        .iter()
+        .map(|r| delegate_dispatch(self_ty, generics, dispatch_to, r));
+
+    quote! {
+        #(#globals)*
+        #(#resources)*
+    }
+}
+
+pub(crate) fn delegate_global_dispatch(
+    self_ty: &syn::Type,
+    generics: &syn::Generics,
+
+    dispatch_to: &syn::Type,
+    global: &Global,
+) -> TokenStream2 {
+    let smithay = smithay();
+    let wayland_server = quote!(#smithay::reexports::wayland_server);
+
+    let Global { interface, data } = &global;
+
+    let (impl_generics, _type_generics, where_clause) = generics.split_for_impl();
+    let trait_name = quote!(#wayland_server::GlobalDispatch<#interface, #data>);
+
+    quote! {
+        #[automatically_derived]
+        impl #impl_generics #trait_name for #self_ty #where_clause {
+            fn bind(
+                state: &mut Self,
+                dhandle: &#wayland_server::DisplayHandle,
+                client: &#wayland_server::Client,
+                resource: #wayland_server::New<#interface>,
+                global_data: &#data,
+                data_init: &mut #wayland_server::DataInit<'_, Self>,
+            ) {
+                <#dispatch_to as #wayland_server::GlobalDispatch<
+                    #interface,
+                    #data,
+                    Self,
+                >>::bind(state, dhandle, client, resource, global_data, data_init)
+            }
+
+            fn can_view(client: #wayland_server::Client, global_data: &#data) -> bool {
+                <#dispatch_to as #wayland_server::GlobalDispatch<
+                    #interface,
+                    #data,
+                    Self,
+                >>::can_view(client, global_data)
+            }
+        }
+    }
+}
+
+pub(crate) fn delegate_dispatch(
+    self_ty: &syn::Type,
+    generics: &syn::Generics,
+
+    dispatch_to: &syn::Type,
+    resource: &Resource,
+) -> TokenStream2 {
+    let smithay = smithay();
+    let wayland_server = quote!(#smithay::reexports::wayland_server);
+
+    let Resource { interface, data } = &resource;
+
+    let (impl_generics, _type_generics, where_clause) = generics.split_for_impl();
+    let trait_name = quote!(#wayland_server::Dispatch<#interface, #data>);
+
+    quote! {
+        #[automatically_derived]
+        impl #impl_generics #trait_name for #self_ty #where_clause {
+            fn request(
+                state: &mut Self,
+                client: &#wayland_server::Client,
+                resource: &#interface,
+                request: <#interface as #wayland_server::Resource>::Request,
+                data: &#data,
+                dhandle: &#wayland_server::DisplayHandle,
+                data_init: &mut #wayland_server::DataInit<'_, Self>,
+            ) {
+                <#dispatch_to as #wayland_server::Dispatch<#interface, #data, Self>>::request(
+                    state, client, resource, request, data, dhandle, data_init,
+                )
+            }
+
+            fn destroyed(
+                state: &mut Self,
+                client: #wayland_server::backend::ClientId,
+                resource: &#interface,
+                data: &#data,
+            ) {
+                <#dispatch_to as #wayland_server::Dispatch<#interface, #data, Self>>::destroyed(
+                    state, client, resource, data,
+                )
+            }
+        }
+    }
+}

--- a/smithay-macros/src/item_impl.rs
+++ b/smithay-macros/src/item_impl.rs
@@ -1,0 +1,51 @@
+use syn::{
+    braced,
+    parse::{Parse, ParseStream},
+    Generics, Ident, Lifetime, Result, Token, Type,
+};
+
+/// Parses: `impl<T> State<T> {}` item
+///
+/// `impl` is optional
+/// `{}` is optional
+pub struct ItemImpl {
+    pub self_ty: Type,
+    pub generics: Generics,
+}
+
+impl Parse for ItemImpl {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let has_impl = input.peek(Token![impl]);
+
+        if has_impl {
+            let _impl_token: Token![impl] = input.parse()?;
+        }
+
+        let has_generics = input.peek(Token![<])
+            && (input.peek2(Token![>])
+                || input.peek2(Token![#])
+                || (input.peek2(Ident) || input.peek2(Lifetime))
+                    && (input.peek3(Token![:])
+                        || input.peek3(Token![,])
+                        || input.peek3(Token![>])
+                        || input.peek3(Token![=]))
+                || input.peek2(Token![const]));
+
+        let mut generics: Generics = if has_impl && has_generics {
+            input.parse()?
+        } else {
+            Generics::default()
+        };
+
+        let self_ty: Type = input.parse()?;
+
+        generics.where_clause = input.parse()?;
+
+        if input.peek(syn::token::Brace) {
+            let _content;
+            let _brace_token = braced!(_content in input);
+        }
+
+        Ok(ItemImpl { self_ty, generics })
+    }
+}

--- a/smithay-macros/src/lib.rs
+++ b/smithay-macros/src/lib.rs
@@ -1,0 +1,51 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, Token};
+
+mod bundle;
+mod delegate_dispatch;
+mod item_impl;
+
+fn smithay() -> TokenStream2 {
+    match proc_macro_crate::crate_name("smithay").expect("smithay should be present in `Cargo.toml`") {
+        // Tehnically `Itself` should result in `quote!(crate)` but doc tests and examples are
+        // missreported as `Itself` so that would breake those,
+        // Smithay never uses those macros so this is fine, and if there is a need to use them
+        // somewhere we can always just do `use crate as smithay`
+        proc_macro_crate::FoundCrate::Itself => quote!(smithay),
+        proc_macro_crate::FoundCrate::Name(name) => {
+            let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
+            ident.to_token_stream()
+        }
+    }
+}
+
+struct DelegateBundleInput {
+    item_impl: item_impl::ItemImpl,
+    bundle: bundle::Bundle,
+}
+
+impl syn::parse::Parse for DelegateBundleInput {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let item_impl: item_impl::ItemImpl = input.parse()?;
+        let _: syn::Token![,] = input.parse()?;
+        let bundle: bundle::Bundle = input.parse()?;
+        let _: Option<Token![,]> = input.parse().ok();
+
+        Ok(DelegateBundleInput { item_impl, bundle })
+    }
+}
+
+#[proc_macro]
+pub fn delegate_bundle(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DelegateBundleInput);
+
+    let rs = delegate_dispatch::delegate_module(
+        &input.item_impl.self_ty,
+        &input.item_impl.generics,
+        &input.bundle,
+    );
+
+    quote!(#rs).into()
+}

--- a/smithay-macros/src/lib.rs
+++ b/smithay-macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{quote, ToTokens};
+use quote::quote;
 use syn::{parse_macro_input, Token};
 
 mod bundle;
@@ -8,17 +8,9 @@ mod delegate_dispatch;
 mod item_impl;
 
 fn smithay() -> TokenStream2 {
-    match proc_macro_crate::crate_name("smithay").expect("smithay should be present in `Cargo.toml`") {
-        // Tehnically `Itself` should result in `quote!(crate)` but doc tests and examples are
-        // missreported as `Itself` so that would breake those,
-        // Smithay never uses those macros so this is fine, and if there is a need to use them
-        // somewhere we can always just do `use crate as smithay`
-        proc_macro_crate::FoundCrate::Itself => quote!(smithay),
-        proc_macro_crate::FoundCrate::Name(name) => {
-            let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
-            ident.to_token_stream()
-        }
-    }
+    // Could use proc_macro_crate here to detect proper name?
+    // But I don't want to bring to many deps in
+    quote!(smithay)
 }
 
 struct DelegateBundleInput {

--- a/src/reexports.rs
+++ b/src/reexports.rs
@@ -14,6 +14,7 @@ pub use input;
 #[cfg(feature = "renderer_pixman")]
 pub use pixman;
 pub use rustix;
+pub use smithay_macros;
 #[cfg(feature = "backend_udev")]
 pub use udev;
 #[cfg(feature = "wayland_frontend")]

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -660,36 +660,62 @@ impl CompositorState {
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Delegate handling of `WlCompositor`, `WlSubcompositor`, `WlSurface`, `WlRegion`, `WlCallback`
+/// `WlSubcompositor`, `WlSubsurface` requests to Smithay.
+///
+/// Requires [`CompositorHandler`] to be implemented for `State`
+/// ```ignore
+/// struct State {}
+///
+/// // impl needed required traits here
+///
+/// smithay::delegate_compositor!(State);
+/// ```
 #[macro_export]
 macro_rules! delegate_compositor {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_compositor::WlCompositor: ()
-        ] => $crate::wayland::compositor::CompositorState);
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_subcompositor::WlSubcompositor: ()
-        ] => $crate::wayland::compositor::CompositorState);
-
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_compositor::WlCompositor: ()
-        ] => $crate::wayland::compositor::CompositorState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_surface::WlSurface: $crate::wayland::compositor::SurfaceUserData
-        ] => $crate::wayland::compositor::CompositorState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_region::WlRegion: $crate::wayland::compositor::RegionUserData
-        ] => $crate::wayland::compositor::CompositorState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_callback::WlCallback: ()
-        ] => $crate::wayland::compositor::CompositorState);
-            // WlSubcompositor
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_subcompositor::WlSubcompositor: ()
-        ] => $crate::wayland::compositor::CompositorState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_subsurface::WlSubsurface: $crate::wayland::compositor::SubsurfaceUserData
-        ] => $crate::wayland::compositor::CompositorState);
+    ($($params:tt)*) => {
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+               dispatch_to: $crate::wayland::compositor::CompositorState,
+               globals: [
+                   Global {
+                       interface: $crate::reexports::wayland_server::protocol::wl_compositor::WlCompositor,
+                       data: (),
+                   },
+                   Global {
+                       interface: $crate::reexports::wayland_server::protocol::wl_subcompositor::WlSubcompositor,
+                       data: (),
+                   },
+               ],
+               resources: [
+                   Resource {
+                       interface: $crate::reexports::wayland_server::protocol::wl_compositor::WlCompositor,
+                       data: (),
+                   },
+                   Resource {
+                       interface: $crate::reexports::wayland_server::protocol::wl_surface::WlSurface,
+                       data: $crate::wayland::compositor::SurfaceUserData,
+                   },
+                   Resource {
+                       interface: $crate::reexports::wayland_server::protocol::wl_region::WlRegion,
+                       data: $crate::wayland::compositor::RegionUserData,
+                   },
+                   Resource {
+                       interface: $crate::reexports::wayland_server::protocol::wl_callback::WlCallback,
+                       data: (),
+                   },
+                   Resource {
+                       interface: $crate::reexports::wayland_server::protocol::wl_subcompositor::WlSubcompositor,
+                       data: (),
+                   },
+                   Resource {
+                       interface: $crate::reexports::wayland_server::protocol::wl_subsurface::WlSubsurface,
+                       data: $crate::wayland::compositor::SubsurfaceUserData,
+                   },
+               ],
+            }
+        );
     };
 }
 

--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -341,18 +341,33 @@ fn shape_to_cursor_icon(shape: Shape) -> CursorIcon {
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the cursor shape to [`CursorShapeManagerState`].
 #[macro_export]
 macro_rules! delegate_cursor_shape {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::cursor_shape::v1::server::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1: ()
-        ] => $crate::wayland::cursor_shape::CursorShapeManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::cursor_shape::v1::server::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1: ()
-        ] => $crate::wayland::cursor_shape::CursorShapeManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::cursor_shape::v1::server::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1: $crate::wayland::cursor_shape::CursorShapeDeviceUserData
-        ] => $crate::wayland::cursor_shape::CursorShapeManagerState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::cursor_shape::v1::server as __cursor_shape;
+
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::cursor_shape::CursorShapeManagerState,
+                globals: [
+                    Global {
+                        interface: __cursor_shape::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __cursor_shape::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __cursor_shape::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1,
+                        data: $crate::wayland::cursor_shape::CursorShapeDeviceUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/drm_lease/mod.rs
+++ b/src/wayland/drm_lease/mod.rs
@@ -971,32 +971,42 @@ where
 /// You must also implement [`DrmLeaseHandler`] to use this.
 #[macro_export]
 macro_rules! delegate_drm_lease {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        type __WpDrmLeaseDeviceV1 =
-            $crate::reexports::wayland_protocols::wp::drm_lease::v1::server::wp_drm_lease_device_v1::WpDrmLeaseDeviceV1;
-        type __WpDrmLeaseConnectorV1 =
-            $crate::reexports::wayland_protocols::wp::drm_lease::v1::server::wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1;
-        type __WpDrmLeaseRequestV1 =
-            $crate::reexports::wayland_protocols::wp::drm_lease::v1::server::wp_drm_lease_request_v1::WpDrmLeaseRequestV1;
-        type __WpDrmLeaseV1 =
-            $crate::reexports::wayland_protocols::wp::drm_lease::v1::server::wp_drm_lease_v1::WpDrmLeaseV1;
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::drm_lease::v1::server as __drm_lease;
+        type __WpDrmLeaseDeviceV1 = __drm_lease::wp_drm_lease_device_v1::WpDrmLeaseDeviceV1;
+        type __WpDrmLeaseConnectorV1 = __drm_lease::wp_drm_lease_connector_v1::WpDrmLeaseConnectorV1;
+        type __WpDrmLeaseRequestV1 = __drm_lease::wp_drm_lease_request_v1::WpDrmLeaseRequestV1;
+        type __WpDrmLeaseV1 = __drm_lease::wp_drm_lease_v1::WpDrmLeaseV1;
 
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            __WpDrmLeaseDeviceV1: $crate::wayland::drm_lease::DrmLeaseDeviceGlobalData
-        ] => $crate::wayland::drm_lease::DrmLeaseState);
-
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            __WpDrmLeaseConnectorV1: $crate::backend::drm::DrmNode
-        ] => $crate::wayland::drm_lease::DrmLeaseState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            __WpDrmLeaseDeviceV1: $crate::backend::drm::DrmNode
-        ] => $crate::wayland::drm_lease::DrmLeaseState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            __WpDrmLeaseRequestV1: $crate::wayland::drm_lease::DrmLeaseRequestData
-        ] => $crate::wayland::drm_lease::DrmLeaseState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            __WpDrmLeaseV1: $crate::wayland::drm_lease::DrmLeaseData
-        ] => $crate::wayland::drm_lease::DrmLeaseState);
-
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::drm_lease::DrmLeaseState,
+                globals: [
+                    Global {
+                        interface: __WpDrmLeaseDeviceV1,
+                        data: $crate::wayland::drm_lease::DrmLeaseDeviceGlobalData,
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __WpDrmLeaseDeviceV1,
+                        data: $crate::backend::drm::DrmNode,
+                    },
+                    Resource {
+                        interface: __WpDrmLeaseConnectorV1,
+                        data: $crate::backend::drm::DrmNode,
+                    },
+                    Resource {
+                        interface: __WpDrmLeaseRequestV1,
+                        data: $crate::wayland::drm_lease::DrmLeaseRequestData,
+                    },
+                    Resource {
+                        interface: __WpDrmLeaseV1,
+                        data: $crate::wayland::drm_lease::DrmLeaseData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/fractional_scale/mod.rs
+++ b/src/wayland/fractional_scale/mod.rs
@@ -283,19 +283,35 @@ where
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the fractional_scale protocol to [`FractionalScaleManagerState`].
+///
+/// You must also implement [`FractionalScaleHandlerg`] to use this.
 #[macro_export]
 macro_rules! delegate_fractional_scale {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::fractional_scale::v1::server::wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1: ()
-        ] => $crate::wayland::fractional_scale::FractionalScaleManagerState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::fractional_scale::v1::server as __fractional_scale;
 
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::fractional_scale::v1::server::wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1: ()
-        ] => $crate::wayland::fractional_scale::FractionalScaleManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::fractional_scale::v1::server::wp_fractional_scale_v1::WpFractionalScaleV1: $crate::reexports::wayland_server::Weak<$crate::reexports::wayland_server::protocol::wl_surface::WlSurface>
-        ] => $crate::wayland::fractional_scale::FractionalScaleManagerState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::fractional_scale::FractionalScaleManagerState,
+                globals: [
+                    Global {
+                        interface: __fractional_scale::wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __fractional_scale::wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __fractional_scale::wp_fractional_scale_v1::WpFractionalScaleV1,
+                        data: $crate::reexports::wayland_server::Weak<$crate::reexports::wayland_server::protocol::wl_surface::WlSurface>,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/idle_inhibit/mod.rs
+++ b/src/wayland/idle_inhibit/mod.rs
@@ -133,20 +133,35 @@ pub trait IdleInhibitHandler {
     fn uninhibit(&mut self, surface: WlSurface);
 }
 
-#[allow(missing_docs)]
+/// Macro to delegate implementation of the idle_inhibit protocol to [`IdleInhibitManagerState`].
+///
+/// You must also implement [`IdleInhibitHandler`] to use this.
 #[macro_export]
 macro_rules! delegate_idle_inhibit {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            smithay::reexports::wayland_protocols::wp::idle_inhibit::zv1::server::zwp_idle_inhibit_manager_v1::ZwpIdleInhibitManagerV1: ()
-        ] => $crate::wayland::idle_inhibit::IdleInhibitManagerState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::idle_inhibit::zv1::server as __idle_inhibit;
 
-        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            smithay::reexports::wayland_protocols::wp::idle_inhibit::zv1::server::zwp_idle_inhibit_manager_v1::ZwpIdleInhibitManagerV1: ()
-        ] => $crate::wayland::idle_inhibit::IdleInhibitManagerState);
-
-        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            smithay::reexports::wayland_protocols::wp::idle_inhibit::zv1::server::zwp_idle_inhibitor_v1::ZwpIdleInhibitorV1: $crate::wayland::idle_inhibit::inhibitor::IdleInhibitorState
-        ] => $crate::wayland::idle_inhibit::IdleInhibitManagerState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::idle_inhibit::IdleInhibitManagerState,
+                globals: [
+                    Global {
+                        interface: __idle_inhibit::zwp_idle_inhibit_manager_v1::ZwpIdleInhibitManagerV1,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __idle_inhibit::zwp_idle_inhibit_manager_v1::ZwpIdleInhibitManagerV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __idle_inhibit::zwp_idle_inhibitor_v1::ZwpIdleInhibitorV1,
+                        data: $crate::wayland::idle_inhibit::inhibitor::IdleInhibitorState,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/input_method/mod.rs
+++ b/src/wayland/input_method/mod.rs
@@ -221,29 +221,43 @@ where
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the input_method protocol to [`InputMethodManagerState`].
+///
+/// You must also implement [`InputMethodHandler`] to use this.
 #[macro_export]
 macro_rules! delegate_input_method_manager {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::zwp_input_method_v2::server::zwp_input_method_manager_v2::ZwpInputMethodManagerV2:
-            $crate::wayland::input_method::InputMethodManagerGlobalData
-        ] => $crate::wayland::input_method::InputMethodManagerState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols_misc::zwp_input_method_v2::server as __input_method;
 
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::zwp_input_method_v2::server::zwp_input_method_manager_v2::ZwpInputMethodManagerV2: ()
-        ] => $crate::wayland::input_method::InputMethodManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::zwp_input_method_v2::server::zwp_input_method_v2::ZwpInputMethodV2:
-            $crate::wayland::input_method::InputMethodUserData<Self>
-        ] => $crate::wayland::input_method::InputMethodManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::zwp_input_method_v2::server::zwp_input_method_keyboard_grab_v2::ZwpInputMethodKeyboardGrabV2:
-            $crate::wayland::input_method::InputMethodKeyboardUserData<Self>
-        ] => $crate::wayland::input_method::InputMethodManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::zwp_input_method_v2::server::zwp_input_popup_surface_v2::ZwpInputPopupSurfaceV2:
-            $crate::wayland::input_method::InputMethodPopupSurfaceUserData
-        ] => $crate::wayland::input_method::InputMethodManagerState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::input_method::InputMethodManagerState,
+                globals: [
+                    Global {
+                        interface: __input_method::zwp_input_method_manager_v2::ZwpInputMethodManagerV2,
+                        data: $crate::wayland::input_method::InputMethodManagerGlobalData,
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __input_method::zwp_input_method_manager_v2::ZwpInputMethodManagerV2,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __input_method::zwp_input_method_v2::ZwpInputMethodV2,
+                        data: $crate::wayland::input_method::InputMethodUserData<Self>,
+                    },
+                    Resource {
+                        interface: __input_method::zwp_input_method_keyboard_grab_v2::ZwpInputMethodKeyboardGrabV2,
+                        data: $crate::wayland::input_method::InputMethodKeyboardUserData<Self>,
+                    },
+                    Resource {
+                        interface: __input_method::zwp_input_popup_surface_v2::ZwpInputPopupSurfaceV2,
+                        data: $crate::wayland::input_method::InputMethodPopupSurfaceUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/keyboard_shortcuts_inhibit/mod.rs
+++ b/src/wayland/keyboard_shortcuts_inhibit/mod.rs
@@ -236,20 +236,40 @@ pub trait KeyboardShortcutsInhibitHandler {
 }
 
 /// Macro to delegate implementation of the keyboard shortcuts inhibit protocol
+/// Delegate handling of `WpKeyboardShortcutsInhibitManager`, `WpKeyboardShortcutsInhibitorV1` requests to Smithay.
 ///
 /// You must also implement [`KeyboardShortcutsInhibitHandler`] to use this.
+/// ```ignore
+/// struct State {}
+///
+/// // impl needed required traits here
+///
+/// smithay::delegate_keyboard_shortcuts_inhibit!(State);
+/// ```
 #[macro_export]
-macro_rules! delegate_keyboard_shortcuts_inhibit {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::keyboard_shortcuts_inhibit::zv1::server::zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1: ()
-        ] => $crate::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitState);
-
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::keyboard_shortcuts_inhibit::zv1::server::zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1: ()
-        ] => $crate::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::keyboard_shortcuts_inhibit::zv1::server::zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1: $crate::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorUserData
-        ] => $crate::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitState);
+macro_rules! delegate_keyboard_shortcuts_inhibit   {
+    ($($params:tt)*) => {
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitState,
+                globals: [
+                    Global {
+                        interface: $crate::reexports::wayland_protocols::wp::keyboard_shortcuts_inhibit::zv1::server::zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: $crate::reexports::wayland_protocols::wp::keyboard_shortcuts_inhibit::zv1::server::zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: $crate::reexports::wayland_protocols::wp::keyboard_shortcuts_inhibit::zv1::server::zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1,
+                        data: $crate::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -290,25 +290,47 @@ impl Output {
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Delegate handling of `WlOutput`, `ZxdgOutputManagerV1`, `ZxdgOutputV1` requests to Smithay.
+///
+/// ```
+/// struct State {}
+///
+/// smithay::delegate_output!(State);
+/// ```
 #[macro_export]
-macro_rules! delegate_output {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_output::WlOutput: $crate::wayland::output::WlOutputData
-        ] => $crate::wayland::output::OutputManagerState);
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_manager_v1::ZxdgOutputManagerV1: ()
-        ] => $crate::wayland::output::OutputManagerState);
+macro_rules! delegate_output  {
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::xdg::xdg_output::zv1::server as __xdg_output;
 
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_output::WlOutput: $crate::wayland::output::OutputUserData
-        ] => $crate::wayland::output::OutputManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_v1::ZxdgOutputV1: $crate::wayland::output::XdgOutputUserData
-        ] => $crate::wayland::output::OutputManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_manager_v1::ZxdgOutputManagerV1: ()
-        ] => $crate::wayland::output::OutputManagerState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::output::OutputManagerState,
+                globals: [
+                    Global {
+                        interface: $crate::reexports::wayland_server::protocol::wl_output::WlOutput,
+                        data: $crate::wayland::output::WlOutputData,
+                    },
+                    Global {
+                        interface: __xdg_output::zxdg_output_manager_v1::ZxdgOutputManagerV1,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: $crate::reexports::wayland_server::protocol::wl_output::WlOutput,
+                        data: $crate::wayland::output::OutputUserData,
+                    },
+                    Resource {
+                        interface: __xdg_output::zxdg_output_v1::ZxdgOutputV1,
+                        data: $crate::wayland::output::XdgOutputUserData,
+                    },
+                    Resource {
+                        interface: __xdg_output::zxdg_output_manager_v1::ZxdgOutputManagerV1,
+                        data: (),
+                    }
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -500,21 +500,37 @@ where
     }
 }
 
-#[allow(missing_docs)]
+/// Macro to delegate implementation of the pointer constraints protocols to [`PointerConstraintsState`].
 #[macro_export]
 macro_rules! delegate_pointer_constraints {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::pointer_constraints::zv1::server::zwp_pointer_constraints_v1::ZwpPointerConstraintsV1: ()
-        ] => $crate::wayland::pointer_constraints::PointerConstraintsState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::pointer_constraints::zv1::server::zwp_pointer_constraints_v1::ZwpPointerConstraintsV1: ()
-        ] => $crate::wayland::pointer_constraints::PointerConstraintsState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::pointer_constraints::zv1::server::zwp_confined_pointer_v1::ZwpConfinedPointerV1: $crate::wayland::pointer_constraints::PointerConstraintUserData<Self>
-        ] => $crate::wayland::pointer_constraints::PointerConstraintsState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::pointer_constraints::zv1::server::zwp_locked_pointer_v1::ZwpLockedPointerV1: $crate::wayland::pointer_constraints::PointerConstraintUserData<Self>
-        ] => $crate::wayland::pointer_constraints::PointerConstraintsState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::pointer_constraints::zv1::server as __pointer_constraints;
+
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::pointer_constraints::PointerConstraintsState,
+                globals: [
+                    Global {
+                        interface: __pointer_constraints::zwp_pointer_constraints_v1::ZwpPointerConstraintsV1,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __pointer_constraints::zwp_pointer_constraints_v1::ZwpPointerConstraintsV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __pointer_constraints::zwp_confined_pointer_v1::ZwpConfinedPointerV1,
+                        data: $crate::wayland::pointer_constraints::PointerConstraintUserData<Self>,
+                    },
+                    Resource {
+                        interface: __pointer_constraints::zwp_locked_pointer_v1::ZwpLockedPointerV1,
+                        data: $crate::wayland::pointer_constraints::PointerConstraintUserData<Self>,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/pointer_gestures.rs
+++ b/src/wayland/pointer_gestures.rs
@@ -330,22 +330,39 @@ where
 
 /// Macro to delegate implementation of the pointer gestures protocol
 #[macro_export]
-macro_rules! delegate_pointer_gestures {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gestures_v1::ZwpPointerGesturesV1: ()
-        ] => $crate::wayland::pointer_gestures::PointerGesturesState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gestures_v1::ZwpPointerGesturesV1: ()
-        ] => $crate::wayland::pointer_gestures::PointerGesturesState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gesture_swipe_v1::ZwpPointerGestureSwipeV1: $crate::wayland::pointer_gestures::PointerGestureUserData<Self>
-        ] => $crate::wayland::pointer_gestures::PointerGesturesState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gesture_pinch_v1::ZwpPointerGesturePinchV1: $crate::wayland::pointer_gestures::PointerGestureUserData<Self>
-        ] => $crate::wayland::pointer_gestures::PointerGesturesState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server::zwp_pointer_gesture_hold_v1::ZwpPointerGestureHoldV1: $crate::wayland::pointer_gestures::PointerGestureUserData<Self>
-        ] => $crate::wayland::pointer_gestures::PointerGesturesState);
+macro_rules! delegate_pointer_gestures  {
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::pointer_gestures::zv1::server as __pointer_gestures;
+
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::pointer_gestures::PointerGesturesState,
+                globals: [
+                    Global {
+                        interface: __pointer_gestures::zwp_pointer_gestures_v1::ZwpPointerGesturesV1,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __pointer_gestures::zwp_pointer_gestures_v1::ZwpPointerGesturesV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __pointer_gestures::zwp_pointer_gesture_swipe_v1::ZwpPointerGestureSwipeV1,
+                        data: $crate::wayland::pointer_gestures::PointerGestureUserData<Self>,
+                    },
+                    Resource {
+                        interface: __pointer_gestures::zwp_pointer_gesture_pinch_v1::ZwpPointerGesturePinchV1,
+                        data: $crate::wayland::pointer_gestures::PointerGestureUserData<Self>,
+                    },
+                    Resource {
+                        interface: __pointer_gestures::zwp_pointer_gesture_hold_v1::ZwpPointerGestureHoldV1,
+                        data: $crate::wayland::pointer_gestures::PointerGestureUserData<Self>,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -213,16 +213,31 @@ where
 
 /// Macro to delegate implementation of the relative pointer protocol
 #[macro_export]
-macro_rules! delegate_relative_pointer {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::relative_pointer::zv1::server::zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1: ()
-        ] => $crate::wayland::relative_pointer::RelativePointerManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::relative_pointer::zv1::server::zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1: ()
-        ] => $crate::wayland::relative_pointer::RelativePointerManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::relative_pointer::zv1::server::zwp_relative_pointer_v1::ZwpRelativePointerV1: $crate::wayland::relative_pointer::RelativePointerUserData<Self>
-        ] => $crate::wayland::relative_pointer::RelativePointerManagerState);
+macro_rules! delegate_relative_pointer   {
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::relative_pointer::zv1::server as __relative_pointer;
+
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::relative_pointer::RelativePointerManagerState,
+                globals: [
+                    Global {
+                        interface: __relative_pointer::zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __relative_pointer::zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __relative_pointer::zwp_relative_pointer_v1::ZwpRelativePointerV1,
+                        data: $crate::wayland::relative_pointer::RelativePointerUserData<Self>,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/security_context/mod.rs
+++ b/src/wayland/security_context/mod.rs
@@ -229,17 +229,34 @@ where
 }
 
 /// Macro to delegate implementation of the security context protocol
+///
+/// You must also implement [`SecurityContextHandler`] to use this.
 #[macro_export]
 macro_rules! delegate_security_context {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::security_context::v1::server::wp_security_context_manager_v1::WpSecurityContextManagerV1: $crate::wayland::security_context::SecurityContextGlobalData
-        ] => $crate::wayland::security_context::SecurityContextState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::security_context::v1::server::wp_security_context_manager_v1::WpSecurityContextManagerV1: ()
-        ] => $crate::wayland::security_context::SecurityContextState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::security_context::v1::server::wp_security_context_v1::WpSecurityContextV1: $crate::wayland::security_context::SecurityContextUserData
-        ] => $crate::wayland::security_context::SecurityContextState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::security_context::v1::server as __security_context;
+
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::security_context::SecurityContextState,
+                globals: [
+                    Global {
+                        interface: __security_context::wp_security_context_manager_v1::WpSecurityContextManagerV1,
+                        data: $crate::wayland::security_context::SecurityContextGlobalData,
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __security_context::wp_security_context_manager_v1::WpSecurityContextManagerV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __security_context::wp_security_context_v1::WpSecurityContextV1,
+                        data: $crate::wayland::security_context::SecurityContextUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -484,22 +484,37 @@ mod handlers {
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the data device protocol
+///
+/// You must also implement [`DataDeviceHandler`] to use this.
 #[macro_export]
 macro_rules! delegate_data_device {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_data_device_manager::WlDataDeviceManager: ()
-        ] => $crate::wayland::selection::data_device::DataDeviceState);
-
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_data_device_manager::WlDataDeviceManager: ()
-        ] => $crate::wayland::selection::data_device::DataDeviceState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_data_device::WlDataDevice: $crate::wayland::selection::data_device::DataDeviceUserData
-        ] => $crate::wayland::selection::data_device::DataDeviceState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_server::protocol::wl_data_source::WlDataSource: $crate::wayland::selection::data_device::DataSourceUserData
-        ] => $crate::wayland::selection::data_device::DataDeviceState);
+    ($($params:tt)*) => {
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::selection::data_device::DataDeviceState,
+                globals: [
+                    Global {
+                        interface: $crate::reexports::wayland_server::protocol::wl_data_device_manager::WlDataDeviceManager,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: $crate::reexports::wayland_server::protocol::wl_data_device_manager::WlDataDeviceManager,
+                        data: (),
+                    },
+                    Resource {
+                        interface: $crate::reexports::wayland_server::protocol::wl_data_device::WlDataDevice,
+                        data: $crate::wayland::selection::data_device::DataDeviceUserData,
+                    },
+                    Resource {
+                        interface: $crate::reexports::wayland_server::protocol::wl_data_source::WlDataSource,
+                        data: $crate::wayland::selection::data_device::DataSourceUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/selection/primary_selection/mod.rs
+++ b/src/wayland/selection/primary_selection/mod.rs
@@ -347,22 +347,39 @@ mod handlers {
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the primary selection protocol
+///
+/// You must also implement [`DataDeviceHandler`] to use this.
 #[macro_export]
 macro_rules! delegate_primary_selection {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1: ()
-        ] => $crate::wayland::selection::primary_selection::PrimarySelectionState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::primary_selection::zv1::server as __primary_selection;
 
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1: ()
-        ] => $crate::wayland::selection::primary_selection::PrimarySelectionState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1: $crate::wayland::selection::primary_selection::PrimaryDeviceUserData
-        ] => $crate::wayland::selection::primary_selection::PrimarySelectionState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1: $crate::wayland::selection::primary_selection::PrimarySourceUserData
-        ] => $crate::wayland::selection::primary_selection::PrimarySelectionState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::selection::primary_selection::PrimarySelectionState,
+                globals: [
+                    Global {
+                        interface: __primary_selection::zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __primary_selection::zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __primary_selection::zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1,
+                        data: $crate::wayland::selection::primary_selection::PrimaryDeviceUserData,
+                    },
+                    Resource {
+                        interface: __primary_selection::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1,
+                        data: $crate::wayland::selection::primary_selection::PrimarySourceUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/selection/wlr_data_control/mod.rs
+++ b/src/wayland/selection/wlr_data_control/mod.rs
@@ -233,21 +233,39 @@ mod handlers {
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the data control protocol
+///
+/// You must also implement [`DataControlHandler`] to use this.
 #[macro_export]
 macro_rules! delegate_data_control {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1: $crate::wayland::selection::wlr_data_control::DataControlManagerGlobalData
-        ] => $crate::wayland::selection::wlr_data_control::DataControlState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1: $crate::wayland::selection::wlr_data_control::DataControlManagerUserData
-        ] => $crate::wayland::selection::wlr_data_control::DataControlState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_device_v1::ZwlrDataControlDeviceV1: $crate::wayland::selection::wlr_data_control::DataControlDeviceUserData
-        ] => $crate::wayland::selection::wlr_data_control::DataControlState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_source_v1::ZwlrDataControlSourceV1: $crate::wayland::selection::wlr_data_control::DataControlSourceUserData
-        ] => $crate::wayland::selection::wlr_data_control::DataControlState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols_wlr::data_control::v1::server as __data_control;
+
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::selection::wlr_data_control::DataControlState,
+                globals: [
+                    Global {
+                        interface: __data_control::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
+                        data: $crate::wayland::selection::wlr_data_control::DataControlManagerGlobalData,
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __data_control::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
+                        data: $crate::wayland::selection::wlr_data_control::DataControlManagerUserData,
+                    },
+                    Resource {
+                        interface: __data_control::zwlr_data_control_device_v1::ZwlrDataControlDeviceV1,
+                        data: $crate::wayland::selection::wlr_data_control::DataControlDeviceUserData,
+                    },
+                    Resource {
+                        interface: __data_control::zwlr_data_control_source_v1::ZwlrDataControlSourceV1,
+                        data: $crate::wayland::selection::wlr_data_control::DataControlSourceUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/shell/kde/decoration.rs
+++ b/src/wayland/shell/kde/decoration.rs
@@ -107,20 +107,35 @@ impl KdeDecorationState {
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the kde server decoration to [`KdeDecorationState`].
+///
+/// You must also implement [`KdeDecorationHandler`] to use this.
 #[macro_export]
 macro_rules! delegate_kde_decoration {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration_manager::OrgKdeKwinServerDecorationManager: ()
-        ] => $crate::wayland::shell::kde::decoration::KdeDecorationState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols_misc::server_decoration::server as __kde_decoration;
 
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration_manager::OrgKdeKwinServerDecorationManager: ()
-        ] => $crate::wayland::shell::kde::decoration::KdeDecorationState);
-
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration::OrgKdeKwinServerDecoration: $crate::reexports::wayland_server::protocol::wl_surface::WlSurface
-        ] => $crate::wayland::shell::kde::decoration::KdeDecorationState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::shell::kde::decoration::KdeDecorationState,
+                globals: [
+                    Global {
+                        interface: __kde_decoration::org_kde_kwin_server_decoration_manager::OrgKdeKwinServerDecorationManager,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __kde_decoration::org_kde_kwin_server_decoration_manager::OrgKdeKwinServerDecorationManager,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __kde_decoration::org_kde_kwin_server_decoration::OrgKdeKwinServerDecoration,
+                        data: $crate::reexports::wayland_server::protocol::wl_surface::WlSurface,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -513,21 +513,30 @@ pub struct LayerSurfaceConfigure {
 /// You must also implement [`WlrLayerShellHandler`] to use this.
 #[macro_export]
 macro_rules! delegate_layer_shell {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        type __ZwlrLayerShellV1 =
-            $crate::reexports::wayland_protocols_wlr::layer_shell::v1::server::zwlr_layer_shell_v1::ZwlrLayerShellV1;
-        type __ZwlrLayerShellSurfaceV1 =
-            $crate::reexports::wayland_protocols_wlr::layer_shell::v1::server::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols_wlr::layer_shell::v1::server as __wlr_layer_shell;
 
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            __ZwlrLayerShellV1: ()
-        ] => $crate::wayland::shell::wlr_layer::WlrLayerShellState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            __ZwlrLayerShellSurfaceV1: $crate::wayland::shell::wlr_layer::WlrLayerSurfaceUserData
-        ] => $crate::wayland::shell::wlr_layer::WlrLayerShellState);
-
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            __ZwlrLayerShellV1: $crate::wayland::shell::wlr_layer::WlrLayerShellGlobalData
-        ] => $crate::wayland::shell::wlr_layer::WlrLayerShellState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::shell::wlr_layer::WlrLayerShellState,
+                globals: [
+                    Global {
+                        interface: __wlr_layer_shell::zwlr_layer_shell_v1::ZwlrLayerShellV1,
+                        data: $crate::wayland::shell::wlr_layer::WlrLayerShellGlobalData,
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __wlr_layer_shell::zwlr_layer_shell_v1::ZwlrLayerShellV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __wlr_layer_shell::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
+                        data: $crate::wayland::shell::wlr_layer::WlrLayerSurfaceUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1997,28 +1997,47 @@ impl From<PopupConfigure> for Configure {
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the xdg shell protocol
+///
+/// You must also implement [`XdgShellHandler`] to use this.
 #[macro_export]
 macro_rules! delegate_xdg_shell {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xdg::shell::server::xdg_wm_base::XdgWmBase: ()
-        ] => $crate::wayland::shell::xdg::XdgShellState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::xdg::shell::server as __xdg_shell;
 
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xdg::shell::server::xdg_wm_base::XdgWmBase: $crate::wayland::shell::xdg::XdgWmBaseUserData
-        ] => $crate::wayland::shell::xdg::XdgShellState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xdg::shell::server::xdg_positioner::XdgPositioner: $crate::wayland::shell::xdg::XdgPositionerUserData
-        ] => $crate::wayland::shell::xdg::XdgShellState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xdg::shell::server::xdg_popup::XdgPopup: $crate::wayland::shell::xdg::XdgShellSurfaceUserData
-        ] => $crate::wayland::shell::xdg::XdgShellState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xdg::shell::server::xdg_surface::XdgSurface: $crate::wayland::shell::xdg::XdgSurfaceUserData
-        ] => $crate::wayland::shell::xdg::XdgShellState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel::XdgToplevel: $crate::wayland::shell::xdg::XdgShellSurfaceUserData
-        ] => $crate::wayland::shell::xdg::XdgShellState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::shell::xdg::XdgShellState,
+                globals: [
+                    Global {
+                        interface: __xdg_shell::xdg_wm_base::XdgWmBase,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __xdg_shell::xdg_wm_base::XdgWmBase,
+                        data: $crate::wayland::shell::xdg::XdgWmBaseUserData,
+                    },
+                    Resource {
+                        interface: __xdg_shell::xdg_positioner::XdgPositioner,
+                        data: $crate::wayland::shell::xdg::XdgPositionerUserData,
+                    },
+                    Resource {
+                        interface: __xdg_shell::xdg_popup::XdgPopup,
+                        data: $crate::wayland::shell::xdg::XdgShellSurfaceUserData,
+                    },
+                    Resource {
+                        interface: __xdg_shell::xdg_surface::XdgSurface,
+                        data: $crate::wayland::shell::xdg::XdgSurfaceUserData,
+                    },
+                    Resource {
+                        interface: __xdg_shell::xdg_toplevel::XdgToplevel,
+                        data: $crate::wayland::shell::xdg::XdgShellSurfaceUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/tablet_manager/mod.rs
+++ b/src/wayland/tablet_manager/mod.rs
@@ -199,25 +199,41 @@ where
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the tablet protocol to [`TabletManagerState`].
 #[macro_export]
 macro_rules! delegate_tablet_manager {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::tablet::zv2::server::zwp_tablet_manager_v2::ZwpTabletManagerV2: ()
-        ] => $crate::wayland::tablet_manager::TabletManagerState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::tablet::zv2::server as __tablet;
 
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::tablet::zv2::server::zwp_tablet_manager_v2::ZwpTabletManagerV2: ()
-        ] => $crate::wayland::tablet_manager::TabletManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::tablet::zv2::server::zwp_tablet_seat_v2::ZwpTabletSeatV2: $crate::wayland::tablet_manager::TabletSeatUserData
-        ] => $crate::wayland::tablet_manager::TabletManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::tablet::zv2::server::zwp_tablet_tool_v2::ZwpTabletToolV2: $crate::wayland::tablet_manager::TabletToolUserData
-        ] => $crate::wayland::tablet_manager::TabletManagerState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::tablet::zv2::server::zwp_tablet_v2::ZwpTabletV2: $crate::wayland::tablet_manager::TabletUserData
-        ] => $crate::wayland::tablet_manager::TabletManagerState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::tablet_manager::TabletManagerState,
+                globals: [
+                    Global {
+                        interface: __tablet::zwp_tablet_manager_v2::ZwpTabletManagerV2,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __tablet::zwp_tablet_manager_v2::ZwpTabletManagerV2,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __tablet::zwp_tablet_seat_v2::ZwpTabletSeatV2,
+                        data: $crate::wayland::tablet_manager::TabletSeatUserData,
+                    },
+                    Resource {
+                        interface: __tablet::zwp_tablet_tool_v2::ZwpTabletToolV2,
+                        data: $crate::wayland::tablet_manager::TabletToolUserData,
+                    },
+                    Resource {
+                        interface: __tablet::zwp_tablet_v2::ZwpTabletV2,
+                        data: $crate::wayland::tablet_manager::TabletUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/text_input/mod.rs
+++ b/src/wayland/text_input/mod.rs
@@ -162,21 +162,33 @@ where
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the text input protocol to [`TextInputManagerState`].
 #[macro_export]
-macro_rules! delegate_text_input_manager {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::text_input::zv3::server::zwp_text_input_manager_v3::ZwpTextInputManagerV3: ()
-        ] => $crate::wayland::text_input::TextInputManagerState);
+macro_rules! delegate_text_input_manager  {
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::text_input::zv3::server as __text_input;
 
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::text_input::zv3::server::zwp_text_input_manager_v3::ZwpTextInputManagerV3: ()
-        ] => $crate::wayland::text_input::TextInputManagerState);
-
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::text_input::zv3::server::zwp_text_input_v3::ZwpTextInputV3:
-            $crate::wayland::text_input::TextInputUserData
-        ] => $crate::wayland::text_input::TextInputManagerState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::text_input::TextInputManagerState,
+                globals: [
+                    Global {
+                        interface: __text_input::zwp_text_input_manager_v3::ZwpTextInputManagerV3,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __text_input::zwp_text_input_manager_v3::ZwpTextInputManagerV3,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __text_input::zwp_text_input_v3::ZwpTextInputV3,
+                        data: $crate::wayland::text_input::TextInputUserData,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/viewporter/mod.rs
+++ b/src/wayland/viewporter/mod.rs
@@ -394,19 +394,44 @@ impl Cacheable for ViewportCachedState {
     }
 }
 
-#[allow(missing_docs)] // TODO
+/// Macro to delegate implementation of the viewporter protocol to [`ViewporterState`].
 #[macro_export]
 macro_rules! delegate_viewporter {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::viewporter::server::wp_viewporter::WpViewporter: ()
-        ] => $crate::wayland::viewporter::ViewporterState);
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::wp::viewporter::server as __viewporter;
 
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::viewporter::server::wp_viewporter::WpViewporter: ()
-        ] => $crate::wayland::viewporter::ViewporterState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::wp::viewporter::server::wp_viewport::WpViewport: $crate::wayland::viewporter::ViewportState
-        ] => $crate::wayland::viewporter::ViewportState);
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::viewporter::ViewporterState,
+                globals: [
+                    Global {
+                        interface: __viewporter::wp_viewporter::WpViewporter,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __viewporter::wp_viewporter::WpViewporter,
+                        data: (),
+                    },
+                ],
+            },
+        );
+
+        // This is delegated to diferent type, not sure why
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::viewporter::ViewportState,
+                globals: [],
+                resources: [
+                    Resource {
+                        interface: __viewporter::wp_viewport::WpViewport,
+                        data: $crate::wayland::viewporter::ViewportState,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/virtual_keyboard/mod.rs
+++ b/src/wayland/virtual_keyboard/mod.rs
@@ -165,20 +165,41 @@ where
     }
 }
 
-#[allow(missing_docs)] //TODO
+/// Macro to delegate implementation of the virtual_keyboard protocol
+/// Delegate handling of `WpVirtualKeyboardManager`, `WpVirtualKeyboard` requests to Smithay.
+///
+/// You must also implement [`SeatHandler`] to use this.
+/// ```ignore
+/// struct State {}
+///
+/// // impl needed required traits here
+///
+/// smithay::delegate_virtual_keyboard_manager!(State);
+/// ```
 #[macro_export]
 macro_rules! delegate_virtual_keyboard_manager {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::zwp_virtual_keyboard_v1::server::zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1: $crate::wayland::virtual_keyboard::VirtualKeyboardManagerGlobalData
-        ] => $crate::wayland::virtual_keyboard::VirtualKeyboardManagerState);
-
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::zwp_virtual_keyboard_v1::server::zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1: ()
-        ] => $crate::wayland::virtual_keyboard::VirtualKeyboardManagerState);
-
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols_misc::zwp_virtual_keyboard_v1::server::zwp_virtual_keyboard_v1::ZwpVirtualKeyboardV1: $crate::wayland::virtual_keyboard::VirtualKeyboardUserData<Self>
-        ] => $crate::wayland::virtual_keyboard::VirtualKeyboardManagerState);
+    ($($params:tt)*) => {
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::virtual_keyboard::VirtualKeyboardManagerState,
+                globals: [
+                    Global {
+                        interface: $crate::reexports::wayland_protocols_misc::zwp_virtual_keyboard_v1::server::zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1,
+                        data: $crate::wayland::virtual_keyboard::VirtualKeyboardManagerGlobalData,
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: $crate::reexports::wayland_protocols_misc::zwp_virtual_keyboard_v1::server::zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: $crate::reexports::wayland_protocols_misc::zwp_virtual_keyboard_v1::server::zwp_virtual_keyboard_v1::ZwpVirtualKeyboardV1,
+                        data: $crate::wayland::virtual_keyboard::VirtualKeyboardUserData<Self>,
+                    },
+                ],
+            },
+        );
     };
 }

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -227,16 +227,31 @@ where
 
 /// Macro to delegate implementation of the xwayland keyboard grab protocol
 #[macro_export]
-macro_rules! delegate_xwayland_keyboard_grab {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xwayland::keyboard_grab::zv1::server::zwp_xwayland_keyboard_grab_manager_v1::ZwpXwaylandKeyboardGrabManagerV1: ()
-        ] => $crate::wayland::xwayland_keyboard_grab::XWaylandKeyboardGrabState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xwayland::keyboard_grab::zv1::server::zwp_xwayland_keyboard_grab_manager_v1::ZwpXwaylandKeyboardGrabManagerV1: ()
-        ] => $crate::wayland::xwayland_keyboard_grab::XWaylandKeyboardGrabState);
-        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::wayland_protocols::xwayland::keyboard_grab::zv1::server::zwp_xwayland_keyboard_grab_v1::ZwpXwaylandKeyboardGrabV1: ()
-        ] => $crate::wayland::xwayland_keyboard_grab::XWaylandKeyboardGrabState);
+macro_rules! delegate_xwayland_keyboard_grab    {
+    ($($params:tt)*) => {
+        use $crate::reexports::wayland_protocols::xwayland::keyboard_grab::zv1::server as __x_keyboard_grab;
+
+        $crate::reexports::smithay_macros::delegate_bundle!(
+            $($params)*,
+            Bundle {
+                dispatch_to: $crate::wayland::xwayland_keyboard_grab::XWaylandKeyboardGrabState,
+                globals: [
+                    Global {
+                        interface: __x_keyboard_grab::zwp_xwayland_keyboard_grab_manager_v1::ZwpXwaylandKeyboardGrabManagerV1,
+                        data: (),
+                    },
+                ],
+                resources: [
+                    Resource {
+                        interface: __x_keyboard_grab::zwp_xwayland_keyboard_grab_manager_v1::ZwpXwaylandKeyboardGrabManagerV1,
+                        data: (),
+                    },
+                    Resource {
+                        interface: __x_keyboard_grab::zwp_xwayland_keyboard_grab_v1::ZwpXwaylandKeyboardGrabV1,
+                        data: (),
+                    },
+                ],
+            },
+        );
     };
 }


### PR DESCRIPTION
So... I was not happy with #1090, it was a bit hacky and required the macro crate to depend on smithay just for module definitions.

So this is take two:
The proc macro allows us to delegate so-called bundles like so:
```rs
struct State<T> {
    my: usize,
    state: usize,
    generic: T,
}

smithay_macros::delegate_bundle!(
    impl<T> State<T> {},
    Bundle {
        dispatch_to: smithay::wayland::shm::ShmState,
        globals: [
            Global {
                interface: smithay::reexports::wayland_server::protocol::wl_shm::WlShm,
                data: (),
            }
        ],
        resources: [
            Resource {
                interface: smithay::reexports::wayland_server::protocol::wl_shm::WlShm,
                data: (),
            },
        ],
    },
);
```

The macro is intentionaly built from valid rust syntax, and therefore this piece of code is fully rustfmt compatible.

Tho, one can opt out of rustfmt compatibility by dropping some optional pieces of syntax for example all of those are valid:
- `impl<T> State<T> {}`
- `impl<T> State<T>`
- `State` (only if your state is not generic)


So, now that we have a nice bundle macro, Smithay can just wrap it like so:
```rs
macro_rules! delegate_shm {
    ($($params:tt)*) => {
        $crate::reexports::smithay_macros::delegate_bundle!(
            $($params)*,
            Bundle {
                dispatch_to: $crate::wayland::shm::ShmState,
                globals: [
                    Global {
                        interface: $crate::reexports::wayland_server::protocol::wl_shm::WlShm,
                        data: (),
                    }
                ],
                resources: [
                    Resource {
                        interface: $crate::reexports::wayland_server::protocol::wl_shm::WlShm,
                        data: (),
                    },
                ],
            },
        );
    };
}
```

And end user can use it more or less like the old macro:
```rs
// Non generic case
delegate_shm!(State);

// Generic case
delegate_shm!(impl<T> State<T>);
```

# Future

Derive macro could call those macros with proper generics automatically, it could look like this:
```rs
#[derive(AutoDelegate)]
#[delegate(
    smithay::delegate_compositor,
    smithay::delegate_output,
    smithay::delegate_shm,
)]
struct Anvil<T: Backend> {
    backend: T,
}

// Any delegates that can't be done automatically:
delegate_dmabuf!(AnvilState<UdevData>);
```  