### PR TITLE
Advertise dmabuf v5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tempfile = { version = "3.0", optional = true }
 thiserror = "1.0.25"
 udev = { version = "0.8.0", optional = true }
 wayland-egl = { version = "0.32.0", optional = true }
-wayland-protocols = { version = "0.31.0", features = ["unstable", "staging", "server"], optional = true }
+wayland-protocols = { version = "0.31.2", features = ["unstable", "staging", "server"], optional = true }
 wayland-protocols-wlr = { version = "0.2.0", features = ["server"], optional = true }
 wayland-protocols-misc = { version = "0.2.0", features = ["server"], optional = true }
 wayland-server = { version = "0.31.0", optional = true }

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -709,12 +709,7 @@ impl DmabufState {
             );
 
         let formats = Arc::new(formats);
-        let version = if default_feedback.is_some() {
-            // TODO: Update to 5 when wayland-protocols is updated
-            4
-        } else {
-            3
-        };
+        let version = if default_feedback.is_some() { 5 } else { 3 };
 
         let known_default_feedbacks = Arc::new(Mutex::new(Vec::new()));
         let default_feedback = default_feedback.map(|f| Arc::new(Mutex::new(f.clone())));


### PR DESCRIPTION
The code to raise a protocol error if planes had different modifiers is already present, this just needed `wayland-protocols` to support version 5.