### PR TITLE
Fix copy_framebuffer for GlesRenderer

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1371,7 +1371,13 @@ impl ExportMem for GlesRenderer {
             let size = (region.size.w * region.size.h * bpp as i32) as isize;
             self.gl
                 .BufferData(ffi::PIXEL_PACK_BUFFER, size, ptr::null(), ffi::STREAM_READ);
-            self.gl.ReadBuffer(ffi::COLOR_ATTACHMENT0);
+            self.gl.ReadBuffer(
+                if matches!(self.target.as_ref(), None | Some(GlesTarget::Surface { .. })) {
+                    ffi::BACK
+                } else {
+                    ffi::COLOR_ATTACHMENT0
+                },
+            );
             self.gl.ReadPixels(
                 region.loc.x,
                 region.loc.y,


### PR DESCRIPTION
When calling copy_framebuffer with a winit backend and GlesRenderer the following error occurs:
```
2024-02-08T18:20:53.020809Z ERROR backend_winit{window=94319884276496}:egl{platform="PLATFORM_WAYLAND_KHR" version=(1, 5)}:egl_context{ptr=94319886251776}:renderer_gles2: smithay::backend::renderer::gles: [GL] GL_INVALID_OPERATION in glReadBuffer(invalid buffer GL_COLOR_ATTACHMENT0)
thread 'main' panicked at smallvil/src/winit.rs:30:10:
Failed to map framebuffer: UnsupportedPixelFormat(DrmFourcc(AR24))
```
Full Backtrace: https://gist.github.com/Meptl/084c4d5c78408df6600a4619466c912a

To test, you can use this patch which modifies smallvil slightly to create a screenshot at `foo.png` when you press '3' on the keyboard:
<details>
  <summary>Click to expand</summary>

```
diff --git a/smallvil/Cargo.toml b/smallvil/Cargo.toml
index c46b1013a..2c31e63db 100644
--- a/smallvil/Cargo.toml
+++ b/smallvil/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 bitflags = "2.2.1"
+image = "0.24.1"
 
 [dependencies.smithay]
 path = "../"
diff --git a/smallvil/src/winit.rs b/smallvil/src/winit.rs
index bd197b2f5..ef88d004d 100644
--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -2,8 +2,11 @@ use std::time::Duration;
 
 use smithay::{
     backend::{
+        allocator::Fourcc,
+        input::{InputEvent, KeyState, KeyboardKeyEvent},
         renderer::{
             damage::OutputDamageTracker, element::surface::WaylandSurfaceRenderElement, gles::GlesRenderer,
+            ExportMem,
         },
         winit::{self, WinitEvent},
     },
@@ -11,9 +14,27 @@ use smithay::{
     reexports::calloop::EventLoop,
     utils::{Rectangle, Transform},
 };
+use std::path::Path;
 
 use crate::{CalloopData, Smallvil};
 
+fn save_buffer_to_png(
+    renderer: &mut GlesRenderer,
+    path: &Path,
+    w: i32,
+    h: i32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Saving image");
+    let mapping = renderer
+        .copy_framebuffer(Rectangle::from_loc_and_size((0, 0), (w, h)), Fourcc::Abgr8888)
+        .expect("Failed to map framebuffer");
+    let copy = renderer.map_texture(&mapping).expect("Failed to read mapping");
+    image::save_buffer(path, copy, w as u32, h as u32, image::ColorType::Rgba8)
+        .expect("Failed to save image");
+    println!("Saved image");
+    Ok(())
+}
+
 pub fn init_winit(
     event_loop: &mut EventLoop<CalloopData>,
     data: &mut CalloopData,
@@ -45,6 +66,8 @@ pub fn init_winit(
 
     let mut damage_tracker = OutputDamageTracker::from_output(&output);
 
+    let mut screenshot_requested = false;
+
     std::env::set_var("WAYLAND_DISPLAY", &state.socket_name);
 
     event_loop.handle().insert_source(winit, move |event, _, data| {
@@ -63,7 +86,18 @@ pub fn init_winit(
                     None,
                 );
             }
-            WinitEvent::Input(event) => state.process_input_event(event),
+            WinitEvent::Input(event) => {
+                match event {
+                    InputEvent::Keyboard { event, .. } => {
+                        if event.key_code() == 4 && event.state() == KeyState::Pressed {
+                            println!("Good key event");
+                            screenshot_requested = true;
+                        }
+                    }
+                    _ => {}
+                };
+                state.process_input_event(event);
+            }
             WinitEvent::Redraw => {
                 let size = backend.window_size();
                 let damage = Rectangle::from_loc_and_size((0, 0), size);
@@ -80,6 +114,16 @@ pub fn init_winit(
                     [0.1, 0.1, 0.1, 1.0],
                 )
                 .unwrap();
+                if screenshot_requested {
+                    let path = Path::new("foo.png");
+                    let current_mode = output.current_mode().unwrap();
+                    if let Err(e) =
+                        save_buffer_to_png(backend.renderer(), path, current_mode.size.w, current_mode.size.h)
+                    {
+                        eprintln!("Failed to save buffer to 'foo.png': {}", e);
+                    }
+                    screenshot_requested = false;
+                }
                 backend.submit(Some(&[damage])).unwrap();
 
                 state.space.elements().for_each(|window| {
```
</details>


This change was at the suggestion of drakulix in the Matrix chatroom. [Link to conversionation](https://matrix.to/#/!qaZCXtKkCIlfHYRUep:safaradeg.net/$NJzlp7j4zoQfRO-aYbiGuNmfVfVk_KypTF5b-Hq8ljQ?via=matrix.org&via=mozilla.org&via=integrations.ems.host)

