### PR TITLE
input: reset pointer image on leave

### DIFF
--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -752,6 +752,7 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
             };
         } else if let Some((old_focus, _)) = self.focus.take() {
             old_focus.leave(seat, data, event.serial, event.time);
+            data.cursor_image(seat, CursorImageStatus::default_named());
         }
     }
 


### PR DESCRIPTION
when nothing is focused we need to reset the cursor image. this has been accidentally removed during touch re-factor.
before the touch re-factor the cursor would have been reset whenever the focus changes, but it should be fine to
only reset it when there is no focus at all.

From the spec:
> When a seat's focus enters a surface, the pointer image is undefined and a client should respond to this event by setting an appropriate pointer image with the set_cursor request.