### PR TITLE
Add OutputHandler trait

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -50,7 +50,7 @@ use smithay::{
         keyboard_shortcuts_inhibit::{
             KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
         },
-        output::OutputManagerState,
+        output::{OutputHandler, OutputManagerState},
         pointer_constraints::{with_pointer_constraint, PointerConstraintsHandler, PointerConstraintsState},
         pointer_gestures::PointerGesturesState,
         presentation::PresentationState,
@@ -191,6 +191,7 @@ impl<BackendData: Backend> ServerDndGrabHandler for AnvilState<BackendData> {
 }
 delegate_data_device!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
+impl<BackendData: Backend> OutputHandler for AnvilState<BackendData> {}
 delegate_output!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> SelectionHandler for AnvilState<BackendData> {

--- a/smallvil/src/handlers/mod.rs
+++ b/smallvil/src/handlers/mod.rs
@@ -10,6 +10,7 @@ use crate::Smallvil;
 use smithay::input::{Seat, SeatHandler, SeatState};
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::Resource;
+use smithay::wayland::output::OutputHandler;
 use smithay::wayland::selection::data_device::{
     set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState, ServerDndGrabHandler,
 };
@@ -58,4 +59,5 @@ delegate_data_device!(Smallvil);
 // Wl Output & Xdg Output
 //
 
+impl OutputHandler for Smallvil {}
 delegate_output!(Smallvil);

--- a/src/wayland/output/handlers.rs
+++ b/src/wayland/output/handlers.rs
@@ -8,7 +8,7 @@ use wayland_server::{
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
 
-use super::{xdg::XdgOutput, Output, OutputManagerState, OutputUserData, WlOutputData};
+use super::{xdg::XdgOutput, Output, OutputHandler, OutputManagerState, OutputUserData, WlOutputData};
 
 /*
  * Wl Output
@@ -18,10 +18,11 @@ impl<D> GlobalDispatch<WlOutput, WlOutputData, D> for OutputManagerState
 where
     D: GlobalDispatch<WlOutput, WlOutputData>,
     D: Dispatch<WlOutput, OutputUserData>,
+    D: OutputHandler,
     D: 'static,
 {
     fn bind(
-        _state: &mut D,
+        state: &mut D,
         _dh: &DisplayHandle,
         client: &Client,
         resource: New<WlOutput>,
@@ -84,7 +85,13 @@ where
             }
         }
 
-        inner.instances.push(output);
+        inner.instances.push(output.clone());
+
+        drop(inner);
+        let o = Output {
+            inner: global_data.inner.clone(),
+        };
+        state.output_bound(o, output);
     }
 }
 

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -24,6 +24,7 @@
 //! use smithay::delegate_output;
 //! use smithay::output::{Output, PhysicalProperties, Scale, Mode, Subpixel};
 //! use smithay::utils::Transform;
+//! use smithay::wayland::output::OutputHandler;
 //!
 //! # struct State;
 //! # let mut display = wayland_server::Display::<State>::new().unwrap();
@@ -55,6 +56,7 @@
 //! output.add_mode(Mode { size: (800, 600).into(), refresh: 60000 });
 //! output.add_mode(Mode { size: (1024, 768).into(), refresh: 60000 });
 //!
+//! impl OutputHandler for State {}
 //! delegate_output!(State);
 //! ```
 
@@ -88,6 +90,12 @@ pub struct OutputManagerState {
 #[derive(Debug)]
 pub struct WlOutputData {
     inner: OutputData,
+}
+
+/// Events initiated by the clients interacting with outputs
+pub trait OutputHandler {
+    /// A client bound a new `wl_output` instance.
+    fn output_bound(&mut self, _output: Output, _wl_output: WlOutput) {}
 }
 
 impl OutputManagerState {


### PR DESCRIPTION
Lets compositors know when a new `wl_output` is bound. Useful for implementing protocols with similar semantics to `wl_surface.enter` where newly bound `wl_output`s must participate in some events immediately.