### PR TITLE
multigpu: Allow api to trigger re-enumeration

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -199,7 +199,7 @@ impl<A: GraphicsApi> GpuManager<A> {
         &'api mut self,
         device: &DrmNode,
     ) -> Result<MultiRenderer<'api, 'api, '_, A, A>, Error<A, A>> {
-        if !self.devices.iter().any(|dev| dev.node() == device) {
+        if !self.devices.iter().any(|dev| dev.node() == device) || self.api.needs_enumeration() {
             self.api
                 .enumerate(&mut self.devices)
                 .map_err(Error::RenderApiError)?;
@@ -245,6 +245,7 @@ impl<A: GraphicsApi> GpuManager<A> {
     {
         if !self.devices.iter().any(|device| device.node() == render_device)
             || !self.devices.iter().any(|device| device.node() == target_device)
+            || self.api.needs_enumeration()
         {
             self.api
                 .enumerate(&mut self.devices)
@@ -319,6 +320,7 @@ impl<A: GraphicsApi> GpuManager<A> {
             .devices
             .iter()
             .any(|device| device.node() == render_device)
+            || render_api.api.needs_enumeration()
         {
             render_api
                 .api
@@ -330,6 +332,7 @@ impl<A: GraphicsApi> GpuManager<A> {
             .devices
             .iter()
             .any(|device| device.node() == target_device)
+            || target_api.api.needs_enumeration()
         {
             target_api
                 .api
@@ -637,6 +640,10 @@ pub trait GraphicsApi {
     ///
     /// Existing devices are guranteed to be not recreated
     fn enumerate(&self, list: &mut Vec<Self::Device>) -> Result<(), Self::Error>;
+    /// Method to force a re-enumeration, e.g. to free resources
+    fn needs_enumeration(&self) -> bool {
+        false
+    }
     /// Unique name for representing the api type in log messages
     fn identifier() -> &'static str;
 }


### PR DESCRIPTION
Right now the `GpuManager` only re-enumerates devices, if the user requests a node it doesn't know already.

This means it will lock resources, even if e.g. the node is removed from the `GbmGlesBackend`.

While this is fine for the `EglGlesBackend`, as there really is no notification of a removed rendering device (except for egl errors trying to use it) and enumeration being expensive, this is bad for the Gbm-backend, as for example the nvidia driver will keep the gpu active as long as EGL resources do exist.

As such introduce a way for the api to trigger re-enumeration on the next render step.