### PR TITLE
Draft: Implement proposed ServerSideOverlay decoration mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,3 +135,6 @@ harness = false
 [profile.release-with-debug]
 inherits = "release"
 debug = true
+
+[patch.crates-io]
+wayland-protocols = { path = "../wayland-rs/wayland-protocols" }

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -599,6 +599,19 @@ impl SpaceElement for WindowElement {
                         &(*point - Point::from((0.0, HEADER_BAR_HEIGHT as f64))),
                     ),
                 }
+        } else if self.decoration_state().ssd_mode == Mode::ServerSideOverlay {
+            (point.y < HEADER_BAR_HEIGHT as f64 && point.x > self.decoration_state().decorations.width as f64 - BUTTON_WIDTH as f64 * 2.)
+                || match self {
+                    WindowElement::Wayland(w) => SpaceElement::is_in_input_region(
+                        w,
+                        &(*point - Point::from((0.0, HEADER_BAR_HEIGHT as f64))),
+                    ),
+                    #[cfg(feature = "xwayland")]
+                    WindowElement::X11(w) => SpaceElement::is_in_input_region(
+                        w,
+                        &(*point - Point::from((0.0, HEADER_BAR_HEIGHT as f64))),
+                    ),
+                }
         } else {
             match self {
                 WindowElement::Wayland(w) => SpaceElement::is_in_input_region(w, point),

--- a/anvil/src/shell/x11.rs
+++ b/anvil/src/shell/x11.rs
@@ -64,7 +64,11 @@ impl<BackendData: Backend> XwmHandler for CalloopData<BackendData> {
             unreachable!()
         };
         xsurface.configure(Some(bbox)).unwrap();
-        window.set_ssd(!xsurface.is_decorated());
+        if xsurface.is_decorated() {
+            window.set_no_ssd();
+        } else {
+            window.set_ssd();
+        }
     }
 
     fn mapped_override_redirect_window(&mut self, _xwm: XwmId, window: X11Surface) {
@@ -175,7 +179,7 @@ impl<BackendData: Backend> XwmHandler for CalloopData<BackendData> {
             let geometry = self.state.space.output_geometry(output).unwrap();
 
             window.set_fullscreen(true).unwrap();
-            elem.set_ssd(false);
+            elem.set_no_ssd();
             window.configure(geometry).unwrap();
             output.user_data().insert_if_missing(FullscreenSurface::default);
             output
@@ -195,7 +199,11 @@ impl<BackendData: Backend> XwmHandler for CalloopData<BackendData> {
             .find(|e| matches!(e, WindowElement::X11(w) if w == &window))
         {
             window.set_fullscreen(false).unwrap();
-            elem.set_ssd(!window.is_decorated());
+            if window.is_decorated() {
+                elem.set_no_ssd();
+            } else {
+                elem.set_ssd();
+            }
             if let Some(output) = self.state.space.outputs().find(|o| {
                 o.user_data()
                     .get::<FullscreenSurface>()

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -193,12 +193,21 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
                 .find(|element| element.wl_surface().as_ref() == Some(&surface));
             if let Some(window) = window {
                 use xdg_decoration::zv1::server::zxdg_toplevel_decoration_v1::Mode;
-                let is_ssd = configure
+                match configure
                     .state
                     .decoration_mode
-                    .map(|mode| mode == Mode::ServerSide)
-                    .unwrap_or(false);
-                window.set_ssd(is_ssd);
+                    .unwrap_or(Mode::ClientSide) {
+                        Mode::ServerSide => {
+                            window.set_ssd();
+                        }
+                        Mode::ClientSide => {
+                            window.set_no_ssd();
+                        }
+                        Mode::ServerSideOverlay => {
+                            window.set_ssd_overlay();
+                        }
+                        _ => { panic!() }
+                    }
             }
         }
     }

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -71,8 +71,8 @@ use smithay::{
         shell::{
             wlr_layer::WlrLayerShellState,
             xdg::{
-                decoration::{XdgDecorationHandler, XdgDecorationState},
-                ToplevelSurface, XdgShellState, XdgToplevelSurfaceData,
+                decoration::{XdgDecorationHandler, XdgDecorationState}, DecorationOverlayArea, 
+                ToplevelSurface, XdgShellState, XdgToplevelSurfaceData
             },
         },
         shm::{ShmHandler, ShmState},
@@ -89,7 +89,7 @@ use smithay::{
 
 #[cfg(feature = "xwayland")]
 use crate::cursor::Cursor;
-use crate::{focus::FocusTarget, shell::WindowElement};
+use crate::{focus::FocusTarget, shell::{ssd::{BUTTON_WIDTH, HEADER_BAR_HEIGHT}, WindowElement}};
 #[cfg(feature = "xwayland")]
 use smithay::{
     delegate_xwayland_keyboard_grab,
@@ -372,6 +372,11 @@ impl<BackendData: Backend> XdgDecorationHandler for AnvilState<BackendData> {
         // Set the default to client side
         toplevel.with_pending_state(|state| {
             state.decoration_mode = Some(Mode::ClientSide);
+            state.decoration_overlay = Some(DecorationOverlayArea {
+                location: xdg_decoration::zv1::server::zxdg_toplevel_decoration_v1::OverlayLocation::Right,
+                width: BUTTON_WIDTH * 2,
+                height: HEADER_BAR_HEIGHT as u32
+            })
         });
     }
     fn request_mode(&mut self, toplevel: ToplevelSurface, mode: DecorationMode) {

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -375,13 +375,8 @@ impl<BackendData: Backend> XdgDecorationHandler for AnvilState<BackendData> {
         });
     }
     fn request_mode(&mut self, toplevel: ToplevelSurface, mode: DecorationMode) {
-        use xdg_decoration::zv1::server::zxdg_toplevel_decoration_v1::Mode;
-
         toplevel.with_pending_state(|state| {
-            state.decoration_mode = Some(match mode {
-                DecorationMode::ServerSide => Mode::ServerSide,
-                _ => Mode::ClientSide,
-            });
+            state.decoration_mode = Some(mode)
         });
 
         let initial_configure_sent = with_states(toplevel.wl_surface(), |states| {

--- a/src/wayland/shell/xdg/decoration.rs
+++ b/src/wayland/shell/xdg/decoration.rs
@@ -94,7 +94,7 @@ use wayland_server::{
     backend::GlobalId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, WEnum,
 };
 
-use super::{ToplevelSurface, XdgShellHandler};
+use super::{DecorationOverlayArea, ToplevelSurface, XdgShellHandler};
 use crate::wayland::shell::xdg::XdgShellSurfaceUserData;
 
 /// Delegate type for handling xdg decoration events.
@@ -189,6 +189,13 @@ pub(super) fn send_decoration_configure(
     mode: Mode,
 ) {
     id.configure(mode)
+}
+
+pub(super) fn send_decoration_overlay_configure(
+    id: &zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1,
+    area: DecorationOverlayArea
+) {
+    id.configure_overlay(area.location, area.width, area.height)
 }
 
 impl<D> GlobalDispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, XdgDecorationManagerGlobalData, D>


### PR DESCRIPTION
Hi Smithay folks :wave:,

This is an implementation of [my proposed `ServerSideOverlay` decoration mode](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/274). The purpose of this is to allow clients to draw headerbars with native looking decorations without any hassle. 

![Screenshot from 2024-01-25 21-37-09](https://github.com/Smithay/smithay/assets/88643996/faa99d67-efab-4a34-bdfd-c0bd8c8c611f)

I implemented the necessary frameworks in Smithay and wrote an example implementation in Anvil.

I enjoyed working with your library, it was a lot of fun!

(Obviously, this will stay a draft until my MR in wayland-prots gets accepted, if it doesn't get denied)