### PR TITLE
Implement the xwayland shell protocol

### DIFF
--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 
 #[cfg(feature = "xwayland")]
 use smithay::xwayland::{X11Wm, XWaylandClientData};
+
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
     desktop::{
@@ -141,7 +142,7 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
 
     fn commit(&mut self, surface: &WlSurface) {
         #[cfg(feature = "xwayland")]
-        X11Wm::commit_hook::<AnvilState<BackendData>>(surface);
+        X11Wm::commit_hook(self, surface);
 
         on_commit_buffer_handler::<Self>(surface);
         self.backend_data.early_import(surface);

--- a/anvil/src/shell/x11.rs
+++ b/anvil/src/shell/x11.rs
@@ -17,6 +17,7 @@ use smithay::{
             },
             SelectionTarget,
         },
+        xwayland_shell::{XWaylandShellHandler, XWaylandShellState},
     },
     xwayland::{
         xwm::{Reorder, ResizeEdge as X11ResizeEdge, XwmId},
@@ -41,6 +42,12 @@ impl OldGeometry {
 
     pub fn restore(&self) -> Option<Rectangle<i32, Logical>> {
         self.0.borrow_mut().take()
+    }
+}
+
+impl<BackendData: Backend> XWaylandShellHandler for AnvilState<BackendData> {
+    fn xwayland_shell_state(&mut self) -> &mut XWaylandShellState {
+        &mut self.xwayland_shell_state
     }
 }
 

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -99,10 +99,11 @@ use crate::{
 };
 #[cfg(feature = "xwayland")]
 use smithay::{
-    delegate_xwayland_keyboard_grab,
+    delegate_xwayland_keyboard_grab, delegate_xwayland_shell,
     utils::{Point, Size},
     wayland::selection::{SelectionSource, SelectionTarget},
     wayland::xwayland_keyboard_grab::{XWaylandKeyboardGrabHandler, XWaylandKeyboardGrabState},
+    wayland::xwayland_shell,
     xwayland::{X11Wm, XWayland, XWaylandEvent},
 };
 
@@ -147,6 +148,8 @@ pub struct AnvilState<BackendData: Backend + 'static> {
     pub presentation_state: PresentationState,
     pub fractional_scale_manager_state: FractionalScaleManagerState,
     pub xdg_foreign_state: XdgForeignState,
+    #[cfg(feature = "xwayland")]
+    pub xwayland_shell_state: xwayland_shell::XWaylandShellState,
 
     pub dnd_icon: Option<WlSurface>,
 
@@ -519,6 +522,9 @@ impl<BackendData: Backend + 'static> XWaylandKeyboardGrabHandler for AnvilState<
 #[cfg(feature = "xwayland")]
 delegate_xwayland_keyboard_grab!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
+#[cfg(feature = "xwayland")]
+delegate_xwayland_shell!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+
 impl<BackendData: Backend> XdgForeignHandler for AnvilState<BackendData> {
     fn xdg_foreign_state(&mut self) -> &mut XdgForeignState {
         &mut self.xdg_foreign_state
@@ -615,6 +621,12 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
 
         let keyboard_shortcuts_inhibit_state = KeyboardShortcutsInhibitState::new::<Self>(&dh);
 
+        #[cfg(feature = "xwayland")]
+        let xwayland_shell_state = xwayland_shell::XWaylandShellState::new::<Self>(&dh.clone());
+
+        #[cfg(feature = "xwayland")]
+        XWaylandKeyboardGrabState::new::<Self>(&dh.clone());
+
         AnvilState {
             backend_data,
             display_handle: dh,
@@ -648,6 +660,8 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
             clock,
 
             #[cfg(feature = "xwayland")]
+            xwayland_shell_state,
+            #[cfg(feature = "xwayland")]
             xwm: None,
             #[cfg(feature = "xwayland")]
             xdisplay: None,
@@ -661,8 +675,6 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
     pub fn start_xwayland(&mut self) {
         use std::process::Stdio;
 
-        XWaylandKeyboardGrabState::new::<Self>(&self.display_handle.clone());
-
         let (xwayland, client) = XWayland::spawn(
             &self.display_handle,
             None,
@@ -674,7 +686,6 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
         )
         .expect("failed to start XWayland");
 
-        let dh = self.display_handle.clone();
         let ret = self
             .handle
             .insert_source(xwayland, move |event, _, data| match event {
@@ -682,7 +693,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                     x11_socket,
                     display_number,
                 } => {
-                    let mut wm = X11Wm::start_wm(data.handle.clone(), dh.clone(), x11_socket, client.clone())
+                    let mut wm = X11Wm::start_wm(data.handle.clone(), x11_socket, client.clone())
                         .expect("Failed to attach X11 Window Manager");
 
                     let cursor = Cursor::load();

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -77,3 +77,5 @@ pub mod xdg_activation;
 pub mod xdg_foreign;
 #[cfg(feature = "xwayland")]
 pub mod xwayland_keyboard_grab;
+#[cfg(feature = "xwayland")]
+pub mod xwayland_shell;

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -1,0 +1,243 @@
+//! Helpers for handling the xwayland shell protocol
+//!
+//! # Example
+//!
+//! ```
+//! use smithay::wayland::xwayland_shell::{
+//!     XWaylandShellHandler,
+//!     XWaylandShellState,
+//! };
+//! use smithay::delegate_xwayland_shell;
+//!
+//! # struct State;
+//! # let mut display = wayland_server::Display::<State>::new().unwrap();
+//! // Create the global:
+//! XWaylandShellState::new::<State>(
+//!     &display.handle(),
+//! );
+//! #
+//! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+//!
+//! impl XWaylandShellHandler for State {
+//!     fn xwayland_shell_state(&mut self) -> &mut XWaylandShellState {
+//!         // Return a reference to the state we created earlier.
+//!         todo!()
+//!     }
+//!
+//!     fn surface_associated(&mut self, _surface: WlSurface, _serial: u64) {
+//!         // Called when XWayland has associated an X11 window with a wl_surface.
+//!         todo!()
+//!     }
+//! }
+//!
+//! // implement Dispatch for your state.
+//! delegate_xwayland_shell!(State);
+//! ```
+
+use std::collections::HashMap;
+
+use wayland_protocols::xwayland::shell::v1::server::{
+    xwayland_shell_v1::{self, XwaylandShellV1},
+    xwayland_surface_v1::{self, XwaylandSurfaceV1},
+};
+use wayland_server::{
+    backend::GlobalId,
+    protocol::wl_surface::{self, WlSurface},
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+};
+
+use crate::{wayland::compositor, xwayland::XWaylandClientData};
+
+/// The role for an xwayland-associated surface.
+pub const XWAYLAND_SHELL_ROLE: &str = "xwayland_shell";
+
+const VERSION: u32 = 1;
+
+/// The global for the xwayland shell protocol.
+#[derive(Debug, Clone)]
+pub struct XWaylandShellState {
+    global: GlobalId,
+    by_serial: HashMap<u64, WlSurface>,
+}
+
+impl XWaylandShellState {
+    /// Registers a new [XwaylandShellV1] global. Only XWayland clients will be
+    /// able to bind it.
+    pub fn new<D>(display: &DisplayHandle) -> Self
+    where
+        D: GlobalDispatch<XwaylandShellV1, ()>,
+        D: Dispatch<XwaylandShellV1, ()>,
+        D: Dispatch<XwaylandSurfaceV1, XWaylandSurfaceUserData>,
+        D: 'static,
+    {
+        let global = display.create_global::<D, XwaylandShellV1, _>(VERSION, ());
+        Self {
+            global,
+            by_serial: HashMap::new(),
+        }
+    }
+
+    /// Retrieve a handle for the [XwaylandShellV1] global.
+    pub fn global(&self) -> GlobalId {
+        self.global.clone()
+    }
+
+    /// Retrieves the surface for a given serial.
+    pub fn surface_for_serial(&self, serial: u64) -> Option<WlSurface> {
+        self.by_serial.get(&serial).cloned()
+    }
+}
+
+/// Userdata for an xwayland shell surface.
+#[derive(Debug, Clone)]
+pub struct XWaylandSurfaceUserData {
+    pub(crate) wl_surface: wl_surface::WlSurface,
+}
+
+/// Handler for the xwayland shell protocol.
+pub trait XWaylandShellHandler {
+    /// Retrieves the global state.
+    fn xwayland_shell_state(&mut self) -> &mut XWaylandShellState;
+
+    /// An X11 window has been associated with a wayland surface. This doesn't
+    /// take effect until the wl_surface is committed.
+    fn surface_associated(&mut self, _surface: wl_surface::WlSurface, _serial: u64) {}
+}
+
+/// Represents a pending X11 serial, used to associate X11 windows with wayland
+/// surfaces.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct XWaylandShellCachedState {
+    /// The serial of the matching X11 window.
+    pub serial: Option<u64>,
+}
+
+impl compositor::Cacheable for XWaylandShellCachedState {
+    fn commit(&mut self, _dh: &DisplayHandle) -> Self {
+        *self
+    }
+
+    fn merge_into(self, into: &mut Self, _dh: &DisplayHandle) {
+        *into = self;
+    }
+}
+
+impl<D> GlobalDispatch<XwaylandShellV1, (), D> for XWaylandShellState
+where
+    D: GlobalDispatch<XwaylandShellV1, ()>,
+    D: Dispatch<XwaylandShellV1, ()>,
+    D: 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: New<XwaylandShellV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(resource, ());
+    }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        client.get_data::<XWaylandClientData>().is_some()
+    }
+}
+
+impl<D> Dispatch<XwaylandShellV1, (), D> for XWaylandShellState
+where
+    D: Dispatch<XwaylandShellV1, ()>,
+    D: Dispatch<XwaylandSurfaceV1, XWaylandSurfaceUserData>,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &Client,
+        resource: &XwaylandShellV1,
+        request: <XwaylandShellV1 as Resource>::Request,
+        _data: &(),
+        _dhandle: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            xwayland_shell_v1::Request::GetXwaylandSurface { id, surface } => {
+                if compositor::give_role(&surface, XWAYLAND_SHELL_ROLE).is_err() {
+                    resource.post_error(xwayland_shell_v1::Error::Role, "Surface already has a role.");
+                    return;
+                }
+
+                data_init.init(id, XWaylandSurfaceUserData { wl_surface: surface });
+                // We call the handler callback once the serial is set.
+            }
+            xwayland_shell_v1::Request::Destroy => {
+                // The child objects created via this interface are unaffected.
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<XwaylandSurfaceV1, XWaylandSurfaceUserData, D> for XWaylandShellState
+where
+    D: Dispatch<XwaylandSurfaceV1, XWaylandSurfaceUserData>,
+    D: XWaylandShellHandler,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        _resource: &XwaylandSurfaceV1,
+        request: <XwaylandSurfaceV1 as Resource>::Request,
+        data: &XWaylandSurfaceUserData,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            xwayland_surface_v1::Request::SetSerial { serial_lo, serial_hi } => {
+                let serial = u64::from(serial_lo) | (u64::from(serial_hi) << 32);
+
+                compositor::with_states(&data.wl_surface, |states| {
+                    states.cached_state.pending::<XWaylandShellCachedState>().serial = Some(serial);
+                });
+
+                compositor::add_pre_commit_hook::<D, _>(&data.wl_surface, register_serial_commit_hook);
+
+                XWaylandShellHandler::surface_associated(state, data.wl_surface.clone(), serial);
+            }
+            xwayland_surface_v1::Request::Destroy => {
+                // Any already existing associations are unaffected.
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn register_serial_commit_hook<D: XWaylandShellHandler + 'static>(
+    state: &mut D,
+    _dh: &DisplayHandle,
+    surface: &WlSurface,
+) {
+    if let Some(serial) = compositor::with_states(surface, |states| {
+        states.cached_state.pending::<XWaylandShellCachedState>().serial
+    }) {
+        XWaylandShellHandler::xwayland_shell_state(state)
+            .by_serial
+            .insert(serial, surface.clone());
+    }
+}
+
+/// Macro to delegate implementation of the xwayland keyboard grab protocol
+#[macro_export]
+macro_rules! delegate_xwayland_shell {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::xwayland::shell::v1::server::xwayland_shell_v1::XwaylandShellV1: ()
+        ] => $crate::wayland::xwayland_shell::XWaylandShellState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::xwayland::shell::v1::server::xwayland_shell_v1::XwaylandShellV1: ()
+        ] => $crate::wayland::xwayland_shell::XWaylandShellState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::xwayland::shell::v1::server::xwayland_surface_v1::XwaylandSurfaceV1: $crate::wayland::xwayland_shell::XWaylandSurfaceUserData
+        ] => $crate::wayland::xwayland_shell::XWaylandShellState);
+    };
+}

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1,12 +1,33 @@
 //!
 //! Xwayland Window Manager module
 //!
-//! Provides an [`X11Wm`] type, which will register itself as a window manager for a previously spawned Xwayland instances,
-//! allowing backwards-compatibility by seemlessly integrating X11 windows into a wayland compositor.
+//! Provides an [`X11Wm`] type, which will register itself as a window manager
+//! for a previously spawned Xwayland instances, allowing
+//! backwards-compatibility by seamlessly integrating X11 windows into a wayland
+//! compositor.
 //!
-//! To use this functionality you must first spawn an [`XWayland`](super::XWayland) instance to attach a [`X11Wm`] to.
+//! To use this functionality you must first spawn an
+//! [`XWayland`](super::XWayland) instance to attach a [`X11Wm`] to.
+//!
+//! # Associating an [X11Surface] with a [WlSurface]
+//!
+//! When an X11 window is created, XWayland will associate it with a
+//! `wl_surface` that it creates via the wayland connection. This happens in two
+//! steps:
+//!
+//!  - Via the [xwayland shell](crate::wayland::xwayland::shell) protocol, a
+//!    serial number is set on the surface, and it is given the
+//!    "xwayland_surface" role.
+//!  - Via the X11 connection, a matching `WL_SURFACE_SERIAL` atom is set on the
+//!    X11 window, which can be queried with
+//!    [`X11Surface::wl_surface_serial()`].
+//!
+//! Note that these two steps can happen in any order.
+//!
+//! # Example
 //!
 //! ```no_run
+//! #  use smithay::wayland::xwayland_shell::{XWaylandShellHandler, XWaylandShellState};
 //! #  use smithay::wayland::selection::SelectionTarget;
 //! #  use smithay::xwayland::{XWayland, XWaylandEvent, X11Wm, X11Surface, XwmHandler, xwm::{XwmId, ResizeEdge, Reorder}};
 //! #  use smithay::utils::{Rectangle, Logical};
@@ -14,6 +35,11 @@
 //! #  use std::process::Stdio;
 //! #
 //! struct State { /* ... */ }
+//! # impl XWaylandShellHandler for State {
+//! #     fn xwayland_shell_state(&mut self) -> &mut XWaylandShellState {
+//! #         unreachable!()
+//! #     }
+//! # }
 //! impl XwmHandler for State {
 //!     fn xwm_state(&mut self, xwm: XwmId) -> &mut X11Wm {
 //!         // ...
@@ -53,7 +79,6 @@
 //!     } => {
 //!         let wm = X11Wm::start_wm(
 //!             handle.clone(),
-//!             dh.clone(),
 //!             x11_socket,
 //!             client.clone(),
 //!         )
@@ -62,21 +87,13 @@
 //!         // store the WM somewhere
 //!     }
 //!     XWaylandEvent::Error => eprintln!("XWayland failed to start!"),
-//! });
-//! if let Err(e) = ret {
-//!     tracing::error!(
-//!         "Failed to insert the XWaylandSource into the event loop: {}", e
-//!     );
-//! }
+//! }); if let Err(e) = ret { tracing::error!( "Failed to insert the
+//! XWaylandSource into the event loop: {}", e ); }
 //! ```
-//!
 
 use crate::{
     utils::{x11rb::X11Source, Logical, Point, Rectangle, Size},
-    wayland::{
-        compositor::{get_role, give_role},
-        selection::SelectionTarget,
-    },
+    wayland::{compositor, selection::SelectionTarget, xwayland_shell},
 };
 use calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction, RegistrationToken};
 use rustix::fs::OFlags;
@@ -91,7 +108,7 @@ use std::{
     sync::Arc,
 };
 use tracing::{debug, debug_span, error, info, trace, warn};
-use wayland_server::{protocol::wl_surface::WlSurface, Client, DisplayHandle, Resource};
+use wayland_server::{protocol::wl_surface::WlSurface, Client, Resource};
 
 use x11rb::{
     connection::Connection as _,
@@ -116,7 +133,6 @@ use x11rb::{
 
 mod surface;
 pub use self::surface::*;
-use super::xserver::XWaylandClientData;
 
 /// X11 wl_surface role
 pub const X11_SURFACE_ROLE: &str = "x11_surface";
@@ -132,6 +148,7 @@ mod atoms {
         AtomsCookie {
             // wayland-stuff
             WL_SURFACE_ID,
+            WL_SURFACE_SERIAL,
 
             // private
             _SMITHAY_CLOSE_CONNECTION,
@@ -194,6 +211,8 @@ mod atoms {
     }
 }
 pub use self::atoms::Atoms;
+
+use super::XWaylandClientData;
 
 crate::utils::ids::id_gen!(next_xwm_id, XWM_ID, XWM_IDS);
 
@@ -365,13 +384,11 @@ pub trait XwmHandler {
 pub struct X11Wm {
     id: XwmId,
     conn: Arc<RustConnection>,
-    dh: DisplayHandle,
     screen: Screen,
     wm_window: X11Window,
     atoms: Atoms,
 
-    wl_client: Client,
-    unpaired_surfaces: HashMap<u32, X11Window>,
+    unpaired_surfaces: HashMap<u64, X11Window>,
     sequences_to_ignore: BinaryHeap<Reverse<u16>>,
 
     // selections
@@ -608,36 +625,6 @@ impl Drop for XWmSelection {
     }
 }
 
-struct X11Injector<D: XwmHandler> {
-    xwm: XwmId,
-    handle: LoopHandle<'static, D>,
-}
-impl<D: XwmHandler> X11Injector<D> {
-    pub fn late_window(&self, surface: &WlSurface) {
-        let xwm_id = self.xwm;
-        let id = surface.id().protocol_id();
-
-        self.handle.insert_idle(move |data| {
-            let xwm = data.xwm_state(xwm_id);
-
-            if let Some(window) = xwm.unpaired_surfaces.remove(&id) {
-                if let Some(surface) = xwm
-                    .windows
-                    .iter()
-                    .find(|x| x.window_id() == window || x.mapped_window_id() == Some(window))
-                {
-                    let wl_surface = xwm
-                        .wl_client
-                        .object_from_protocol_id::<WlSurface>(&xwm.dh, id)
-                        .unwrap();
-                    let surface = surface.clone();
-                    X11Wm::new_surface(data, xwm_id, surface, wl_surface);
-                }
-            }
-        });
-    }
-}
-
 /// Edge values for resizing
 ///
 // These values are used to indicate which edge of a surface is being dragged in a resize operation.
@@ -684,12 +671,13 @@ impl X11Wm {
     /// - `client` is the wayland client instance of the Xwayland instance
     pub fn start_wm<D>(
         handle: LoopHandle<'static, D>,
-        dh: DisplayHandle,
         connection: UnixStream,
         client: Client,
     ) -> Result<Self, Box<dyn std::error::Error>>
     where
-        D: XwmHandler + 'static,
+        D: XwmHandler,
+        D: xwayland_shell::XWaylandShellHandler,
+        D: 'static,
     {
         let id = XwmId(next_xwm_id());
         let span = debug_span!("xwayland_wm", id = id.0);
@@ -822,15 +810,12 @@ impl X11Wm {
         let conn = Arc::new(conn);
         let source = X11Source::new(Arc::clone(&conn), win, atoms._SMITHAY_CLOSE_CONNECTION);
 
-        let injector = X11Injector {
-            xwm: id,
-            handle: handle.clone(),
-        };
+        // We need this for the commit hook.
         client
             .get_data::<XWaylandClientData>()
             .unwrap()
             .user_data()
-            .insert_if_missing(move || injector);
+            .insert_if_missing(|| id);
 
         let _xfixes_data = conn
             .query_extension(x11rb::protocol::xfixes::X11_EXTENSION_NAME.as_bytes())?
@@ -847,12 +832,10 @@ impl X11Wm {
         drop(_guard);
         let wm = Self {
             id,
-            dh,
             conn,
             screen,
             atoms,
             wm_window: win,
-            wl_client: client,
             _xfixes_data,
             clipboard,
             primary,
@@ -1031,35 +1014,51 @@ impl X11Wm {
         self.update_stacking_order_impl(order, StackingDirection::Upwards)
     }
 
-    /// This function has to be called on [`CompositorHandler::commit`](crate::wayland::compositor::CompositorHandler::commit) to correctly
-    /// update the internal state of Xwayland WMs.
-    pub fn commit_hook<D: XwmHandler + 'static>(surface: &WlSurface) {
+    /// This function has to be called on [`CompositorHandler::commit`](crate::wayland::compositor::CompositorHandler::commit) to
+    /// handle associating surfaces with X11 windows.
+    pub fn commit_hook<D>(state: &mut D, surface: &WlSurface)
+    where
+        D: XwmHandler,
+        D: xwayland_shell::XWaylandShellHandler,
+        D: 'static,
+    {
         if let Some(client) = surface.client() {
-            if let Some(x11) = client
+            // We only care about surfaces created by XWayland.
+            if let Some(xwm_id) = client
                 .get_data::<XWaylandClientData>()
-                .and_then(|data| data.user_data().get::<X11Injector<D>>())
+                .and_then(|data| data.user_data().get::<XwmId>())
             {
-                if get_role(surface).is_none() {
-                    x11.late_window(surface);
+                let serial = compositor::with_states(surface, |states| {
+                    states
+                        .cached_state
+                        .current::<xwayland_shell::XWaylandShellCachedState>()
+                        .serial
+                });
+
+                // This handles the case that the serial was set on the X11
+                // window before surface. To handle the other case, we look for
+                // a matching surface when the WL_SURFACE_SERIAL atom is sent.
+                if let Some(serial) = serial {
+                    let xwm = XwmHandler::xwm_state(state, *xwm_id);
+
+                    if let Some(window) = xwm.unpaired_surfaces.remove(&serial) {
+                        if let Some(xsurface) = xwm
+                            .windows
+                            .iter()
+                            .find(|x| x.window_id() == window || x.mapped_window_id() == Some(window))
+                        {
+                            debug!(
+                                window = xsurface.window_id(),
+                                wl_surface = ?surface.id().protocol_id(),
+                                "associated X11 window to wl_surface in commit hook",
+                            );
+
+                            xsurface.state.lock().unwrap().wl_surface = Some(surface.clone());
+                        }
+                    }
                 }
             }
         }
-    }
-
-    fn new_surface<D: XwmHandler>(state: &mut D, xwm_id: XwmId, surface: X11Surface, wl_surface: WlSurface) {
-        info!(
-            window_id = surface.window_id(),
-            surface = ?wl_surface,
-            "Matched X11 surface to wayland surface",
-        );
-        if give_role(&wl_surface, X11_SURFACE_ROLE).is_err() {
-            // It makes no sense to post a protocol error here since that would only kill Xwayland
-            error!(surface = ?wl_surface, "Surface already has a role?!");
-            return;
-        }
-
-        surface.state.lock().unwrap().wl_surface = Some(wl_surface);
-        state.map_window_notify(xwm_id, surface);
     }
 
     /// Set the default cursor used by X clients.
@@ -1282,12 +1281,17 @@ impl X11Wm {
     }
 }
 
-fn handle_event<D: XwmHandler + 'static>(
+fn handle_event<D>(
     loop_handle: &LoopHandle<'_, D>,
     state: &mut D,
     xwm_id: XwmId,
     event: Event,
-) -> Result<(), ReplyOrIdError> {
+) -> Result<(), ReplyOrIdError>
+where
+    D: XwmHandler,
+    D: xwayland_shell::XWaylandShellHandler,
+    D: 'static,
+{
     let xwm = state.xwm_state(xwm_id);
     let _guard = xwm.span.enter();
     let conn = xwm.conn.clone();
@@ -2141,22 +2145,50 @@ fn handle_event<D: XwmHandler + 'static>(
                         .iter_mut()
                         .find(|x| x.window_id() == msg.window || x.mapped_window_id() == Some(msg.window))
                     {
-                        // We get a WL_SURFACE_ID message when Xwayland creates a WlSurface for a
-                        // window. Both the creation of the surface and this client message happen at
-                        // roughly the same time and are sent over different sockets (X11 socket and
-                        // wayland socket). Thus, we could receive these two in any order. Hence, it
-                        // can happen that we get None below when X11 was faster than Wayland.
+                        // This is the old, deprecated method for associating a
+                        // wl_surface with an X11 window. It can race with the
+                        // lifecycle of the wl_surface. Still, we can make it
+                        // available to compositors who want to support old
+                        // versions of xwayland by manually matching on ID in an
+                        // idle callback.
+                        surface.state.lock().unwrap().wl_surface_id = Some(wid);
+                    }
+                }
+                x if x == xwm.atoms.WL_SURFACE_SERIAL => {
+                    // This handles the case that the serial was already set on
+                    // the wayland side. For the reverse order, we have a commit
+                    // hook.
+                    if let Some(xsurface) = xwm
+                        .windows
+                        .iter_mut()
+                        .find(|x| x.window_id() == msg.window || x.mapped_window_id() == Some(msg.window))
+                    {
+                        drop(_guard);
 
-                        let wl_surface = xwm.wl_client.object_from_protocol_id::<WlSurface>(&xwm.dh, wid);
-                        match wl_surface {
-                            Err(_) => {
-                                xwm.unpaired_surfaces.insert(wid, msg.window);
-                            }
-                            Ok(wl_surface) => {
-                                let surface = surface.clone();
-                                drop(_guard);
-                                X11Wm::new_surface(state, xwm_id, surface, wl_surface);
-                            }
+                        let serial_lo = msg.data.as_data32()[0];
+                        let serial_hi = msg.data.as_data32()[1];
+                        let serial = u64::from(serial_lo) | (u64::from(serial_hi) << 32);
+
+                        let surface_state = xsurface.state.clone();
+                        let mut guard = surface_state.lock().unwrap();
+                        guard.wl_surface_serial = Some(serial);
+
+                        xwm.unpaired_surfaces.insert(serial, msg.window);
+
+                        if let Some(wl_surface) =
+                            xwayland_shell::XWaylandShellHandler::xwayland_shell_state(state)
+                                .surface_for_serial(serial)
+                                .clone()
+                        {
+                            debug!(
+                                window = ?msg.window,
+                                wl_surface = ?wl_surface.id().protocol_id(),
+                                "associated X11 window to wl_surface",
+                            );
+
+                            guard.wl_surface = Some(wl_surface);
+                        } else {
+                            guard.wl_surface = None;
                         }
                     }
                 }

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::{input::KeyState, renderer::element::Id},
+    backend::input::KeyState,
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
         pointer::{
@@ -11,6 +11,7 @@ use crate::{
         Seat, SeatHandler,
     },
     utils::{user_data::UserDataMap, IsAlive, Logical, Rectangle, Serial, Size},
+    wayland::compositor,
 };
 use encoding_rs::WINDOWS_1252;
 use std::{
@@ -52,9 +53,13 @@ const MWM_HINTS_DECORATIONS: u32 = 1 << 1;
 #[derive(Debug)]
 pub(crate) struct SharedSurfaceState {
     pub(super) alive: bool,
-    pub(crate) wl_surface: Option<WlSurface>,
+    pub(super) wl_surface_id: Option<u32>,
+    pub(super) wl_surface_serial: Option<u64>,
     pub(super) mapped_onto: Option<X11Window>,
     pub(super) geometry: Rectangle<i32, Logical>,
+
+    // The associated wl_surface.
+    pub(crate) wl_surface: Option<WlSurface>,
 
     title: String,
     class: String,
@@ -162,6 +167,8 @@ impl X11Surface {
             atoms,
             state: Arc::new(Mutex::new(SharedSurfaceState {
                 alive: true,
+                wl_surface_id: None,
+                wl_surface_serial: None,
                 wl_surface: None,
                 mapped_onto: None,
                 geometry,
@@ -241,7 +248,7 @@ impl X11Surface {
     /// Returns if the window is currently mapped or not
     pub fn is_mapped(&self) -> bool {
         let state = self.state.lock().unwrap();
-        state.wl_surface.is_some() || state.mapped_onto.is_some()
+        state.wl_surface.is_some()
     }
 
     /// Returns if the window is still alive
@@ -286,12 +293,36 @@ impl X11Surface {
         Ok(())
     }
 
-    /// Returns the `wl_surface` corresponding to the underlying X11 window.
+    /// Returns the associated wl_surface.
     ///
-    /// An X11 window only has a matching wl_surface if is considered visible
-    /// by Xwayland, which will only happen once it is mapped.
+    /// This will only return `Some` once:
+    ///   - The `WL_SURFACE_SERIAL` has been set on the x11 window, and
+    ///   - The wl_surface has been assigned the same serial using the [xwayland
+    ///     shell](crate::wayland::xwayland_shell) protocol on the wayland side,
+    ///     and then committed.
     pub fn wl_surface(&self) -> Option<WlSurface> {
         self.state.lock().unwrap().wl_surface.clone()
+    }
+
+    /// Returns the associated `wl_surface` id, once it has been set by
+    /// xwayland.
+    ///
+    /// Note that XWayland will only set this if it was unable to bind the
+    /// [xwayland shell](crate::wayland::xwayland_shell) protocol on the wayland
+    /// side.
+    #[deprecated = "Since XWayland 23.1, the recommended approach is to use [wl_surface_serial] and the [xwayland shell](crate::wayland::xwayland_shell) protocol on the wayland side to match X11 windows."]
+    pub fn wl_surface_id(&self) -> Option<u32> {
+        self.state.lock().unwrap().wl_surface_id
+    }
+
+    /// Returns the associated `wl_surface` serial, once it has been set by
+    /// xwayland.
+    ///
+    /// XWayland will set this if it has bound the [xwayland
+    /// shell](crate::wayland::xwayland_shell) protocol on the wayland side.
+    /// Otherwise, it will set [wl_surface_id] instead.
+    pub fn wl_surface_serial(&self) -> Option<u64> {
+        self.state.lock().unwrap().wl_surface_serial
     }
 
     /// Returns the current geometry of the underlying X11 window
@@ -836,24 +867,14 @@ impl X11Relatable for X11Surface {
 
 impl X11Relatable for WlSurface {
     fn is_window(&self, window: &X11Surface) -> bool {
-        let state = window.state.lock().unwrap();
-        state
-            .wl_surface
-            .as_ref()
-            .map(|surface| surface == self)
-            .unwrap_or(false)
-    }
-}
+        let serial = compositor::with_states(self, |states| {
+            states
+                .cached_state
+                .current::<crate::wayland::xwayland_shell::XWaylandShellCachedState>()
+                .serial
+        });
 
-impl X11Relatable for Id {
-    fn is_window(&self, window: &X11Surface) -> bool {
-        let state = window.state.lock().unwrap();
-        state
-            .wl_surface
-            .as_ref()
-            .map(Id::from_wayland_resource)
-            .map(|id| &id == self)
-            .unwrap_or(false)
+        window.wl_surface_serial() == serial
     }
 }
 


### PR DESCRIPTION
Depends on #1350 (but only trivially).

The xwayland shell protocol moves the responsibility of setting the "xwayland_surface" role on the wl_surface from the x11 side of the connection to the wayland side. Among other things, this avoids the xwm racing the lifecycle of the surface.

Since we can check the serial with a commit hook, this also removes the need for a ugly idle callback in the `Xwm`, and may allow for better separation of concerns in the future, for example moving the association state tracking out of Xwm.

Without the idle callback, we may be able to remove the hard dependency on calloop in the xwayland stack (which is my ulterior motive). It's still required for `send_selection` - I'll attempt to figure those issues out in another PR.