### PR TITLE
Fix plane artifacts

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -357,7 +357,7 @@ pub fn run_udev() {
                         lease_global.resume::<AnvilState<UdevData>>();
                     }
                     for surface in backend.surfaces.values_mut() {
-                        if let Err(err) = surface.compositor.surface().reset_state() {
+                        if let Err(err) = surface.compositor.reset_state() {
                             warn!("Failed to reset drm surface state: {}", err);
                         }
                     }
@@ -666,6 +666,16 @@ impl SurfaceComposition {
         match self {
             SurfaceComposition::Compositor(c) => c.reset_buffers(),
             SurfaceComposition::Surface { surface, .. } => surface.reset_buffers(),
+        }
+    }
+
+    fn reset_state(&mut self) -> Result<(), SwapBuffersError> {
+        match self {
+            SurfaceComposition::Compositor(c) => c.reset_state().map_err(Into::<SwapBuffersError>::into),
+            SurfaceComposition::Surface { surface, .. } => surface
+                .surface()
+                .reset_state()
+                .map_err(Into::<SwapBuffersError>::into),
         }
     }
 

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -737,7 +737,7 @@ impl SurfaceComposition {
                         element.sync.wait();
                     }
                     SurfaceCompositorRenderResult {
-                        rendered: render_frame_result.damage.is_some(),
+                        rendered: !render_frame_result.is_empty,
                         damage: None,
                         states: render_frame_result.states,
                         sync: None,

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -31,12 +31,18 @@ use tracing::{debug, info, info_span, instrument, trace, warn};
 
 use super::{PlaneConfig, PlaneState};
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct State {
     pub active: bool,
     pub mode: Mode,
     pub blob: property::Value<'static>,
     pub connectors: HashSet<connector::Handle>,
+}
+
+impl PartialEq for State {
+    fn eq(&self, other: &Self) -> bool {
+        self.active == other.active && self.mode == other.mode && self.connectors == other.connectors
+    }
 }
 
 impl State {

--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -18,6 +18,7 @@ use tracing::{debug, info, info_span, instrument, trace};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct State {
+    pub active: bool,
     pub mode: Mode,
     pub connectors: HashSet<connector::Handle>,
 }
@@ -73,6 +74,9 @@ impl State {
         // we need to be sure, we require a mode to always be set without relying on the compiler.
         // So we cheat, because it works and is easier to handle later.
         Ok(State {
+            // On legacy there is not (reliable) way to read-back the dpms state.
+            // So we just always assume it is off.
+            active: false,
             mode: current_mode.unwrap_or_else(|| unsafe { std::mem::zeroed() }),
             connectors: current_connectors,
         })
@@ -103,6 +107,7 @@ impl LegacyDrmSurface {
 
         let state = State::current_state(&*fd, crtc)?;
         let pending = State {
+            active: true,
             mode,
             connectors: connectors.iter().copied().collect(),
         };


### PR DESCRIPTION
This should hopefully provide a fix for all kind of plane artifact issues after suspend/resume and dpms.

The comments on the single commits should be enough to describe the motivation behind the changes.

Just some warning, this breaks some existing behavior by fixing an issue I found in the `reset_state` function of the atomic surface. Before that change every call to `reset_state` would make the surface require a commit.
With this fixed `DrmCompositor` will no longer always submit a complete state after calling `reset_state`
which might result in artifacts.
The correct way to resolve this is to call `DrmCompositor::reset_state` instead directly on the surface.
This will make sure the next call to `render_frame`/`queue_frame` will produce a full update, updating
all planes.
