### PR TITLE
Allow forcibly setting text-input activation state

### DIFF
--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -158,7 +158,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for WlSurface {
         let input_method = seat.input_method();
 
         if input_method.has_instance() {
-            input_method.deactivate_input_method(state, true);
+            input_method.deactivate_input_method(state);
         }
 
         // NOTE: Always set focus regardless whether the client actually has the
@@ -178,7 +178,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for WlSurface {
         let input_method = seat.input_method();
 
         if input_method.has_instance() {
-            input_method.deactivate_input_method(state, true);
+            input_method.deactivate_input_method(state);
             text_input.leave();
         }
 

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -158,7 +158,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for WlSurface {
         let input_method = seat.input_method();
 
         if input_method.has_instance() {
-            input_method.deactivate_input_method(state);
+            input_method.deactivate_input_method(state, true);
         }
 
         // NOTE: Always set focus regardless whether the client actually has the
@@ -178,7 +178,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for WlSurface {
         let input_method = seat.input_method();
 
         if input_method.has_instance() {
-            input_method.deactivate_input_method(state);
+            input_method.deactivate_input_method(state, true);
             text_input.leave();
         }
 

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -181,11 +181,12 @@ where
         };
 
         match request {
-            zwp_text_input_v3::Request::Enable => {
-                data.input_method_handle.activate_input_method(state, &focus)
-            }
+            zwp_text_input_v3::Request::Enable => data
+                .input_method_handle
+                .activate_input_method(state, Some(&focus)),
             zwp_text_input_v3::Request::Disable => {
-                data.input_method_handle.deactivate_input_method(state, false);
+                data.input_method_handle
+                    .deactivate_input_method_internal(state, false);
             }
             zwp_text_input_v3::Request::SetSurroundingText { text, cursor, anchor } => {
                 data.input_method_handle.with_instance(|input_method| {
@@ -245,7 +246,7 @@ where
         };
 
         if deactivate_im {
-            data.input_method_handle.deactivate_input_method(state, true);
+            data.input_method_handle.deactivate_input_method(state);
         }
     }
 }

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -183,10 +183,10 @@ where
         match request {
             zwp_text_input_v3::Request::Enable => data
                 .input_method_handle
-                .activate_input_method(state, Some(&focus)),
+                .activate_input_method(state, Some(&focus), false),
             zwp_text_input_v3::Request::Disable => {
                 data.input_method_handle
-                    .deactivate_input_method_internal(state, false);
+                    .deactivate_input_method(state, false);
             }
             zwp_text_input_v3::Request::SetSurroundingText { text, cursor, anchor } => {
                 data.input_method_handle.with_instance(|input_method| {
@@ -246,7 +246,7 @@ where
         };
 
         if deactivate_im {
-            data.input_method_handle.deactivate_input_method(state);
+            data.input_method_handle.deactivate_input_method(state, true);
         }
     }
 }

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -181,12 +181,12 @@ where
         };
 
         match request {
-            zwp_text_input_v3::Request::Enable => data
-                .input_method_handle
-                .activate_input_method(state, Some(&focus), false),
-            zwp_text_input_v3::Request::Disable => {
+            zwp_text_input_v3::Request::Enable => {
                 data.input_method_handle
-                    .deactivate_input_method(state, false);
+                    .activate_input_method(state, Some(&focus), false)
+            }
+            zwp_text_input_v3::Request::Disable => {
+                data.input_method_handle.deactivate_input_method(state, false);
             }
             zwp_text_input_v3::Request::SetSurroundingText { text, cursor, anchor } => {
                 data.input_method_handle.with_instance(|input_method| {


### PR DESCRIPTION
This patch adds a new `InputMethodHandle::set_active` method, which allows setting the input method to either force-on, force-off, or automatic (based on text-input).

---

Opening a draft because there's three things I'd like some feedback on:

Firstly I've only tested this with virtual keyboard. I'd assume it should work just as well for IME but I'm not aware of its intricacies so feedback would be welcome on this.

Secondly this currently requires a `clone` on the client side to be used, but I'm not sure there's a better API possible:

```rust
let cseat = self.seat.clone();
cseat.input_method().set_active(self, None, self.ime_override);
```

If the seat isn't stored on the state the clone wouldn't be necessary obviously, but I'd assume this is usually where it is stored.

Thirdly currently force-disabling IME works just fine, but force-enabling IME doesn't work. When force-enabling IME it won't go away once it is opened, but it will not open my virtual keyboard if nothing is focused. I thought for a second this might be because no surface is passed to `activate_input_method`, but I don't see why it would require a surface considering that `zwp_input_method_v1::activate` doesn't require any surfaces. This is the only thing I consider critical enough to keep this in the draft stage.