### PR TITLE
Add `Frame::{set_,}{up,down}scale_filter()`

### DIFF
--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -79,6 +79,10 @@
 //! #         unimplemented!()
 //! #     }
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
+//! #     fn set_downscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn set_upscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn downscale_filter(&self) -> TextureFilter { unimplemented!() }
+//! #     fn upscale_filter(&self) -> TextureFilter { unimplemented!() }
 //! # }
 //! #
 //! # #[derive(Debug)]

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -75,6 +75,10 @@
 //! #         unimplemented!()
 //! #     }
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
+//! #     fn set_downscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn set_upscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn downscale_filter(&self) -> TextureFilter { unimplemented!() }
+//! #     fn upscale_filter(&self) -> TextureFilter { unimplemented!() }
 //! # }
 //! #
 //! # #[derive(Debug)]

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -1292,6 +1292,10 @@ macro_rules! render_elements_internal {
 /// #         unimplemented!()
 /// #     }
 /// #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
+/// #     fn set_downscale_filter(&mut self, _filter: TextureFilter) {}
+/// #     fn set_upscale_filter(&mut self, _filter: TextureFilter) {}
+/// #     fn downscale_filter(&self) -> TextureFilter { unimplemented!() }
+/// #     fn upscale_filter(&self) -> TextureFilter { unimplemented!() }
 /// # }
 /// #
 /// # #[derive(Debug)]

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -62,6 +62,10 @@
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> {
 //! #         unimplemented!()
 //! #     }
+//! #     fn set_downscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn set_upscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn downscale_filter(&self) -> TextureFilter { unimplemented!() }
+//! #     fn upscale_filter(&self) -> TextureFilter { unimplemented!() }
 //! # }
 //! #
 //! # #[derive(Debug)]

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -78,6 +78,10 @@
 //! #         unimplemented!()
 //! #     }
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
+//! #     fn set_downscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn set_upscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn downscale_filter(&self) -> TextureFilter { unimplemented!() }
+//! #     fn upscale_filter(&self) -> TextureFilter { unimplemented!() }
 //! # }
 //! #
 //! # #[derive(Debug)]

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -93,6 +93,10 @@
 //! #         unimplemented!()
 //! #     }
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
+//! #     fn set_downscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn set_upscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn downscale_filter(&self) -> TextureFilter { unimplemented!() }
+//! #     fn upscale_filter(&self) -> TextureFilter { unimplemented!() }
 //! # }
 //! #
 //! # #[derive(Debug)]
@@ -250,6 +254,10 @@
 //! #         unimplemented!()
 //! #     }
 //! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
+//! #     fn set_downscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn set_upscale_filter(&mut self, _filter: TextureFilter) {}
+//! #     fn downscale_filter(&self) -> TextureFilter { unimplemented!() }
+//! #     fn upscale_filter(&self) -> TextureFilter { unimplemented!() }
 //! # }
 //! #
 //! # #[derive(Debug)]

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -2529,6 +2529,22 @@ impl<'frame> Frame for GlesFrame<'frame> {
     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> {
         self.renderer.wait(sync)
     }
+
+    fn set_downscale_filter(&mut self, filter: TextureFilter) {
+        self.renderer.min_filter = filter;
+    }
+
+    fn set_upscale_filter(&mut self, filter: TextureFilter) {
+        self.renderer.max_filter = filter;
+    }
+
+    fn downscale_filter(&self) -> TextureFilter {
+        self.renderer.min_filter
+    }
+
+    fn upscale_filter(&self) -> TextureFilter {
+        self.renderer.max_filter
+    }
 }
 
 impl<'frame> GlesFrame<'frame> {

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -315,6 +315,22 @@ impl<'frame> Frame for GlowFrame<'frame> {
     fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
         self.frame.as_mut().unwrap().wait(sync)
     }
+
+    fn set_downscale_filter(&mut self, filter: TextureFilter) {
+        self.frame.as_mut().unwrap().set_downscale_filter(filter);
+    }
+
+    fn set_upscale_filter(&mut self, filter: TextureFilter) {
+        self.frame.as_mut().unwrap().set_upscale_filter(filter);
+    }
+
+    fn downscale_filter(&self) -> TextureFilter {
+        self.frame.as_ref().unwrap().downscale_filter()
+    }
+
+    fn upscale_filter(&self) -> TextureFilter {
+        self.frame.as_ref().unwrap().upscale_filter()
+    }
 }
 
 impl<'frame> GlowFrame<'frame> {

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -242,6 +242,17 @@ pub trait Frame {
     /// Leaking might make the renderer return Errors and force it's recreation.
     /// Leaking may not cause otherwise undefined behavior and program execution will always continue normally.
     fn finish(self) -> Result<sync::SyncPoint, Self::Error>;
+
+    /// Set the filter method to be used when rendering a texture into a smaller area than its
+    /// size.
+    fn set_downscale_filter(&mut self, filter: TextureFilter);
+    /// Set the filter method to be used when rendering a texture into a larger area than its size.
+    fn set_upscale_filter(&mut self, filter: TextureFilter);
+
+    /// Get the current downscale filter.
+    fn downscale_filter(&self) -> TextureFilter;
+    /// Get the current upscale filter.
+    fn upscale_filter(&self) -> TextureFilter;
 }
 
 bitflags::bitflags! {

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1556,6 +1556,22 @@ where
     fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
         self.frame.as_mut().unwrap().wait(sync).map_err(Error::Render)
     }
+
+    fn set_downscale_filter(&mut self, filter: TextureFilter) {
+        self.frame.as_mut().unwrap().set_downscale_filter(filter);
+    }
+
+    fn set_upscale_filter(&mut self, filter: TextureFilter) {
+        self.frame.as_mut().unwrap().set_upscale_filter(filter);
+    }
+
+    fn downscale_filter(&self) -> TextureFilter {
+        self.frame.as_ref().unwrap().downscale_filter()
+    }
+
+    fn upscale_filter(&self) -> TextureFilter {
+        self.frame.as_ref().unwrap().upscale_filter()
+    }
 }
 
 #[cfg(feature = "wayland_frontend")]

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -598,6 +598,22 @@ impl<'frame> Frame for PixmanFrame<'frame> {
     fn finish(mut self) -> Result<super::sync::SyncPoint, Self::Error> {
         self.finish_internal()
     }
+
+    fn set_downscale_filter(&mut self, filter: TextureFilter) {
+        self.renderer.downscale_filter = filter;
+    }
+
+    fn set_upscale_filter(&mut self, filter: TextureFilter) {
+        self.renderer.upscale_filter = filter;
+    }
+
+    fn downscale_filter(&self) -> TextureFilter {
+        self.renderer.downscale_filter
+    }
+
+    fn upscale_filter(&self) -> TextureFilter {
+        self.renderer.upscale_filter
+    }
 }
 
 impl<'frame> PixmanFrame<'frame> {

--- a/src/backend/renderer/test.rs
+++ b/src/backend/renderer/test.rs
@@ -216,6 +216,15 @@ impl Frame for DummyFrame {
     fn finish(self) -> Result<SyncPoint, Self::Error> {
         Ok(SyncPoint::default())
     }
+
+    fn set_downscale_filter(&mut self, _filter: TextureFilter) {}
+    fn set_upscale_filter(&mut self, _filter: TextureFilter) {}
+    fn downscale_filter(&self) -> TextureFilter {
+        TextureFilter::Linear
+    }
+    fn upscale_filter(&self) -> TextureFilter {
+        TextureFilter::Linear
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Allows changing the filter on the fly, especially useful within `RenderElements::draw()` where the renderer is inaccessible.

Example use: https://github.com/YaLTeR/niri/pull/189