### PR TITLE
egl: Fix dead weak handles

### DIFF
--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -224,6 +224,7 @@ impl EGLDisplay {
             let weak_disp = WeakEGLDisplayHandle::from(new_display.clone());
 
             let mut displays = DISPLAYS.lock().unwrap();
+            displays.retain(|handle| handle.handle.upgrade().is_some());
             if displays.insert(weak_disp.clone()) {
                 new_display
             } else {


### PR DESCRIPTION
Somehow I removed this during refactoring, so now the `unwrap` in 231/232 can panic without this line.