### PR TITLE
chore: Fix deprecated indexmap remove method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,11 +113,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Rust toolchain
-        # currently nightly has an ICE affecting bytemuck
-        # see: https://github.com/Lokathor/bytemuck/issues/197
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-06-17
+        uses: dtolnay/rust-toolchain@nightly
       - name: Get date for registry cache
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
@@ -407,11 +403,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-registry-
 
       - name: Rust toolchain
-        # currently nightly has an ICE affecting bytemuck
-        # see: https://github.com/Lokathor/bytemuck/issues/197
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-06-17
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: System dependencies
         run: sudo apt-get update; sudo apt-get install -y libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,7 +419,7 @@ jobs:
       - name: Build Documentation
         env: 
           RUSTDOCFLAGS: --cfg=docsrs
-        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop -p drm -p gbm -p input -p udev:0.8.0 -p wayland-server -p wayland-backend -p wayland-protocols:0.31.0 -p winit -p x11rb:0.13.0 -p tracing
+        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop -p drm -p gbm -p input -p udev -p wayland-server -p wayland-backend -p wayland-protocols -p winit -p x11rb -p tracing
         
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ use_bindgen = ["drm-ffi/use_bindgen", "gbm/use_bindgen", "input/use_bindgen"]
 wayland_frontend = ["wayland-server", "wayland-protocols", "wayland-protocols-wlr", "wayland-protocols-misc", "tempfile"]
 x11rb_event_source = ["x11rb"]
 xwayland = ["encoding_rs", "wayland_frontend", "x11rb/composite", "x11rb/xfixes", "x11rb_event_source", "scopeguard"]
-test_all_features = ["default", "use_system_lib", "renderer_glow", "renderer_test", "renderer_pixman"]
+test_all_features = ["default", "use_system_lib", "renderer_glow", "renderer_test"]
 
 [[example]]
 name = "minimal"

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1370,8 +1370,8 @@ impl OverlayPlaneElementIds {
     }
 
     fn remove_plane(&mut self, plane: &plane::Handle) {
-        if let Some(plane_id) = self.plane_plane_ids.remove(plane) {
-            self.plane_id_element_ids.remove(&plane_id);
+        if let Some(plane_id) = self.plane_plane_ids.swap_remove(plane) {
+            self.plane_id_element_ids.swap_remove(&plane_id);
         }
     }
 }
@@ -2119,7 +2119,7 @@ where
                 {
                     cursor_plane_element.take()
                 } else {
-                    overlay_plane_elements.remove(plane)
+                    overlay_plane_elements.shift_remove(plane)
                 };
 
                 // If we have no element on this plane skip the rest

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -196,6 +196,7 @@ impl RenderElementState {
     }
 }
 
+#[allow(dead_code)] // This structs purpose is to keep buffer objects alive, most variants won't be read
 #[derive(Debug)]
 enum ScanoutBuffer<B: Buffer> {
     Wayland(crate::backend::renderer::utils::Buffer),

--- a/src/backend/renderer/gles/version.rs
+++ b/src/backend/renderer/gles/version.rs
@@ -64,7 +64,7 @@ mod tests {
     fn test_parse_mesa_3_2() {
         let gl_version = "OpenGL ES 3.2 Mesa 20.3.5";
         let gl_version_str = unsafe { CStr::from_ptr(gl_version.as_ptr() as *const c_char) };
-        assert_eq!(GlVersion::try_from(gl_version_str), Ok(GlVersion::new(3, 2)))
+        assert_eq!(GlVersion::try_from(gl_version_str).unwrap(), GlVersion::new(3, 2))
     }
 
     #[test]

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -66,7 +66,7 @@ where
                 data.known_surfaces
                     .lock()
                     .unwrap()
-                    .remove(&xdg_surface.downgrade());
+                    .swap_remove(&xdg_surface.downgrade());
 
                 if !data.wl_surface.alive() {
                     // the wl_surface is destroyed, this means the client is not


### PR DESCRIPTION
Looks like the IndexMap is used in all these places for a stable iterator order, possibly even z-order in the compositor, so shift_remove is likely the expected behavior here.