### PR TITLE
touch re-factor

### DIFF
--- a/anvil/src/focus.rs
+++ b/anvil/src/focus.rs
@@ -14,9 +14,12 @@ pub use smithay::{
 };
 use smithay::{
     desktop::{Window, WindowSurface},
-    input::pointer::{
-        GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent,
-        GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent,
+    input::{
+        pointer::{
+            GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent,
+            GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent,
+        },
+        touch::TouchTarget,
     },
 };
 
@@ -343,6 +346,101 @@ impl<BackendData: Backend> KeyboardTarget<AnvilState<BackendData>> for KeyboardF
             KeyboardFocusTarget::Popup(p) => {
                 KeyboardTarget::modifiers(p.wl_surface(), seat, data, modifiers, serial)
             }
+        }
+    }
+}
+
+impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for PointerFocusTarget {
+    fn down(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &smithay::input::touch::DownEvent,
+        seq: Serial,
+    ) {
+        match self {
+            PointerFocusTarget::WlSurface(w) => TouchTarget::down(w, seat, data, event, seq),
+            #[cfg(feature = "xwayland")]
+            PointerFocusTarget::X11Surface(w) => TouchTarget::down(w, seat, data, event, seq),
+            PointerFocusTarget::SSD(w) => TouchTarget::down(w, seat, data, event, seq),
+        }
+    }
+
+    fn up(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &smithay::input::touch::UpEvent,
+        seq: Serial,
+    ) {
+        match self {
+            PointerFocusTarget::WlSurface(w) => TouchTarget::up(w, seat, data, event, seq),
+            #[cfg(feature = "xwayland")]
+            PointerFocusTarget::X11Surface(w) => TouchTarget::up(w, seat, data, event, seq),
+            PointerFocusTarget::SSD(w) => TouchTarget::up(w, seat, data, event, seq),
+        }
+    }
+
+    fn motion(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &smithay::input::touch::MotionEvent,
+        seq: Serial,
+    ) {
+        match self {
+            PointerFocusTarget::WlSurface(w) => TouchTarget::motion(w, seat, data, event, seq),
+            #[cfg(feature = "xwayland")]
+            PointerFocusTarget::X11Surface(w) => TouchTarget::motion(w, seat, data, event, seq),
+            PointerFocusTarget::SSD(w) => TouchTarget::motion(w, seat, data, event, seq),
+        }
+    }
+
+    fn frame(&self, seat: &Seat<AnvilState<BackendData>>, data: &mut AnvilState<BackendData>, seq: Serial) {
+        match self {
+            PointerFocusTarget::WlSurface(w) => TouchTarget::frame(w, seat, data, seq),
+            #[cfg(feature = "xwayland")]
+            PointerFocusTarget::X11Surface(w) => TouchTarget::frame(w, seat, data, seq),
+            PointerFocusTarget::SSD(w) => TouchTarget::frame(w, seat, data, seq),
+        }
+    }
+
+    fn cancel(&self, seat: &Seat<AnvilState<BackendData>>, data: &mut AnvilState<BackendData>, seq: Serial) {
+        match self {
+            PointerFocusTarget::WlSurface(w) => TouchTarget::cancel(w, seat, data, seq),
+            #[cfg(feature = "xwayland")]
+            PointerFocusTarget::X11Surface(w) => TouchTarget::cancel(w, seat, data, seq),
+            PointerFocusTarget::SSD(w) => TouchTarget::cancel(w, seat, data, seq),
+        }
+    }
+
+    fn shape(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &smithay::input::touch::ShapeEvent,
+        seq: Serial,
+    ) {
+        match self {
+            PointerFocusTarget::WlSurface(w) => TouchTarget::shape(w, seat, data, event, seq),
+            #[cfg(feature = "xwayland")]
+            PointerFocusTarget::X11Surface(w) => TouchTarget::shape(w, seat, data, event, seq),
+            PointerFocusTarget::SSD(w) => TouchTarget::shape(w, seat, data, event, seq),
+        }
+    }
+
+    fn orientation(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &smithay::input::touch::OrientationEvent,
+        seq: Serial,
+    ) {
+        match self {
+            PointerFocusTarget::WlSurface(w) => TouchTarget::orientation(w, seat, data, event, seq),
+            #[cfg(feature = "xwayland")]
+            PointerFocusTarget::X11Surface(w) => TouchTarget::orientation(w, seat, data, event, seq),
+            PointerFocusTarget::SSD(w) => TouchTarget::orientation(w, seat, data, event, seq),
         }
     }
 }

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -14,6 +14,7 @@ use smithay::{
             GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
             GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
         },
+        touch::TouchTarget,
         Seat,
     },
     output::Output,
@@ -248,6 +249,70 @@ impl<Backend: crate::state::Backend> PointerTarget<AnvilState<Backend>> for SSD 
         _seat: &Seat<AnvilState<Backend>>,
         _data: &mut AnvilState<Backend>,
         _event: &GestureHoldEndEvent,
+    ) {
+    }
+}
+
+impl<Backend: crate::state::Backend> TouchTarget<AnvilState<Backend>> for SSD {
+    fn down(
+        &self,
+        seat: &Seat<AnvilState<Backend>>,
+        data: &mut AnvilState<Backend>,
+        event: &smithay::input::touch::DownEvent,
+        _seq: Serial,
+    ) {
+        let mut state = self.0.decoration_state();
+        if state.is_ssd {
+            state.header_bar.pointer_enter(event.location);
+            state.header_bar.touch_down(seat, data, &self.0, event.serial);
+        }
+    }
+
+    fn up(
+        &self,
+        seat: &Seat<AnvilState<Backend>>,
+        data: &mut AnvilState<Backend>,
+        event: &smithay::input::touch::UpEvent,
+        _seq: Serial,
+    ) {
+        let mut state = self.0.decoration_state();
+        if state.is_ssd {
+            state.header_bar.touch_up(seat, data, &self.0, event.serial);
+        }
+    }
+
+    fn motion(
+        &self,
+        _seat: &Seat<AnvilState<Backend>>,
+        _data: &mut AnvilState<Backend>,
+        event: &smithay::input::touch::MotionEvent,
+        _seq: Serial,
+    ) {
+        let mut state = self.0.decoration_state();
+        if state.is_ssd {
+            state.header_bar.pointer_enter(event.location);
+        }
+    }
+
+    fn frame(&self, _seat: &Seat<AnvilState<Backend>>, _data: &mut AnvilState<Backend>, _seq: Serial) {}
+
+    fn cancel(&self, _seat: &Seat<AnvilState<Backend>>, _data: &mut AnvilState<Backend>, _seq: Serial) {}
+
+    fn shape(
+        &self,
+        _seat: &Seat<AnvilState<Backend>>,
+        _data: &mut AnvilState<Backend>,
+        _event: &smithay::input::touch::ShapeEvent,
+        _seq: Serial,
+    ) {
+    }
+
+    fn orientation(
+        &self,
+        _seat: &Seat<AnvilState<Backend>>,
+        _data: &mut AnvilState<Backend>,
+        _event: &smithay::input::touch::OrientationEvent,
+        _seq: Serial,
     ) {
     }
 }

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -17,7 +17,7 @@ use smithay::{utils::Rectangle, xwayland::xwm::ResizeEdge as X11ResizeEdge};
 
 use super::{SurfaceData, WindowElement};
 use crate::{
-    focus::FocusTarget,
+    focus::PointerFocusTarget,
     state::{AnvilState, Backend},
 };
 
@@ -32,7 +32,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for MoveSurfaceG
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        _focus: Option<(FocusTarget, Point<i32, Logical>)>,
+        _focus: Option<(PointerFocusTarget, Point<i32, Logical>)>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -49,7 +49,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for MoveSurfaceG
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        focus: Option<(FocusTarget, Point<i32, Logical>)>,
+        focus: Option<(PointerFocusTarget, Point<i32, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);
@@ -246,7 +246,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        _focus: Option<(FocusTarget, Point<i32, Logical>)>,
+        _focus: Option<(PointerFocusTarget, Point<i32, Logical>)>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -330,7 +330,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for ResizeSurfac
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        focus: Option<(FocusTarget, Point<i32, Logical>)>,
+        focus: Option<(PointerFocusTarget, Point<i32, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);

--- a/anvil/src/shell/ssd.rs
+++ b/anvil/src/shell/ssd.rs
@@ -20,7 +20,6 @@ use super::WindowElement;
 
 pub struct WindowState {
     pub is_ssd: bool,
-    pub ptr_entered_window: bool,
     pub header_bar: HeaderBar,
 }
 
@@ -207,7 +206,6 @@ impl WindowElement {
         self.user_data().insert_if_missing(|| {
             RefCell::new(WindowState {
                 is_ssd: false,
-                ptr_entered_window: false,
                 header_bar: HeaderBar {
                     pointer_loc: None,
                     width: 0,

--- a/anvil/src/shell/x11.rs
+++ b/anvil/src/shell/x11.rs
@@ -25,7 +25,7 @@ use smithay::{
 };
 use tracing::{error, trace};
 
-use crate::{focus::FocusTarget, state::Backend, AnvilState, CalloopData};
+use crate::{focus::KeyboardFocusTarget, state::Backend, AnvilState, CalloopData};
 
 use super::{
     place_new_window, FullscreenSurface, MoveSurfaceGrab, ResizeData, ResizeState, ResizeSurfaceGrab,
@@ -263,8 +263,8 @@ impl<BackendData: Backend> XwmHandler for CalloopData<BackendData> {
     fn allow_selection_access(&mut self, xwm: XwmId, _selection: SelectionTarget) -> bool {
         if let Some(keyboard) = self.state.seat.get_keyboard() {
             // check that an X11 window is focused
-            if let Some(FocusTarget::Window(w)) = keyboard.current_focus() {
-                if let Some(surface) = w.0.x11_surface() {
+            if let Some(KeyboardFocusTarget::Window(w)) = keyboard.current_focus() {
+                if let Some(surface) = w.x11_surface() {
                     if surface.xwm_id().unwrap() == xwm {
                         return true;
                     }

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -28,7 +28,7 @@ use smithay::{
 use tracing::{trace, warn};
 
 use crate::{
-    focus::FocusTarget,
+    focus::KeyboardFocusTarget,
     state::{AnvilState, Backend},
 };
 
@@ -331,7 +331,7 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
                 .elements()
                 .find(|w| w.wl_surface().map(|s| s == root).unwrap_or(false))
                 .cloned()
-                .map(FocusTarget::Window)
+                .map(KeyboardFocusTarget::from)
                 .or_else(|| {
                     self.space
                         .outputs()
@@ -339,7 +339,7 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
                             let map = layer_map_for_output(o);
                             map.layer_for_surface(&root, WindowSurfaceType::TOPLEVEL).cloned()
                         })
-                        .map(FocusTarget::LayerSurface)
+                        .map(KeyboardFocusTarget::LayerSurface)
                 })
         }) {
             let ret = self.popups.grab_popup(root, kind, &seat, serial);

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -89,7 +89,10 @@ use smithay::{
 
 #[cfg(feature = "xwayland")]
 use crate::cursor::Cursor;
-use crate::{focus::FocusTarget, shell::WindowElement};
+use crate::{
+    focus::{KeyboardFocusTarget, PointerFocusTarget},
+    shell::WindowElement,
+};
 #[cfg(feature = "xwayland")]
 use smithay::{
     delegate_xwayland_keyboard_grab,
@@ -246,14 +249,14 @@ impl<BackendData: Backend> ShmHandler for AnvilState<BackendData> {
 delegate_shm!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> SeatHandler for AnvilState<BackendData> {
-    type KeyboardFocus = FocusTarget;
-    type PointerFocus = FocusTarget;
+    type KeyboardFocus = KeyboardFocusTarget;
+    type PointerFocus = PointerFocusTarget;
 
     fn seat_state(&mut self) -> &mut SeatState<AnvilState<BackendData>> {
         &mut self.seat_state
     }
 
-    fn focus_changed(&mut self, seat: &Seat<Self>, target: Option<&FocusTarget>) {
+    fn focus_changed(&mut self, seat: &Seat<Self>, target: Option<&KeyboardFocusTarget>) {
         let dh = &self.display_handle;
 
         let wl_surface = target.and_then(WaylandFocus::wl_surface);
@@ -498,12 +501,12 @@ delegate_security_context!(@<BackendData: Backend + 'static> AnvilState<BackendD
 
 #[cfg(feature = "xwayland")]
 impl<BackendData: Backend + 'static> XWaylandKeyboardGrabHandler for AnvilState<BackendData> {
-    fn keyboard_focus_for_xsurface(&self, surface: &WlSurface) -> Option<FocusTarget> {
+    fn keyboard_focus_for_xsurface(&self, surface: &WlSurface) -> Option<KeyboardFocusTarget> {
         let elem = self
             .space
             .elements()
             .find(|elem| elem.wl_surface().as_ref() == Some(surface))?;
-        Some(FocusTarget::Window(elem.clone()))
+        Some(KeyboardFocusTarget::Window(elem.0.clone()))
     }
 }
 #[cfg(feature = "xwayland")]

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -251,6 +251,7 @@ delegate_shm!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 impl<BackendData: Backend> SeatHandler for AnvilState<BackendData> {
     type KeyboardFocus = KeyboardFocusTarget;
     type PointerFocus = PointerFocusTarget;
+    type TouchFocus = PointerFocusTarget;
 
     fn seat_state(&mut self) -> &mut SeatState<AnvilState<BackendData>> {
         &mut self.seat_state

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -110,6 +110,7 @@ impl ShmHandler for App {
 impl SeatHandler for App {
     type KeyboardFocus = WlSurface;
     type PointerFocus = WlSurface;
+    type TouchFocus = WlSurface;
 
     fn seat_state(&mut self) -> &mut SeatState<Self> {
         &mut self.seat_state

--- a/examples/seat.rs
+++ b/examples/seat.rs
@@ -16,6 +16,7 @@ struct App {
 impl SeatHandler for App {
     type KeyboardFocus = WlSurface;
     type PointerFocus = WlSurface;
+    type TouchFocus = WlSurface;
 
     fn seat_state(&mut self) -> &mut SeatState<Self> {
         &mut self.seat_state

--- a/smallvil/src/handlers/mod.rs
+++ b/smallvil/src/handlers/mod.rs
@@ -20,6 +20,7 @@ use smithay::{delegate_data_device, delegate_output, delegate_seat};
 impl SeatHandler for Smallvil {
     type KeyboardFocus = WlSurface;
     type PointerFocus = WlSurface;
+    type TouchFocus = WlSurface;
 
     fn seat_state(&mut self) -> &mut SeatState<Smallvil> {
         &mut self.seat_state

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -1,19 +1,9 @@
 #[cfg(feature = "xwayland")]
 use crate::xwayland::X11Surface;
 use crate::{
-    backend::input::KeyState,
     desktop::{space::RenderZindex, utils::*, PopupManager},
-    input::{
-        keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-        pointer::{
-            AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
-            GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
-            GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
-        },
-        Seat, SeatHandler,
-    },
     output::Output,
-    utils::{user_data::UserDataMap, IsAlive, Logical, Point, Rectangle, Serial},
+    utils::{user_data::UserDataMap, IsAlive, Logical, Point, Rectangle},
     wayland::{
         compositor::{with_states, SurfaceData},
         dmabuf::DmabufFeedback,
@@ -52,7 +42,6 @@ pub(crate) struct WindowInner {
     surface: WindowSurface,
     bbox: Mutex<Rectangle<i32, Logical>>,
     pub(crate) z_index: AtomicU8,
-    focused_surface: Mutex<Option<wl_surface::WlSurface>>,
     user_data: UserDataMap,
 }
 
@@ -124,7 +113,6 @@ impl Window {
             surface: WindowSurface::Wayland(toplevel),
             bbox: Mutex::new(Rectangle::from_loc_and_size((0, 0), (0, 0))),
             z_index: AtomicU8::new(RenderZindex::Shell as u8),
-            focused_surface: Mutex::new(None),
             user_data: UserDataMap::new(),
         }))
     }
@@ -139,7 +127,6 @@ impl Window {
             surface: WindowSurface::X11(surface),
             bbox: Mutex::new(Rectangle::from_loc_and_size((0, 0), (0, 0))),
             z_index: AtomicU8::new(RenderZindex::Shell as u8),
-            focused_surface: Mutex::new(None),
             user_data: UserDataMap::new(),
         }))
     }
@@ -383,144 +370,6 @@ impl Window {
     /// Returns a [`UserDataMap`] to allow associating arbitrary data with this window.
     pub fn user_data(&self) -> &UserDataMap {
         &self.0.user_data
-    }
-}
-
-impl<D: SeatHandler + 'static> PointerTarget<D> for Window {
-    fn enter(&self, seat: &Seat<D>, data: &mut D, event: &MotionEvent) {
-        if let Some((surface, loc)) = self.surface_under(event.location, WindowSurfaceType::ALL) {
-            let mut new_event = event.clone();
-            new_event.location -= loc.to_f64();
-            if let Some(old_surface) = self.0.focused_surface.lock().unwrap().replace(surface.clone()) {
-                if old_surface != surface {
-                    PointerTarget::<D>::leave(&old_surface, seat, data, event.serial, event.time);
-                    PointerTarget::<D>::enter(&surface, seat, data, &new_event);
-                } else {
-                    PointerTarget::<D>::motion(&surface, seat, data, &new_event);
-                }
-            } else {
-                PointerTarget::<D>::enter(&surface, seat, data, &new_event)
-            }
-        }
-    }
-    fn motion(&self, seat: &Seat<D>, data: &mut D, event: &MotionEvent) {
-        PointerTarget::<D>::enter(self, seat, data, event)
-    }
-    fn relative_motion(&self, seat: &Seat<D>, data: &mut D, event: &RelativeMotionEvent) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::relative_motion(surface, seat, data, event)
-        }
-    }
-    fn button(&self, seat: &Seat<D>, data: &mut D, event: &ButtonEvent) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::button(surface, seat, data, event)
-        }
-    }
-    fn axis(&self, seat: &Seat<D>, data: &mut D, frame: AxisFrame) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::axis(surface, seat, data, frame)
-        }
-    }
-    fn frame(&self, seat: &Seat<D>, data: &mut D) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::frame(surface, seat, data)
-        }
-    }
-    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().take() {
-            PointerTarget::<D>::leave(&surface, seat, data, serial, time)
-        }
-    }
-
-    fn gesture_swipe_begin(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeBeginEvent) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::gesture_swipe_begin(surface, seat, data, event)
-        }
-    }
-
-    fn gesture_swipe_update(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeUpdateEvent) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::gesture_swipe_update(surface, seat, data, event)
-        }
-    }
-
-    fn gesture_swipe_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureSwipeEndEvent) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::gesture_swipe_end(surface, seat, data, event)
-        }
-    }
-
-    fn gesture_pinch_begin(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchBeginEvent) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::gesture_pinch_begin(surface, seat, data, event)
-        }
-    }
-
-    fn gesture_pinch_update(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchUpdateEvent) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::gesture_pinch_update(surface, seat, data, event)
-        }
-    }
-
-    fn gesture_pinch_end(&self, seat: &Seat<D>, data: &mut D, event: &GesturePinchEndEvent) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::gesture_pinch_end(surface, seat, data, event)
-        }
-    }
-
-    fn gesture_hold_begin(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldBeginEvent) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::gesture_hold_begin(surface, seat, data, event)
-        }
-    }
-
-    fn gesture_hold_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldEndEvent) {
-        if let Some(surface) = self.0.focused_surface.lock().unwrap().as_ref() {
-            PointerTarget::<D>::gesture_hold_end(surface, seat, data, event)
-        }
-    }
-}
-
-impl<D: SeatHandler + 'static> KeyboardTarget<D> for Window {
-    fn enter(&self, seat: &Seat<D>, data: &mut D, keys: Vec<KeysymHandle<'_>>, serial: Serial) {
-        match &self.0.surface {
-            WindowSurface::Wayland(s) => KeyboardTarget::<D>::enter(s.wl_surface(), seat, data, keys, serial),
-            #[cfg(feature = "xwayland")]
-            WindowSurface::X11(s) => KeyboardTarget::<D>::enter(s, seat, data, keys, serial),
-        }
-    }
-    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial) {
-        match &self.0.surface {
-            WindowSurface::Wayland(s) => KeyboardTarget::leave(s.wl_surface(), seat, data, serial),
-            #[cfg(feature = "xwayland")]
-            WindowSurface::X11(s) => KeyboardTarget::leave(s, seat, data, serial),
-        }
-    }
-    fn key(
-        &self,
-        seat: &Seat<D>,
-        data: &mut D,
-        key: KeysymHandle<'_>,
-        state: KeyState,
-        serial: Serial,
-        time: u32,
-    ) {
-        match &self.0.surface {
-            WindowSurface::Wayland(s) => {
-                KeyboardTarget::<D>::key(s.wl_surface(), seat, data, key, state, serial, time)
-            }
-            #[cfg(feature = "xwayland")]
-            WindowSurface::X11(s) => KeyboardTarget::<D>::key(s, seat, data, key, state, serial, time),
-        }
-    }
-    fn modifiers(&self, seat: &Seat<D>, data: &mut D, modifiers: ModifiersState, serial: Serial) {
-        match &self.0.surface {
-            WindowSurface::Wayland(s) => {
-                KeyboardTarget::<D>::modifiers(s.wl_surface(), seat, data, modifiers, serial)
-            }
-            #[cfg(feature = "xwayland")]
-            WindowSurface::X11(s) => KeyboardTarget::<D>::modifiers(s, seat, data, modifiers, serial),
-        }
     }
 }
 

--- a/src/input/touch/grab.rs
+++ b/src/input/touch/grab.rs
@@ -1,0 +1,256 @@
+use std::fmt;
+
+use crate::{
+    backend::input::TouchSlot,
+    input::SeatHandler,
+    utils::{Logical, Point, Serial},
+};
+
+use super::{DownEvent, MotionEvent, TouchInnerHandle, UpEvent};
+
+/// A trait to implement a touch grab
+///
+/// In some context, it is necessary to temporarily change the behavior of the touch handler. This is
+/// typically known as a touch grab. A typical example would be, during a drag'n'drop operation,
+/// the underlying surfaces will no longer receive classic pointer event, but rather special events.
+///
+/// This trait is the interface to intercept regular touch events and change them as needed, its
+/// interface mimics the [`TouchHandle`](super::TouchHandle) interface.
+///
+/// Any interactions with [`TouchHandle`](super::TouchHandle)
+/// should be done using [`TouchInnerHandle`], as handle is borrowed/locked before grab methods are called,
+/// so calling methods on [`TouchHandle`](super::TouchHandle) would result in a deadlock.
+///
+/// If your logic decides that the grab should end, both [`TouchInnerHandle`]
+/// and [`TouchHandle`](super::TouchHandle) have
+/// a method to change it.
+///
+/// When your grab ends (either as you requested it or if it was forcefully cancelled by the server),
+/// the struct implementing this trait will be dropped. As such you should put clean-up logic in the destructor,
+/// rather than trying to guess when the grab will end.
+pub trait TouchGrab<D: SeatHandler>: Send {
+    /// A new touch point appeared
+    ///
+    /// This method allows you attach additional behavior to a down event, possibly altering it.
+    /// You generally will want to invoke [`TouchInnerHandle::down`] as part of your processing. If you
+    /// don't, the rest of the compositor will behave as if the down event never occurred.
+    ///
+    /// Some grabs (such as drag'n'drop, shell resize and motion) drop down events while they are active,
+    /// the default touch grab will keep the focus on the surface that started the grab.
+    fn down(
+        &mut self,
+        data: &mut D,
+        handle: &mut TouchInnerHandle<'_, D>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &DownEvent,
+        seq: Serial,
+    );
+    /// A touch point disappeared
+    ///
+    /// This method allows you attach additional behavior to a up event, possibly altering it.
+    /// You generally will want to invoke [`TouchInnerHandle::up`] as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the up event never occurred.
+    ///
+    /// Some grabs (such as drag'n'drop, shell resize and motion) drop up events while they are active,
+    /// but will end when the touch point that initiated the grab disappeared.
+    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent, seq: Serial);
+
+    /// A touch point has changed coordinates.
+    ///
+    /// This method allows you attach additional behavior to a motion event, possibly altering it.
+    /// You generally will want to invoke [`TouchInnerHandle::motion`] as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the motion event never occurred.
+    ///
+    /// **Note** that this is **not** intended to update the focus of the touch point, the focus
+    /// is only set on a down event. The focus provided to this function can be used to find DnD
+    /// targets during touch motion.
+    fn motion(
+        &mut self,
+        data: &mut D,
+        handle: &mut TouchInnerHandle<'_, D>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &MotionEvent,
+        seq: Serial,
+    );
+
+    /// Marks the end of a set of events that logically belong together.
+    ///
+    /// This method allows you attach additional behavior to a frame event, possibly altering it.
+    /// You generally will want to invoke [`TouchInnerHandle::frame`] as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the frame event never occurred.
+    ///
+    /// This will to be called after one or more calls to down/motion events.
+    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial);
+
+    /// A touch session has been cancelled.
+    ///
+    /// This method allows you attach additional behavior to a cancel event, possibly altering it.
+    /// You generally will want to invoke [`TouchInnerHandle::cancel`] as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the cancel event never occurred.
+    ///
+    /// Usually called in case the compositor decides the touch stream is a global gesture.
+    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial);
+
+    /// The data about the event that started the grab.
+    fn start_data(&self) -> &GrabStartData<D>;
+}
+
+/// Data about the event that started the grab.
+pub struct GrabStartData<D: SeatHandler> {
+    /// The focused surface and its location, if any, at the start of the grab.
+    ///
+    /// The location coordinates are in the global compositor space.
+    pub focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+    /// The touch point that initiated the grab.
+    pub slot: TouchSlot,
+    /// The location of the down event that initiated the grab, in the global compositor space.
+    pub location: Point<f64, Logical>,
+}
+
+impl<D: SeatHandler + 'static> fmt::Debug for GrabStartData<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GrabStartData")
+            .field("focus", &self.focus.as_ref().map(|_| "..."))
+            .field("slot", &self.slot)
+            .field("location", &self.location)
+            .finish()
+    }
+}
+
+impl<D: SeatHandler + 'static> Clone for GrabStartData<D> {
+    fn clone(&self) -> Self {
+        GrabStartData {
+            focus: self.focus.clone(),
+            slot: self.slot,
+            location: self.location,
+        }
+    }
+}
+
+pub(super) enum GrabStatus<D> {
+    None,
+    Active(Serial, Box<dyn TouchGrab<D>>),
+    Borrowed,
+}
+
+// TouchGrab is a trait, so we have to impl Debug manually
+impl<D> fmt::Debug for GrabStatus<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GrabStatus::None => f.debug_tuple("GrabStatus::None").finish(),
+            GrabStatus::Active(serial, _) => f.debug_tuple("GrabStatus::Active").field(&serial).finish(),
+            GrabStatus::Borrowed => f.debug_tuple("GrabStatus::Borrowed").finish(),
+        }
+    }
+}
+
+// The default grab, the behavior when no particular grab is in progress
+pub(super) struct DefaultGrab;
+
+impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
+    fn down(
+        &mut self,
+        data: &mut D,
+        handle: &mut TouchInnerHandle<'_, D>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &DownEvent,
+        seq: Serial,
+    ) {
+        handle.down(data, focus.clone(), event, seq);
+        handle.set_grab(
+            data,
+            event.serial,
+            ClickGrab {
+                start_data: GrabStartData {
+                    focus,
+                    slot: event.slot,
+                    location: event.location,
+                },
+                touch_points: 1,
+            },
+        );
+    }
+
+    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent, seq: Serial) {
+        handle.up(data, event, seq)
+    }
+
+    fn motion(
+        &mut self,
+        data: &mut D,
+        handle: &mut TouchInnerHandle<'_, D>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &MotionEvent,
+        seq: Serial,
+    ) {
+        handle.motion(data, focus, event, seq)
+    }
+
+    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
+        handle.frame(data, seq)
+    }
+
+    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
+        handle.cancel(data, seq)
+    }
+
+    fn start_data(&self) -> &GrabStartData<D> {
+        unreachable!()
+    }
+}
+
+// A click grab, basic grab started when an user clicks a surface
+// to maintain it focused until the user releases the click.
+//
+// In case the user maintains several simultaneous clicks, release
+// the grab once all are released.
+struct ClickGrab<D: SeatHandler> {
+    start_data: GrabStartData<D>,
+    touch_points: usize,
+}
+
+impl<D: SeatHandler + 'static> TouchGrab<D> for ClickGrab<D> {
+    fn down(
+        &mut self,
+        data: &mut D,
+        handle: &mut TouchInnerHandle<'_, D>,
+        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &DownEvent,
+        seq: Serial,
+    ) {
+        handle.down(data, self.start_data.focus.clone(), event, seq);
+        self.touch_points += 1;
+    }
+
+    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent, seq: Serial) {
+        handle.up(data, event, seq);
+        self.touch_points = self.touch_points.saturating_sub(1);
+        if self.touch_points == 0 {
+            handle.unset_grab(data);
+        }
+    }
+
+    fn motion(
+        &mut self,
+        data: &mut D,
+        handle: &mut TouchInnerHandle<'_, D>,
+        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &MotionEvent,
+        seq: Serial,
+    ) {
+        handle.motion(data, self.start_data.focus.clone(), event, seq)
+    }
+
+    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
+        handle.frame(data, seq)
+    }
+
+    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
+        handle.cancel(data, seq);
+        handle.unset_grab(data);
+    }
+
+    fn start_data(&self) -> &GrabStartData<D> {
+        &self.start_data
+    }
+}

--- a/src/input/touch/grab.rs
+++ b/src/input/touch/grab.rs
@@ -144,8 +144,9 @@ impl<D> fmt::Debug for GrabStatus<D> {
     }
 }
 
-// The default grab, the behavior when no particular grab is in progress
-pub(super) struct DefaultGrab;
+/// The default grab, the behavior when no particular grab is in progress
+#[derive(Debug)]
+pub struct DefaultGrab;
 
 impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
     fn down(
@@ -160,7 +161,7 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
         handle.set_grab(
             data,
             event.serial,
-            ClickGrab {
+            TouchDownGrab {
                 start_data: GrabStartData {
                     focus,
                     slot: event.slot,
@@ -199,17 +200,28 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
     }
 }
 
-// A click grab, basic grab started when an user clicks a surface
-// to maintain it focused until the user releases the click.
-//
-// In case the user maintains several simultaneous clicks, release
-// the grab once all are released.
-struct ClickGrab<D: SeatHandler> {
-    start_data: GrabStartData<D>,
-    touch_points: usize,
+/// A touch down grab, basic grab started when an user touches a surface
+/// to maintain it focused until the user releases the touch.
+///
+/// In case the user maintains several simultaneous touch points, release
+/// the grab once all are released.
+pub struct TouchDownGrab<D: SeatHandler> {
+    /// Start date for this grab
+    pub start_data: GrabStartData<D>,
+    /// Currently active touch points
+    pub touch_points: usize,
 }
 
-impl<D: SeatHandler + 'static> TouchGrab<D> for ClickGrab<D> {
+impl<D: SeatHandler + 'static> fmt::Debug for TouchDownGrab<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TouchDownGrab")
+            .field("start_data", &self.start_data)
+            .field("touch_points", &self.touch_points)
+            .finish()
+    }
+}
+
+impl<D: SeatHandler + 'static> TouchGrab<D> for TouchDownGrab<D> {
     fn down(
         &mut self,
         data: &mut D,

--- a/src/input/touch/mod.rs
+++ b/src/input/touch/mod.rs
@@ -1,0 +1,582 @@
+//! Touch-related types for smithay's input abstraction
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use tracing::{info_span, instrument};
+
+use crate::backend::input::TouchSlot;
+use crate::utils::{IsAlive, Logical, Point, Serial, SerialCounter};
+
+use self::grab::{DefaultGrab, GrabStatus};
+pub use grab::{GrabStartData, TouchGrab};
+
+use super::{Seat, SeatHandler};
+
+mod grab;
+
+/// An handle to a touch handler
+///
+/// It can be cloned and all clones manipulate the same internal state.
+///
+/// This handle gives you access to an interface to send touch events to your
+/// clients.
+///
+/// When sending events using this handle, they will be intercepted by a touch
+/// grab if any is active. See the [`TouchGrab`] trait for details.
+pub struct TouchHandle<D: SeatHandler> {
+    pub(crate) inner: Arc<Mutex<TouchInternal<D>>>,
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) known_instances:
+        Arc<Mutex<Vec<(wayland_server::protocol::wl_touch::WlTouch, Option<Serial>)>>>,
+    pub(crate) span: tracing::Span,
+}
+
+#[cfg(not(feature = "wayland_frontend"))]
+impl<D: SeatHandler> fmt::Debug for TouchHandle<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TouchHandle").field("inner", &self.inner).finish()
+    }
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl<D: SeatHandler> fmt::Debug for TouchHandle<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TouchHandle")
+            .field("inner", &self.inner)
+            .field("known_instances", &self.known_instances)
+            .finish()
+    }
+}
+
+impl<D: SeatHandler> Clone for TouchHandle<D> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            #[cfg(feature = "wayland_frontend")]
+            known_instances: self.known_instances.clone(),
+            span: self.span.clone(),
+        }
+    }
+}
+
+impl<D: SeatHandler> std::hash::Hash for TouchHandle<D> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.inner).hash(state)
+    }
+}
+
+impl<D: SeatHandler> std::cmp::PartialEq for TouchHandle<D> {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl<D: SeatHandler> std::cmp::Eq for TouchHandle<D> {}
+
+pub(crate) struct TouchInternal<D: SeatHandler> {
+    focus: HashMap<TouchSlot, TouchSlotState<D>>,
+    seq_counter: SerialCounter,
+    grab: GrabStatus<D>,
+}
+
+struct TouchSlotState<D: SeatHandler> {
+    focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+    pending: Serial,
+    current: Option<Serial>,
+}
+
+impl<D: SeatHandler> fmt::Debug for TouchSlotState<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TouchSlotState")
+            .field("focus", &self.focus)
+            .field("pending", &self.pending)
+            .field("current", &self.current)
+            .finish()
+    }
+}
+
+// image_callback does not implement debug, so we have to impl Debug manually
+impl<D: SeatHandler> fmt::Debug for TouchInternal<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TouchInternal")
+            .field("focus", &self.focus)
+            .field("grab", &self.grab)
+            .finish()
+    }
+}
+
+/// Pointer motion event
+#[derive(Debug, Clone)]
+pub struct DownEvent {
+    /// Slot of this event
+    pub slot: TouchSlot,
+    /// Location of the touch in compositor space
+    pub location: Point<f64, Logical>,
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+}
+
+/// Pointer motion event
+#[derive(Debug, Clone)]
+pub struct UpEvent {
+    /// Slot of this event
+    pub slot: TouchSlot,
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+}
+
+/// Pointer motion event
+#[derive(Debug, Clone)]
+pub struct MotionEvent {
+    /// Slot of this event
+    pub slot: TouchSlot,
+    /// Location of the touch in compositor space
+    pub location: Point<f64, Logical>,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+}
+
+/// Pointer motion event
+#[derive(Debug, Clone, Copy)]
+pub struct ShapeEvent {
+    /// Slot of this event
+    pub slot: TouchSlot,
+    /// Length of the major axis in surface-local coordinates
+    pub major: f64,
+    /// Length of the minor axis in surface-local coordinates
+    pub minor: f64,
+}
+
+/// Pointer motion event
+#[derive(Debug, Clone, Copy)]
+pub struct OrientationEvent {
+    /// Slot of this event
+    pub slot: TouchSlot,
+    /// Angle between major axis and positive surface y-axis in degrees
+    pub orientation: f64,
+}
+
+/// Trait representing object that can receive touch interactions
+pub trait TouchTarget<D>: IsAlive + PartialEq + Clone + fmt::Debug + Send
+where
+    D: SeatHandler,
+{
+    /// A new touch point has appeared on the target.
+    ///
+    /// This touch point is assigned a unique ID. Future events from this touch point reference this ID.
+    /// The ID ceases to be valid after a touch up event and may be reused in the future.
+    fn down(&self, seat: &Seat<D>, data: &mut D, event: &DownEvent, seq: Serial);
+
+    /// The touch point has disappeared.
+    ///
+    /// No further events will be sent for this touch point and the touch point's ID
+    /// is released and may be reused in a future touch down event.
+    fn up(&self, seat: &Seat<D>, data: &mut D, event: &UpEvent, seq: Serial);
+
+    /// A touch point has changed coordinates.
+    fn motion(&self, seat: &Seat<D>, data: &mut D, event: &MotionEvent, seq: Serial);
+
+    /// Indicates the end of a set of events that logically belong together.
+    fn frame(&self, seat: &Seat<D>, data: &mut D, seq: Serial);
+
+    /// Touch session cancelled.
+    ///
+    /// Touch cancellation applies to all touch points currently active on this target.
+    /// The client is responsible for finalizing the touch points, future touch points on
+    /// this target may reuse the touch point ID.
+    fn cancel(&self, seat: &Seat<D>, data: &mut D, seq: Serial);
+
+    /// Sent when a touch point has changed its shape.
+    ///
+    /// A touch point shape is approximated by an ellipse through the major and minor axis length.
+    /// The major axis length describes the longer diameter of the ellipse, while the minor axis
+    /// length describes the shorter diameter. Major and minor are orthogonal and both are specified
+    /// in surface-local coordinates. The center of the ellipse is always at the touch point location
+    /// as reported by [`TouchTarget::down`] or [`TouchTarget::motion`].
+    fn shape(&self, seat: &Seat<D>, data: &mut D, event: &ShapeEvent, seq: Serial);
+
+    /// Sent when a touch point has changed its orientation.
+    ///
+    /// The orientation describes the clockwise angle of a touch point's major axis to the positive surface
+    /// y-axis and is normalized to the -180 to +180 degree range. The granularity of orientation depends
+    /// on the touch device, some devices only support binary rotation values between 0 and 90 degrees.
+    fn orientation(&self, seat: &Seat<D>, data: &mut D, event: &OrientationEvent, seq: Serial);
+}
+
+impl<D: SeatHandler + 'static> TouchHandle<D> {
+    pub(crate) fn new() -> TouchHandle<D> {
+        TouchHandle {
+            inner: Arc::new(Mutex::new(TouchInternal::new())),
+            #[cfg(feature = "wayland_frontend")]
+            known_instances: Arc::new(Mutex::new(Vec::new())),
+            span: info_span!("input_touch"),
+        }
+    }
+
+    /// Change the current grab on this touch to the provided grab
+    ///
+    /// Overwrites any current grab.
+    #[instrument(level = "debug", parent = &self.span, skip(self, data, grab))]
+    pub fn set_grab<G: TouchGrab<D> + 'static>(&self, data: &mut D, grab: G, serial: Serial) {
+        let seat = self.get_seat(data);
+        self.inner.lock().unwrap().set_grab(data, &seat, serial, grab);
+    }
+
+    /// Remove any current grab on this touch, resetting it to the default behavior
+    #[instrument(level = "debug", parent = &self.span, skip(self, data))]
+    pub fn unset_grab(&self, data: &mut D) {
+        let seat = self.get_seat(data);
+        self.inner.lock().unwrap().unset_grab(data, &seat);
+    }
+
+    /// Check if this touch is currently grabbed with this serial
+    pub fn has_grab(&self, serial: Serial) -> bool {
+        let guard = self.inner.lock().unwrap();
+        match guard.grab {
+            GrabStatus::Active(s, _) => s == serial,
+            _ => false,
+        }
+    }
+
+    /// Check if this touch is currently being grabbed
+    pub fn is_grabbed(&self) -> bool {
+        let guard = self.inner.lock().unwrap();
+        !matches!(guard.grab, GrabStatus::None)
+    }
+
+    /// Returns the start data for the grab, if any.
+    pub fn grab_start_data(&self) -> Option<GrabStartData<D>> {
+        let guard = self.inner.lock().unwrap();
+        match &guard.grab {
+            GrabStatus::Active(_, g) => Some(g.start_data().clone()),
+            _ => None,
+        }
+    }
+
+    /// Notify that a new touch point appeared
+    ///
+    /// You provide the location of the touch, in the form of:
+    ///
+    /// - The coordinates of the touch in the global compositor space
+    /// - The surface on top of which the touch point is, and the coordinates of its
+    ///   origin in the global compositor space (or `None` of the touch is not
+    ///   on top of a client surface).
+    pub fn down(
+        &self,
+        data: &mut D,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &DownEvent,
+    ) {
+        let mut inner = self.inner.lock().unwrap();
+        let seat = self.get_seat(data);
+        let seq = inner.seq_counter.next_serial();
+        inner.with_grab(&seat, |handle, grab| {
+            grab.down(data, handle, focus, event, seq);
+        });
+    }
+
+    /// Notify that a touch point disappeared
+    pub fn up(&self, data: &mut D, event: &UpEvent) {
+        let mut inner = self.inner.lock().unwrap();
+        let seat = self.get_seat(data);
+        let seq = inner.seq_counter.next_serial();
+        inner.with_grab(&seat, |handle, grab| {
+            grab.up(data, handle, event, seq);
+        });
+    }
+
+    /// Notify that a touch point has changed coordinates.
+    ///
+    /// You provide the location of the touch, in the form of:
+    ///
+    /// - The coordinates of the touch in the global compositor space
+    /// - The surface on top of which the touch point is, and the coordinates of its
+    ///   origin in the global compositor space (or `None` of the touch is not
+    ///   on top of a client surface).
+    ///
+    /// **Note** that this will **not** update the focus of the touch point, the focus
+    /// is only set on [`TouchHandle::down`]. The focus provided to this function
+    /// can be used to find DnD targets during touch motion.
+    pub fn motion(
+        &self,
+        data: &mut D,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &MotionEvent,
+    ) {
+        let mut inner = self.inner.lock().unwrap();
+        let seat = self.get_seat(data);
+        let seq = inner.seq_counter.next_serial();
+        inner.with_grab(&seat, |handle, grab| {
+            grab.motion(data, handle, focus, event, seq);
+        });
+    }
+
+    /// Notify about the end of a set of events that logically belong together.
+    ///
+    /// This needs to be called after one or move calls to [`TouchHandle::down`] or [`TouchHandle::motion`]
+    pub fn frame(&self, data: &mut D) {
+        let mut inner = self.inner.lock().unwrap();
+        let seat = self.get_seat(data);
+        let seq = inner.seq_counter.next_serial();
+        inner.with_grab(&seat, |handle, grab| {
+            grab.frame(data, handle, seq);
+        });
+    }
+
+    /// Notify that the touch session has been cancelled.
+    ///
+    /// Use in case you decide the touch stream is a global gesture.
+    /// This will remove all current focus targets, and no further events will be sent
+    /// until a new touch point appears.
+    pub fn cancel(&self, data: &mut D) {
+        let mut inner = self.inner.lock().unwrap();
+        let seat = self.get_seat(data);
+        let seq = inner.seq_counter.next_serial();
+        inner.with_grab(&seat, |handle, grab| {
+            grab.cancel(data, handle, seq);
+        });
+    }
+
+    fn get_seat(&self, data: &mut D) -> Seat<D> {
+        let seat_state = data.seat_state();
+        seat_state
+            .seats
+            .iter()
+            .find(|seat| seat.get_touch().map(|h| &h == self).unwrap_or(false))
+            .cloned()
+            .unwrap()
+    }
+}
+
+/// This inner handle is accessed from inside a pointer grab logic, and directly
+/// sends event to the client
+pub struct TouchInnerHandle<'a, D: SeatHandler> {
+    inner: &'a mut TouchInternal<D>,
+    seat: &'a Seat<D>,
+}
+
+impl<'a, D: SeatHandler> fmt::Debug for TouchInnerHandle<'a, D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TouchInnerHandle")
+            .field("inner", &self.inner)
+            .field("seat", &self.seat.arc.name)
+            .finish()
+    }
+}
+
+impl<'a, D: SeatHandler + 'static> TouchInnerHandle<'a, D> {
+    /// Change the current grab on this pointer to the provided grab
+    ///
+    /// Overwrites any current grab.
+    pub fn set_grab<G: TouchGrab<D> + 'static>(&mut self, data: &mut D, serial: Serial, grab: G) {
+        self.inner.set_grab(data, self.seat, serial, grab);
+    }
+
+    /// Remove any current grab on this pointer, resetting it to the default behavior
+    ///
+    /// This will also restore the focus of the underlying pointer if restore_focus
+    /// is [`true`]
+    pub fn unset_grab(&mut self, data: &mut D) {
+        self.inner.unset_grab(data, self.seat);
+    }
+
+    /// Notify that a new touch point appeared
+    ///
+    /// You provide the location of the touch, in the form of:
+    ///
+    /// - The coordinates of the touch in the global compositor space
+    /// - The surface on top of which the touch point is, and the coordinates of its
+    ///   origin in the global compositor space (or `None` of the touch is not
+    ///   on top of a client surface).
+    pub fn down(
+        &mut self,
+        data: &mut D,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &DownEvent,
+        seq: Serial,
+    ) {
+        self.inner.down(data, self.seat, focus, event, seq)
+    }
+
+    /// Notify that a touch point disappeared
+    pub fn up(&mut self, data: &mut D, event: &UpEvent, seq: Serial) {
+        self.inner.up(data, self.seat, event, seq)
+    }
+
+    /// Notify that a touch point has changed coordinates.
+    ///
+    /// You provide the location of the touch, in the form of:
+    ///
+    /// - The coordinates of the touch in the global compositor space
+    /// - The surface on top of which the touch point is, and the coordinates of its
+    ///   origin in the global compositor space (or `None` of the touch is not
+    ///   on top of a client surface).
+    ///
+    /// **Note** that this will **not** update the focus of the touch point, the focus
+    /// is only set on [`TouchHandle::down`]. The focus provided to this function
+    /// can be used to find DnD targets during touch motion.
+    pub fn motion(
+        &mut self,
+        data: &mut D,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &MotionEvent,
+        seq: Serial,
+    ) {
+        self.inner.motion(data, self.seat, focus, event, seq)
+    }
+
+    /// Notify about the end of a set of events that logically belong together.
+    ///
+    /// This needs to be called after one or move calls to [`TouchHandle::down`] or [`TouchHandle::motion`]
+    pub fn frame(&mut self, data: &mut D, seq: Serial) {
+        self.inner.frame(data, self.seat, seq)
+    }
+
+    /// Notify that the touch session has been cancelled.
+    ///
+    /// Use in case you decide the touch stream is a global gesture.
+    /// This will remove all current focus targets, and no further events will be sent
+    /// until a new touch point appears.
+    pub fn cancel(&mut self, data: &mut D, seq: Serial) {
+        self.inner.cancel(data, self.seat, seq)
+    }
+}
+
+impl<D: SeatHandler + 'static> TouchInternal<D> {
+    fn new() -> Self {
+        Self {
+            focus: Default::default(),
+            seq_counter: SerialCounter::new(),
+            grab: GrabStatus::None,
+        }
+    }
+
+    fn set_grab<G: TouchGrab<D> + 'static>(
+        &mut self,
+        _data: &mut D,
+        _seat: &Seat<D>,
+        serial: Serial,
+        grab: G,
+    ) {
+        self.grab = GrabStatus::Active(serial, Box::new(grab));
+    }
+
+    fn unset_grab(&mut self, _data: &mut D, _seat: &Seat<D>) {
+        self.grab = GrabStatus::None;
+    }
+
+    fn down(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &DownEvent,
+        seq: Serial,
+    ) {
+        self.focus
+            .entry(event.slot)
+            .and_modify(|state| {
+                state.pending = seq;
+                state.focus = focus.clone();
+            })
+            .or_insert_with(|| TouchSlotState {
+                focus,
+                pending: seq,
+                current: None,
+            });
+        let state = self.focus.get(&event.slot).unwrap();
+        if let Some((focus, loc)) = state.focus.as_ref() {
+            let mut new_event = event.clone();
+            new_event.location -= loc.to_f64();
+            focus.down(seat, data, &new_event, seq);
+        }
+    }
+
+    fn up(&mut self, data: &mut D, seat: &Seat<D>, event: &UpEvent, seq: Serial) {
+        let Some(state) = self.focus.get_mut(&event.slot) else {
+            return;
+        };
+        state.pending = seq;
+        if let Some((focus, _)) = state.focus.take() {
+            focus.up(seat, data, event, seq);
+        }
+    }
+
+    fn motion(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        event: &MotionEvent,
+        seq: Serial,
+    ) {
+        let Some(state) = self.focus.get_mut(&event.slot) else {
+            return;
+        };
+        state.pending = seq;
+        if let Some((focus, loc)) = state.focus.as_ref() {
+            let mut new_event = event.clone();
+            new_event.location -= loc.to_f64();
+            focus.motion(seat, data, &new_event, seq);
+        }
+    }
+
+    fn frame(&mut self, data: &mut D, seat: &Seat<D>, seq: Serial) {
+        for state in self.focus.values_mut() {
+            if state.current.map(|c| c >= state.pending).unwrap_or(false) {
+                continue;
+            }
+            state.current = Some(seq);
+            if let Some((focus, _)) = state.focus.as_ref() {
+                focus.frame(seat, data, seq);
+            }
+        }
+    }
+
+    fn cancel(&mut self, data: &mut D, seat: &Seat<D>, seq: Serial) {
+        for state in self.focus.values_mut() {
+            if state.current.map(|c| c >= state.pending).unwrap_or(false) {
+                continue;
+            }
+            state.current = Some(seq);
+            if let Some((focus, _)) = state.focus.take() {
+                focus.cancel(seat, data, seq);
+            }
+        }
+    }
+
+    fn with_grab<F>(&mut self, seat: &Seat<D>, f: F)
+    where
+        F: FnOnce(&mut TouchInnerHandle<'_, D>, &mut dyn TouchGrab<D>),
+    {
+        let mut grab = std::mem::replace(&mut self.grab, GrabStatus::Borrowed);
+        match grab {
+            GrabStatus::Borrowed => panic!("Accessed a touch grab from within a touch grab access."),
+            GrabStatus::Active(_, ref mut handler) => {
+                // If this grab is associated with a surface that is no longer alive, discard it
+                if let Some((ref focus, _)) = handler.start_data().focus {
+                    if !focus.alive() {
+                        self.grab = GrabStatus::None;
+                        f(&mut TouchInnerHandle { inner: self, seat }, &mut DefaultGrab);
+                        return;
+                    }
+                }
+                f(&mut TouchInnerHandle { inner: self, seat }, &mut **handler);
+            }
+            GrabStatus::None => {
+                f(&mut TouchInnerHandle { inner: self, seat }, &mut DefaultGrab);
+            }
+        }
+
+        if let GrabStatus::Borrowed = self.grab {
+            // the grab has not been ended nor replaced, put it back in place
+            self.grab = grab;
+        }
+    }
+}

--- a/src/utils/serial.rs
+++ b/src/utils/serial.rs
@@ -3,9 +3,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 /// A global [`SerialCounter`] for use in your compositor.
 ///
 /// Is is also used internally by some parts of Smithay.
-pub static SERIAL_COUNTER: SerialCounter = SerialCounter {
-    serial: AtomicU32::new(1),
-};
+pub static SERIAL_COUNTER: SerialCounter = SerialCounter::new();
 
 /// A serial type, whose comparison takes into account the wrapping-around behavior of the
 /// underlying counter.
@@ -69,6 +67,13 @@ pub struct SerialCounter {
 }
 
 impl SerialCounter {
+    /// Create a new counter starting at `1`
+    pub const fn new() -> Self {
+        Self {
+            serial: AtomicU32::new(1),
+        }
+    }
+
     /// Retrieve the next serial from the counter
     pub fn next_serial(&self) -> Serial {
         let _ = self

--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -19,6 +19,7 @@
 //! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
 //! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
+//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
 //! #   Seat, SeatHandler, SeatState,
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
@@ -67,6 +68,15 @@
 //! #   ) {}
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
+//! # impl TouchTarget<State> for Target {
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
+//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
+//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
+//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+//! # }
 //! # struct State {
 //! #     seat_state: SeatState<Self>,
 //! # };
@@ -74,6 +84,7 @@
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = Target;
 //! #     type PointerFocus = Target;
+//! #     type TouchFocus = Target;
 //! #
 //! #     fn seat_state(&mut self) -> &mut SeatState<Self> {
 //! #         &mut self.seat_state

--- a/src/wayland/idle_notify/mod.rs
+++ b/src/wayland/idle_notify/mod.rs
@@ -23,6 +23,7 @@
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = WlSurface;
 //! #     type PointerFocus = WlSurface;
+//! #     type TouchFocus = WlSurface;
 //! #     fn seat_state(&mut self) -> &mut SeatState<Self> { unimplemented!() }
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }

--- a/src/wayland/input_method/mod.rs
+++ b/src/wayland/input_method/mod.rs
@@ -39,6 +39,7 @@
 //! impl SeatHandler for State {
 //!     type KeyboardFocus = WlSurface;
 //!     type PointerFocus = WlSurface;
+//!     type TouchFocus = WlSurface;
 //!     fn seat_state(&mut self) -> &mut SeatState<Self> {
 //!         &mut self.seat_state
 //!     }

--- a/src/wayland/keyboard_shortcuts_inhibit/mod.rs
+++ b/src/wayland/keyboard_shortcuts_inhibit/mod.rs
@@ -183,6 +183,7 @@ pub trait KeyboardShortcutsInhibitorSeat {
     /// # impl SeatHandler for State {
     /// #     type KeyboardFocus = WlSurface;
     /// #     type PointerFocus = WlSurface;
+    /// #     type TouchFocus = WlSurface;
     /// #     fn seat_state(&mut self) -> &mut SeatState<Self> { unimplemented!() }
     /// #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
     /// #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }

--- a/src/wayland/pointer_gestures.rs
+++ b/src/wayland/pointer_gestures.rs
@@ -28,6 +28,7 @@
 //! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
 //! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
+//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
 //! #   Seat, SeatHandler, SeatState,
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
@@ -68,6 +69,15 @@
 //! #   ) {}
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
+//! # impl TouchTarget<State> for Target {
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
+//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
+//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
+//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+//! # }
 //! # struct State {
 //! #     seat_state: SeatState<Self>,
 //! # };
@@ -75,6 +85,7 @@
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = Target;
 //! #     type PointerFocus = Target;
+//! #     type TouchFocus = Target;
 //! #
 //! #     fn seat_state(&mut self) -> &mut SeatState<Self> {
 //! #         &mut self.seat_state

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -16,6 +16,7 @@
 //! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
 //! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
+//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
 //! #   Seat, SeatHandler, SeatState,
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
@@ -56,6 +57,15 @@
 //! #   ) {}
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
+//! # impl TouchTarget<State> for Target {
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
+//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
+//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
+//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+//! # }
 //! # struct State {
 //! #     seat_state: SeatState<Self>,
 //! # };
@@ -63,6 +73,7 @@
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = Target;
 //! #     type PointerFocus = Target;
+//! #     type TouchFocus = Target;
 //! #
 //! #     fn seat_state(&mut self) -> &mut SeatState<Self> {
 //! #         &mut self.seat_state

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::fmt;
 
 use wayland_server::{
     backend::ClientId,
@@ -10,186 +7,116 @@ use wayland_server::{
 };
 
 use super::{SeatHandler, SeatState};
-use crate::backend::input::TouchSlot;
-use crate::utils::Serial;
-use crate::utils::{Logical, Point};
-use crate::wayland::seat::wl_surface::WlSurface;
+use crate::input::touch::TouchTarget;
+use crate::input::{
+    touch::{MotionEvent, OrientationEvent, ShapeEvent},
+    Seat,
+};
+use crate::{input::touch::DownEvent, wayland::seat::wl_surface::WlSurface};
+use crate::{input::touch::TouchHandle, utils::Serial};
 
-/// An handle to a touch handler.
-///
-/// It can be cloned and all clones manipulate the same internal state.
-///
-/// This handle gives you access to an interface to send touch events to your
-/// clients.
-#[derive(Debug, Clone)]
-pub struct TouchHandle {
-    inner: Arc<Mutex<TouchInternal>>,
-}
-
-impl TouchHandle {
-    pub(crate) fn new() -> Self {
-        Self {
-            inner: Default::default(),
-        }
-    }
-
-    /// Register a new touch handle to this handler
-    ///
-    /// This should be done first, before anything else is done with this touch handle.
+impl<D: SeatHandler> TouchHandle<D> {
     pub(crate) fn new_touch(&self, touch: WlTouch) {
-        self.inner.lock().unwrap().known_handles.push(touch);
-    }
-
-    /// Notify clients about new touch points.
-    ///
-    /// The `position` parameter is in surface-local coordinates.
-    pub fn down(
-        &self,
-        serial: Serial,
-        time: u32,
-        surface: &WlSurface,
-        position: Point<f64, Logical>,
-        slot: TouchSlot,
-    ) {
-        self.inner
-            .lock()
-            .unwrap()
-            .down(serial, time, surface, position, slot);
-    }
-
-    /// Notify clients about touch point removal.
-    pub fn up(&self, serial: Serial, time: u32, slot: TouchSlot) {
-        self.inner.lock().unwrap().up(serial, time, slot);
-    }
-
-    /// Notify clients about touch motion.
-    pub fn motion(&self, time: u32, slot: TouchSlot, location: Point<f64, Logical>) {
-        self.inner.lock().unwrap().motion(time, slot, location);
-    }
-
-    /// Notify clients about touch shape changes.
-    pub fn shape(&self, slot: TouchSlot, major: f64, minor: f64) {
-        self.inner.lock().unwrap().shape(slot, major, minor);
-    }
-
-    /// Notify clients about touch shape orientation.
-    pub fn orientation(&self, slot: TouchSlot, orientation: f64) {
-        self.inner.lock().unwrap().orientation(slot, orientation);
-    }
-
-    /// Notify clients about touch cancellation.
-    ///
-    /// This should be sent by the compositor when the touch stream is recognized as
-    /// a global gesture. Cancellation applies to all currently active touch slots.
-    pub fn cancel(&self) {
-        self.inner.lock().unwrap().cancel();
+        let mut guard = self.known_instances.lock().unwrap();
+        guard.push((touch, None));
     }
 }
 
-/// Touch-slot focused Wayland client state.
-#[derive(Default, Debug)]
-struct TouchFocus {
-    surface_offset: Point<f64, Logical>,
-    handles: Vec<WlTouch>,
-}
-
-#[derive(Default, Debug)]
-struct TouchInternal {
-    known_handles: Vec<WlTouch>,
-    focus: HashMap<TouchSlot, TouchFocus>,
-}
-
-impl TouchInternal {
-    fn down(
-        &mut self,
-        serial: Serial,
-        time: u32,
-        surface: &WlSurface,
-        position: Point<f64, Logical>,
-        slot: TouchSlot,
-    ) {
-        // Update focused client state.
-        let focus = self.focus.entry(slot).or_default();
-        focus.handles.clear();
-
-        // Select all WlTouch instances associated to the active WlSurface.
-        for handle in &self.known_handles {
-            if handle.id().same_client_as(&surface.id()) {
-                focus.handles.push(handle.clone());
-            }
-        }
-
-        self.with_focused_handles(slot, |handle| {
-            handle.down(serial.into(), time, surface, slot.into(), position.x, position.y)
-        });
-    }
-
-    fn up(&mut self, serial: Serial, time: u32, slot: TouchSlot) {
-        self.with_focused_handles(slot, |handle| handle.up(serial.into(), time, slot.into()));
-
-        // Clear this slot's associated WlTouch handles.
-        if let Some(focus) = self.focus.get_mut(&slot) {
-            focus.handles.clear();
-        }
-    }
-
-    fn motion(&self, time: u32, slot: TouchSlot, location: Point<f64, Logical>) {
-        let focus = match self.focus.get(&slot) {
-            Some(slot) => slot,
-            None => return,
-        };
-
-        let (x, y) = (location - focus.surface_offset).into();
-        self.with_focused_handles(slot, |handle| handle.motion(time, slot.into(), x, y));
-    }
-
-    fn shape(&self, slot: TouchSlot, major: f64, minor: f64) {
-        self.with_focused_handles(slot, |handle| {
-            if handle.version() >= 6 {
-                handle.shape(slot.into(), major, minor);
-            }
-        });
-    }
-
-    fn orientation(&self, slot: TouchSlot, orientation: f64) {
-        self.with_focused_handles(slot, |handle| {
-            if handle.version() >= 6 {
-                handle.orientation(slot.into(), orientation);
-            }
-        });
-    }
-
-    fn cancel(&mut self) {
-        for handle in &self.known_handles {
-            handle.cancel();
-        }
-
-        self.focus.clear();
-    }
-
-    #[inline]
-    fn with_focused_handles<F>(&self, slot: TouchSlot, mut f: F)
-    where
-        F: FnMut(&WlTouch),
-    {
-        if let Some(focus) = self.focus.get(&slot) {
-            for handle in &focus.handles {
-                f(handle);
-                handle.frame();
+fn for_each_focused_touch<D: SeatHandler + 'static>(
+    seat: &Seat<D>,
+    surface: &WlSurface,
+    seq: Serial,
+    mut f: impl FnMut(WlTouch),
+) {
+    if let Some(touch) = seat.get_touch() {
+        let mut inner = touch.known_instances.lock().unwrap();
+        for (ptr, last_seq) in &mut *inner {
+            if ptr.id().same_client_as(&surface.id()) && last_seq.map(|last| last < seq).unwrap_or(true) {
+                *last_seq = Some(seq);
+                f(ptr.clone());
             }
         }
     }
 }
 
-/// User data for keyboard
-#[derive(Debug)]
-pub struct TouchUserData {
-    pub(crate) handle: Option<TouchHandle>,
-}
-
-impl<D> Dispatch<WlTouch, TouchUserData, D> for SeatState<D>
+#[cfg(feature = "wayland_frontend")]
+impl<D> TouchTarget<D> for WlSurface
 where
-    D: Dispatch<WlTouch, TouchUserData>,
+    D: SeatHandler + 'static,
+{
+    fn down(&self, seat: &Seat<D>, _data: &mut D, event: &DownEvent, seq: Serial) {
+        let serial = event.serial;
+        let slot = event.slot;
+        for_each_focused_touch(seat, self, seq, |touch| {
+            touch.down(
+                serial.into(),
+                event.time,
+                self,
+                slot.into(),
+                event.location.x,
+                event.location.y,
+            );
+        })
+    }
+
+    fn up(&self, seat: &Seat<D>, _data: &mut D, event: &crate::input::touch::UpEvent, seq: Serial) {
+        let serial = event.serial;
+        let slot = event.slot;
+        for_each_focused_touch(seat, self, seq, |touch| {
+            touch.up(serial.into(), event.time, slot.into());
+        })
+    }
+
+    fn motion(&self, seat: &Seat<D>, _data: &mut D, event: &MotionEvent, seq: Serial) {
+        let slot = event.slot;
+        for_each_focused_touch(seat, self, seq, |touch| {
+            touch.motion(event.time, slot.into(), event.location.x, event.location.y);
+        })
+    }
+
+    fn frame(&self, seat: &Seat<D>, _data: &mut D, seq: Serial) {
+        for_each_focused_touch(seat, self, seq, |touch| {
+            touch.frame();
+        })
+    }
+
+    fn cancel(&self, seat: &Seat<D>, _data: &mut D, seq: Serial) {
+        for_each_focused_touch(seat, self, seq, |touch| {
+            touch.cancel();
+        })
+    }
+
+    fn shape(&self, seat: &Seat<D>, _data: &mut D, event: &ShapeEvent, seq: Serial) {
+        let slot = event.slot;
+        for_each_focused_touch(seat, self, seq, |touch| {
+            touch.shape(slot.into(), event.major, event.minor);
+        })
+    }
+
+    fn orientation(&self, seat: &Seat<D>, _data: &mut D, event: &OrientationEvent, seq: Serial) {
+        let slot = event.slot;
+        for_each_focused_touch(seat, self, seq, |touch| {
+            touch.orientation(slot.into(), event.orientation);
+        })
+    }
+}
+
+/// User data for touch
+pub struct TouchUserData<D: SeatHandler> {
+    pub(crate) handle: Option<TouchHandle<D>>,
+}
+
+impl<D: SeatHandler> fmt::Debug for TouchUserData<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TouchUserData")
+            .field("handle", &self.handle)
+            .finish()
+    }
+}
+
+impl<D> Dispatch<WlTouch, TouchUserData<D>, D> for SeatState<D>
+where
+    D: Dispatch<WlTouch, TouchUserData<D>>,
     D: SeatHandler,
     D: 'static,
 {
@@ -198,20 +125,19 @@ where
         _client: &wayland_server::Client,
         _resource: &WlTouch,
         _request: wl_touch::Request,
-        _data: &TouchUserData,
+        _data: &TouchUserData<D>,
         _dhandle: &DisplayHandle,
         _data_init: &mut wayland_server::DataInit<'_, D>,
     ) {
     }
 
-    fn destroyed(_state: &mut D, _client_id: ClientId, touch: &WlTouch, data: &TouchUserData) {
+    fn destroyed(_state: &mut D, _client_id: ClientId, touch: &WlTouch, data: &TouchUserData<D>) {
         if let Some(ref handle) = data.handle {
             handle
-                .inner
+                .known_instances
                 .lock()
                 .unwrap()
-                .known_handles
-                .retain(|k| k.id() != touch.id())
+                .retain(|(p, _)| p.id() != touch.id());
         }
     }
 }

--- a/src/wayland/selection/primary_selection/mod.rs
+++ b/src/wayland/selection/primary_selection/mod.rs
@@ -46,6 +46,7 @@
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = WlSurface;
 //! #     type PointerFocus = WlSurface;
+//! #     type TouchFocus = WlSurface;
 //! #     fn seat_state(&mut self) -> &mut SeatState<Self> { unimplemented!() }
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }

--- a/src/wayland/selection/wlr_data_control/mod.rs
+++ b/src/wayland/selection/wlr_data_control/mod.rs
@@ -27,6 +27,7 @@
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = WlSurface;
 //! #     type PointerFocus = WlSurface;
+//! #     type TouchFocus = WlSurface;
 //! #     fn seat_state(&mut self) -> &mut SeatState<Self> { unimplemented!() }
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }

--- a/src/wayland/shell/xdg/decoration.rs
+++ b/src/wayland/shell/xdg/decoration.rs
@@ -68,6 +68,7 @@
 //! impl SeatHandler for State {
 //!     type KeyboardFocus = Target;
 //!     type PointerFocus = Target;
+//!     type TouchFocus = Target;
 //!
 //!     fn seat_state(&mut self) -> &mut SeatState<Self> {
 //!         &mut self.seat_state

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -81,6 +81,7 @@
 //! impl SeatHandler for State {
 //!     type KeyboardFocus = Target;
 //!     type PointerFocus = Target;
+//!     type TouchFocus = Target;
 //!
 //!     fn seat_state(&mut self) -> &mut SeatState<Self> {
 //!         &mut self.seat_state

--- a/src/wayland/tablet_manager/mod.rs
+++ b/src/wayland/tablet_manager/mod.rs
@@ -40,6 +40,7 @@
 //! impl SeatHandler for State {
 //!     type KeyboardFocus = WlSurface;
 //!     type PointerFocus = WlSurface;
+//!     type TouchFocus = WlSurface;
 //!     fn seat_state(&mut self) -> &mut SeatState<Self> {
 //!         &mut self.seat_state
 //!     }

--- a/src/wayland/text_input/mod.rs
+++ b/src/wayland/text_input/mod.rs
@@ -28,6 +28,7 @@
 //! impl SeatHandler for State {
 //!     type KeyboardFocus = WlSurface;
 //!     type PointerFocus = WlSurface;
+//!     type TouchFocus = WlSurface;
 //!     fn seat_state(&mut self) -> &mut SeatState<Self> {
 //!         &mut self.seat_state
 //!     }

--- a/src/wayland/virtual_keyboard/mod.rs
+++ b/src/wayland/virtual_keyboard/mod.rs
@@ -27,6 +27,7 @@
 //! impl SeatHandler for State {
 //!     type KeyboardFocus = WlSurface;
 //!     type PointerFocus = WlSurface;
+//!     type TouchFocus = WlSurface;
 //!     fn seat_state(&mut self) -> &mut SeatState<Self> {
 //!         &mut self.seat_state
 //!     }

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -19,6 +19,7 @@
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = WlSurface;
 //! #     type PointerFocus = WlSurface;
+//! #     type TouchFocus = WlSurface;
 //! #     fn seat_state(&mut self) -> &mut SeatState<Self> { unimplemented!() }
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -7,6 +7,7 @@ use crate::{
             GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
             GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
         },
+        touch::TouchTarget,
         Seat, SeatHandler,
     },
     utils::{user_data::UserDataMap, IsAlive, Logical, Rectangle, Serial, Size},
@@ -993,6 +994,56 @@ impl<D: SeatHandler + 'static> PointerTarget<D> for X11Surface {
     fn gesture_hold_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldEndEvent) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
             PointerTarget::gesture_hold_end(surface, seat, data, event)
+        }
+    }
+}
+
+impl<D: SeatHandler + 'static> TouchTarget<D> for X11Surface {
+    fn down(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::DownEvent, seq: Serial) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TouchTarget::down(surface, seat, data, event, seq)
+        }
+    }
+
+    fn up(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::UpEvent, seq: Serial) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TouchTarget::up(surface, seat, data, event, seq)
+        }
+    }
+
+    fn motion(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::MotionEvent, seq: Serial) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TouchTarget::motion(surface, seat, data, event, seq)
+        }
+    }
+
+    fn frame(&self, seat: &Seat<D>, data: &mut D, seq: Serial) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TouchTarget::frame(surface, seat, data, seq)
+        }
+    }
+
+    fn cancel(&self, seat: &Seat<D>, data: &mut D, seq: Serial) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TouchTarget::cancel(surface, seat, data, seq)
+        }
+    }
+
+    fn shape(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::ShapeEvent, seq: Serial) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TouchTarget::shape(surface, seat, data, event, seq)
+        }
+    }
+
+    fn orientation(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        event: &crate::input::touch::OrientationEvent,
+        seq: Serial,
+    ) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TouchTarget::orientation(surface, seat, data, event, seq)
         }
     }
 }


### PR DESCRIPTION
The current implementation has a few limitations and does not provide an abstraction on the same level as pointer or keyboard. For proper support including DnD we also need to support grabs. 

This also removes the implementation of `PointerTarget` and `KeyboardTarget` on the desktop abstractions. I described the motivation behind this [here](https://github.com/Smithay/smithay/pull/1334#issuecomment-1949422631)
The last commit also implements the base for the idea mentioned in the above comment.