### PR TITLE
Fix the X11 window instance getter returning the class instead of the instance

### DIFF
--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -296,7 +296,7 @@ impl X11Surface {
 
     /// Returns the current window instance of the underlying X11 window
     pub fn instance(&self) -> String {
-        self.state.lock().unwrap().class.clone()
+        self.state.lock().unwrap().instance.clone()
     }
 
     /// Returns the startup id of the underlying X11 window


### PR DESCRIPTION
I guess this is a typical copy-paste bug as someone forgot to change the body of this function to return the right thing.