### PR TITLE
Add `unset` method to input grab traits

### DIFF
--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -163,6 +163,8 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerMoveS
     fn start_data(&self) -> &PointerGrabStartData<AnvilState<BackendData>> {
         &self.start_data
     }
+
+    fn unset(&mut self, _data: &mut AnvilState<BackendData>) {}
 }
 
 pub struct TouchMoveSurfaceGrab<B: Backend + 'static> {
@@ -242,6 +244,8 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
     fn start_data(&self) -> &smithay::input::touch::GrabStartData<AnvilState<BackendData>> {
         &self.start_data
     }
+
+    fn unset(&mut self, _data: &mut AnvilState<BackendData>) {}
 }
 
 bitflags::bitflags! {
@@ -603,6 +607,8 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerResiz
     fn start_data(&self) -> &PointerGrabStartData<AnvilState<BackendData>> {
         &self.start_data
     }
+
+    fn unset(&mut self, _data: &mut AnvilState<BackendData>) {}
 }
 
 pub struct TouchResizeSurfaceGrab<B: Backend + 'static> {
@@ -831,4 +837,6 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
     fn start_data(&self) -> &smithay::input::touch::GrabStartData<AnvilState<BackendData>> {
         &self.start_data
     }
+
+    fn unset(&mut self, _data: &mut AnvilState<BackendData>) {}
 }

--- a/smallvil/src/grabs/move_grab.rs
+++ b/smallvil/src/grabs/move_grab.rs
@@ -150,4 +150,6 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
     fn start_data(&self) -> &PointerGrabStartData<Smallvil> {
         &self.start_data
     }
+
+    fn unset(&mut self, _data: &mut Smallvil) {}
 }

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -260,6 +260,8 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
     fn start_data(&self) -> &PointerGrabStartData<Smallvil> {
         &self.start_data
     }
+
+    fn unset(&mut self, _data: &mut Smallvil) {}
 }
 
 /// State of the resize operation.

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         SeatHandler,
     },
-    utils::{DeadResource, IsAlive, Logical, Point, Serial},
+    utils::{DeadResource, IsAlive, Logical, Point, Serial, SERIAL_COUNTER},
     wayland::{compositor::get_role, seat::WaylandFocus, shell::xdg::XDG_POPUP_ROLE},
 };
 
@@ -486,6 +486,8 @@ where
     fn start_data(&self) -> &KeyboardGrabStartData<D> {
         self.popup_grab.keyboard_grab_start_data()
     }
+
+    fn unset(&mut self, _data: &mut D) {}
 }
 
 /// Default implementation of a [`PointerGrab`] for [`PopupGrab`]
@@ -552,7 +554,6 @@ where
     ) {
         if self.popup_grab.has_ended() {
             handle.unset_grab(data, event.serial, event.time, true);
-            self.popup_grab.unset_keyboard_grab(data, event.serial);
             return;
         }
 
@@ -593,7 +594,6 @@ where
         if self.popup_grab.has_ended() {
             handle.unset_grab(data, serial, time, true);
             handle.button(data, event);
-            self.popup_grab.unset_keyboard_grab(data, serial);
             return;
         }
 
@@ -612,7 +612,6 @@ where
             let _ = self.popup_grab.ungrab(PopupUngrabStrategy::All);
             handle.unset_grab(data, serial, time, true);
             handle.button(data, event);
-            self.popup_grab.unset_keyboard_grab(data, serial);
             return;
         }
 
@@ -701,5 +700,10 @@ where
 
     fn start_data(&self) -> &PointerGrabStartData<D> {
         self.popup_grab.pointer_grab_start_data()
+    }
+
+    fn unset(&mut self, data: &mut D) {
+        let serial = SERIAL_COUNTER.next_serial();
+        self.popup_grab.unset_keyboard_grab(data, serial);
     }
 }

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -167,6 +167,8 @@ pub trait PointerGrab<D: SeatHandler>: Send {
     );
     /// The data about the event that started the grab.
     fn start_data(&self) -> &GrabStartData<D>;
+    /// The grab has been unset or replaced with another grab.
+    fn unset(&mut self, data: &mut D);
 }
 
 /// Data about the event that started the grab.
@@ -343,6 +345,8 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
     fn start_data(&self) -> &GrabStartData<D> {
         unreachable!()
     }
+
+    fn unset(&mut self, _data: &mut D) {}
 }
 
 // A click grab, basic grab started when an user clicks a surface
@@ -466,4 +470,6 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
     fn start_data(&self) -> &GrabStartData<D> {
         &self.start_data
     }
+
+    fn unset(&mut self, _data: &mut D) {}
 }

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -244,7 +244,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
         let mut inner = self.inner.lock().unwrap();
         inner.pending_focus = focus.clone();
         let seat = self.get_seat(data);
-        inner.with_grab(&seat, |handle, grab| {
+        inner.with_grab(data, &seat, |data, handle, grab| {
             grab.motion(data, handle, focus, event);
         });
     }
@@ -264,7 +264,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
         let mut inner = self.inner.lock().unwrap();
         inner.pending_focus = focus.clone();
         let seat = self.get_seat(data);
-        inner.with_grab(&seat, |handle, grab| {
+        inner.with_grab(data, &seat, |data, handle, grab| {
             grab.relative_motion(data, handle, focus, event);
         });
     }
@@ -285,7 +285,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
             }
         }
         let seat = self.get_seat(data);
-        inner.with_grab(&seat, |handle, grab| {
+        inner.with_grab(data, &seat, |data, handle, grab| {
             grab.button(data, handle, event);
         });
     }
@@ -296,9 +296,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn axis(&self, data: &mut D, details: AxisFrame) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
-            grab.axis(data, handle, details);
-        });
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(data, &seat, |data, handle, grab| {
+                grab.axis(data, handle, details);
+            });
     }
 
     /// End of a pointer frame
@@ -307,9 +310,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn frame(&self, data: &mut D) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
-            grab.frame(data, handle);
-        });
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(data, &seat, |data, handle, grab| {
+                grab.frame(data, handle);
+            });
     }
 
     /// Notify about swipe gesture begin
@@ -320,9 +326,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_swipe_begin(&self, data: &mut D, event: &GestureSwipeBeginEvent) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
-            grab.gesture_swipe_begin(data, handle, event);
-        });
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(data, &seat, |data, handle, grab| {
+                grab.gesture_swipe_begin(data, handle, event);
+            });
     }
 
     /// Notify about swipe gesture update
@@ -333,9 +342,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_swipe_update(&self, data: &mut D, event: &GestureSwipeUpdateEvent) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
-            grab.gesture_swipe_update(data, handle, event);
-        });
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(data, &seat, |data, handle, grab| {
+                grab.gesture_swipe_update(data, handle, event);
+            });
     }
 
     /// Notify about swipe gesture end
@@ -346,9 +358,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_swipe_end(&self, data: &mut D, event: &GestureSwipeEndEvent) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
-            grab.gesture_swipe_end(data, handle, event);
-        });
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(data, &seat, |data, handle, grab| {
+                grab.gesture_swipe_end(data, handle, event);
+            });
     }
 
     /// Notify about pinch gesture begin
@@ -359,9 +374,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_pinch_begin(&self, data: &mut D, event: &GesturePinchBeginEvent) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
-            grab.gesture_pinch_begin(data, handle, event);
-        });
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(data, &seat, |data, handle, grab| {
+                grab.gesture_pinch_begin(data, handle, event);
+            });
     }
 
     /// Notify about pinch gesture update
@@ -372,9 +390,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_pinch_update(&self, data: &mut D, event: &GesturePinchUpdateEvent) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
-            grab.gesture_pinch_update(data, handle, event);
-        });
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(data, &seat, |data, handle, grab| {
+                grab.gesture_pinch_update(data, handle, event);
+            });
     }
 
     /// Notify about pinch gesture end
@@ -385,9 +406,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_pinch_end(&self, data: &mut D, event: &GesturePinchEndEvent) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
-            grab.gesture_pinch_end(data, handle, event);
-        });
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(data, &seat, |data, handle, grab| {
+                grab.gesture_pinch_end(data, handle, event);
+            });
     }
 
     /// Notify about hold gesture begin
@@ -398,9 +422,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_hold_begin(&self, data: &mut D, event: &GestureHoldBeginEvent) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
-            grab.gesture_hold_begin(data, handle, event);
-        });
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(data, &seat, |data, handle, grab| {
+                grab.gesture_hold_begin(data, handle, event);
+            });
     }
 
     /// Notify about hold gesture end
@@ -411,9 +438,12 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_hold_end(&self, data: &mut D, event: &GestureHoldEndEvent) {
         let seat = self.get_seat(data);
-        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
-            grab.gesture_hold_end(data, handle, event);
-        });
+        self.inner
+            .lock()
+            .unwrap()
+            .with_grab(data, &seat, |data, handle, grab| {
+                grab.gesture_hold_end(data, handle, event);
+            });
     }
 
     /// Access the current location of this pointer in the global space
@@ -686,6 +716,9 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
         grab: G,
         focus: Focus,
     ) {
+        if let GrabStatus::Active(_, handler) = &mut self.grab {
+            handler.unset(data);
+        }
         self.grab = GrabStatus::Active(serial, Box::new(grab));
 
         if matches!(focus, Focus::Clear) {
@@ -704,6 +737,9 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
     }
 
     fn unset_grab(&mut self, data: &mut D, seat: &Seat<D>, serial: Serial, time: u32, restore_focus: bool) {
+        if let GrabStatus::Active(_, handler) = &mut self.grab {
+            handler.unset(data);
+        }
         self.grab = GrabStatus::None;
         if restore_focus {
             // restore the focus
@@ -817,9 +853,9 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
         }
     }
 
-    fn with_grab<F>(&mut self, seat: &Seat<D>, f: F)
+    fn with_grab<F>(&mut self, data: &mut D, seat: &Seat<D>, f: F)
     where
-        F: FnOnce(&mut PointerInnerHandle<'_, D>, &mut dyn PointerGrab<D>),
+        F: FnOnce(&mut D, &mut PointerInnerHandle<'_, D>, &mut dyn PointerGrab<D>),
     {
         let mut grab = std::mem::replace(&mut self.grab, GrabStatus::Borrowed);
         match grab {
@@ -829,20 +865,34 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
                 if let Some((ref focus, _)) = handler.start_data().focus {
                     if !focus.alive() {
                         self.grab = GrabStatus::None;
-                        f(&mut PointerInnerHandle { inner: self, seat }, &mut DefaultGrab);
+                        f(
+                            data,
+                            &mut PointerInnerHandle { inner: self, seat },
+                            &mut DefaultGrab,
+                        );
                         return;
                     }
                 }
-                f(&mut PointerInnerHandle { inner: self, seat }, &mut **handler);
+                f(
+                    data,
+                    &mut PointerInnerHandle { inner: self, seat },
+                    &mut **handler,
+                );
             }
             GrabStatus::None => {
-                f(&mut PointerInnerHandle { inner: self, seat }, &mut DefaultGrab);
+                f(
+                    data,
+                    &mut PointerInnerHandle { inner: self, seat },
+                    &mut DefaultGrab,
+                );
             }
         }
 
         if let GrabStatus::Borrowed = self.grab {
-            // the grab has not been ended nor replaced, put it back in place
+            // The grab has not been ended nor replaced, put it back in place
             self.grab = grab;
+        } else if let GrabStatus::Active(_, mut handler) = grab {
+            handler.unset(data);
         }
     }
 }

--- a/src/input/touch/grab.rs
+++ b/src/input/touch/grab.rs
@@ -93,6 +93,9 @@ pub trait TouchGrab<D: SeatHandler>: Send {
 
     /// The data about the event that started the grab.
     fn start_data(&self) -> &GrabStartData<D>;
+
+    /// The grab has been unset or replaced with another grab.
+    fn unset(&mut self, data: &mut D);
 }
 
 /// Data about the event that started the grab.
@@ -198,6 +201,8 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
     fn start_data(&self) -> &GrabStartData<D> {
         unreachable!()
     }
+
+    fn unset(&mut self, _data: &mut D) {}
 }
 
 /// A touch down grab, basic grab started when an user touches a surface
@@ -265,4 +270,6 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for TouchDownGrab<D> {
     fn start_data(&self) -> &GrabStartData<D> {
         &self.start_data
     }
+
+    fn unset(&mut self, _data: &mut D) {}
 }

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -78,6 +78,8 @@ where
     fn start_data(&self) -> &KeyboardGrabStartData<D> {
         &KeyboardGrabStartData { focus: None }
     }
+
+    fn unset(&mut self, _data: &mut D) {}
 }
 
 /// User data of ZwpInputKeyboardGrabV2 object

--- a/src/wayland/selection/data_device/dnd_grab.rs
+++ b/src/wayland/selection/data_device/dnd_grab.rs
@@ -291,7 +291,6 @@ where
     fn button(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, event: &ButtonEvent) {
         if handle.current_pressed().is_empty() {
             // the user dropped, proceed to the drop
-            self.drop(data);
             handle.unset_grab(data, event.serial, event.time, true);
         }
     }
@@ -380,6 +379,10 @@ where
     fn start_data(&self) -> &PointerGrabStartData<D> {
         self.pointer_start_data.as_ref().unwrap()
     }
+
+    fn unset(&mut self, data: &mut D) {
+        self.drop(data);
+    }
 }
 
 impl<D> TouchGrab<D> for DnDGrab<D>
@@ -411,7 +414,6 @@ where
             return;
         }
 
-        self.drop(data);
         handle.unset_grab(data);
     }
 
@@ -450,6 +452,10 @@ where
 
     fn start_data(&self) -> &TouchGrabStartData<D> {
         self.touch_start_data.as_ref().unwrap()
+    }
+
+    fn unset(&mut self, data: &mut D) {
+        self.drop(data);
     }
 }
 

--- a/src/wayland/selection/data_device/server_dnd_grab.rs
+++ b/src/wayland/selection/data_device/server_dnd_grab.rs
@@ -266,7 +266,6 @@ where
 
         if handle.current_pressed().is_empty() {
             // the user dropped, proceed to the drop
-            self.drop(data);
             handle.unset_grab(data, serial, time, true);
         }
     }
@@ -355,6 +354,10 @@ where
     fn start_data(&self) -> &PointerGrabStartData<D> {
         self.pointer_start_data.as_ref().unwrap()
     }
+
+    fn unset(&mut self, data: &mut D) {
+        self.drop(data);
+    }
 }
 
 impl<D> TouchGrab<D> for ServerDnDGrab<D>
@@ -387,7 +390,6 @@ where
         }
 
         // the user dropped, proceed to the drop
-        self.drop(data);
         handle.unset_grab(data);
     }
 
@@ -429,6 +431,10 @@ where
 
     fn start_data(&self) -> &TouchGrabStartData<D> {
         self.touch_start_data.as_ref().unwrap()
+    }
+
+    fn unset(&mut self, data: &mut D) {
+        self.drop(data);
     }
 }
 

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -123,6 +123,8 @@ impl<D: XWaylandKeyboardGrabHandler + 'static> KeyboardGrab<D> for XWaylandKeybo
     fn start_data(&self) -> &keyboard::GrabStartData<D> {
         &self.start_data
     }
+
+    fn unset(&mut self, _data: &mut D) {}
 }
 
 /// State of the xwayland keyboard grab global


### PR DESCRIPTION
`PointerGrab::unset` is called when a grab is removed or replaced with another grab.

This fixes https://github.com/pop-os/cosmic-comp/issues/403. I've seen issues with one or two of cosmic-comp's grabs if something isn't cleaned up correctly when `unset` is called, so this should help with them, as well as some other Smithay grabs.

I still need to add this for keyboard and touch grabs, but it seems workable.