### PR TITLE
desktop/window: Fix `bbox()` for XWayland Windows

### DIFF
--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "xwayland")]
-use crate::xwayland::X11Surface;
 use crate::{
     backend::input::KeyState,
     desktop::{space::RenderZindex, utils::*, PopupManager},
@@ -21,6 +19,8 @@ use crate::{
         shell::xdg::{SurfaceCachedState, ToplevelSurface},
     },
 };
+#[cfg(feature = "xwayland")]
+use crate::{desktop::space::SpaceElement, xwayland::X11Surface};
 use std::{
     hash::{Hash, Hasher},
     sync::{
@@ -170,7 +170,11 @@ impl Window {
 
     /// Returns a bounding box over this window and its children.
     pub fn bbox(&self) -> Rectangle<i32, Logical> {
-        *self.0.bbox.lock().unwrap()
+        match &self.0.surface {
+            WindowSurface::Wayland(_) => *self.0.bbox.lock().unwrap(),
+            #[cfg(feature = "xwayland")]
+            WindowSurface::X11(s) => s.bbox(),
+        }
     }
 
     /// Returns a bounding box over this window and children including popups.


### PR DESCRIPTION
This fixes a bug with the latest version of Epiphany not rendering/working, when run in XWayland, on anvil or cosmic-comp, as reported on https://github.com/Smithay/smithay/pull/1319. Presumably it fixes similar issues reported with other clients; not sure why this doesn't break XWayland more consistently...

`xtrace` shows `ConfigureNotify` was being sent with a size of `(0, 0)` because of this. If `Window::bbox` calls `X11Surface::bbox`, the behavior should be the same as it was before the `Window` change.

This probably isn't the best way to do things, with a `bbox` field that's only used for Wayland toplevels. Not sure what would be better.