### PR TITLE
add #[must_use] to AxisFrame

### DIFF
--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -970,7 +970,7 @@ pub struct ButtonEvent {
 ///     .value(Axis::Vertical, 30, time)
 ///     .stop(Axis::Vertical);
 /// ```
-#[must_use]
+#[must_use = "AxisFrame uses a builder-like pattern, so its result must be used"]
 #[derive(Copy, Clone, Debug)]
 pub struct AxisFrame {
     /// Source of the axis event, if known

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -970,6 +970,7 @@ pub struct ButtonEvent {
 ///     .value(Axis::Vertical, 30, time)
 ///     .stop(Axis::Vertical);
 /// ```
+#[must_use]
 #[derive(Copy, Clone, Debug)]
 pub struct AxisFrame {
     /// Source of the axis event, if known


### PR DESCRIPTION
it's very easy to accidentally forget the `frame =` reassignment when working with an `AxisFrame`, especially because it doesn't actually "consume" it, since it is `Copy`.

```rs
let mut frame = AxisFrame::new(evt.time_msec()).source(evt.source());
if horizontal_amount != 0.0 {
    // this line does nothing but it doesn't warn me
    frame.relative_direction(Axis::Horizontal, evt.relative_direction(Axis::Horizontal));
    frame = frame.value(Axis::Horizontal, horizontal_amount);
}
```