### PR TITLE
Don't panic if parent is missing in find_popup_root_surface()

### DIFF
--- a/src/desktop/wayland/popup/manager.rs
+++ b/src/desktop/wayland/popup/manager.rs
@@ -226,8 +226,8 @@ pub fn find_popup_root_surface(popup: &PopupKind) -> Result<WlSurface, DeadResou
                 .parent
                 .as_ref()
                 .cloned()
-                .unwrap()
-        });
+        })
+        .ok_or(DeadResource)?;
     }
     Ok(parent)
 }


### PR DESCRIPTION
Turns out popup grabs with IMEs are kinda not working in Smithay, but they don't have to crash the compositor.

This particular thing happens if an IME with a popup is spawned while a popup with a grab is open, and you try to call this function. For whatever reason. Not completely sure. Let's not crash anyway.