### PR TITLE
input: add support for keyboard led state

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -25,7 +25,7 @@ use smithay::{
         PopupKind, PopupManager, Space,
     },
     input::{
-        keyboard::{Keysym, XkbConfig},
+        keyboard::{Keysym, LedState, XkbConfig},
         pointer::{CursorImageStatus, PointerHandle},
         Seat, SeatHandler, SeatState,
     },
@@ -263,6 +263,10 @@ impl<BackendData: Backend> SeatHandler for AnvilState<BackendData> {
     }
     fn cursor_image(&mut self, _seat: &Seat<Self>, image: CursorImageStatus) {
         *self.cursor_status.lock().unwrap() = image;
+    }
+
+    fn led_state_changed(&mut self, _seat: &Seat<Self>, led_state: LedState) {
+        self.backend_data.update_led_state(led_state)
     }
 }
 delegate_seat!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
@@ -793,4 +797,5 @@ pub trait Backend {
     fn seat_name(&self) -> String;
     fn reset_buffers(&mut self, output: &Output);
     fn early_import(&mut self, surface: &WlSurface);
+    fn update_led_state(&mut self, led_state: LedState);
 }

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -27,7 +27,10 @@ use smithay::{
         SwapBuffersError,
     },
     delegate_dmabuf,
-    input::pointer::{CursorImageAttributes, CursorImageStatus},
+    input::{
+        keyboard::LedState,
+        pointer::{CursorImageAttributes, CursorImageStatus},
+    },
     output::{Mode, Output, PhysicalProperties, Subpixel},
     reexports::{
         calloop::EventLoop,
@@ -88,6 +91,7 @@ impl Backend for WinitData {
         self.full_redraw = 4;
     }
     fn early_import(&mut self, _surface: &wl_surface::WlSurface) {}
+    fn update_led_state(&mut self, _led_state: LedState) {}
 }
 
 pub fn run_winit() {

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -31,7 +31,10 @@ use smithay::{
         x11::{WindowBuilder, X11Backend, X11Event, X11Surface},
     },
     delegate_dmabuf,
-    input::pointer::{CursorImageAttributes, CursorImageStatus},
+    input::{
+        keyboard::LedState,
+        pointer::{CursorImageAttributes, CursorImageStatus},
+    },
     output::{Mode, Output, PhysicalProperties, Subpixel},
     reexports::{
         ash::vk::ExtPhysicalDeviceDrmFn,
@@ -91,6 +94,7 @@ impl Backend for X11Data {
         self.surface.reset_buffers();
     }
     fn early_import(&mut self, _surface: &wl_surface::WlSurface) {}
+    fn update_led_state(&mut self, _led_state: LedState) {}
 }
 
 pub fn run_x11() {

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -647,6 +647,22 @@ impl From<event::pointer::ButtonState> for backend::ButtonState {
     }
 }
 
+impl From<crate::input::keyboard::LedState> for libinput::Led {
+    fn from(value: crate::input::keyboard::LedState) -> Self {
+        let mut leds = libinput::Led::empty();
+        if value.num.unwrap_or_default() {
+            leds |= libinput::Led::NUMLOCK;
+        }
+        if value.caps.unwrap_or_default() {
+            leds |= libinput::Led::CAPSLOCK;
+        }
+        if value.scroll.unwrap_or_default() {
+            leds |= libinput::Led::SCROLLLOCK;
+        }
+        leds
+    }
+}
+
 /// Wrapper for types implementing the [`Session`] trait to provide
 /// a [`libinput::LibinputInterface`] implementation.
 #[cfg(feature = "backend_session")]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -117,7 +117,7 @@ use std::{
 
 use tracing::{info_span, instrument};
 
-use self::keyboard::{Error as KeyboardError, KeyboardHandle, KeyboardTarget};
+use self::keyboard::{Error as KeyboardError, KeyboardHandle, KeyboardTarget, LedState};
 use self::pointer::{CursorImageStatus, PointerHandle, PointerTarget};
 use crate::utils::user_data::UserDataMap;
 
@@ -139,6 +139,9 @@ pub trait SeatHandler: Sized {
 
     /// Callback that will be notified whenever a client requests to set a custom cursor image.
     fn cursor_image(&mut self, _seat: &Seat<Self>, _image: CursorImageStatus) {}
+
+    /// Callback that will be notified whenever the keyboard led state changes.
+    fn led_state_changed(&mut self, _seat: &Seat<Self>, _led_state: LedState) {}
 }
 /// Delegate type for all [Seat] globals.
 ///

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -41,6 +41,7 @@ impl Backend for TestState {
 
     fn reset_buffers(&mut self, _output: &Output) {}
     fn early_import(&mut self, _surface: &wl_surface::WlSurface) {}
+    fn update_led_state(&mut self, led_state: smithay::input::keyboard::LedState) {}
 }
 
 pub fn run(channel: Channel<WlcsEvent>) {


### PR DESCRIPTION
An attempt to make the leds on the keyboard to show up.

~~As I am normally not working on the input side this might be complete bogus, but at least it seems to work for me.
What I am especially uncertain at is the `update_led` function on the keyboard input event, but it also did not
feel correct to add it to the generic device trait.~~

Ok, so this should now represent a much saner implementation. The `SeatHandler` now has a notify function which
is automatically called on changes to the led state. The only remaining thing downstream has to do is to track all
keyboards, listen to the led state updates and update all keyboard led states.