### PR TITLE
Fix various slight tree-iteration issues

### DIFF
--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -576,14 +576,20 @@ impl LayerSurface {
     ) -> Option<(WlSurface, Point<i32, Logical>)> {
         let point = point.into();
         let surface = self.wl_surface();
-        for (popup, location) in PopupManager::popups_for_surface(surface) {
-            let surface = popup.wl_surface();
-            if let Some(result) = under_from_surface_tree(surface, point, location, surface_type) {
-                return Some(result);
+        if surface_type.contains(WindowSurfaceType::POPUP) {
+            for (popup, location) in PopupManager::popups_for_surface(surface) {
+                let surface = popup.wl_surface();
+                if let Some(result) = under_from_surface_tree(surface, point, location, surface_type) {
+                    return Some(result);
+                }
             }
         }
 
-        under_from_surface_tree(surface, point, (0, 0), surface_type)
+        if surface_type.contains(WindowSurfaceType::TOPLEVEL) {
+            return under_from_surface_tree(surface, point, (0, 0), surface_type);
+        }
+
+        None
     }
 
     /// Sends the frame callback to all the subsurfaces in this layer that requested it

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -87,6 +87,8 @@ bitflags::bitflags! {
         /// Include the toplevel surface
         const TOPLEVEL = 1;
         /// Include all subsurfaces
+        ///
+        /// This value only works in addition to either `TOPLEVEL` or `POPUP`.
         const SUBSURFACE = 2;
         /// Include all popup surfaces
         const POPUP = 4;
@@ -336,10 +338,12 @@ impl Window {
                 }
             }
 
-            under_from_surface_tree(surface, point, (0, 0), surface_type)
-        } else {
-            None
+            if surface_type.contains(WindowSurfaceType::TOPLEVEL) {
+                return under_from_surface_tree(surface, point, (0, 0), surface_type);
+            }
         }
+
+        None
     }
 
     /// Returns the underlying xdg toplevel surface


### PR DESCRIPTION
Stumbled upon these looking into https://github.com/Smithay/smithay/issues/1352.

Some clear mistakes (like only using the `filter` closure in `under_for_surface_tree`), but mostly just some inconsistencies handling `WindowSurfaceType`.

Best reviewed commit-by-commit.

Draft, because this needs more testing.