### PR TITLE
[wayland.compositor] Removable hooks

### DIFF
--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -134,7 +134,7 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
                     }
                 }
             }
-        })
+        });
     }
 
     fn commit(&mut self, surface: &WlSurface) {

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -305,7 +305,7 @@ where
             .compositor_state()
             .surfaces
             .retain(|s| s.id() != surface.id());
-        PrivateSurfaceData::cleanup(state, data, surface.id());
+        PrivateSurfaceData::cleanup(state, data, surface);
     }
 }
 

--- a/src/wayland/compositor/hook.rs
+++ b/src/wayland/compositor/hook.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+crate::utils::ids::id_gen!(next_hooks_id, HOOK_ID, HOOKS_IDS);
+
+/// Unique hook identifier used to unregister commit/descruction hooks
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct HookId(usize);
+
+pub(super) struct Hook<T: ?Sized> {
+    pub id: HookId,
+    pub cb: Arc<T>,
+}
+
+impl<T: ?Sized> Clone for Hook<T> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            cb: self.cb.clone(),
+        }
+    }
+}
+
+impl<T: ?Sized> Hook<T> {
+    pub fn new(cb: Arc<T>) -> Self {
+        Self {
+            id: HookId(next_hooks_id()),
+            cb,
+        }
+    }
+}
+
+impl<T: ?Sized> Drop for Hook<T> {
+    fn drop(&mut self) {
+        HOOKS_IDS.lock().unwrap().remove(&self.id.0);
+    }
+}


### PR DESCRIPTION
[[wayland.compositor] Removable hooks](https://github.com/Smithay/smithay/commit/2f1833259db1737c3613bf4b3344221570e60fee) - Adds `HookId`, and a way to use it to unregister the hooks. Also brings destruction hook inline with other hooks by unlocking the mutex during a hook call.
[[wayland.compositor] Use lock_user_data for all methods](https://github.com/Smithay/smithay/commit/a7e52006726aceb3070b8e0e5140d990dfc64a7e) - While at it, use user data getter added in previous commit in other unrelated functions to clean up the code a bit.