### PR TITLE
More fixes around `set_grab`/`unset_grab`

### DIFF
--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -67,7 +67,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerMoveS
         handle.button(data, event);
         if handle.current_pressed().is_empty() {
             // No more buttons are pressed, release the grab.
-            handle.unset_grab(data, event.serial, event.time, true);
+            handle.unset_grab(self, data, event.serial, event.time, true);
         }
     }
 
@@ -199,7 +199,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
         }
 
         handle.up(data, event, seq);
-        handle.unset_grab(data);
+        handle.unset_grab(self, data);
     }
 
     fn motion(
@@ -238,7 +238,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
         seq: Serial,
     ) {
         handle.cancel(data, seq);
-        handle.unset_grab(data);
+        handle.unset_grab(self, data);
     }
 
     fn start_data(&self) -> &smithay::input::touch::GrabStartData<AnvilState<BackendData>> {
@@ -340,7 +340,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerResiz
 
         // It is impossible to get `min_size` and `max_size` of dead toplevel, so we return early.
         if !self.window.alive() {
-            handle.unset_grab(data, event.serial, event.time, true);
+            handle.unset_grab(self, data, event.serial, event.time, true);
             return;
         }
 
@@ -431,7 +431,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerResiz
         handle.button(data, event);
         if handle.current_pressed().is_empty() {
             // No more buttons are pressed, release the grab.
-            handle.unset_grab(data, event.serial, event.time, true);
+            handle.unset_grab(self, data, event.serial, event.time, true);
 
             // If toplevel is dead, we can't resize it, so we return early.
             if !self.window.alive() {
@@ -644,7 +644,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
         if event.slot != self.start_data.slot {
             return;
         }
-        handle.unset_grab(data);
+        handle.unset_grab(self, data);
 
         // If toplevel is dead, we can't resize it, so we return early.
         if !self.window.alive() {
@@ -744,7 +744,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
 
         // It is impossible to get `min_size` and `max_size` of dead toplevel, so we return early.
         if !self.window.alive() {
-            handle.unset_grab(data);
+            handle.unset_grab(self, data);
             return;
         }
 
@@ -831,7 +831,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
         seq: Serial,
     ) {
         handle.cancel(data, seq);
-        handle.unset_grab(data);
+        handle.unset_grab(self, data);
     }
 
     fn start_data(&self) -> &smithay::input::touch::GrabStartData<AnvilState<BackendData>> {

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -414,7 +414,7 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
                         return;
                     }
                     keyboard.set_focus(self, grab.current_grab(), serial);
-                    keyboard.set_grab(PopupKeyboardGrab::new(&grab), serial);
+                    keyboard.set_grab(self, PopupKeyboardGrab::new(&grab), serial);
                 }
                 if let Some(pointer) = seat.get_pointer() {
                     if pointer.is_grabbed()

--- a/smallvil/src/grabs/move_grab.rs
+++ b/smallvil/src/grabs/move_grab.rs
@@ -58,7 +58,7 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
 
         if !handle.current_pressed().contains(&BTN_LEFT) {
             // No more buttons are pressed, release the grab.
-            handle.unset_grab(data, event.serial, event.time, true);
+            handle.unset_grab(self, data, event.serial, event.time, true);
         }
     }
 

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -153,7 +153,7 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
 
         if !handle.current_pressed().contains(&BTN_LEFT) {
             // No more buttons are pressed, release the grab.
-            handle.unset_grab(data, event.serial, event.time, true);
+            handle.unset_grab(self, data, event.serial, event.time, true);
 
             let xdg = self.window.toplevel().unwrap();
             xdg.with_pending_state(|state| {

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -382,7 +382,7 @@ where
                 && (keyboard.has_grab(self.serial)
                     || keyboard.has_grab(self.previous_serial.unwrap_or(self.serial)))
             {
-                keyboard.unset_grab();
+                keyboard.unset_grab(data);
                 keyboard.set_focus(data, Some(self.root.clone()), serial);
             }
         }

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -455,7 +455,7 @@ where
         }
 
         if self.popup_grab.has_ended() {
-            handle.unset_grab(data, serial, false);
+            handle.unset_grab(self, data, serial, false);
         }
 
         handle.input(data, keycode, state, modifiers, serial, time)
@@ -471,7 +471,7 @@ where
         // Ignore focus changes unless the grab has ended
         if self.popup_grab.has_ended() {
             handle.set_focus(data, focus, serial);
-            handle.unset_grab(data, serial, false);
+            handle.unset_grab(self, data, serial, false);
             return;
         }
 
@@ -553,7 +553,7 @@ where
         event: &MotionEvent,
     ) {
         if self.popup_grab.has_ended() {
-            handle.unset_grab(data, event.serial, event.time, true);
+            handle.unset_grab(self, data, event.serial, event.time, true);
             return;
         }
 
@@ -592,7 +592,7 @@ where
         let state = event.state;
 
         if self.popup_grab.has_ended() {
-            handle.unset_grab(data, serial, time, true);
+            handle.unset_grab(self, data, serial, time, true);
             handle.button(data, event);
             return;
         }
@@ -610,7 +610,7 @@ where
                 .unwrap_or(false)
         {
             let _ = self.popup_grab.ungrab(PopupUngrabStrategy::All);
-            handle.unset_grab(data, serial, time, true);
+            handle.unset_grab(self, data, serial, time, true);
             handle.button(data, event);
             return;
         }

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -207,9 +207,9 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
         (modifiers_changed, leds_changed)
     }
 
-    fn with_grab<F>(&mut self, data: &mut D, seat: &Seat<D>, f: F)
+    fn with_grab<F>(&mut self, seat: &Seat<D>, f: F)
     where
-        F: FnOnce(&mut D, &mut KeyboardInnerHandle<'_, D>, &mut dyn KeyboardGrab<D>),
+        F: FnOnce(&mut KeyboardInnerHandle<'_, D>, &mut dyn KeyboardGrab<D>),
     {
         let mut grab = std::mem::replace(&mut self.grab, GrabStatus::Borrowed);
         match grab {
@@ -219,34 +219,20 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
                 if let Some(ref surface) = handler.start_data().focus {
                     if !surface.alive() {
                         self.grab = GrabStatus::None;
-                        f(
-                            data,
-                            &mut KeyboardInnerHandle { inner: self, seat },
-                            &mut DefaultGrab,
-                        );
+                        f(&mut KeyboardInnerHandle { inner: self, seat }, &mut DefaultGrab);
                         return;
                     }
                 }
-                f(
-                    data,
-                    &mut KeyboardInnerHandle { inner: self, seat },
-                    &mut **handler,
-                );
+                f(&mut KeyboardInnerHandle { inner: self, seat }, &mut **handler);
             }
             GrabStatus::None => {
-                f(
-                    data,
-                    &mut KeyboardInnerHandle { inner: self, seat },
-                    &mut DefaultGrab,
-                );
+                f(&mut KeyboardInnerHandle { inner: self, seat }, &mut DefaultGrab);
             }
         }
 
         if let GrabStatus::Borrowed = self.grab {
             // the grab has not been ended nor replaced, put it back in place
             self.grab = grab;
-        } else if let GrabStatus::Active(_, mut handler) = grab {
-            handler.unset(data);
         }
     }
 }
@@ -951,7 +937,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         // forward to client if no keybinding is triggered
         let seat = self.get_seat(data);
         let modifiers = mods_changed.then_some(guard.mods_state);
-        guard.with_grab(data, &seat, |data, handle, grab| {
+        guard.with_grab(&seat, |handle, grab| {
             grab.input(data, handle, keycode, state, modifiers, serial, time);
         });
         if guard.focus.is_some() {
@@ -972,7 +958,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         let mut guard = self.arc.internal.lock().unwrap();
         guard.pending_focus = focus.clone();
         let seat = self.get_seat(data);
-        guard.with_grab(data, &seat, |data, handle, grab| {
+        guard.with_grab(&seat, |handle, grab| {
             grab.set_focus(data, handle, focus, serial);
         });
     }
@@ -1087,10 +1073,14 @@ impl<'a, D: SeatHandler + 'static> KeyboardInnerHandle<'a, D> {
     /// Change the current grab on this keyboard to the provided grab
     ///
     /// Overwrites any current grab.
-    pub fn set_grab<G: KeyboardGrab<D> + 'static>(&mut self, data: &mut D, serial: Serial, grab: G) {
-        if let GrabStatus::Active(_, handler) = &mut self.inner.grab {
-            handler.unset(data);
-        }
+    pub fn set_grab<G: KeyboardGrab<D> + 'static>(
+        &mut self,
+        handler: &mut dyn KeyboardGrab<D>,
+        data: &mut D,
+        serial: Serial,
+        grab: G,
+    ) {
+        handler.unset(data);
         self.inner.grab = GrabStatus::Active(serial, Box::new(grab));
     }
 
@@ -1098,10 +1088,14 @@ impl<'a, D: SeatHandler + 'static> KeyboardInnerHandle<'a, D> {
     ///
     /// This will also restore the focus of the underlying keyboard if restore_focus
     /// is [`true`]
-    pub fn unset_grab(&mut self, data: &mut D, serial: Serial, restore_focus: bool) {
-        if let GrabStatus::Active(_, handler) = &mut self.inner.grab {
-            handler.unset(data);
-        }
+    pub fn unset_grab(
+        &mut self,
+        handler: &mut dyn KeyboardGrab<D>,
+        data: &mut D,
+        serial: Serial,
+        restore_focus: bool,
+    ) {
+        handler.unset(data);
         self.inner.grab = GrabStatus::None;
         // restore the focus
         if restore_focus {

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -16,7 +16,7 @@ use tracing::{debug, error, info, info_span, instrument, trace};
 use xkbcommon::xkb::ffi::XKB_STATE_LAYOUT_EFFECTIVE;
 pub use xkbcommon::xkb::{self, keysyms, Keycode, Keysym};
 
-use super::{Seat, SeatHandler};
+use super::{GrabStatus, Seat, SeatHandler};
 
 #[cfg(feature = "wayland_frontend")]
 mod keymap_file;
@@ -50,12 +50,6 @@ where
     );
     /// Hold modifiers were changed on a keyboard from a given seat
     fn modifiers(&self, seat: &Seat<D>, data: &mut D, modifiers: ModifiersState, serial: Serial);
-}
-
-enum GrabStatus<D> {
-    None,
-    Active(Serial, Box<dyn KeyboardGrab<D>>),
-    Borrowed,
 }
 
 /// Mapping of the led of a keymap
@@ -133,7 +127,7 @@ pub(crate) struct KbdInternal<D: SeatHandler> {
     pub(crate) repeat_delay: i32,
     led_mapping: LedMapping,
     pub(crate) led_state: LedState,
-    grab: GrabStatus<D>,
+    grab: GrabStatus<dyn KeyboardGrab<D>>,
 }
 
 // focus_hook does not implement debug, so we have to impl Debug manually

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -135,7 +135,7 @@ use self::{
     pointer::{CursorImageStatus, PointerHandle, PointerTarget},
     touch::TouchGrab,
 };
-use crate::utils::user_data::UserDataMap;
+use crate::utils::{user_data::UserDataMap, Serial};
 
 pub mod keyboard;
 pub mod pointer;
@@ -644,5 +644,22 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// Gets this seat's name
     pub fn name(&self) -> &str {
         &self.arc.name
+    }
+}
+
+pub(super) enum GrabStatus<G: ?Sized> {
+    None,
+    Active(Serial, Box<G>),
+    Borrowed,
+}
+
+// `G` is not `Debug`, so we have to impl Debug manually
+impl<G: ?Sized> fmt::Debug for GrabStatus<G> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GrabStatus::None => f.debug_tuple("GrabStatus::None").finish(),
+            GrabStatus::Active(serial, _) => f.debug_tuple("GrabStatus::Active").field(&serial).finish(),
+            GrabStatus::Borrowed => f.debug_tuple("GrabStatus::Borrowed").finish(),
+        }
     }
 }

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use crate::{
     backend::input::ButtonState,
     input::SeatHandler,
-    utils::Serial,
     utils::{Logical, Point},
 };
 
@@ -199,23 +198,6 @@ impl<D: SeatHandler + 'static> Clone for GrabStartData<D> {
             focus: self.focus.clone(),
             button: self.button,
             location: self.location,
-        }
-    }
-}
-
-pub(super) enum GrabStatus<D> {
-    None,
-    Active(Serial, Box<dyn PointerGrab<D>>),
-    Borrowed,
-}
-
-// PointerGrab is a trait, so we have to impl Debug manually
-impl<D> fmt::Debug for GrabStatus<D> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            GrabStatus::None => f.debug_tuple("GrabStatus::None").finish(),
-            GrabStatus::Active(serial, _) => f.debug_tuple("GrabStatus::Active").field(&serial).finish(),
-            GrabStatus::Borrowed => f.debug_tuple("GrabStatus::Borrowed").finish(),
         }
     }
 }

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -230,6 +230,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
         handle.button(data, event);
         if event.state == ButtonState::Pressed {
             handle.set_grab(
+                self,
                 data,
                 event.serial,
                 Focus::Keep,
@@ -365,7 +366,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
         handle.button(data, event);
         if handle.current_pressed().is_empty() {
             // no more buttons are pressed, release the grab
-            handle.unset_grab(data, event.serial, event.time, false);
+            handle.unset_grab(self, data, event.serial, event.time, false);
         }
     }
 

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     backend::input::{Axis, AxisRelativeDirection, AxisSource, ButtonState},
-    input::{Seat, SeatHandler},
+    input::{GrabStatus, Seat, SeatHandler},
     utils::Serial,
     utils::{IsAlive, Logical, Point},
 };
@@ -17,7 +17,7 @@ pub use cursor_icon::CursorIcon;
 pub use cursor_image::{CursorImageAttributes, CursorImageStatus, CursorImageSurfaceData};
 
 mod grab;
-use grab::{DefaultGrab, GrabStatus};
+use grab::DefaultGrab;
 pub use grab::{GrabStartData, PointerGrab};
 use tracing::{info_span, instrument};
 
@@ -679,7 +679,7 @@ pub(crate) struct PointerInternal<D: SeatHandler> {
     pub(crate) focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
     pending_focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
     location: Point<f64, Logical>,
-    grab: GrabStatus<D>,
+    grab: GrabStatus<dyn PointerGrab<D>>,
     pressed_buttons: Vec<u32>,
 }
 

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -244,7 +244,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
         let mut inner = self.inner.lock().unwrap();
         inner.pending_focus = focus.clone();
         let seat = self.get_seat(data);
-        inner.with_grab(data, &seat, |data, handle, grab| {
+        inner.with_grab(&seat, |handle, grab| {
             grab.motion(data, handle, focus, event);
         });
     }
@@ -264,7 +264,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
         let mut inner = self.inner.lock().unwrap();
         inner.pending_focus = focus.clone();
         let seat = self.get_seat(data);
-        inner.with_grab(data, &seat, |data, handle, grab| {
+        inner.with_grab(&seat, |handle, grab| {
             grab.relative_motion(data, handle, focus, event);
         });
     }
@@ -285,7 +285,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
             }
         }
         let seat = self.get_seat(data);
-        inner.with_grab(data, &seat, |data, handle, grab| {
+        inner.with_grab(&seat, |handle, grab| {
             grab.button(data, handle, event);
         });
     }
@@ -296,12 +296,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn axis(&self, data: &mut D, details: AxisFrame) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(data, &seat, |data, handle, grab| {
-                grab.axis(data, handle, details);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.axis(data, handle, details);
+        });
     }
 
     /// End of a pointer frame
@@ -310,12 +307,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn frame(&self, data: &mut D) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(data, &seat, |data, handle, grab| {
-                grab.frame(data, handle);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.frame(data, handle);
+        });
     }
 
     /// Notify about swipe gesture begin
@@ -326,12 +320,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_swipe_begin(&self, data: &mut D, event: &GestureSwipeBeginEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(data, &seat, |data, handle, grab| {
-                grab.gesture_swipe_begin(data, handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_swipe_begin(data, handle, event);
+        });
     }
 
     /// Notify about swipe gesture update
@@ -342,12 +333,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_swipe_update(&self, data: &mut D, event: &GestureSwipeUpdateEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(data, &seat, |data, handle, grab| {
-                grab.gesture_swipe_update(data, handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_swipe_update(data, handle, event);
+        });
     }
 
     /// Notify about swipe gesture end
@@ -358,12 +346,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_swipe_end(&self, data: &mut D, event: &GestureSwipeEndEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(data, &seat, |data, handle, grab| {
-                grab.gesture_swipe_end(data, handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_swipe_end(data, handle, event);
+        });
     }
 
     /// Notify about pinch gesture begin
@@ -374,12 +359,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_pinch_begin(&self, data: &mut D, event: &GesturePinchBeginEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(data, &seat, |data, handle, grab| {
-                grab.gesture_pinch_begin(data, handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_pinch_begin(data, handle, event);
+        });
     }
 
     /// Notify about pinch gesture update
@@ -390,12 +372,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_pinch_update(&self, data: &mut D, event: &GesturePinchUpdateEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(data, &seat, |data, handle, grab| {
-                grab.gesture_pinch_update(data, handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_pinch_update(data, handle, event);
+        });
     }
 
     /// Notify about pinch gesture end
@@ -406,12 +385,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_pinch_end(&self, data: &mut D, event: &GesturePinchEndEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(data, &seat, |data, handle, grab| {
-                grab.gesture_pinch_end(data, handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_pinch_end(data, handle, event);
+        });
     }
 
     /// Notify about hold gesture begin
@@ -422,12 +398,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_hold_begin(&self, data: &mut D, event: &GestureHoldBeginEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(data, &seat, |data, handle, grab| {
-                grab.gesture_hold_begin(data, handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_hold_begin(data, handle, event);
+        });
     }
 
     /// Notify about hold gesture end
@@ -438,12 +411,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     #[instrument(level = "trace", parent = &self.span, skip(self, data))]
     pub fn gesture_hold_end(&self, data: &mut D, event: &GestureHoldEndEvent) {
         let seat = self.get_seat(data);
-        self.inner
-            .lock()
-            .unwrap()
-            .with_grab(data, &seat, |data, handle, grab| {
-                grab.gesture_hold_end(data, handle, event);
-            });
+        self.inner.lock().unwrap().with_grab(&seat, |handle, grab| {
+            grab.gesture_hold_end(data, handle, event);
+        });
     }
 
     /// Access the current location of this pointer in the global space
@@ -503,11 +473,13 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     /// Overwrites any current grab.
     pub fn set_grab<G: PointerGrab<D> + 'static>(
         &mut self,
+        handler: &mut dyn PointerGrab<D>,
         data: &mut D,
         serial: Serial,
         focus: Focus,
         grab: G,
     ) {
+        handler.unset(data);
         self.inner.set_grab(data, self.seat, serial, grab, focus);
     }
 
@@ -515,7 +487,15 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     ///
     /// This will also restore the focus of the underlying pointer if restore_focus
     /// is [`true`]
-    pub fn unset_grab(&mut self, data: &mut D, serial: Serial, time: u32, restore_focus: bool) {
+    pub fn unset_grab(
+        &mut self,
+        handler: &mut dyn PointerGrab<D>,
+        data: &mut D,
+        serial: Serial,
+        time: u32,
+        restore_focus: bool,
+    ) {
+        handler.unset(data);
         self.inner
             .unset_grab(data, self.seat, serial, time, restore_focus);
     }
@@ -853,9 +833,9 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
         }
     }
 
-    fn with_grab<F>(&mut self, data: &mut D, seat: &Seat<D>, f: F)
+    fn with_grab<F>(&mut self, seat: &Seat<D>, f: F)
     where
-        F: FnOnce(&mut D, &mut PointerInnerHandle<'_, D>, &mut dyn PointerGrab<D>),
+        F: FnOnce(&mut PointerInnerHandle<'_, D>, &mut dyn PointerGrab<D>),
     {
         let mut grab = std::mem::replace(&mut self.grab, GrabStatus::Borrowed);
         match grab {
@@ -865,34 +845,20 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
                 if let Some((ref focus, _)) = handler.start_data().focus {
                     if !focus.alive() {
                         self.grab = GrabStatus::None;
-                        f(
-                            data,
-                            &mut PointerInnerHandle { inner: self, seat },
-                            &mut DefaultGrab,
-                        );
+                        f(&mut PointerInnerHandle { inner: self, seat }, &mut DefaultGrab);
                         return;
                     }
                 }
-                f(
-                    data,
-                    &mut PointerInnerHandle { inner: self, seat },
-                    &mut **handler,
-                );
+                f(&mut PointerInnerHandle { inner: self, seat }, &mut **handler);
             }
             GrabStatus::None => {
-                f(
-                    data,
-                    &mut PointerInnerHandle { inner: self, seat },
-                    &mut DefaultGrab,
-                );
+                f(&mut PointerInnerHandle { inner: self, seat }, &mut DefaultGrab);
             }
         }
 
         if let GrabStatus::Borrowed = self.grab {
             // The grab has not been ended nor replaced, put it back in place
             self.grab = grab;
-        } else if let GrabStatus::Active(_, mut handler) = grab {
-            handler.unset(data);
         }
     }
 }

--- a/src/input/touch/grab.rs
+++ b/src/input/touch/grab.rs
@@ -145,6 +145,7 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
     ) {
         handle.down(data, focus.clone(), event, seq);
         handle.set_grab(
+            self,
             data,
             event.serial,
             TouchDownGrab {
@@ -226,7 +227,7 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for TouchDownGrab<D> {
         handle.up(data, event, seq);
         self.touch_points = self.touch_points.saturating_sub(1);
         if self.touch_points == 0 {
-            handle.unset_grab(data);
+            handle.unset_grab(self, data);
         }
     }
 
@@ -247,7 +248,7 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for TouchDownGrab<D> {
 
     fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
         handle.cancel(data, seq);
-        handle.unset_grab(data);
+        handle.unset_grab(self, data);
     }
 
     fn start_data(&self) -> &GrabStartData<D> {

--- a/src/input/touch/grab.rs
+++ b/src/input/touch/grab.rs
@@ -130,23 +130,6 @@ impl<D: SeatHandler + 'static> Clone for GrabStartData<D> {
     }
 }
 
-pub(super) enum GrabStatus<D> {
-    None,
-    Active(Serial, Box<dyn TouchGrab<D>>),
-    Borrowed,
-}
-
-// TouchGrab is a trait, so we have to impl Debug manually
-impl<D> fmt::Debug for GrabStatus<D> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            GrabStatus::None => f.debug_tuple("GrabStatus::None").finish(),
-            GrabStatus::Active(serial, _) => f.debug_tuple("GrabStatus::Active").field(&serial).finish(),
-            GrabStatus::Borrowed => f.debug_tuple("GrabStatus::Borrowed").finish(),
-        }
-    }
-}
-
 /// The default grab, the behavior when no particular grab is in progress
 #[derive(Debug)]
 pub struct DefaultGrab;

--- a/src/input/touch/mod.rs
+++ b/src/input/touch/mod.rs
@@ -9,10 +9,9 @@ use tracing::{info_span, instrument};
 use crate::backend::input::TouchSlot;
 use crate::utils::{IsAlive, Logical, Point, Serial, SerialCounter};
 
-use self::grab::GrabStatus;
 pub use grab::{DefaultGrab, GrabStartData, TouchDownGrab, TouchGrab};
 
-use super::{Seat, SeatHandler};
+use super::{GrabStatus, Seat, SeatHandler};
 
 mod grab;
 
@@ -79,7 +78,7 @@ pub(crate) struct TouchInternal<D: SeatHandler> {
     focus: HashMap<TouchSlot, TouchSlotState<D>>,
     seq_counter: SerialCounter,
     default_grab: Box<dyn Fn() -> Box<dyn TouchGrab<D>> + Send + 'static>,
-    grab: GrabStatus<D>,
+    grab: GrabStatus<dyn TouchGrab<D>>,
 }
 
 struct TouchSlotState<D: SeatHandler> {

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -264,8 +264,11 @@ where
             }
             zwp_input_method_v2::Request::GrabKeyboard { keyboard } => {
                 let input_method = data.handle.inner.lock().unwrap();
-                data.keyboard_handle
-                    .set_grab(input_method.keyboard_grab.clone(), SERIAL_COUNTER.next_serial());
+                data.keyboard_handle.set_grab(
+                    state,
+                    input_method.keyboard_grab.clone(),
+                    SERIAL_COUNTER.next_serial(),
+                );
                 let instance = data_init.init(
                     keyboard,
                     InputMethodKeyboardUserData {

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -101,13 +101,13 @@ impl<D: SeatHandler + 'static> Dispatch<ZwpInputMethodKeyboardGrabV2, InputMetho
     for InputMethodManagerState
 {
     fn destroyed(
-        _state: &mut D,
+        state: &mut D,
         _client: ClientId,
         _object: &ZwpInputMethodKeyboardGrabV2,
         data: &InputMethodKeyboardUserData<D>,
     ) {
         data.handle.inner.lock().unwrap().grab = None;
-        data.keyboard_handle.unset_grab();
+        data.keyboard_handle.unset_grab(state);
     }
 
     fn request(

--- a/src/wayland/selection/data_device/dnd_grab.rs
+++ b/src/wayland/selection/data_device/dnd_grab.rs
@@ -291,7 +291,7 @@ where
     fn button(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, event: &ButtonEvent) {
         if handle.current_pressed().is_empty() {
             // the user dropped, proceed to the drop
-            handle.unset_grab(data, event.serial, event.time, true);
+            handle.unset_grab(self, data, event.serial, event.time, true);
         }
     }
 
@@ -414,7 +414,7 @@ where
             return;
         }
 
-        handle.unset_grab(data);
+        handle.unset_grab(self, data);
     }
 
     fn motion(
@@ -447,7 +447,7 @@ where
         _seq: crate::utils::Serial,
     ) {
         // TODO: should we cancel something here?
-        handle.unset_grab(data);
+        handle.unset_grab(self, data);
     }
 
     fn start_data(&self) -> &TouchGrabStartData<D> {

--- a/src/wayland/selection/data_device/server_dnd_grab.rs
+++ b/src/wayland/selection/data_device/server_dnd_grab.rs
@@ -266,7 +266,7 @@ where
 
         if handle.current_pressed().is_empty() {
             // the user dropped, proceed to the drop
-            handle.unset_grab(data, serial, time, true);
+            handle.unset_grab(self, data, serial, time, true);
         }
     }
 
@@ -390,7 +390,7 @@ where
         }
 
         // the user dropped, proceed to the drop
-        handle.unset_grab(data);
+        handle.unset_grab(self, data);
     }
 
     fn motion(
@@ -426,7 +426,7 @@ where
         _seq: Serial,
     ) {
         // TODO: should we cancel something here?
-        handle.unset_grab(data);
+        handle.unset_grab(self, data);
     }
 
     fn start_data(&self) -> &TouchGrabStartData<D> {

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -101,7 +101,7 @@ impl<D: XWaylandKeyboardGrabHandler + 'static> KeyboardGrab<D> for XWaylandKeybo
         handle.set_focus(data, self.start_data.focus.clone(), serial);
 
         if !self.grab.is_alive() {
-            handle.unset_grab(data, serial, false);
+            handle.unset_grab(self, data, serial, false);
         }
 
         handle.input(data, keycode, state, modifiers, serial, time)
@@ -115,7 +115,7 @@ impl<D: XWaylandKeyboardGrabHandler + 'static> KeyboardGrab<D> for XWaylandKeybo
         serial: Serial,
     ) {
         if !self.grab.is_alive() {
-            handle.unset_grab(data, serial, false);
+            handle.unset_grab(self, data, serial, false);
             handle.set_focus(data, focus, serial);
         }
     }

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -66,7 +66,7 @@ pub trait XWaylandKeyboardGrabHandler: SeatHandler {
     /// has a keyboard.
     fn grab(&mut self, _surface: wl_surface::WlSurface, seat: Seat<Self>, grab: XWaylandKeyboardGrab<Self>) {
         if let Some(keyboard) = seat.get_keyboard() {
-            keyboard.set_grab(grab, SERIAL_COUNTER.next_serial());
+            keyboard.set_grab(self, grab, SERIAL_COUNTER.next_serial());
         }
     }
 


### PR DESCRIPTION
This is a followup to https://github.com/Smithay/smithay/pull/1386, which I noticed an issue with: cancelled drags in clients like Firefox and Nautilus caused the window to act like it didn't have pointer focus until it lost and regained it. It seems the the previous change in `KeyboardGrab` also wasn't quite right.

See commit messages for more specific details.

This is a breaking API change requiring passing additional arguments, but although a bit annoying to update for, it's pretty straightforward.