### PR TITLE
Update `input` to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ drm-ffi = { version = "0.7.1", optional = true }
 errno = "0.3.5"
 gbm = { version = "0.14.0", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.12", optional = true }
-input = { version = "0.8.2", default-features = false, features=["libinput_1_19"], optional = true }
+input = { version = "0.9.0", default-features = false, features=["libinput_1_19"], optional = true }
 indexmap = "2.0"
 lazy_static = "1"
 libc = "0.2.103"
@@ -102,7 +102,7 @@ renderer_multi = ["backend_drm"]
 renderer_pixman = ["pixman"]
 renderer_test = []
 use_system_lib = ["wayland_frontend", "wayland-backend/server_system", "wayland-sys", "gbm?/import-wayland"]
-use_bindgen = ["drm-ffi/use_bindgen", "gbm/use_bindgen", "input/gen"]
+use_bindgen = ["drm-ffi/use_bindgen", "gbm/use_bindgen", "input/use_bindgen"]
 wayland_frontend = ["wayland-server", "wayland-protocols", "wayland-protocols-wlr", "wayland-protocols-misc", "tempfile"]
 x11rb_event_source = ["x11rb"]
 xwayland = ["encoding_rs", "wayland_frontend", "x11rb/composite", "x11rb/xfixes", "x11rb_event_source", "scopeguard"]


### PR DESCRIPTION
With `drm`, `gbm`, and `input` updated to use the same bindings across platforms, building Smithay on RISC-V or OpenBSD should be a bit easier.