### PR TITLE
Expose focus events through the X11 backend

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -545,7 +545,7 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
 
     pub fn release_all_keys(&mut self) {
         let keyboard = self.seat.get_keyboard().unwrap();
-        for keycode in keyboard.with_pressed_keys(std::convert::identity) {
+        for keycode in keyboard.pressed_keys() {
             keyboard.input(
                 self,
                 keycode.raw(),

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -542,6 +542,20 @@ impl<Backend: crate::state::Backend> AnvilState<Backend> {
         );
         pointer.frame(self);
     }
+
+    pub fn release_all_keys(&mut self) {
+        let keyboard = self.seat.get_keyboard().unwrap();
+        for keycode in keyboard.with_pressed_keys(std::convert::identity) {
+            keyboard.input(
+                self,
+                keycode.raw(),
+                KeyState::Released,
+                SCOUNTER.next_serial(),
+                0,
+                |_, _, _| FilterResult::Forward::<bool>,
+            );
+        }
+    }
 }
 
 #[cfg(feature = "udev")]

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -280,6 +280,10 @@ pub fn run_x11() {
                 data.state
                     .process_input_event_windowed(&data.display_handle, event, OUTPUT_NAME)
             }
+            X11Event::Focus(false) => {
+                data.state.release_all_keys();
+            }
+            _ => {}
         })
         .expect("Failed to insert X11 Backend into event loop");
 

--- a/src/backend/x11/mod.rs
+++ b/src/backend/x11/mod.rs
@@ -134,6 +134,9 @@ pub enum X11Event {
         window_id: u32,
     },
 
+    /// The focus state of the window changed.
+    Focus(bool),
+
     /// An input event occurred.
     Input(InputEvent<X11Input>),
 
@@ -642,11 +645,19 @@ impl X11Inner {
             }
         }
 
-        use self::X11Event::Input;
+        use self::X11Event::{Focus, Input};
 
         // If X11 is deadlocking somewhere here, make sure you drop your mutex guards.
 
         match event {
+            x11::Event::FocusIn(_focus_in) => {
+                callback(Focus(true), &mut ());
+            }
+
+            x11::Event::FocusOut(_focus_out) => {
+                callback(Focus(false), &mut ());
+            }
+
             x11::Event::ButtonPress(button_press) => {
                 if let Some(window) = X11Inner::window_ref_from_id(inner, &button_press.event) {
                     // X11 decided to associate scroll wheel with a button, 4, 5, 6 and 7 for

--- a/src/backend/x11/window_inner.rs
+++ b/src/backend/x11/window_inner.rs
@@ -117,6 +117,7 @@ impl WindowInner {
             | EventMask::POINTER_MOTION // Mouse movement
             | EventMask::ENTER_WINDOW // Track whether the cursor enters of leaves the window.
             | EventMask::LEAVE_WINDOW
+            | EventMask::FOCUS_CHANGE
             | EventMask::EXPOSURE
             | EventMask::NO_EVENT,
             )

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -851,6 +851,23 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         });
     }
 
+    /// Iterate over the key codes of the currently pressed keys.
+    pub fn with_pressed_keys<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(HashSet<Keycode>) -> R,
+        R: 'static,
+    {
+        let guard = self.arc.internal.lock().unwrap();
+        {
+            let handles = guard
+                .pressed_keys
+                .iter()
+                .map(|&code| code.into())
+                .collect::<HashSet<Keycode>>();
+            f(handles)
+        }
+    }
+
     /// Iterate over the keysyms of the currently pressed keys.
     pub fn with_pressed_keysyms<F, R>(&self, f: F) -> R
     where

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -851,21 +851,15 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         });
     }
 
-    /// Iterate over the key codes of the currently pressed keys.
-    pub fn with_pressed_keys<F, R>(&self, f: F) -> R
-    where
-        F: FnOnce(HashSet<Keycode>) -> R,
-        R: 'static,
+    /// Return the key codes of the currently pressed keys.
+    pub fn pressed_keys(&self) -> HashSet<Keycode>
     {
         let guard = self.arc.internal.lock().unwrap();
-        {
-            let handles = guard
-                .pressed_keys
-                .iter()
-                .map(|&code| code.into())
-                .collect::<HashSet<Keycode>>();
-            f(handles)
-        }
+        guard
+            .pressed_keys
+            .iter()
+            .map(|&code| code.into())
+            .collect()
     }
 
     /// Iterate over the keysyms of the currently pressed keys.

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -855,11 +855,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     pub fn pressed_keys(&self) -> HashSet<Keycode>
     {
         let guard = self.arc.internal.lock().unwrap();
-        guard
-            .pressed_keys
-            .iter()
-            .map(|&code| code.into())
-            .collect()
+        guard.pressed_keys.iter().map(|&code| code.into()).collect()
     }
 
     /// Iterate over the keysyms of the currently pressed keys.

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -852,8 +852,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     }
 
     /// Return the key codes of the currently pressed keys.
-    pub fn pressed_keys(&self) -> HashSet<Keycode>
-    {
+    pub fn pressed_keys(&self) -> HashSet<Keycode> {
         let guard = self.arc.internal.lock().unwrap();
         guard.pressed_keys.iter().map(|&code| code.into()).collect()
     }


### PR DESCRIPTION
Expose FocusIn and FocusOut events through the X11 backend. Focus was already exposed on the Winit backend, so why not have the same on the X11 one. Also, a helper function has been added that returns the key codes of currently pressed keys.

My use case:
When I run the compositor in a window under X11 and I Alt+Tab, the Alt key is permanently stuck in the pressed state because the host compositor never sends me a release event. When I lose focus, I want to iterate over all the keys that are being pressed and artificially release them, so that next time I focus the window no keys are stuck down.
