### PR TITLE
Allow `set_cursor` when there is a pointer grab for client

### DIFF
--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -112,7 +112,8 @@ use wayland_server::{backend::GlobalId, Dispatch, DisplayHandle};
 
 use crate::input::pointer::{CursorIcon, CursorImageStatus};
 use crate::input::SeatHandler;
-use crate::wayland::seat::WaylandFocus;
+use crate::utils::Serial;
+use crate::wayland::seat::{pointer::allow_setting_cursor, WaylandFocus};
 
 use super::seat::PointerUserData;
 use super::tablet_manager::{TabletSeatHandler, TabletToolUserData};
@@ -244,24 +245,7 @@ where
                             None => return,
                         };
 
-                        // Ignore mismatches in serial.
-                        if !handle
-                            .last_enter
-                            .lock()
-                            .unwrap()
-                            .as_ref()
-                            .map(|last_serial| last_serial.0 == serial)
-                            .unwrap_or(false)
-                        {
-                            return;
-                        }
-
-                        // Check that pointer focus matches.
-                        if !handle
-                            .current_focus()
-                            .map(|focus| focus.same_client_as(&pointer.id()))
-                            .unwrap_or(false)
-                        {
+                        if !allow_setting_cursor(handle, Serial(serial), &pointer.id()) {
                             return;
                         }
 

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -57,7 +57,7 @@
 //! to change the cursor icon.
 
 pub(crate) mod keyboard;
-mod pointer;
+pub(crate) mod pointer;
 mod touch;
 
 use std::{fmt, sync::Arc};


### PR DESCRIPTION
This fixes calls to `set_cursor` during drag-and-drop. Nautilus is a good client to test this with, though most drag-and-drop clients should work.

The Wayland spec doesn't seem that specific about how `set_cursor`, pointer focus, and drag-and-drop interact. But this seems to mostly match Sway: the surface loses pointer focus at the start of drag-and-drop, but can still set the cursor.

I'm not sure if this is likely to be desirable or undesirable when there is a grab other than a drag-and-drop grab. It could be restricted to drag-and-drop, but there is not currently any way in Smithay to check what the drag is, or if there is a drag-and-drop operation. But it should be possible to downcast the `dyn PointerGrab<D>`, I guess.