### PR TITLE
Forwarding dispatch implementation

### DIFF
--- a/examples/forward_test.rs
+++ b/examples/forward_test.rs
@@ -1,0 +1,253 @@
+use std::sync::{Arc, Mutex};
+
+use smithay::reexports::wayland_server::Display;
+
+use smithay::wayland::xdg_activation::*;
+
+use wayland_server::backend::ClientData;
+use wayland_server::{Client, Dispatch, GlobalDispatch, ListeningSocket};
+
+struct App {
+    sub: Mutex<SubType>,
+}
+
+struct SubType {
+    xdg_activation_state: XdgActivationState,
+}
+
+impl XdgActivationHandler for SubType {
+    fn activation_state(&mut self) -> &mut XdgActivationState {
+        &mut self.xdg_activation_state
+    }
+
+    fn request_activation(
+        &mut self,
+        token: XdgActivationToken,
+        _token_data: XdgActivationTokenData,
+        _surface: wayland_server::protocol::wl_surface::WlSurface,
+    ) {
+        self.xdg_activation_state.remove_token(&token);
+    }
+}
+
+#[derive(Debug, Default)]
+struct ClientState;
+impl ClientData for ClientState {}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut display: Display<App> = Display::new()?;
+    let dh = display.handle();
+
+    let xdg_activation_state = XdgActivationState::new::<App>(&dh);
+
+    let mut state = App {
+        sub: Mutex::new(SubType { xdg_activation_state }),
+    };
+
+    let listener = ListeningSocket::bind("wayland-5").unwrap();
+
+    let mut clients = Vec::new();
+
+    loop {
+        if let Some(stream) = listener.accept().unwrap() {
+            println!("Got a client: {:?}", stream);
+
+            let client = display
+                .handle()
+                .insert_client(stream, Arc::new(ClientState::default()))
+                .unwrap();
+            clients.push(client);
+        }
+
+        display.dispatch_clients(&mut state)?;
+        display.flush_clients()?;
+    }
+}
+
+impl GlobalDispatch<xdg_activation_v1::XdgActivationV1, (), App> for App {
+    fn bind(
+        state: &mut App,
+        handle: &wayland_server::DisplayHandle,
+        client: &Client,
+        resource: wayland_server::New<xdg_activation_v1::XdgActivationV1>,
+        global_data: &(),
+        data_init: &mut wayland_server::DataInit<'_, App>,
+    ) {
+        let mut guard = state.sub.lock().unwrap();
+        <SubType as GlobalDispatch<xdg_activation_v1::XdgActivationV1, (), SubType, App>>::bind(
+            &mut *guard,
+            handle,
+            client,
+            resource,
+            global_data,
+            data_init,
+        )
+    }
+
+    fn can_view(client: Client, global_data: &()) -> bool {
+        <SubType as GlobalDispatch<xdg_activation_v1::XdgActivationV1, (), SubType, App>>::can_view(
+            client,
+            global_data,
+        )
+    }
+}
+
+impl Dispatch<xdg_activation_v1::XdgActivationV1, (), App> for App {
+    fn request(
+        state: &mut App,
+        client: &Client,
+        resource: &xdg_activation_v1::XdgActivationV1,
+        request: <xdg_activation_v1::XdgActivationV1 as wayland_server::Resource>::Request,
+        data: &(),
+        dhandle: &wayland_server::DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, App>,
+    ) {
+        let mut guard = state.sub.lock().unwrap();
+        <SubType as Dispatch<xdg_activation_v1::XdgActivationV1, (), SubType, App>>::request(
+            &mut *guard,
+            client,
+            resource,
+            request,
+            data,
+            dhandle,
+            data_init,
+        )
+    }
+
+    fn destroyed(
+        state: &mut App,
+        client: wayland_server::backend::ClientId,
+        resource: &xdg_activation_v1::XdgActivationV1,
+        data: &(),
+    ) {
+        let mut guard = state.sub.lock().unwrap();
+        <SubType as Dispatch<xdg_activation_v1::XdgActivationV1, (), SubType, App>>::destroyed(
+            &mut *guard,
+            client,
+            resource,
+            data,
+        )
+    }
+}
+
+impl Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData, App> for App {
+    fn request(
+        state: &mut App,
+        client: &Client,
+        resource: &xdg_activation_token_v1::XdgActivationTokenV1,
+        request: <xdg_activation_token_v1::XdgActivationTokenV1 as wayland_server::Resource>::Request,
+        data: &ActivationTokenData,
+        dhandle: &wayland_server::DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, App>,
+    ) {
+        let mut guard = state.sub.lock().unwrap();
+        <SubType as Dispatch<
+            xdg_activation_token_v1::XdgActivationTokenV1,
+            ActivationTokenData,
+            SubType,
+            App,
+        >>::request(&mut *guard, client, resource, request, data, dhandle, data_init)
+    }
+
+    fn destroyed(
+        state: &mut App,
+        client: wayland_server::backend::ClientId,
+        resource: &xdg_activation_token_v1::XdgActivationTokenV1,
+        data: &ActivationTokenData,
+    ) {
+        let mut guard = state.sub.lock().unwrap();
+        <SubType as Dispatch<
+            xdg_activation_token_v1::XdgActivationTokenV1,
+            ActivationTokenData,
+            SubType,
+            App,
+        >>::destroyed(&mut *guard, client, resource, data)
+    }
+}
+
+impl GlobalDispatch<xdg_activation_v1::XdgActivationV1, (), SubType, App> for SubType {
+    fn bind(
+        state: &mut SubType,
+        handle: &wayland_server::DisplayHandle,
+        client: &Client,
+        resource: wayland_server::New<xdg_activation_v1::XdgActivationV1>,
+        global_data: &(),
+        data_init: &mut wayland_server::DataInit<'_, App>,
+    ) {
+        <XdgActivationState as GlobalDispatch<xdg_activation_v1::XdgActivationV1, (), SubType, App>>::bind(
+            state,
+            handle,
+            client,
+            resource,
+            global_data,
+            data_init,
+        )
+    }
+
+    fn can_view(client: Client, global_data: &()) -> bool {
+        <XdgActivationState as GlobalDispatch<xdg_activation_v1::XdgActivationV1, (), SubType, App>>::can_view(
+            client,
+            global_data,
+        )
+    }
+}
+
+impl Dispatch<xdg_activation_v1::XdgActivationV1, (), SubType, App> for SubType {
+    fn request(
+        state: &mut SubType,
+        client: &Client,
+        resource: &xdg_activation_v1::XdgActivationV1,
+        request: <xdg_activation_v1::XdgActivationV1 as wayland_server::Resource>::Request,
+        data: &(),
+        dhandle: &wayland_server::DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, App>,
+    ) {
+        <XdgActivationState as Dispatch<xdg_activation_v1::XdgActivationV1, (), SubType, App>>::request(
+            state, client, resource, request, data, dhandle, data_init,
+        )
+    }
+
+    fn destroyed(
+        state: &mut SubType,
+        client: wayland_server::backend::ClientId,
+        resource: &xdg_activation_v1::XdgActivationV1,
+        data: &(),
+    ) {
+        <XdgActivationState as Dispatch<xdg_activation_v1::XdgActivationV1, (), SubType, App>>::destroyed(
+            state, client, resource, data,
+        )
+    }
+}
+
+impl Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData, SubType, App> for SubType {
+    fn request(
+        state: &mut SubType,
+        client: &Client,
+        resource: &xdg_activation_token_v1::XdgActivationTokenV1,
+        request: <xdg_activation_token_v1::XdgActivationTokenV1 as wayland_server::Resource>::Request,
+        data: &ActivationTokenData,
+        dhandle: &wayland_server::DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, App>,
+    ) {
+        <XdgActivationState as Dispatch<
+            xdg_activation_token_v1::XdgActivationTokenV1,
+            ActivationTokenData,
+            SubType,
+            App,
+        >>::request(state, client, resource, request, data, dhandle, data_init)
+    }
+
+    fn destroyed(
+        state: &mut SubType,
+        client: wayland_server::backend::ClientId,
+        resource: &xdg_activation_token_v1::XdgActivationTokenV1,
+        data: &ActivationTokenData,
+    ) {
+        <XdgActivationState as Dispatch<
+            xdg_activation_token_v1::XdgActivationTokenV1,
+            ActivationTokenData,
+            SubType,
+            App,
+        >>::destroyed(state, client, resource, data)
+    }
+}

--- a/src/wayland/xdg_activation/dispatch.rs
+++ b/src/wayland/xdg_activation/dispatch.rs
@@ -12,15 +12,16 @@ use super::{
     ActivationTokenData, TokenBuilder, XdgActivationHandler, XdgActivationState, XdgActivationTokenData,
 };
 
-impl<D> Dispatch<xdg_activation_v1::XdgActivationV1, (), D> for XdgActivationState
+impl<D, F> Dispatch<xdg_activation_v1::XdgActivationV1, (), F, D> for XdgActivationState
 where
-    D: Dispatch<xdg_activation_v1::XdgActivationV1, ()>
-        + Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData>
-        + XdgActivationHandler
+    D: Dispatch<xdg_activation_v1::XdgActivationV1, (), D>
+        + Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData, D>
         + 'static,
+    F: XdgActivationHandler
+        + Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData, F, D>,
 {
     fn request(
-        state: &mut D,
+        state: &mut F,
         _: &Client,
         _: &xdg_activation_v1::XdgActivationV1,
         request: xdg_activation_v1::Request,
@@ -61,16 +62,16 @@ where
     }
 }
 
-impl<D> GlobalDispatch<xdg_activation_v1::XdgActivationV1, (), D> for XdgActivationState
+impl<D, F> GlobalDispatch<xdg_activation_v1::XdgActivationV1, (), F, D> for XdgActivationState
 where
-    D: GlobalDispatch<xdg_activation_v1::XdgActivationV1, ()>
-        + Dispatch<xdg_activation_v1::XdgActivationV1, ()>
-        + Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData>
-        + XdgActivationHandler
+    D: GlobalDispatch<xdg_activation_v1::XdgActivationV1, (), D>
+        + Dispatch<xdg_activation_v1::XdgActivationV1, (), D>
+        + Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData, D>
         + 'static,
+    F: XdgActivationHandler + Dispatch<xdg_activation_v1::XdgActivationV1, (), F, D>,
 {
     fn bind(
-        _: &mut D,
+        _: &mut F,
         _: &DisplayHandle,
         _: &Client,
         resource: New<xdg_activation_v1::XdgActivationV1>,
@@ -81,12 +82,14 @@ where
     }
 }
 
-impl<D> Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData, D> for XdgActivationState
+impl<D, F> Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData, F, D>
+    for XdgActivationState
 where
-    D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData> + XdgActivationHandler,
+    D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, ActivationTokenData, D, D>,
+    F: XdgActivationHandler,
 {
     fn request(
-        state: &mut D,
+        state: &mut F,
         client: &Client,
         token: &xdg_activation_token_v1::XdgActivationTokenV1,
         request: xdg_activation_token_v1::Request,
@@ -172,7 +175,7 @@ where
     }
 
     fn destroyed(
-        _: &mut D,
+        _: &mut F,
         _: ClientId,
         _: &xdg_activation_token_v1::XdgActivationTokenV1,
         _: &ActivationTokenData,

--- a/src/wayland/xdg_activation/mod.rs
+++ b/src/wayland/xdg_activation/mod.rs
@@ -51,7 +51,7 @@ use std::{
     time::Instant,
 };
 
-use wayland_protocols::xdg::activation::v1::server::xdg_activation_v1;
+pub use wayland_protocols::xdg::activation::v1::server::{xdg_activation_token_v1, xdg_activation_v1};
 use wayland_server::{
     backend::{ClientId, GlobalId},
     protocol::{wl_seat::WlSeat, wl_surface::WlSurface},
@@ -163,9 +163,8 @@ impl XdgActivationState {
     /// In order to use this abstraction, your `D` type needs to implement [`XdgActivationHandler`].
     pub fn new<D>(display: &DisplayHandle) -> XdgActivationState
     where
-        D: GlobalDispatch<xdg_activation_v1::XdgActivationV1, ()>
-            + Dispatch<xdg_activation_v1::XdgActivationV1, ()>
-            + XdgActivationHandler
+        D: GlobalDispatch<xdg_activation_v1::XdgActivationV1, (), D>
+            + Dispatch<xdg_activation_v1::XdgActivationV1, (), D>
             + 'static,
     {
         let global = display.create_global::<D, xdg_activation_v1::XdgActivationV1, _>(1, ());


### PR DESCRIPTION
Draft while I didn't even crate a wayland-rs PR for the required changed. See https://github.com/Drakulix/wayland-rs/commit/62a7ec520ad811c03fbc72ec27fc7e0c5c7cbe6d.

Example for xdg-activation (semi random pick).

This allows forwarding Dispatch implementation, e.g. to handle internal locks.

As a side effect this requires almost the opposite direction of what https://github.com/Smithay/smithay/pull/1327 tries to accomplish. So far it looks like we need `D` to implement `GlobalDispatch`/`Dispatch` for this to work, I haven't been able to get this to compile with @PolyMeilex patches without introduces heaps of new generics.

For this to be usable we obviously need `delegate_dispatch!`/`delegate_global_dispatch` to optionally handle the new `F` parameter, which would get rid of at least one of the manual implementations in the example.

I would additionally like to add a `forward_dispatch!`-macro to get rid of the other.

Open for comments and further discussion. This would be very useful for cosmic-comp for a variety of reasons.

E.g. this enables internal locks for more fine-grained multi-threading (as can be seen in the example). This also allows to limit implementations of our `*Handler`-traits to parts of `D`. E.g. the `SeatHandler` could run on a subset of `D`, allowing `set_grab` and other to be called inside of the window-management code, where you might not have access to all of `D`.