### PR TITLE
fix buffer offset handling

### DIFF
--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -152,6 +152,22 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
             }
             if let Some(window) = self.window_for_surface(&root) {
                 window.0.on_commit();
+
+                if &root == surface {
+                    let buffer_offset = with_states(surface, |states| {
+                        states
+                            .cached_state
+                            .get::<SurfaceAttributes>()
+                            .current()
+                            .buffer_delta
+                            .take()
+                    });
+
+                    if let Some(buffer_offset) = buffer_offset {
+                        let current_loc = self.space.element_location(&window).unwrap();
+                        self.space.map_element(window, current_loc + buffer_offset, false);
+                    }
+                }
             }
         }
         self.popups.commit(surface);

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -178,6 +178,21 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
             });
         }
 
+        if matches!(&self.dnd_icon, Some(icon) if &icon.surface == surface) {
+            let dnd_icon = self.dnd_icon.as_mut().unwrap();
+            with_states(&dnd_icon.surface, |states| {
+                let buffer_delta = states
+                    .cached_state
+                    .get::<SurfaceAttributes>()
+                    .current()
+                    .buffer_delta
+                    .take()
+                    .unwrap_or_default();
+                tracing::trace!(offset = ?dnd_icon.offset, ?buffer_delta, "moving dnd offset");
+                dnd_icon.offset += buffer_delta;
+            });
+        }
+
         ensure_initial_configure(surface, &self.space, &mut self.popups)
     }
 }

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -277,8 +277,7 @@ pub fn run_winit() {
             } else {
                 (0, 0).into()
             };
-            let cursor_pos = state.pointer.current_location() - cursor_hotspot.to_f64();
-            let cursor_pos_scaled = cursor_pos.to_physical(scale).to_i32_round();
+            let cursor_pos = state.pointer.current_location();
 
             #[cfg(feature = "debug")]
             let mut renderdoc = state.renderdoc.as_mut();
@@ -310,15 +309,27 @@ pub fn run_winit() {
 
                 let mut elements = Vec::<CustomRenderElements<GlesRenderer>>::new();
 
-                elements.extend(pointer_element.render_elements(renderer, cursor_pos_scaled, scale, 1.0));
+                elements.extend(
+                    pointer_element.render_elements(
+                        renderer,
+                        (cursor_pos - cursor_hotspot.to_f64())
+                            .to_physical(scale)
+                            .to_i32_round(),
+                        scale,
+                        1.0,
+                    ),
+                );
 
                 // draw the dnd icon if any
-                if let Some(surface) = dnd_icon {
-                    if surface.alive() {
+                if let Some(icon) = dnd_icon {
+                    let dnd_icon_pos = (cursor_pos + icon.offset.to_f64())
+                        .to_physical(scale)
+                        .to_i32_round();
+                    if icon.surface.alive() {
                         elements.extend(AsRenderElements::<GlesRenderer>::render_elements(
-                            &smithay::desktop::space::SurfaceTree::from_surface(surface),
+                            &smithay::desktop::space::SurfaceTree::from_surface(&icon.surface),
                             renderer,
-                            cursor_pos_scaled,
+                            dnd_icon_pos,
                             scale,
                             1.0,
                         ));

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -346,24 +346,30 @@ pub fn run_x11() {
             } else {
                 (0, 0).into()
             };
-            let cursor_pos = state.pointer.current_location() - cursor_hotspot.to_f64();
-            let cursor_pos_scaled = cursor_pos.to_physical(scale).to_i32_round();
+            let cursor_pos = state.pointer.current_location();
 
             pointer_element.set_status(state.cursor_status.clone());
-            elements.extend(pointer_element.render_elements(
-                &mut backend_data.renderer,
-                cursor_pos_scaled,
-                scale,
-                1.0,
-            ));
+            elements.extend(
+                pointer_element.render_elements(
+                    &mut backend_data.renderer,
+                    (cursor_pos - cursor_hotspot.to_f64())
+                        .to_physical(scale)
+                        .to_i32_round(),
+                    scale,
+                    1.0,
+                ),
+            );
 
             // draw the dnd icon if any
-            if let Some(surface) = state.dnd_icon.as_ref() {
-                if surface.alive() {
+            if let Some(icon) = state.dnd_icon.as_ref() {
+                let dnd_icon_pos = (cursor_pos + icon.offset.to_f64())
+                    .to_physical(scale)
+                    .to_i32_round();
+                if icon.surface.alive() {
                     elements.extend(AsRenderElements::<GlesRenderer>::render_elements(
-                        &smithay::desktop::space::SurfaceTree::from_surface(surface),
+                        &smithay::desktop::space::SurfaceTree::from_surface(&icon.surface),
                         &mut backend_data.renderer,
-                        cursor_pos_scaled,
+                        dnd_icon_pos,
                         scale,
                         1.0,
                     ));

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -115,19 +115,30 @@ pub fn run(channel: Channel<WlcsEvent>) {
             } else {
                 (0, 0).into()
             };
-            let cursor_pos = state.pointer.current_location() - cursor_hotspot.to_f64();
-            let cursor_pos_scaled = cursor_pos.to_physical(scale).to_i32_round();
+            let cursor_pos = state.pointer.current_location();
 
             pointer_element.set_status(state.cursor_status.clone());
-            elements.extend(pointer_element.render_elements(&mut renderer, cursor_pos_scaled, scale, 1.0));
+            elements.extend(
+                pointer_element.render_elements(
+                    &mut renderer,
+                    (cursor_pos - cursor_hotspot.to_f64())
+                        .to_physical(scale)
+                        .to_i32_round(),
+                    scale,
+                    1.0,
+                ),
+            );
 
             // draw the dnd icon if any
-            if let Some(surface) = state.dnd_icon.as_ref() {
-                if surface.alive() {
+            if let Some(icon) = state.dnd_icon.as_ref() {
+                if icon.surface.alive() {
+                    let dnd_icon_pos = (cursor_pos + icon.offset.to_f64())
+                        .to_physical(scale)
+                        .to_i32_round();
                     elements.extend(AsRenderElements::<DummyRenderer>::render_elements(
-                        &smithay::desktop::space::SurfaceTree::from_surface(surface),
+                        &smithay::desktop::space::SurfaceTree::from_surface(&icon.surface),
                         &mut renderer,
-                        cursor_pos_scaled,
+                        dnd_icon_pos,
                         scale,
                         1.0,
                     ));


### PR DESCRIPTION
fixes the regression introduced in https://github.com/Smithay/smithay/pull/1123#issuecomment-1953661036
(not that is was working correctly before, but pointer was broken at bit less)

what I do not like is all the manual plumbing in the Dnd handling, handling this in smithay will require re-structuring a few things. From the spec of DnD start:

> The icon surface is an optional (can be NULL) surface that provides an icon to be moved around with the cursor. Initially, the top-left corner of the icon surface is placed at the cursor hotspot, but subsequent wl_surface.attach request can move the relative position.

According to this we need the cursor hotspot at the start of the grab to initialize the DnD icon offset. But as the hotspot is stored in the current pointer surface we can no access it in smithay. On commit of the DnD icon we need to be able to change the current DnD offset by the surface offset if any. But again we can not do this internally as we have no access to the icon.

We can probably do better by either:
- moving some parts that are now in anvil/downstream into smithay
- providing some helpers
- requiring access to some state held by downstream (similar to `SeatState`)

based on https://github.com/Smithay/smithay/pull/1340