### PR TITLE
pointer: Reset image on focus change

### DIFF
--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -150,6 +150,7 @@ where
         event: &MotionEvent,
     ) {
         PointerTarget::<D>::leave(&replaced, seat, data, event.serial, event.time);
+        data.cursor_image(seat, CursorImageStatus::default_named());
         PointerTarget::<D>::enter(self, seat, data, event);
     }
 }


### PR DESCRIPTION
Smithay doesn't reset the cursor image, when we replace focus. This can be the default thing that happens with e.g. swaybg or cosmic-bg running, causing the last cursor image to be stuck, if any newly entered surface doesn't care to set a new image.

Lets reset on swapping focus as well, not just when nothing is focused.