### PR TITLE
Perf/reduce mem allocations

### DIFF
--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -190,15 +190,15 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn render_output<R>(
-    output: &Output,
-    space: &Space<WindowElement>,
+pub fn render_output<'a, 'd, R>(
+    output: &'a Output,
+    space: &'a Space<WindowElement>,
     custom_elements: impl IntoIterator<Item = CustomRenderElements<R>>,
-    renderer: &mut R,
-    damage_tracker: &mut OutputDamageTracker,
+    renderer: &'a mut R,
+    damage_tracker: &'d mut OutputDamageTracker,
     age: usize,
     show_window_preview: bool,
-) -> Result<RenderOutputResult, OutputDamageTrackerError<R>>
+) -> Result<RenderOutputResult<'d>, OutputDamageTrackerError<R>>
 where
     R: Renderer + ImportAll + ImportMem,
     R::TextureId: Clone + 'static,

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -359,7 +359,7 @@ pub fn run_winit() {
                 Ok(render_output_result) => {
                     let has_rendered = render_output_result.damage.is_some();
                     if let Some(damage) = render_output_result.damage {
-                        if let Err(err) = backend.submit(Some(&*damage)) {
+                        if let Err(err) = backend.submit(Some(damage)) {
                             warn!("Failed to submit buffer: {}", err);
                         }
                     }

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -397,27 +397,13 @@ pub fn run_x11() {
             match render_res {
                 Ok(render_output_result) => {
                     trace!("Finished rendering");
-                    if let Err(err) = backend_data.surface.submit() {
+                    let submitted = if let Err(err) = backend_data.surface.submit() {
                         backend_data.surface.reset_buffers();
                         warn!("Failed to submit buffer: {}. Retrying", err);
+                        false
                     } else {
-                        state.backend_data.render = false;
+                        true
                     };
-
-                    #[cfg(feature = "debug")]
-                    if render_output_result.damage.is_some() {
-                        if let Some(renderdoc) = state.renderdoc.as_mut() {
-                            renderdoc.end_frame_capture(
-                                state.backend_data.renderer.egl_context().get_context_handle(),
-                                std::ptr::null(),
-                            );
-                        }
-                    } else if let Some(renderdoc) = state.renderdoc.as_mut() {
-                        renderdoc.discard_frame_capture(
-                            state.backend_data.renderer.egl_context().get_context_handle(),
-                            std::ptr::null(),
-                        );
-                    }
 
                     // Send frame events so that client start drawing their next frame
                     let time = state.clock.now();
@@ -436,6 +422,23 @@ pub fn run_x11() {
                             wp_presentation_feedback::Kind::Vsync,
                         )
                     }
+
+                    #[cfg(feature = "debug")]
+                    if render_output_result.damage.is_some() {
+                        if let Some(renderdoc) = state.renderdoc.as_mut() {
+                            renderdoc.end_frame_capture(
+                                state.backend_data.renderer.egl_context().get_context_handle(),
+                                std::ptr::null(),
+                            );
+                        }
+                    } else if let Some(renderdoc) = state.renderdoc.as_mut() {
+                        renderdoc.discard_frame_capture(
+                            state.backend_data.renderer.egl_context().get_context_handle(),
+                            std::ptr::null(),
+                        );
+                    }
+
+                    state.backend_data.render = !submitted;
                 }
                 Err(err) => {
                     #[cfg(feature = "debug")]

--- a/src/backend/allocator/gbm.rs
+++ b/src/backend/allocator/gbm.rs
@@ -124,6 +124,9 @@ impl<T> Buffer for GbmBuffer<T> {
 
     fn format(&self) -> Format {
         Format {
+            // FIXME: self.format() calls drm_fourcc::Format::try_from which would be a good candidate for inline, but it is not. Fix in drm_fourcc
+            // Also we should think about caching the format and modifier, it should probably not change during runtime...same for all fields actually
+            // as those upgrade a weak each time
             code: self.format().unwrap_or(Fourcc::Argb8888), // we got to return something, but this should never happen anyway
             modifier: self.modifier().unwrap_or(Modifier::Invalid),
         }

--- a/src/backend/drm/compositor/elements.rs
+++ b/src/backend/drm/compositor/elements.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::renderer::{
         element::{Element, Id, RenderElement},
-        utils::CommitCounter,
+        utils::{CommitCounter, DamageSet},
         Frame, Renderer,
     },
     render_elements,
@@ -154,12 +154,8 @@ impl Element for OverlayPlaneElement {
         Transform::Normal
     }
 
-    fn damage_since(
-        &self,
-        _scale: Scale<f64>,
-        _commit: Option<CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
-        vec![]
+    fn damage_since(&self, _scale: Scale<f64>, _commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
+        DamageSet::default()
     }
 
     fn opaque_regions(&self, _scale: Scale<f64>) -> Vec<Rectangle<i32, Physical>> {

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -162,7 +162,7 @@ use crate::{
                 RenderElementStates, RenderingReason, UnderlyingStorage,
             },
             sync::SyncPoint,
-            utils::{CommitCounter, DamageBag, DamageSnapshot},
+            utils::{CommitCounter, DamageBag, DamageSet, DamageSnapshot},
             Bind, Blit, DebugFlags, Frame as RendererFrame, Renderer, Texture,
         },
         SwapBuffersError,
@@ -974,11 +974,7 @@ impl<'a, 'b, B: Buffer> Element for SwapchainElement<'a, 'b, B> {
         self.transform
     }
 
-    fn damage_since(
-        &self,
-        scale: Scale<f64>,
-        commit: Option<CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
+    fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
         self.damage
             .damage_since(commit)
             .map(|d| {
@@ -986,7 +982,7 @@ impl<'a, 'b, B: Buffer> Element for SwapchainElement<'a, 'b, B> {
                     .map(|d| d.to_logical(1, self.transform, &self.slot.size()).to_physical(1))
                     .collect()
             })
-            .unwrap_or_else(|| vec![self.geometry(scale)])
+            .unwrap_or_else(|| DamageSet::from_slice(&[self.geometry(scale)]))
     }
 
     fn opaque_regions(&self, scale: Scale<f64>) -> Vec<Rectangle<i32, Physical>> {
@@ -1046,11 +1042,7 @@ where
         }
     }
 
-    fn damage_since(
-        &self,
-        scale: Scale<f64>,
-        commit: Option<CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
+    fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
         match self {
             FrameResultDamageElement::Element(e) => e.damage_since(scale, commit),
             FrameResultDamageElement::Swapchain(e) => e.damage_since(scale, commit),

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -789,7 +789,8 @@ impl OutputDamageTracker {
         <R as Renderer>::TextureId: Texture,
         F: FnOnce(&mut R) -> Result<(), <R as Renderer>::Error>,
     {
-        let (output_size, output_scale, output_transform) = self.mode.clone().try_into()?;
+        let (output_size, output_scale, output_transform) =
+            std::convert::TryInto::<(Size<i32, Physical>, Scale<f64>, Transform)>::try_into(&self.mode)?;
 
         // Output transform is specified in surface-rotation, so inversion gives us the
         // render transform for the output itself.

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -282,6 +282,9 @@ pub struct OutputDamageTracker {
     mode: OutputModeSource,
     last_state: RendererState,
     damage_shaper: DamageShaper,
+    damage: Vec<Rectangle<i32, Physical>>,
+    element_damage: Vec<Rectangle<i32, Physical>>,
+    opaque_regions: Vec<(usize, Vec<Rectangle<i32, Physical>>)>,
     span: tracing::Span,
 }
 
@@ -298,16 +301,16 @@ pub enum Error<R: Renderer> {
 
 /// Represents the result from rendering the output
 #[derive(Debug)]
-pub struct RenderOutputResult {
+pub struct RenderOutputResult<'a> {
     /// Holds the sync point of the rendering operation
     pub sync: SyncPoint,
     /// Holds the damage from the rendering operation
-    pub damage: Option<Vec<Rectangle<i32, Physical>>>,
+    pub damage: Option<&'a Vec<Rectangle<i32, Physical>>>,
     /// Holds the render element states
     pub states: RenderElementStates,
 }
 
-impl RenderOutputResult {
+impl<'a> RenderOutputResult<'a> {
     fn skipped(states: RenderElementStates) -> Self {
         Self {
             sync: SyncPoint::signaled(),
@@ -341,6 +344,9 @@ impl OutputDamageTracker {
             },
             last_state: Default::default(),
             damage_shaper: Default::default(),
+            damage: Default::default(),
+            element_damage: Default::default(),
+            opaque_regions: Default::default(),
             span: info_span!("renderer_damage"),
         }
     }
@@ -354,6 +360,9 @@ impl OutputDamageTracker {
         Self {
             mode: OutputModeSource::Auto(output.clone()),
             damage_shaper: Default::default(),
+            damage: Default::default(),
+            element_damage: Default::default(),
+            opaque_regions: Default::default(),
             last_state: Default::default(),
             span: info_span!("renderer_damage", output = output.name()),
         }
@@ -369,6 +378,9 @@ impl OutputDamageTracker {
             mode: output_mode_source.into(),
             span: info_span!("render_damage"),
             damage_shaper: Default::default(),
+            damage: Default::default(),
+            element_damage: Default::default(),
+            opaque_regions: Default::default(),
             last_state: Default::default(),
         }
     }
@@ -390,7 +402,7 @@ impl OutputDamageTracker {
         age: usize,
         elements: &[E],
         clear_color: [f32; 4],
-    ) -> Result<RenderOutputResult, Error<R>>
+    ) -> Result<RenderOutputResult<'_>, Error<R>>
     where
         E: RenderElement<R>,
         R: Renderer + Bind<B>,
@@ -410,7 +422,7 @@ impl OutputDamageTracker {
         age: usize,
         elements: &[E],
         clear_color: [f32; 4],
-    ) -> Result<RenderOutputResult, Error<R>>
+    ) -> Result<RenderOutputResult<'_>, Error<R>>
     where
         E: RenderElement<R>,
         R: Renderer,
@@ -424,11 +436,11 @@ impl OutputDamageTracker {
     /// - `elements` for this output in front-to-back order
     #[instrument(level = "trace", parent = &self.span, skip(elements))]
     #[profiling::function]
-    pub fn damage_output<E>(
-        &mut self,
+    pub fn damage_output<'a, 'e, E>(
+        &'a mut self,
         age: usize,
-        elements: &[E],
-    ) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), OutputNoMode>
+        elements: &'e [E],
+    ) -> Result<(Option<&'a Vec<Rectangle<i32, Physical>>>, RenderElementStates), OutputNoMode>
     where
         E: Element,
     {
@@ -443,25 +455,20 @@ impl OutputDamageTracker {
         // damage with the wrong size
         let output_geo = Rectangle::from_loc_and_size((0, 0), output_transform.transform_size(output_size));
 
-        // This will hold all the damage we need for this rendering step
-        let mut damage: Vec<Rectangle<i32, Physical>> = Vec::new();
         let mut render_elements: Vec<&E> = Vec::with_capacity(elements.len());
-        let mut opaque_regions: Vec<(usize, Vec<Rectangle<i32, Physical>>)> = Vec::new();
         let states = self.damage_output_internal(
             age,
             elements,
             output_scale,
             output_transform,
             output_geo,
-            &mut damage,
             &mut render_elements,
-            &mut opaque_regions,
         );
 
-        if damage.is_empty() {
+        if self.damage.is_empty() {
             Ok((None, states))
         } else {
-            Ok((Some(damage), states))
+            Ok((Some(&self.damage), states))
         }
     }
 
@@ -474,16 +481,21 @@ impl OutputDamageTracker {
         output_scale: Scale<f64>,
         output_transform: Transform,
         output_geo: Rectangle<i32, Physical>,
-        damage: &mut Vec<Rectangle<i32, Physical>>,
         render_elements: &mut Vec<&'a E>,
-        opaque_regions: &mut Vec<(usize, Vec<Rectangle<i32, Physical>>)>,
     ) -> RenderElementStates
     where
         E: Element,
     {
+        self.damage.clear();
+        self.element_damage.clear();
+        self.opaque_regions.clear();
+
         let mut element_render_states = RenderElementStates {
             states: HashMap::with_capacity(elements.len()),
         };
+
+        // we have to take the element damage to be able to move it around
+        let mut element_damage = std::mem::take(&mut self.element_damage);
 
         // We use an explicit z-index because the following loop can skip
         // elements that are completely hidden and we want the z-index to
@@ -501,8 +513,9 @@ impl OutputDamageTracker {
             };
 
             // Then test if the element is completely hidden behind opaque regions
+            // FIXME: We should be able to calculate that without allocating a temp vec
             let element_visible_area = element_output_geometry
-                .subtract_rects(opaque_regions.iter().flat_map(|(_, r)| r).copied())
+                .subtract_rects(self.opaque_regions.iter().flat_map(|(_, r)| r).copied())
                 .into_iter()
                 .fold(0usize, |acc, item| acc + (item.size.w * item.size.h) as usize);
 
@@ -518,6 +531,8 @@ impl OutputDamageTracker {
                 continue;
             }
 
+            // FIXME: Getting rid of this allocation requires to return a reference and
+            // this needs changes in the element trait
             let element_output_damage = element
                 .damage_since(
                     output_scale,
@@ -528,10 +543,12 @@ impl OutputDamageTracker {
                     d.loc += element_loc;
                     d
                 })
-                .filter_map(|geo| geo.intersection(output_geo))
-                .collect::<Vec<_>>();
-            damage.extend(element_output_damage);
+                .filter_map(|geo| geo.intersection(output_geo));
+            self.damage.extend(element_output_damage);
 
+            // FIXME: This will be a bit more tricky, but should be doable.
+            // It is necessary that we can sort/filter the opaque regions, but having
+            // a vec in a vec...
             let element_opaque_regions = element
                 .opaque_regions(output_scale)
                 .into_iter()
@@ -541,7 +558,7 @@ impl OutputDamageTracker {
                 })
                 .filter_map(|geo| geo.intersection(output_geo))
                 .collect::<Vec<_>>();
-            opaque_regions.push((z_index, element_opaque_regions));
+            self.opaque_regions.push((z_index, element_opaque_regions));
             render_elements.push(element);
 
             if let Some(state) = element_render_states.states.get_mut(element_id) {
@@ -564,22 +581,26 @@ impl OutputDamageTracker {
             .last_state
             .elements
             .iter()
-            .filter(|(id, _)| !render_elements.iter().any(|e| e.id() == *id))
-            .flat_map(|(_, state)| {
-                Rectangle::subtract_rects_many(
-                    state
-                        .last_instances
-                        .iter()
-                        .filter_map(|i| i.last_geometry.intersection(output_geo)),
-                    opaque_regions
-                        .iter()
-                        .filter(|(z_index, _)| state.last_instances.iter().any(|i| *z_index < i.last_z_index))
-                        .flat_map(|(_, opaque_regions)| opaque_regions)
-                        .copied(),
-                )
-            })
-            .collect::<Vec<_>>();
-        damage.extend(elements_gone);
+            .filter(|(id, _)| !render_elements.iter().any(|e| e.id() == *id));
+
+        for (_, state) in elements_gone {
+            element_damage.clear();
+            element_damage.extend(
+                state
+                    .last_instances
+                    .iter()
+                    .filter_map(|i| i.last_geometry.intersection(output_geo)),
+            );
+            element_damage = Rectangle::subtract_rects_many_in_place(
+                element_damage,
+                self.opaque_regions
+                    .iter()
+                    .filter(|(z_index, _)| state.last_instances.iter().any(|i| *z_index < i.last_z_index))
+                    .flat_map(|(_, opaque_regions)| opaque_regions)
+                    .copied(),
+            );
+            self.damage.extend_from_slice(&element_damage);
+        }
 
         // if the element has been moved or it's alpha or z index changed, damage it
         for (z_index, element) in render_elements.iter().enumerate() {
@@ -601,11 +622,10 @@ impl OutputDamageTracker {
                 })
                 .unwrap_or(true)
             {
-                let mut element_damage = if let Some(damage) = element_geometry.intersection(output_geo) {
-                    vec![damage]
-                } else {
-                    vec![]
-                };
+                element_damage.clear();
+                if let Some(damage) = element_geometry.intersection(output_geo) {
+                    element_damage.push(damage);
+                }
                 if let Some(state) = element_last_state {
                     element_damage.extend(
                         state
@@ -615,22 +635,30 @@ impl OutputDamageTracker {
                     );
                 }
 
-                damage.extend(Rectangle::subtract_rects_many_in_place(
+                element_damage = Rectangle::subtract_rects_many_in_place(
                     element_damage,
-                    opaque_regions
+                    self.opaque_regions
                         .iter()
                         .filter(|(index, _)| *index < z_index)
                         .flat_map(|(_, opaque_regions)| opaque_regions)
                         .copied(),
-                ));
+                );
+                self.damage.extend_from_slice(&element_damage);
             }
         }
 
         // damage regions no longer covered by opaque regions
-        damage.extend(Rectangle::subtract_rects_many_in_place(
-            self.last_state.opaque_regions.clone(),
-            opaque_regions.iter().flat_map(|(_, r)| r).copied(),
-        ));
+        element_damage.clear();
+        element_damage.extend_from_slice(&self.last_state.opaque_regions);
+        element_damage = Rectangle::subtract_rects_many_in_place(
+            element_damage,
+            self.opaque_regions.iter().flat_map(|(_, r)| r).copied(),
+        );
+        self.damage.extend_from_slice(&element_damage);
+
+        // we no longer need the element damage, return it so that we can
+        // re-use its allocation next time
+        std::mem::swap(&mut self.element_damage, &mut element_damage);
 
         if self.last_state.size != Some(output_geo.size)
             || self.last_state.transform != Some(output_transform)
@@ -642,18 +670,21 @@ impl OutputDamageTracker {
                 previous_transform = ?self.last_state.transform,
                 current_transform = ?output_transform,
                 "Output geometry or transform changed, damaging whole output geometry");
-            *damage = vec![output_geo];
+            self.damage.clear();
+            self.damage.push(output_geo);
         }
 
         // That is all completely new damage, which we need to store for subsequent renders
-        let new_damage = damage.clone();
+        let mut new_damage = self.damage.clone();
+        new_damage.shrink_to_fit();
 
         // We now add old damage states, if we have an age value
         if age > 0 && self.last_state.old_damage.len() >= age {
             trace!("age of {} recent enough, using old damage", age);
             // We do not need even older states anymore
             self.last_state.old_damage.truncate(age);
-            damage.extend(self.last_state.old_damage.iter().take(age - 1).flatten().copied());
+            self.damage
+                .extend(self.last_state.old_damage.iter().take(age - 1).flatten().copied());
         } else {
             trace!(
                 "no old damage available, re-render everything. age: {} old_damage len: {}",
@@ -665,13 +696,14 @@ impl OutputDamageTracker {
             // an age of 0
             self.last_state.old_damage.truncate(MAX_AGE);
             // just damage everything, if we have no damage
-            *damage = vec![output_geo];
+            self.damage.clear();
+            self.damage.push(output_geo);
         };
 
         // Optimize the damage for rendering
 
         // Clamp all rectangles to the bounds removing the ones without intersection.
-        damage.retain_mut(|rect| {
+        self.damage.retain_mut(|rect| {
             if let Some(intersected) = rect.intersection(output_geo) {
                 *rect = intersected;
                 true
@@ -680,52 +712,54 @@ impl OutputDamageTracker {
             }
         });
 
-        self.damage_shaper.shape_damage(damage);
+        self.damage_shaper.shape_damage(&mut self.damage);
 
-        if damage.is_empty() {
+        if self.damage.is_empty() {
             trace!("nothing damaged, exiting early");
             return element_render_states;
         }
 
-        trace!("damage to be rendered: {:#?}", &damage);
+        let mut new_elements_state = std::mem::take(&mut self.last_state.elements);
+        new_elements_state.clear();
+        new_elements_state.reserve(render_elements.len());
+        let new_elements_state =
+            render_elements
+                .iter()
+                .enumerate()
+                .fold(new_elements_state, |mut map, (z_index, elem)| {
+                    let id = elem.id();
+                    let elem_src = elem.src();
+                    let elem_alpha = elem.alpha();
+                    let elem_geometry = elem.geometry(output_scale);
+                    let elem_transform = elem.transform();
 
-        let new_elements_state = render_elements.iter().enumerate().fold(
-            IndexMap::<Id, ElementState>::with_capacity(render_elements.len()),
-            |mut map, (z_index, elem)| {
-                let id = elem.id();
-                let elem_src = elem.src();
-                let elem_alpha = elem.alpha();
-                let elem_geometry = elem.geometry(output_scale);
-                let elem_transform = elem.transform();
+                    if let Some(state) = map.get_mut(id) {
+                        state.last_instances.push(ElementInstanceState {
+                            last_src: elem_src,
+                            last_geometry: elem_geometry,
+                            last_transform: elem_transform,
+                            last_alpha: elem_alpha,
+                            last_z_index: z_index,
+                        });
+                    } else {
+                        let current_commit = elem.current_commit();
+                        map.insert(
+                            id.clone(),
+                            ElementState {
+                                last_commit: current_commit,
+                                last_instances: smallvec![ElementInstanceState {
+                                    last_src: elem_src,
+                                    last_geometry: elem_geometry,
+                                    last_transform: elem_transform,
+                                    last_alpha: elem_alpha,
+                                    last_z_index: z_index,
+                                }],
+                            },
+                        );
+                    }
 
-                if let Some(state) = map.get_mut(id) {
-                    state.last_instances.push(ElementInstanceState {
-                        last_src: elem_src,
-                        last_geometry: elem_geometry,
-                        last_transform: elem_transform,
-                        last_alpha: elem_alpha,
-                        last_z_index: z_index,
-                    });
-                } else {
-                    let current_commit = elem.current_commit();
-                    map.insert(
-                        id.clone(),
-                        ElementState {
-                            last_commit: current_commit,
-                            last_instances: smallvec![ElementInstanceState {
-                                last_src: elem_src,
-                                last_geometry: elem_geometry,
-                                last_transform: elem_transform,
-                                last_alpha: elem_alpha,
-                                last_z_index: z_index,
-                            }],
-                        },
-                    );
-                }
-
-                map
-            },
-        );
+                    map
+                });
 
         self.last_state.size = Some(output_geo.size);
         self.last_state.transform = Some(output_transform);
@@ -734,20 +768,21 @@ impl OutputDamageTracker {
         self.last_state.opaque_regions.clear();
         self.last_state
             .opaque_regions
-            .extend(opaque_regions.iter().flat_map(|(_, r)| r.iter().copied()));
+            .extend(self.opaque_regions.iter().flat_map(|(_, r)| r.iter().copied()));
         self.last_state.opaque_regions.shrink_to_fit();
 
         element_render_states
     }
 
-    fn render_output_internal<E, R, F>(
-        &mut self,
+    #[profiling::function]
+    fn render_output_internal<'a, 'e, E, R, F>(
+        &'a mut self,
         renderer: &mut R,
         age: usize,
-        elements: &[E],
+        elements: &'e [E],
         clear_color: [f32; 4],
         pre_render: F,
-    ) -> Result<RenderOutputResult, Error<R>>
+    ) -> Result<RenderOutputResult<'a>, Error<R>>
     where
         E: RenderElement<R>,
         R: Renderer,
@@ -766,43 +801,46 @@ impl OutputDamageTracker {
         let output_geo = Rectangle::from_loc_and_size((0, 0), output_transform.transform_size(output_size));
 
         // This will hold all the damage we need for this rendering step
-        let mut damage: Vec<Rectangle<i32, Physical>> = Vec::new();
         let mut render_elements: Vec<&E> = Vec::with_capacity(elements.len());
-        let mut opaque_regions: Vec<(usize, Vec<Rectangle<i32, Physical>>)> = Vec::new();
         let states = self.damage_output_internal(
             age,
             elements,
             output_scale,
             output_transform,
             output_geo,
-            &mut damage,
             &mut render_elements,
-            &mut opaque_regions,
         );
 
-        if damage.is_empty() {
+        if self.damage.is_empty() {
             trace!("no damage, skipping rendering");
             return Ok(RenderOutputResult::skipped(states));
         }
 
         trace!(
             "rendering with damage {:?} and opaque regions {:?}",
-            damage,
-            opaque_regions
+            self.damage,
+            self.opaque_regions
         );
 
         pre_render(renderer).map_err(Error::Rendering)?;
 
         let render_res = (|| {
+            // we have to take the element damage to be able to move it around
+            let mut element_damage = std::mem::take(&mut self.element_damage);
             let mut frame = renderer.render(output_size, output_transform)?;
 
-            let clear_damage = Rectangle::subtract_rects_many_in_place(
-                damage.clone(),
-                opaque_regions.iter().flat_map(|(_, regions)| regions).copied(),
+            element_damage.clear();
+            element_damage.extend_from_slice(&self.damage);
+            element_damage = Rectangle::subtract_rects_many_in_place(
+                element_damage,
+                self.opaque_regions
+                    .iter()
+                    .flat_map(|(_, regions)| regions)
+                    .copied(),
             );
 
-            trace!("clearing damage {:?}", clear_damage);
-            frame.clear(clear_color, &clear_damage)?;
+            trace!("clearing damage {:?}", element_damage);
+            frame.clear(clear_color, &element_damage)?;
 
             for (mut z_index, element) in render_elements.iter().rev().enumerate() {
                 // This is necessary because we reversed the render elements to draw
@@ -813,20 +851,23 @@ impl OutputDamageTracker {
                 let element_id = element.id();
                 let element_geometry = element.geometry(output_scale);
 
-                let element_damage = Rectangle::subtract_rects_many(
-                    damage.iter().filter_map(|d| d.intersection(element_geometry)),
-                    opaque_regions
+                element_damage.clear();
+                element_damage.extend(
+                    self.damage
+                        .iter()
+                        .filter_map(|d| d.intersection(element_geometry)),
+                );
+                element_damage = Rectangle::subtract_rects_many_in_place(
+                    element_damage,
+                    self.opaque_regions
                         .iter()
                         .filter(|(index, _)| *index < z_index)
                         .flat_map(|(_, regions)| regions)
                         .copied(),
-                )
-                .into_iter()
-                .map(|mut d| {
+                );
+                element_damage.iter_mut().for_each(|d| {
                     d.loc -= element_geometry.loc;
-                    d
-                })
-                .collect::<Vec<_>>();
+                });
 
                 if element_damage.is_empty() {
                     trace!(
@@ -847,13 +888,15 @@ impl OutputDamageTracker {
                 element.draw(&mut frame, element.src(), element_geometry, &element_damage)?;
             }
 
+            // return the element damage so that we can re-use the allocation
+            std::mem::swap(&mut self.element_damage, &mut element_damage);
             frame.finish()
         })();
 
         match render_res {
             Ok(sync) => Ok(RenderOutputResult {
                 sync,
-                damage: Some(damage),
+                damage: Some(&self.damage),
                 states,
             }),
             Err(err) => {

--- a/src/backend/renderer/damage/shaper.rs
+++ b/src/backend/renderer/damage/shaper.rs
@@ -44,6 +44,7 @@ impl<const MIN_TILE_SIDE: i32> DamageShaper<MIN_TILE_SIDE> {
     // _tile_ based shaper, where the damage bounding box is split into tiles and damage is being
     // computed for each tile individually by walking all the current damage rectangles.
     #[inline(never)]
+    #[profiling::function]
     fn shape_damage_impl(
         &mut self,
         in_damage: &mut [Rectangle<i32, Physical>],
@@ -181,6 +182,7 @@ impl<const MIN_TILE_SIDE: i32> DamageShaper<MIN_TILE_SIDE> {
     }
 
     #[inline]
+    #[profiling::function]
     fn shape_damage_tiled(
         &mut self,
         in_damage: &[Rectangle<i32, Physical>],

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -220,7 +220,7 @@ use crate::{
     backend::{
         allocator::{format::get_bpp, Fourcc},
         renderer::{
-            utils::{CommitCounter, DamageBag},
+            utils::{CommitCounter, DamageBag, DamageSet},
             Frame, ImportMem, Renderer,
         },
     },
@@ -635,11 +635,7 @@ impl<R: Renderer> MemoryRenderBufferRenderElement<R> {
         .to_size()
     }
 
-    fn damage_since(
-        &self,
-        scale: Scale<f64>,
-        commit: Option<CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
+    fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
         let src = self.src();
         let logical_size = self.logical_size();
         let physical_size = self.physical_size(scale);
@@ -666,9 +662,11 @@ impl<R: Renderer> MemoryRenderBufferRenderElement<R> {
                                 rect.to_physical_precise_up(surface_scale * scale)
                             })
                     })
-                    .collect::<Vec<_>>()
+                    .collect::<DamageSet<_, _>>()
             })
-            .unwrap_or_else(|| vec![Rectangle::from_loc_and_size(Point::default(), physical_size)])
+            .unwrap_or_else(|| {
+                DamageSet::from_slice(&[Rectangle::from_loc_and_size(Point::default(), physical_size)])
+            })
     }
 
     fn opaque_regions(&self, scale: Scale<f64>) -> Vec<Rectangle<i32, Physical>> {
@@ -744,11 +742,7 @@ impl<R: Renderer> Element for MemoryRenderBufferRenderElement<R> {
         Rectangle::from_loc_and_size(self.location.to_i32_round(), self.physical_size(scale))
     }
 
-    fn damage_since(
-        &self,
-        scale: Scale<f64>,
-        commit: Option<CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
+    fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
         self.damage_since(scale, commit)
     }
 

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -31,7 +31,10 @@ use crate::{
 
 #[cfg(feature = "wayland_frontend")]
 use super::utils::Buffer;
-use super::{utils::CommitCounter, Renderer};
+use super::{
+    utils::{CommitCounter, DamageSet},
+    Renderer,
+};
 
 pub mod memory;
 pub mod solid;
@@ -354,15 +357,11 @@ pub trait Element {
     /// Get the geometry relative to the output
     fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical>;
     /// Get the damage since the provided commit relative to the element
-    fn damage_since(
-        &self,
-        scale: Scale<f64>,
-        commit: Option<CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
+    fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
         if commit != Some(self.current_commit()) {
-            vec![Rectangle::from_loc_and_size((0, 0), self.geometry(scale).size)]
+            DamageSet::from_slice(&[Rectangle::from_loc_and_size((0, 0), self.geometry(scale).size)])
         } else {
-            vec![]
+            DamageSet::default()
         }
     }
     /// Get the opaque regions of the element relative to the element
@@ -443,11 +442,7 @@ where
         (*self).geometry(scale)
     }
 
-    fn damage_since(
-        &self,
-        scale: Scale<f64>,
-        commit: Option<CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
+    fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
         (*self).damage_since(scale, commit)
     }
 
@@ -703,7 +698,7 @@ macro_rules! render_elements_internal {
             }
         }
 
-        fn damage_since(&self, scale: $crate::utils::Scale<f64>, commit: Option<$crate::backend::renderer::utils::CommitCounter>) -> Vec<$crate::utils::Rectangle<i32, $crate::utils::Physical>> {
+        fn damage_since(&self, scale: $crate::utils::Scale<f64>, commit: Option<$crate::backend::renderer::utils::CommitCounter>) -> $crate::backend::renderer::utils::DamageSet<i32, $crate::utils::Physical> {
             match self {
                 $(
                     #[allow(unused_doc_comments)]
@@ -1436,11 +1431,7 @@ where
         self.0.geometry(scale)
     }
 
-    fn damage_since(
-        &self,
-        scale: Scale<f64>,
-        commit: Option<CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
+    fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
         self.0.damage_since(scale, commit)
     }
 

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -222,7 +222,10 @@ use tracing::{instrument, warn};
 use wayland_server::protocol::wl_surface;
 
 use crate::{
-    backend::renderer::{utils::RendererSurfaceStateUserData, Frame, ImportAll, Renderer, Texture},
+    backend::renderer::{
+        utils::{DamageSet, RendererSurfaceStateUserData},
+        Frame, ImportAll, Renderer, Texture,
+    },
     utils::{Buffer, Physical, Point, Rectangle, Scale, Size, Transform},
     wayland::compositor::{self, SurfaceData, TraversalAction},
 };
@@ -406,11 +409,7 @@ impl<R: Renderer + ImportAll> Element for WaylandSurfaceRenderElement<R> {
         .unwrap_or_default()
     }
 
-    fn damage_since(
-        &self,
-        scale: Scale<f64>,
-        commit: Option<CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
+    fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
         let dst_size = self.size(scale);
 
         compositor::with_states(&self.surface, |states| {
@@ -448,7 +447,7 @@ impl<R: Renderer + ImportAll> Element for WaylandSurfaceRenderElement<R> {
                                     rect.to_physical_precise_up(surface_scale * scale)
                                 })
                         })
-                        .collect::<Vec<_>>();
+                        .collect::<DamageSet<_, _>>();
 
                     Some(damage)
                 } else {

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -406,7 +406,7 @@ use crate::{
     backend::{
         allocator::Fourcc,
         renderer::{
-            utils::{DamageBag, DamageSnapshot},
+            utils::{DamageBag, DamageSet, DamageSnapshot},
             Frame, ImportMem, Renderer, Texture,
         },
     },
@@ -633,12 +633,12 @@ pub struct TextureRenderElement<T> {
 }
 
 impl<T: Texture> TextureRenderElement<T> {
-    fn damage_since(&self, commit: Option<CommitCounter>) -> Vec<Rectangle<i32, Buffer>> {
+    fn damage_since(&self, commit: Option<CommitCounter>) -> DamageSet<i32, Buffer> {
         self.snapshot.damage_since(commit).unwrap_or_else(|| {
-            vec![Rectangle::from_loc_and_size(
+            DamageSet::from_slice(&[Rectangle::from_loc_and_size(
                 Point::default(),
                 self.texture.size(),
-            )]
+            )])
         })
     }
 }
@@ -830,11 +830,7 @@ where
             .to_buffer(self.scale as f64, self.transform, &size.to_f64())
     }
 
-    fn damage_since(
-        &self,
-        scale: Scale<f64>,
-        commit: Option<CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
+    fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
         let src = self.src();
         let texture_size = self.texture.size();
         let physical_size = self.physical_size(scale);
@@ -851,7 +847,7 @@ where
                         rect.to_physical_precise_up(surface_scale * scale)
                     })
             })
-            .collect::<Vec<_>>()
+            .collect::<DamageSet<_, _>>()
     }
 
     fn opaque_regions(&self, scale: Scale<f64>) -> Vec<Rectangle<i32, Physical>> {

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -3,6 +3,7 @@
 use crate::{
     backend::renderer::{
         element::{AsRenderElements, Element, Id, Kind, RenderElement, UnderlyingStorage},
+        utils::DamageSet,
         Renderer,
     },
     utils::{Buffer, Physical, Point, Rectangle, Scale},
@@ -66,12 +67,12 @@ impl<E: Element> Element for RescaleRenderElement<E> {
         &self,
         scale: crate::utils::Scale<f64>,
         commit: Option<crate::backend::renderer::utils::CommitCounter>,
-    ) -> Vec<crate::utils::Rectangle<i32, crate::utils::Physical>> {
+    ) -> DamageSet<i32, Physical> {
         self.element
             .damage_since(scale, commit)
             .into_iter()
             .map(|rect| rect.to_f64().upscale(self.scale).to_i32_up())
-            .collect::<Vec<_>>()
+            .collect::<DamageSet<_, _>>()
     }
 
     fn opaque_regions(
@@ -233,7 +234,7 @@ impl<E: Element> Element for CropRenderElement<E> {
         &self,
         scale: Scale<f64>,
         commit: Option<crate::backend::renderer::utils::CommitCounter>,
-    ) -> Vec<crate::utils::Rectangle<i32, Physical>> {
+    ) -> DamageSet<i32, Physical> {
         if let Some(element_crop_rect) = self.element_crop_rect(scale) {
             self.element
                 .damage_since(scale, commit)
@@ -244,7 +245,7 @@ impl<E: Element> Element for CropRenderElement<E> {
                         rect
                     })
                 })
-                .collect::<Vec<_>>()
+                .collect::<DamageSet<_, _>>()
         } else {
             Default::default()
         }
@@ -359,7 +360,7 @@ impl<E: Element> Element for RelocateRenderElement<E> {
         &self,
         scale: Scale<f64>,
         commit: Option<crate::backend::renderer::utils::CommitCounter>,
-    ) -> Vec<Rectangle<i32, Physical>> {
+    ) -> DamageSet<i32, Physical> {
         self.element.damage_since(scale, commit)
     }
 

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -3,7 +3,6 @@
 use cgmath::{prelude::*, Matrix3, Vector2};
 use core::slice;
 use std::{
-    borrow::Cow,
     collections::{HashMap, HashSet},
     ffi::{CStr, CString},
     fmt, mem,
@@ -40,10 +39,6 @@ use super::{
     sync::SyncPoint, Bind, Blit, DebugFlags, ExportMem, Frame, ImportDma, ImportMem, Offscreen, Renderer,
     Texture, TextureFilter, TextureMapping, Unbind,
 };
-use crate::backend::egl::{
-    ffi::egl::{self as ffi_egl, types::EGLImage},
-    EGLContext, EGLSurface, MakeCurrentError,
-};
 use crate::backend::{
     allocator::{
         dmabuf::{Dmabuf, WeakDmabuf},
@@ -53,6 +48,13 @@ use crate::backend::{
     egl::fence::EGLFence,
 };
 use crate::utils::{Buffer as BufferCoord, Physical, Rectangle, Size, Transform};
+use crate::{
+    backend::egl::{
+        ffi::egl::{self as ffi_egl, types::EGLImage},
+        EGLContext, EGLSurface, MakeCurrentError,
+    },
+    utils::Point,
+};
 
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
 use super::ImportEgl;
@@ -400,6 +402,7 @@ pub struct GlesRenderer {
     buffers: Vec<GlesBuffer>,
     dmabuf_cache: std::collections::HashMap<WeakDmabuf, GlesTexture>,
     vbos: [ffi::types::GLuint; 3],
+    vertices: Vec<f32>,
 
     // cleanup
     destruction_callback: Receiver<CleanupResource>,
@@ -426,6 +429,7 @@ pub struct GlesFrame<'frame> {
     size: Size<i32, Physical>,
     tex_program_override: Option<(GlesTexProgram, Vec<Uniform<'static>>)>,
     finished: AtomicBool,
+
     span: EnteredSpan,
 }
 
@@ -725,8 +729,8 @@ impl GlesRenderer {
         context
             .user_data()
             .insert_if_missing(|| RendererId(next_renderer_id()));
-
         drop(_guard);
+
         let renderer = GlesRenderer {
             gl,
             egl: context,
@@ -747,6 +751,7 @@ impl GlesRenderer {
             target: None,
             buffers: Vec::new(),
             dmabuf_cache: std::collections::HashMap::new(),
+            vertices: Vec::with_capacity(6 * 16),
 
             destruction_callback: rx,
             destruction_callback_sender: tx,
@@ -2333,6 +2338,7 @@ impl Renderer for GlesRenderer {
             size: output_size,
             tex_program_override: None,
             finished: AtomicBool::new(false),
+
             span,
         })
     }
@@ -2633,7 +2639,7 @@ impl<'frame> GlesFrame<'frame> {
     }
 
     /// Draw a solid color to the current target at the specified destination with the specified color.
-    #[instrument(skip(self), parent = &self.span)]
+    #[instrument(level = "trace", skip(self), parent = &self.span)]
     #[profiling::function]
     pub fn draw_solid(
         &mut self,
@@ -2648,9 +2654,10 @@ impl<'frame> GlesFrame<'frame> {
         let mut mat = Matrix3::<f32>::identity();
         mat = self.current_projection * mat;
 
-        let instances = damage
-            .iter()
-            .flat_map(|rect| {
+        // prepare the vertices
+        self.renderer.vertices.clear();
+        if self.renderer.capabilities.contains(&Capability::Instancing) {
+            self.renderer.vertices.extend(damage.iter().flat_map(|rect| {
                 let dest_size = dest.size;
 
                 let rect_constrained_loc = rect
@@ -2667,8 +2674,30 @@ impl<'frame> GlesFrame<'frame> {
                     rect.size.w as f32,
                     rect.size.h as f32,
                 ]
-            })
-            .collect::<Vec<_>>();
+            }))
+        } else {
+            self.renderer.vertices.extend(damage.iter().flat_map(|rect| {
+                let dest_size = dest.size;
+
+                let rect_constrained_loc = rect
+                    .loc
+                    .constrain(Rectangle::from_extemities((0, 0), dest_size.to_point()));
+                let rect_clamped_size = rect
+                    .size
+                    .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
+
+                let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+                // Add the 4 f32s per damage rectangle for each of the 6 vertices.
+                (0..6).flat_map(move |_| {
+                    [
+                        (dest.loc.x + rect.loc.x) as f32,
+                        (dest.loc.y + rect.loc.y) as f32,
+                        rect.size.w as f32,
+                        rect.size.h as f32,
+                    ]
+                })
+            }));
+        }
 
         let gl = &self.renderer.gl;
         unsafe {
@@ -2698,26 +2727,12 @@ impl<'frame> GlesFrame<'frame> {
                 std::ptr::null(),
             );
 
-            // Damage vertices.
-            let vertices = if self.renderer.capabilities.contains(&Capability::Instancing) {
-                instances
-            } else {
-                // Add the 4 f32s per damage rectangle for each of the 6 vertices.
-                let mut vertices = Vec::with_capacity(instances.len() * 6);
-                for chunk in instances.chunks(4) {
-                    for _ in 0..6 {
-                        vertices.extend_from_slice(chunk);
-                    }
-                }
-                vertices
-            };
-
             gl.EnableVertexAttribArray(self.renderer.solid_program.attrib_position as u32);
             gl.BindBuffer(ffi::ARRAY_BUFFER, self.renderer.vbos[1]);
             gl.BufferData(
                 ffi::ARRAY_BUFFER,
-                (std::mem::size_of::<ffi::types::GLfloat>() * vertices.len()) as isize,
-                vertices.as_ptr() as *const _,
+                (std::mem::size_of::<ffi::types::GLfloat>() * self.renderer.vertices.len()) as isize,
+                self.renderer.vertices.as_ptr() as *const _,
                 ffi::STREAM_DRAW,
             );
 
@@ -2804,33 +2819,30 @@ impl<'frame> GlesFrame<'frame> {
             tex_mat = Matrix3::new(1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0) * tex_mat;
         }
 
-        let instances = damage
-            .iter()
-            .flat_map(|rect| {
-                let dest_size = dest.size;
+        let instances = damage.iter().flat_map(|rect| {
+            let dest_size = dest.size;
 
-                let rect_constrained_loc = rect
-                    .loc
-                    .constrain(Rectangle::from_extemities((0, 0), dest_size.to_point()));
-                let rect_clamped_size = rect
-                    .size
-                    .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
+            let rect_constrained_loc = rect
+                .loc
+                .constrain(Rectangle::from_extemities((0, 0), dest_size.to_point()));
+            let rect_clamped_size = rect
+                .size
+                .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
 
-                let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
-                [
-                    rect.loc.x as f32,
-                    rect.loc.y as f32,
-                    rect.size.w as f32,
-                    rect.size.h as f32,
-                ]
-            })
-            .collect::<Vec<_>>();
+            let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+            [
+                rect.loc.x as f32,
+                rect.loc.y as f32,
+                rect.size.w as f32,
+                rect.size.h as f32,
+            ]
+        });
 
         self.render_texture(
             texture,
             tex_mat,
             mat,
-            Some(&instances),
+            Some(instances),
             alpha,
             program,
             additional_uniforms,
@@ -2851,7 +2863,7 @@ impl<'frame> GlesFrame<'frame> {
     /// Additionally the matrix can be used to crop the texture.
     ///
     /// Optionally allows a custom texture program and matching additional uniforms to be passed in.
-    #[instrument(level = "trace", skip(self), parent = &self.span)]
+    #[instrument(level = "trace", skip(self, instances), parent = &self.span)]
     #[profiling::function]
     #[allow(clippy::too_many_arguments)]
     pub fn render_texture(
@@ -2859,13 +2871,47 @@ impl<'frame> GlesFrame<'frame> {
         tex: &GlesTexture,
         tex_matrix: Matrix3<f32>,
         mut matrix: Matrix3<f32>,
-        instances: Option<&[ffi::types::GLfloat]>,
+        instances: Option<impl IntoIterator<Item = ffi::types::GLfloat>>,
         alpha: f32,
         program: Option<&GlesTexProgram>,
         additional_uniforms: &[Uniform<'_>],
     ) -> Result<(), GlesError> {
-        let damage = instances.unwrap_or(&[0.0, 0.0, 1.0, 1.0]);
-        if damage.is_empty() {
+        // prepare the vertices
+        self.renderer.vertices.clear();
+        let damage_len = if let Some(instances) = instances {
+            if self.renderer.capabilities.contains(&Capability::Instancing) {
+                self.renderer.vertices.extend(instances);
+                self.renderer.vertices.len() / 4
+            } else {
+                let mut damage = 0;
+                let mut instances = instances.into_iter();
+                while let Some(first) = instances.next() {
+                    damage += 1;
+                    let vertices = [
+                        first,
+                        instances.next().unwrap(),
+                        instances.next().unwrap(),
+                        instances.next().unwrap(),
+                    ];
+                    // Add the 4 f32s per damage rectangle for each of the 6 vertices.
+                    for _ in 0..6 {
+                        self.renderer.vertices.extend_from_slice(&vertices);
+                    }
+                }
+                damage
+            }
+        } else if self.renderer.capabilities.contains(&Capability::Instancing) {
+            self.renderer.vertices.extend_from_slice(&[0.0, 0.0, 1.0, 1.0]);
+            1
+        } else {
+            // Add the 4 f32s per damage rectangle for each of the 6 vertices.
+            for _ in 0..6 {
+                self.renderer.vertices.extend_from_slice(&[0.0, 0.0, 1.0, 1.0]);
+            }
+            1
+        };
+
+        if self.renderer.vertices.is_empty() {
             return Ok(());
         }
 
@@ -2947,27 +2993,13 @@ impl<'frame> GlesFrame<'frame> {
                 std::ptr::null(),
             );
 
-            // Damage vertices.
-            let vertices = if self.renderer.capabilities.contains(&Capability::Instancing) {
-                Cow::Borrowed(damage)
-            } else {
-                let mut vertices = Vec::with_capacity(damage.len() * 6);
-                // Add the 4 f32s per damage rectangle for each of the 6 vertices.
-                for chunk in damage.chunks(4) {
-                    for _ in 0..6 {
-                        vertices.extend_from_slice(chunk);
-                    }
-                }
-                Cow::Owned(vertices)
-            };
-
             // vert_position
             gl.EnableVertexAttribArray(program.attrib_vert_position as u32);
             gl.BindBuffer(ffi::ARRAY_BUFFER, self.renderer.vbos[1]);
             gl.BufferData(
                 ffi::ARRAY_BUFFER,
-                (std::mem::size_of::<ffi::types::GLfloat>() * vertices.len()) as isize,
-                vertices.as_ptr() as *const _,
+                (std::mem::size_of::<ffi::types::GLfloat>() * self.renderer.vertices.len()) as isize,
+                self.renderer.vertices.as_ptr() as *const _,
                 ffi::STREAM_DRAW,
             );
 
@@ -2980,19 +3012,18 @@ impl<'frame> GlesFrame<'frame> {
                 std::ptr::null(),
             );
 
-            let damage_len = (damage.len() / 4) as i32;
             if self.renderer.capabilities.contains(&Capability::Instancing) {
                 gl.VertexAttribDivisor(program.attrib_vert as u32, 0);
                 gl.VertexAttribDivisor(program.attrib_vert_position as u32, 1);
 
-                gl.DrawArraysInstanced(ffi::TRIANGLE_STRIP, 0, 4, damage_len);
+                gl.DrawArraysInstanced(ffi::TRIANGLE_STRIP, 0, 4, damage_len as i32);
             } else {
                 // When we have more than 10 rectangles, draw them in batches of 10.
                 for i in 0..(damage_len - 1) / 10 {
                     gl.DrawArrays(ffi::TRIANGLES, 0, 6);
 
                     // Set damage pointer to the next 10 rectangles.
-                    let offset = (i + 1) as usize * 6 * 4 * std::mem::size_of::<ffi::types::GLfloat>();
+                    let offset = (i + 1) * 6 * 4 * std::mem::size_of::<ffi::types::GLfloat>();
                     gl.VertexAttribPointer(
                         program.attrib_vert_position as u32,
                         4,
@@ -3005,7 +3036,7 @@ impl<'frame> GlesFrame<'frame> {
 
                 // Draw the up to 10 remaining rectangles.
                 let count = ((damage_len - 1) % 10 + 1) * 6;
-                gl.DrawArrays(ffi::TRIANGLES, 0, count);
+                gl.DrawArrays(ffi::TRIANGLES, 0, count as i32);
             }
 
             gl.BindBuffer(ffi::ARRAY_BUFFER, 0);
@@ -3027,33 +3058,55 @@ impl<'frame> GlesFrame<'frame> {
         alpha: f32,
         additional_uniforms: &[Uniform<'_>],
     ) -> Result<(), GlesError> {
-        let damage = damage
-            .map(|damage| {
-                damage
-                    .iter()
-                    .flat_map(|rect| {
-                        let dest_size = dest.size;
+        let fallback_damage = &[Rectangle::from_loc_and_size(Point::default(), dest.size)];
+        let damage = damage.unwrap_or(fallback_damage);
 
-                        let rect_constrained_loc = rect
-                            .loc
-                            .constrain(Rectangle::from_extemities((0, 0), dest_size.to_point()));
-                        let rect_clamped_size = rect
-                            .size
-                            .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
+        // prepare the vertices
+        self.renderer.vertices.clear();
+        if self.renderer.capabilities.contains(&Capability::Instancing) {
+            self.renderer.vertices.extend(damage.iter().flat_map(|rect| {
+                let dest_size = dest.size;
 
-                        let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
-                        [
-                            rect.loc.x as f32,
-                            rect.loc.y as f32,
-                            rect.size.w as f32,
-                            rect.size.h as f32,
-                        ]
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_else(|| vec![0.0, 0.0, 1.0, 1.0]);
+                let rect_constrained_loc = rect
+                    .loc
+                    .constrain(Rectangle::from_extemities((0, 0), dest_size.to_point()));
+                let rect_clamped_size = rect
+                    .size
+                    .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
 
-        if damage.is_empty() {
+                let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+                [
+                    rect.loc.x as f32,
+                    rect.loc.y as f32,
+                    rect.size.w as f32,
+                    rect.size.h as f32,
+                ]
+            }));
+        } else {
+            self.renderer.vertices.extend(damage.iter().flat_map(|rect| {
+                let dest_size = dest.size;
+
+                let rect_constrained_loc = rect
+                    .loc
+                    .constrain(Rectangle::from_extemities((0, 0), dest_size.to_point()));
+                let rect_clamped_size = rect
+                    .size
+                    .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
+
+                let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+                // Add the 4 f32s per damage rectangle for each of the 6 vertices.
+                (0..6).flat_map(move |_| {
+                    [
+                        rect.loc.x as f32,
+                        rect.loc.y as f32,
+                        rect.size.w as f32,
+                        rect.size.h as f32,
+                    ]
+                })
+            }));
+        }
+
+        if self.renderer.vertices.is_empty() {
             return Ok(());
         }
 
@@ -3115,27 +3168,13 @@ impl<'frame> GlesFrame<'frame> {
                 std::ptr::null(),
             );
 
-            // Damage vertices.
-            let vertices = if self.renderer.capabilities.contains(&Capability::Instancing) {
-                Cow::Borrowed(&damage)
-            } else {
-                let mut vertices = Vec::with_capacity(damage.len() * 6);
-                // Add the 4 f32s per damage rectangle for each of the 6 vertices.
-                for chunk in damage.chunks(4) {
-                    for _ in 0..6 {
-                        vertices.extend_from_slice(chunk);
-                    }
-                }
-                Cow::Owned(vertices)
-            };
-
             // vert_position
             gl.EnableVertexAttribArray(program.attrib_position as u32);
             gl.BindBuffer(ffi::ARRAY_BUFFER, self.renderer.vbos[1]);
             gl.BufferData(
                 ffi::ARRAY_BUFFER,
-                (std::mem::size_of::<ffi::types::GLfloat>() * vertices.len()) as isize,
-                vertices.as_ptr() as *const _,
+                (std::mem::size_of::<ffi::types::GLfloat>() * self.renderer.vertices.len()) as isize,
+                self.renderer.vertices.as_ptr() as *const _,
                 ffi::STREAM_DRAW,
             );
 
@@ -3148,7 +3187,7 @@ impl<'frame> GlesFrame<'frame> {
                 std::ptr::null(),
             );
 
-            let damage_len = (damage.len() / 4) as i32;
+            let damage_len = damage.len() as i32;
             if self.renderer.capabilities.contains(&Capability::Instancing) {
                 gl.VertexAttribDivisor(program.attrib_vert as u32, 0);
                 gl.VertexAttribDivisor(program.attrib_position as u32, 1);

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -472,6 +472,7 @@ impl<A: GraphicsApi> GpuManager<A> {
                             // we only import the most recent set of damage here.
                             // If we need more on rendering - which we cannot know at this point - we will call import_missing later
                             // to receive the rest.
+                            // FIXME: We should be able to get rid of this allocation here
                             let buffer_damage = data.damage().take(1).flatten().cloned().fold(
                                 Vec::<Rectangle<i32, BufferCoords>>::new(),
                                 |damage, mut rect| {

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -215,6 +215,7 @@ impl<N: Coordinate, Kind> DamageSnapshot<N, Kind> {
     }
 
     fn add(&mut self, damage: impl IntoIterator<Item = Rectangle<N, Kind>>) {
+        // FIXME: Get rid of this allocation here
         let mut damage = damage.into_iter().filter(|d| !d.is_empty()).collect::<Vec<_>>();
 
         if damage.is_empty() {

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -72,7 +72,7 @@ pub struct DamageBag<N, Kind> {
 pub struct DamageSnapshot<N, Kind> {
     limit: usize,
     commit_counter: CommitCounter,
-    damage: Arc<VecDeque<Vec<Rectangle<N, Kind>>>>,
+    damage: Arc<VecDeque<smallvec::SmallVec<[Rectangle<N, Kind>; MAX_DAMAGE_RECTS]>>>,
 }
 
 impl<N, Kind> Clone for DamageSnapshot<N, Kind> {
@@ -139,11 +139,13 @@ impl<N: fmt::Debug> fmt::Debug for DamageSnapshot<N, Logical> {
     }
 }
 
-const MAX_DAMAGE: usize = 4;
+const MAX_DAMAGE_AGE: usize = 4;
+const MAX_DAMAGE_RECTS: usize = 16;
+const MAX_DAMAGE_SET: usize = MAX_DAMAGE_RECTS * 2;
 
 impl<N: Clone, Kind> Default for DamageBag<N, Kind> {
     fn default() -> Self {
-        DamageBag::new(MAX_DAMAGE)
+        DamageBag::new(MAX_DAMAGE_AGE)
     }
 }
 
@@ -176,8 +178,8 @@ impl<N: Clone, Kind> DamageSnapshot<N, Kind> {
     }
 
     /// Provides raw access to the stored damage
-    pub fn damage(&self) -> impl Iterator<Item = &Vec<Rectangle<N, Kind>>> {
-        self.damage.iter()
+    pub fn damage(&self) -> impl Iterator<Item = impl Iterator<Item = &Rectangle<N, Kind>>> {
+        self.damage.iter().map(|d| d.iter())
     }
 
     fn reset(&mut self) {
@@ -195,44 +197,35 @@ impl<N: Coordinate, Kind> DamageSnapshot<N, Kind> {
     ///
     /// If the commit is recent enough and no damage has occurred
     /// an empty `Vec` will be returned
-    pub fn damage_since(&self, commit: Option<CommitCounter>) -> Option<Vec<Rectangle<N, Kind>>> {
+    pub fn damage_since(&self, commit: Option<CommitCounter>) -> Option<DamageSet<N, Kind>> {
         let distance = self.commit_counter.distance(commit);
 
         if distance
             .map(|distance| distance <= self.damage.len())
             .unwrap_or(false)
         {
-            Some(
-                self.damage
-                    .iter()
-                    .take(distance.unwrap())
-                    .fold(Vec::new(), |mut acc, elem| {
-                        acc.extend(elem);
-                        acc
-                    }),
-            )
+            let mut damage_set = DamageSet::default();
+            for damage in self.damage.iter().take(distance.unwrap()) {
+                damage_set.damage.extend_from_slice(damage);
+            }
+            Some(damage_set)
         } else {
             None
         }
     }
 
     fn add(&mut self, damage: impl IntoIterator<Item = Rectangle<N, Kind>>) {
-        let damage = damage.into_iter().collect::<Vec<_>>();
+        let mut damage = damage.into_iter().filter(|d| !d.is_empty()).collect::<Vec<_>>();
 
-        if damage.is_empty() || damage.iter().all(|d| d.is_empty()) {
+        if damage.is_empty() {
             // do not track empty damage
             return;
         }
 
-        let mut damage = damage
-            .iter()
-            .copied()
-            .filter(|d| !d.is_empty())
-            .collect::<Vec<_>>();
         damage.dedup();
 
         let inner_damage = Arc::make_mut(&mut self.damage);
-        inner_damage.push_front(damage);
+        inner_damage.push_front(smallvec::SmallVec::from_vec(damage));
         inner_damage.truncate(self.limit);
 
         self.commit_counter.increment();
@@ -254,7 +247,7 @@ impl<N: Clone, Kind> DamageBag<N, Kind> {
     }
 
     /// Provides raw access to the stored damage
-    pub fn damage(&self) -> impl Iterator<Item = &Vec<Rectangle<N, Kind>>> {
+    pub fn damage(&self) -> impl Iterator<Item = impl Iterator<Item = &Rectangle<N, Kind>>> {
         self.state.damage()
     }
 
@@ -288,8 +281,117 @@ impl<N: Coordinate, Kind> DamageBag<N, Kind> {
     ///
     /// If the commit is recent enough and no damage has occurred
     /// an empty `Vec` will be returned
-    pub fn damage_since(&self, commit: Option<CommitCounter>) -> Option<Vec<Rectangle<N, Kind>>> {
+    pub fn damage_since(&self, commit: Option<CommitCounter>) -> Option<DamageSet<N, Kind>> {
         self.state.damage_since(commit)
+    }
+}
+
+/// A set of damage returned from [`DamageBag::damage_since`] of [`DamageSnapshot::damage_since`]
+pub struct DamageSet<N, Kind> {
+    damage: smallvec::SmallVec<[Rectangle<N, Kind>; MAX_DAMAGE_SET]>,
+}
+
+impl<N, Kind> Default for DamageSet<N, Kind> {
+    fn default() -> Self {
+        Self {
+            damage: Default::default(),
+        }
+    }
+}
+
+impl<N: Copy, Kind> DamageSet<N, Kind> {
+    /// Copy the damage from a slice into a new `DamageSet`.
+    pub fn from_slice(slice: &[Rectangle<N, Kind>]) -> Self {
+        Self {
+            damage: smallvec::SmallVec::from_slice(slice),
+        }
+    }
+}
+
+impl<N, Kind> std::ops::Deref for DamageSet<N, Kind> {
+    type Target = [Rectangle<N, Kind>];
+
+    fn deref(&self) -> &Self::Target {
+        &self.damage
+    }
+}
+
+impl<N, Kind> IntoIterator for DamageSet<N, Kind> {
+    type Item = Rectangle<N, Kind>;
+
+    type IntoIter = DamageSetIter<N, Kind>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        DamageSetIter {
+            inner: self.damage.into_iter(),
+        }
+    }
+}
+
+impl<N, Kind> FromIterator<Rectangle<N, Kind>> for DamageSet<N, Kind> {
+    fn from_iter<T: IntoIterator<Item = Rectangle<N, Kind>>>(iter: T) -> Self {
+        Self {
+            damage: smallvec::SmallVec::from_iter(iter),
+        }
+    }
+}
+
+/// Iterator for [`DamageSet::into_iter`]
+pub struct DamageSetIter<N, Kind> {
+    inner: smallvec::IntoIter<[Rectangle<N, Kind>; MAX_DAMAGE_SET]>,
+}
+
+impl<N: fmt::Debug> fmt::Debug for DamageSetIter<N, BufferCoord> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DamageSetIter")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<N: fmt::Debug> fmt::Debug for DamageSetIter<N, Physical> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DamageSetIter")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<N: fmt::Debug> fmt::Debug for DamageSetIter<N, Logical> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DamageSetIter")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<N, Kind> Iterator for DamageSetIter<N, Kind> {
+    type Item = Rectangle<N, Kind>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<N: fmt::Debug> fmt::Debug for DamageSet<N, BufferCoord> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DamageSet").field("damage", &self.damage).finish()
+    }
+}
+
+impl<N: fmt::Debug> fmt::Debug for DamageSet<N, Physical> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DamageSet").field("damage", &self.damage).finish()
+    }
+}
+
+impl<N: fmt::Debug> fmt::Debug for DamageSet<N, Logical> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DamageSet").field("damage", &self.damage).finish()
     }
 }
 

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -663,6 +663,7 @@ where
 #[profiling::function]
 pub fn render_output<
     'a,
+    'd,
     #[cfg(feature = "wayland_frontend")] R: Renderer + ImportAll,
     #[cfg(not(feature = "wayland_frontend"))] R: Renderer,
     C: RenderElement<R>,
@@ -675,9 +676,9 @@ pub fn render_output<
     age: usize,
     spaces: S,
     custom_elements: &'a [C],
-    damage_tracker: &mut OutputDamageTracker,
+    damage_tracker: &'d mut OutputDamageTracker,
     clear_color: [f32; 4],
-) -> Result<RenderOutputResult, OutputDamageTrackerError<R>>
+) -> Result<RenderOutputResult<'d>, OutputDamageTrackerError<R>>
 where
     <R as Renderer>::TextureId: Texture + 'static,
     <E as AsRenderElements<R>>::RenderElement: 'a,

--- a/src/wayland/compositor/transaction.rs
+++ b/src/wayland/compositor/transaction.rs
@@ -238,6 +238,7 @@ impl TransactionQueue {
     }
 
     pub(crate) fn take_ready(&mut self) -> Vec<Transaction> {
+        // FIXME: Get rid of this allocation here
         let mut ready_transactions = Vec::new();
         // this is a very non-optimized implementation
         // we just iterate over the queue of transactions, keeping track of which


### PR DESCRIPTION
attempt on reducing mem allocations in hot-code paths and some performance improvements

not sure how to best handle the `Space::refresh`/`Output::enter`/`Output::leave` stuff. this is called way to often
imo and we need to get the alive checks out of enter/leave.