### PR TITLE
fix: Don't unwrap RendererSurfaceState

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y libdrm-dev libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev
       - name: Downgrade to minimal dependencies
         run: cargo update -Z minimal-versions
+      - name: Fixup ahash with current nightly
+        run: cargo update -p ahash --precise 0.8.7
       - name: Check
         run: cargo check --features "test_all_features"
 

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -409,18 +409,16 @@ impl SurfaceView {
 
 /// Access the buffer related states associated to this surface
 ///
-/// Calls [`compositor::with_states`] internally
-pub fn with_renderer_surface_state<F, T>(surface: &WlSurface, cb: F) -> T
+/// Calls [`compositor::with_states`] internally.
+///
+/// Returns `None`, if there never was an commit processed through `on_commit_buffer_handler`.
+pub fn with_renderer_surface_state<F, T>(surface: &WlSurface, cb: F) -> Option<T>
 where
     F: FnOnce(&mut RendererSurfaceState) -> T,
 {
     compositor::with_states(surface, |states| {
-        let mut data = states
-            .data_map
-            .get::<RendererSurfaceStateUserData>()
-            .unwrap()
-            .borrow_mut();
-        cb(&mut data)
+        let data = states.data_map.get::<RendererSurfaceStateUserData>()?;
+        Some(cb(&mut data.borrow_mut()))
     })
 }
 


### PR DESCRIPTION
Makes `with_renderer_surface_state` not panic, should there have never been an import. (Which can be particularly easy to trigger with unmapped Xwayland windows.)