### PR TITLE
Asynchronous input filtering

### DIFF
--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -726,6 +726,65 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         }
     }
 
+    /// TODO
+    pub fn intercept<T, F>(
+        &self,
+        data: &mut D,
+        keycode: u32,
+        state: KeyState,
+        filter: F,
+    ) -> (T, bool)
+        where F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> T,
+    {
+        trace!("Handling keystroke");
+
+        let mut guard = self.arc.internal.lock().unwrap();
+        let mods_changed = guard.key_input(keycode, state);
+        let key_handle = KeysymHandle {
+            // Offset the keycode by 8, as the evdev XKB rules reflect X's
+            // broken keycode system, which starts at 8.
+            keycode: (keycode + 8).into(),
+            state: &guard.state,
+            keymap: &guard.keymap,
+        };
+
+        trace!(mods_state = ?guard.mods_state, sym = xkb::keysym_get_name(key_handle.modified_sym()), "Calling input filter");
+        (filter(data, &guard.mods_state, key_handle), mods_changed)
+    }
+
+    /// TODO
+    pub fn forward(
+        &self,
+        data: &mut D,
+        keycode: u32,
+        state: KeyState,
+        serial: Serial,
+        time: u32,
+        mods_changed: bool,
+    ) {
+        let mut guard = self.arc.internal.lock().unwrap();
+        match state {
+            KeyState::Pressed => {
+                guard.forwarded_pressed_keys.insert(keycode);
+            }
+            KeyState::Released => {
+                guard.forwarded_pressed_keys.remove(&keycode);
+            }
+        };
+
+        // forward to client if no keybinding is triggered
+        let seat = self.get_seat(data);
+        let modifiers = mods_changed.then_some(guard.mods_state);
+        guard.with_grab(&seat, |handle, grab| {
+            grab.input(data, handle, keycode, state, modifiers, serial, time);
+        });
+        if guard.focus.is_some() {
+            trace!("Input forwarded to client");
+        } else {
+            trace!("No client currently focused");
+        }
+    }
+
     /// Handle a keystroke
     ///
     /// All keystrokes from the input backend should be fed _in order_ to this method of the
@@ -752,47 +811,14 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     where
         F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> FilterResult<T>,
     {
-        trace!("Handling keystroke");
-
-        let mut guard = self.arc.internal.lock().unwrap();
-        let mods_changed = guard.key_input(keycode, state);
-        let key_handle = KeysymHandle {
-            // Offset the keycode by 8, as the evdev XKB rules reflect X's
-            // broken keycode system, which starts at 8.
-            keycode: (keycode + 8).into(),
-            state: &guard.state,
-            keymap: &guard.keymap,
-        };
-
-        trace!(mods_state = ?guard.mods_state, sym = xkb::keysym_get_name(key_handle.modified_sym()), "Calling input filter");
-
-        if let FilterResult::Intercept(val) = filter(data, &guard.mods_state, key_handle) {
+        let (filter_result, mods_changed) = self.intercept(data, keycode, state, filter);
+        if let FilterResult::Intercept(val) = filter_result {
             // the filter returned false, we do not forward to client
             trace!("Input was intercepted by filter");
             return Some(val);
         }
 
-        match state {
-            KeyState::Pressed => {
-                guard.forwarded_pressed_keys.insert(keycode);
-            }
-            KeyState::Released => {
-                guard.forwarded_pressed_keys.remove(&keycode);
-            }
-        };
-
-        // forward to client if no keybinding is triggered
-        let seat = self.get_seat(data);
-        let modifiers = mods_changed.then_some(guard.mods_state);
-        guard.with_grab(&seat, |handle, grab| {
-            grab.input(data, handle, keycode, state, modifiers, serial, time);
-        });
-        if guard.focus.is_some() {
-            trace!("Input forwarded to client");
-        } else {
-            trace!("No client currently focused");
-        }
-
+        self.forward(data, keycode, state, serial, time, mods_changed);
         None
     }
 

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -752,25 +752,25 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     where
         F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> FilterResult<T>,
     {
-        let (filter_result, mods_changed) = self.intercept(data, keycode, state, filter);
+        let (filter_result, mods_changed) = self.input_intercept(data, keycode, state, filter);
         if let FilterResult::Intercept(val) = filter_result {
-            // the filter returned false, we do not forward to client
+            // the filter returned `FilterResult::Intercept(T)`, we do not forward to client
             trace!("Input was intercepted by filter");
             return Some(val);
         }
 
-        self.forward(data, keycode, state, serial, time, mods_changed);
+        self.input_forward(data, keycode, state, serial, time, mods_changed);
         None
     }
 
     /// Update the state of the keyboard without forwarding the event to the focused client
     ///
-    /// Useful in conjunction with [`KeyboardHandle::forward`] in case you want
+    /// Useful in conjunction with [`KeyboardHandle::input_forward`] in case you want
     /// to asynchronously decide if the event should be forwarded to the focused client.
     ///
     /// Prefer using [`KeyboardHandle::input`] if this decision can be done synchronously
     /// in the `filter` closure.
-    pub fn intercept<T, F>(&self, data: &mut D, keycode: u32, state: KeyState, filter: F) -> (T, bool)
+    pub fn input_intercept<T, F>(&self, data: &mut D, keycode: u32, state: KeyState, filter: F) -> (T, bool)
     where
         F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> T,
     {
@@ -790,10 +790,10 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         (filter(data, &guard.mods_state, key_handle), mods_changed)
     }
 
-    /// Forward a key event to the focused client.
+    /// Forward a key event to the focused client
     ///
-    /// Useful in conjunction with [`KeyboardHandle::intercept`].
-    pub fn forward(
+    /// Useful in conjunction with [`KeyboardHandle::input_intercept`].
+    pub fn input_forward(
         &self,
         data: &mut D,
         keycode: u32,

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -770,14 +770,9 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     ///
     /// Prefer using [`KeyboardHandle::input`] if this decision can be done synchronously
     /// in the `filter` closure.
-    pub fn intercept<T, F>(
-        &self,
-        data: &mut D,
-        keycode: u32,
-        state: KeyState,
-        filter: F,
-    ) -> (T, bool)
-        where F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> T,
+    pub fn intercept<T, F>(&self, data: &mut D, keycode: u32, state: KeyState, filter: F) -> (T, bool)
+    where
+        F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> T,
     {
         trace!("Handling keystroke");
 


### PR DESCRIPTION
The internals of `KeyboardHandle::input` have been exposed as 2 separate functions `KeyboardHandle::input_intercept` and `KeyboardHandle::input_forward` to allow for asynchronously deciding if a key event should be forwarded to the client or not.

It was not possible to do this using `KeyboardHandle::input` because this decision must be done in the `filter` closure before returning the result of the decision.

I'm using an external toolkit that handles keyboard shortcuts and I cannot synchronously decide what key events should be forwarded or not. I have to send a message to another thread and wait for the response to come on the event loop. Blocking in the `filter` closure and waiting for an answer is not an option because I'm also blocking the event loop and I will end up in a deadlock.

By having 2 separate functions that split the functionality of `KeyboardHandle::input`, I can:

- call `KeyboardHandle::input_intercept` when I receive a key event
- ask the toolkit if the event is consumed or not
- when I get an answer, call `KeyboardHandle::input_forward`