### PR TITLE
desktop: test sibling surfaces for input

### DIFF
--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -120,8 +120,8 @@ where
                     TraversalAction::SkipChildren
                 }
             } else {
-                // We are completely hidden
-                TraversalAction::Break
+                // We are completely hidden, no point in traversing our children
+                TraversalAction::SkipChildren
             }
         },
         |wl_surface, states, location: &Point<i32, Logical>| {


### PR DESCRIPTION
TraversalAction::Break will stop the traversal early, which can result in us missing some sibling surfaces. Skipping the children is fine as they are also unmapped.

fixes #1360 