### PR TITLE
egl: Fix multiple references to same EGLDisplay

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -884,7 +884,7 @@ impl AnvilState<UdevData> {
             )
             .unwrap();
 
-        let render_node = EGLDevice::device_for_display(&EGLDisplay::new(gbm.clone()).unwrap())
+        let render_node = EGLDevice::device_for_display(&unsafe { EGLDisplay::new(gbm.clone()).unwrap() })
             .ok()
             .and_then(|x| x.try_get_render_node().ok().flatten())
             .unwrap_or(node);

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -109,7 +109,7 @@ pub fn run_x11() {
     // Create the gbm device for buffer allocation.
     let device = gbm::Device::new(DeviceFd::from(fd)).expect("Failed to create gbm device");
     // Initialize EGL using the GBM device.
-    let egl = EGLDisplay::new(device.clone()).expect("Failed to create EGLDisplay");
+    let egl = unsafe { EGLDisplay::new(device.clone()).expect("Failed to create EGLDisplay") };
     // Create the OpenGL context
     let context = EGLContext::new(&egl).expect("Failed to create EGLContext");
 

--- a/examples/buffer_test.rs
+++ b/examples/buffer_test.rs
@@ -127,7 +127,7 @@ fn format_test(render: Vec<String>, sample: Vec<String>) {
                         || device.render_device_path().ok().as_ref() == Some(&path)
                 })
                 .expect("Unable to find egl device");
-            let display = EGLDisplay::new(device).expect("Failed to create EGL display");
+            let display = unsafe { EGLDisplay::new(device).expect("Failed to create EGL display") };
             display.dmabuf_render_formats().clone()
         })
         .chain(sample.iter().map(|path| {
@@ -139,7 +139,7 @@ fn format_test(render: Vec<String>, sample: Vec<String>) {
                         || device.render_device_path().ok().as_ref() == Some(&path)
                 })
                 .expect("Unable to find egl device");
-            let display = EGLDisplay::new(device).expect("Failed to create EGL display");
+            let display = unsafe { EGLDisplay::new(device).expect("Failed to create EGL display") };
             display.dmabuf_texture_formats().clone()
         }))
         .fold(None, |set, formats| match set {
@@ -222,7 +222,7 @@ fn buffer_test(args: TestArgs) {
                         || device.render_device_path().ok().as_ref() == Some(&path)
                 })
                 .expect("Unable to find egl device");
-            let display = EGLDisplay::new(device).expect("Failed to create EGL display");
+            let display = unsafe { EGLDisplay::new(device).expect("Failed to create EGL display") };
 
             let context = EGLContext::new(&display).expect("Failed to create EGL context");
             let mut renderer = unsafe { GlesRenderer::new(context).expect("Failed to init GL ES renderer") };
@@ -248,7 +248,7 @@ fn buffer_test(args: TestArgs) {
                         || device.render_device_path().ok().as_ref() == Some(&path)
                 })
                 .expect("Unable to find egl device");
-            let display = EGLDisplay::new(device).expect("Failed to create EGL display");
+            let display = unsafe { EGLDisplay::new(device).expect("Failed to create EGL display") };
 
             display
                 .create_image_from_dmabuf(&buffer)
@@ -262,7 +262,7 @@ fn buffer_test(args: TestArgs) {
                         || device.render_device_path().ok().as_ref() == Some(&path)
                 })
                 .expect("Unable to find egl device");
-            let display = EGLDisplay::new(device).expect("Failed to create EGL display");
+            let display = unsafe { EGLDisplay::new(device).expect("Failed to create EGL display") };
 
             let context = EGLContext::new(&display).expect("Failed to create EGL context");
             let mut renderer = unsafe { GlesRenderer::new(context).expect("Failed to init GL ES renderer") };

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -1,10 +1,10 @@
 //! Type safe native types for safe egl initialisation
 
 use std::ffi::{c_int, CStr};
+use std::hash::{Hash, Hasher};
 use std::mem::MaybeUninit;
 use std::ops::Deref;
 use std::sync::Arc;
-#[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
 use std::sync::{Mutex, Weak};
 use std::{
     collections::HashSet,
@@ -39,6 +39,9 @@ use tracing::{debug, error, info, info_span, instrument, trace, warn};
 lazy_static::lazy_static! {
     pub(crate) static ref BUFFER_READER: Mutex<Option<WeakBufferReader>> = Mutex::new(None);
 }
+lazy_static::lazy_static! {
+    static ref DISPLAYS: Mutex<HashSet<WeakEGLDisplayHandle>> = Mutex::new(HashSet::new());
+}
 
 /// Wrapper around [`ffi::EGLDisplay`](ffi::egl::types::EGLDisplay) to ensure display is only destroyed
 /// once all resources bound to it have been dropped.
@@ -46,11 +49,44 @@ lazy_static::lazy_static! {
 pub struct EGLDisplayHandle {
     /// ffi EGLDisplay ptr
     pub handle: ffi::egl::types::EGLDisplay,
+    should_terminate: bool,
     _native: Box<dyn std::any::Any + 'static>,
 }
 // EGLDisplay has an internal Mutex
 unsafe impl Send for EGLDisplayHandle {}
 unsafe impl Sync for EGLDisplayHandle {}
+
+#[derive(Clone)]
+struct WeakEGLDisplayHandle {
+    handle: Weak<EGLDisplayHandle>,
+    ptr: ffi::egl::types::EGLDisplay,
+}
+
+unsafe impl Send for WeakEGLDisplayHandle {}
+unsafe impl Sync for WeakEGLDisplayHandle {}
+
+impl From<Arc<EGLDisplayHandle>> for WeakEGLDisplayHandle {
+    fn from(other: Arc<EGLDisplayHandle>) -> Self {
+        WeakEGLDisplayHandle {
+            handle: Arc::downgrade(&other),
+            ptr: other.handle,
+        }
+    }
+}
+
+impl Hash for WeakEGLDisplayHandle {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.ptr.hash(state);
+    }
+}
+
+impl PartialEq for WeakEGLDisplayHandle {
+    fn eq(&self, other: &Self) -> bool {
+        self.ptr == other.ptr
+    }
+}
+
+impl Eq for WeakEGLDisplayHandle {}
 
 impl Deref for EGLDisplayHandle {
     type Target = ffi::egl::types::EGLDisplay;
@@ -62,9 +98,11 @@ impl Deref for EGLDisplayHandle {
 
 impl Drop for EGLDisplayHandle {
     fn drop(&mut self) {
-        unsafe {
-            // ignore errors on drop
-            ffi::egl::Terminate(self.handle);
+        if self.should_terminate {
+            unsafe {
+                // ignore errors on drop
+                ffi::egl::Terminate(self.handle);
+            }
         }
     }
 }
@@ -139,8 +177,23 @@ unsafe fn select_platform_display<N: EGLNativeDisplay + 'static>(
 }
 
 impl EGLDisplay {
-    /// Create a new [`EGLDisplay`] from a given [`EGLNativeDisplay`]
-    pub fn new<N>(native: N) -> Result<EGLDisplay, Error>
+    /// Create a new [`EGLDisplay`] from a given [`EGLNativeDisplay`].
+    ///
+    /// # Safety
+    ///
+    /// smithay internally tracks EGLDisplay instances as
+    /// calls with the same parameters to `eglGetPlatformDisplay` will return
+    /// references to the same underlying display.
+    ///
+    /// You don't have to worry about this, when using just smithay,
+    /// but if other code calls `eglGetPlatformDisplay` it is possible to close the resulting
+    /// EGLDisplay via `eglTerminate` without invalidating smithay's instances.
+    ///
+    /// If you are using other code creating `EGLDisplay`s, don't use this method,
+    /// but use the external code to create the display and use `EGLDisplay::from_raw`
+    /// to make it usable in smithay. This way `eglTerminate` will be skipped and you
+    /// can clean up the display externally.
+    pub unsafe fn new<N>(native: N) -> Result<EGLDisplay, Error>
     where
         N: EGLNativeDisplay + 'static,
     {
@@ -156,17 +209,38 @@ impl EGLDisplay {
 
         let dp_extensions = ffi::make_sure_egl_is_loaded()?;
         debug!("Supported EGL client extensions: {:?}", dp_extensions);
+        let surface_type = native.surface_type();
+
         // we create an EGLDisplay
         let (display, platform) = unsafe { select_platform_display(&native, &dp_extensions)? };
         span.record("platform", platform);
+
+        let display = {
+            let new_display = Arc::new(EGLDisplayHandle {
+                handle: display,
+                should_terminate: true,
+                _native: Box::new(native),
+            });
+            let weak_disp = WeakEGLDisplayHandle::from(new_display.clone());
+
+            let mut displays = DISPLAYS.lock().unwrap();
+            if displays.insert(weak_disp.clone()) {
+                new_display
+            } else {
+                Arc::try_unwrap(new_display).unwrap().should_terminate = false;
+                displays.get(&weak_disp).unwrap().handle.upgrade().unwrap()
+            }
+        };
 
         // We can then query the egl api version
         let egl_version = unsafe {
             let mut major: MaybeUninit<ffi::egl::types::EGLint> = MaybeUninit::uninit();
             let mut minor: MaybeUninit<ffi::egl::types::EGLint> = MaybeUninit::uninit();
 
-            wrap_egl_call_bool(|| ffi::egl::Initialize(display, major.as_mut_ptr(), minor.as_mut_ptr()))
-                .map_err(Error::InitFailed)?;
+            wrap_egl_call_bool(|| {
+                ffi::egl::Initialize(display.handle, major.as_mut_ptr(), minor.as_mut_ptr())
+            })
+            .map_err(Error::InitFailed)?;
 
             let major = major.assume_init();
             let minor = minor.assume_init();
@@ -180,11 +254,11 @@ impl EGLDisplay {
 
         // the list of extensions supported by the client once initialized is different from the
         // list of extensions obtained earlier
-        let extensions = EGLDisplay::get_extensions(egl_version, display)?;
+        let extensions = EGLDisplay::get_extensions(egl_version, display.handle)?;
         info!("Supported EGL display extensions: {:?}", extensions);
 
         let (dmabuf_import_formats, dmabuf_render_formats) =
-            get_dmabuf_formats(&display, &extensions).map_err(Error::DisplayCreationError)?;
+            get_dmabuf_formats(&display.handle, &extensions).map_err(Error::DisplayCreationError)?;
 
         // egl <= 1.2 does not support OpenGL ES (maybe we want to support OpenGL in the future?)
         if egl_version <= (1, 2) {
@@ -193,16 +267,12 @@ impl EGLDisplay {
         wrap_egl_call_bool(|| unsafe { ffi::egl::BindAPI(ffi::egl::OPENGL_ES_API) })
             .map_err(|source| Error::OpenGlesNotSupported(Some(source)))?;
 
-        let surface_type = native.surface_type();
         let has_fences = extensions.iter().any(|s| s == "EGL_KHR_fence_sync");
         let supports_native_fences =
             has_fences && extensions.iter().any(|s| s == "EGL_ANDROID_native_fence_sync");
 
         Ok(EGLDisplay {
-            display: Arc::new(EGLDisplayHandle {
-                handle: display,
-                _native: Box::new(native) as Box<dyn std::any::Any + 'static>,
-            }),
+            display,
             surface_type,
             egl_version,
             extensions,
@@ -220,6 +290,8 @@ impl EGLDisplay {
     ///
     /// - The display must be created from the system default EGL library (`dlopen("libEGL.so")`)
     /// - The `display` and `config` must be valid for the lifetime of the returned display and any handles created by this display (using [`EGLDisplay::get_display_handle`])
+    /// - smithay can't track the parameters used to create this display, which may cause two Displays to point to the same underlying instance. For this reason displays created
+    ///   using this method will not call `eglTerminate` on destruction. You will have to cleanup manually.
     pub unsafe fn from_raw(display: *const c_void, config_id: *const c_void) -> Result<EGLDisplay, Error> {
         let span = info_span!("egl", platform = "unknown/raw", version = tracing::field::Empty);
 
@@ -289,6 +361,7 @@ impl EGLDisplay {
         Ok(EGLDisplay {
             display: Arc::new(EGLDisplayHandle {
                 handle: display,
+                should_terminate: false,
                 _native: Box::new(()),
             }),
             surface_type,

--- a/src/backend/renderer/multigpu/egl.rs
+++ b/src/backend/renderer/multigpu/egl.rs
@@ -123,7 +123,7 @@ impl<R: From<GlesRenderer> + Renderer<Error = GlesError>> GraphicsApi for EglGle
             .filter(|(_, node)| !list.iter().any(|renderer| &renderer.node == node))
             .map(|(device, node)| {
                 info!("Trying to initialize {:?} from {}", device, node);
-                let display = EGLDisplay::new(device).map_err(Error::Egl)?;
+                let display = unsafe { EGLDisplay::new(device).map_err(Error::Egl) }?;
                 let renderer = if let Some(factory) = self.factory.as_ref() {
                     factory(&display)?.into()
                 } else {

--- a/src/backend/renderer/multigpu/gbm.rs
+++ b/src/backend/renderer/multigpu/gbm.rs
@@ -124,9 +124,8 @@ impl<R> GbmGlesBackend<R> {
             return Ok(());
         }
 
-        self.devices.insert(node, EGLDisplay::new(gbm)?);
+        self.devices.insert(node, unsafe { EGLDisplay::new(gbm)? });
         self.needs_enumeration.store(true, Ordering::SeqCst);
-
         Ok(())
     }
 

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -123,7 +123,7 @@ where
     debug!("Window created");
 
     let (display, context, surface, is_x11) = {
-        let display = EGLDisplay::new(window.clone())?;
+        let display = unsafe { EGLDisplay::new(window.clone())? };
 
         let context = EGLContext::new_with_config(&display, attributes, PixelFormatRequirements::_10_bit())
             .or_else(|_| {

--- a/src/backend/x11/mod.rs
+++ b/src/backend/x11/mod.rs
@@ -936,7 +936,7 @@ impl X11Inner {
 }
 
 fn egl_init(_: &X11Inner) -> Result<(DrmNode, OwnedFd), EGLInitError> {
-    let display = EGLDisplay::new(X11DefaultDisplay)?;
+    let display = unsafe { EGLDisplay::new(X11DefaultDisplay)? };
     let device = EGLDevice::device_for_display(&display)?;
     let path = path_to_type(device.drm_device_path()?, NodeType::Render)?;
     let node = DrmNode::from_path(&path)


### PR DESCRIPTION
Attempt at "fixing" (at least in the context of smithay) #1263 as reported by @YaLTeR.

Essentially this works around this part of the [`eglGetPlatformDisplay`-docs](https://registry.khronos.org/EGL/sdk/docs/man/html/eglGetPlatformDisplay.xhtml) as well as we can:

> Multiple calls made to eglGetPlatformDisplay with the same parameters will return the same EGLDisplay handle. 

There is no way to disallow other code to call `eglGetPlatformDisplay` behind our back, so I felt like this method warrents an `unsafe`. However this is debatable.

1. We do have places where `EGLDisplay::new` is called inside safe code, which is difficult to propagate (e.g. `EglGlesBackend::enumerate`).
2. Calling `eglGetPlatformDisplay` requires unsafe code in other code or libraries anyway.
3. `EGLDisplay`s broken this way will normally not crash the program, but calls using it will all error out.

Another possible solution would be to make calling `eglTerminate` explicit?