### PR TITLE
Thread-safety for rendering related states

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -66,7 +66,7 @@ impl<R: Renderer> std::fmt::Debug for PointerRenderElement<R> {
     }
 }
 
-impl<T: Texture + Clone + 'static, R> AsRenderElements<R> for PointerElement
+impl<T: Texture + Clone + Send + 'static, R> AsRenderElements<R> for PointerElement
 where
     R: Renderer<TextureId = T> + ImportAll + ImportMem,
 {

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -156,7 +156,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
 
         for layer in self.layer_shell_state.layer_surfaces().rev() {
             let data = with_states(layer.wl_surface(), |states| {
-                *states.cached_state.current::<LayerSurfaceCachedState>()
+                *states.cached_state.get::<LayerSurfaceCachedState>().current()
             });
             if data.keyboard_interactivity == KeyboardInteractivity::Exclusive
                 && (data.layer == WlrLayer::Top || data.layer == WlrLayer::Overlay)

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -391,7 +391,8 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerResiz
 
         let (min_size, max_size) = if let Some(surface) = self.window.wl_surface() {
             with_states(&surface, |states| {
-                let data = states.cached_state.current::<SurfaceCachedState>();
+                let mut guard = states.cached_state.get::<SurfaceCachedState>();
+                let data = guard.current();
                 (data.min_size, data.max_size)
             })
         } else {
@@ -787,7 +788,8 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
 
         let (min_size, max_size) = if let Some(surface) = self.window.wl_surface() {
             with_states(&surface, |states| {
-                let data = states.cached_state.current::<SurfaceCachedState>();
+                let mut guard = states.cached_state.get::<SurfaceCachedState>();
+                let data = guard.current();
                 (data.min_size, data.max_size)
             })
         } else {

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -114,7 +114,8 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
             let maybe_dmabuf = with_states(surface, |surface_data| {
                 surface_data
                     .cached_state
-                    .pending::<SurfaceAttributes>()
+                    .get::<SurfaceAttributes>()
+                    .pending()
                     .buffer
                     .as_ref()
                     .and_then(|assignment| match assignment {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -265,7 +265,8 @@ pub fn send_frames_surface_tree(surface: &wl_surface::WlSurface, time: u32) {
             // yet been commited
             for callback in states
                 .cached_state
-                .current::<SurfaceAttributes>()
+                .get::<SurfaceAttributes>()
+                .current()
                 .frame_callbacks
                 .drain(..)
             {

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -105,7 +105,8 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
 
         let (min_size, max_size) =
             compositor::with_states(self.window.toplevel().unwrap().wl_surface(), |states| {
-                let data = states.cached_state.current::<SurfaceCachedState>();
+                let mut guard = states.cached_state.get::<SurfaceCachedState>();
+                let data = guard.current();
                 (data.min_size, data.max_size)
             });
 

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -353,8 +353,8 @@ impl<R: Renderer + ImportAll> WaylandSurfaceRenderElement<R> {
         let id = Id::from_wayland_resource(surface);
         crate::backend::renderer::utils::import_surface(renderer, states)?;
 
-        let alpha_modifier_state = states.cached_state.current::<AlphaModifierSurfaceCachedState>();
-        let alpha_multiplier = alpha_modifier_state.multiplier_f32().unwrap_or(1.0);
+        let mut alpha_modifier_state = states.cached_state.get::<AlphaModifierSurfaceCachedState>();
+        let alpha_multiplier = alpha_modifier_state.current().multiplier_f32().unwrap_or(1.0);
 
         let Some(data_ref) = states.data_map.get::<RendererSurfaceStateUserData>() else {
             return Ok(None);

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -269,9 +269,7 @@ where
             let data = states.data_map.get::<RendererSurfaceStateUserData>();
 
             if let Some(data) = data {
-                let data = &*data.borrow();
-
-                if let Some(view) = data.view() {
+                if let Some(view) = data.lock().unwrap().view() {
                     location += view.offset.to_f64().to_physical(scale);
                     TraversalAction::DoChildren(location)
                 } else {
@@ -286,7 +284,7 @@ where
             let data = states.data_map.get::<RendererSurfaceStateUserData>();
 
             if let Some(data) = data {
-                let has_view = if let Some(view) = data.borrow().view() {
+                let has_view = if let Some(view) = data.lock().unwrap().view() {
                     location += view.offset.to_f64().to_physical(scale);
                     true
                 } else {
@@ -367,7 +365,7 @@ impl<R: Renderer + ImportAll> WaylandSurfaceRenderElement<R> {
             location,
             alpha * alpha_multiplier,
             kind,
-            &data_ref.borrow(),
+            &data_ref.lock().unwrap(),
         ))
     }
 

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -730,7 +730,7 @@ impl GlesRenderer {
 
         context
             .user_data()
-            .insert_if_missing(|| RendererId(next_renderer_id()));
+            .insert_if_missing_threadsafe(|| RendererId(next_renderer_id()));
         drop(_guard);
 
         let renderer = GlesRenderer {

--- a/src/backend/renderer/gles/texture.rs
+++ b/src/backend/renderer/gles/texture.rs
@@ -1,8 +1,9 @@
 use super::*;
+use std::sync::Arc;
 
 /// A handle to a GLES texture
 #[derive(Debug, Clone)]
-pub struct GlesTexture(pub(super) Rc<GlesTextureInternal>);
+pub struct GlesTexture(pub(super) Arc<GlesTextureInternal>);
 
 impl GlesTexture {
     /// Create a GlesTexture from a raw gl texture id.
@@ -21,7 +22,7 @@ impl GlesTexture {
         tex: ffi::types::GLuint,
         size: Size<i32, BufferCoord>,
     ) -> GlesTexture {
-        GlesTexture(Rc::new(GlesTextureInternal {
+        GlesTexture(Arc::new(GlesTextureInternal {
             texture: tex,
             format: internal_format,
             has_alpha: !opaque,
@@ -57,6 +58,8 @@ pub(super) struct GlesTextureInternal {
     pub(super) egl_images: Option<Vec<EGLImage>>,
     pub(super) destruction_callback_sender: Sender<CleanupResource>,
 }
+unsafe impl Send for GlesTextureInternal {}
+unsafe impl Sync for GlesTextureInternal {}
 
 impl Drop for GlesTextureInternal {
     fn drop(&mut self) {

--- a/src/backend/renderer/multigpu/gbm.rs
+++ b/src/backend/renderer/multigpu/gbm.rs
@@ -278,7 +278,7 @@ where
         + ImportEgl
         + ExportMem
         + 'static,
-    <R as Renderer>::TextureId: Clone,
+    <R as Renderer>::TextureId: Clone + Send,
 {
     fn bind_wl_display(&mut self, display: &wayland_server::DisplayHandle) -> Result<(), EGLError> {
         self.render.renderer_mut().bind_wl_display(display)

--- a/src/backend/renderer/multigpu/gbm.rs
+++ b/src/backend/renderer/multigpu/gbm.rs
@@ -278,6 +278,7 @@ where
         + ImportEgl
         + ExportMem
         + 'static,
+    <R as Renderer>::TextureId: Clone,
 {
     fn bind_wl_display(&mut self, display: &wayland_server::DisplayHandle) -> Result<(), EGLError> {
         self.render.renderer_mut().bind_wl_display(display)

--- a/src/backend/renderer/multigpu/gbm.rs
+++ b/src/backend/renderer/multigpu/gbm.rs
@@ -315,7 +315,7 @@ where
             let res = self.import_dmabuf_internal(&dmabuf, texture, Some(damage));
             if res.is_ok() {
                 if let Some(surface) = surface {
-                    surface.data_map.insert_if_missing(|| texture_ref);
+                    surface.data_map.insert_if_missing_threadsafe(|| texture_ref);
                 }
             }
             return res;

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -857,7 +857,7 @@ where
     T::Error: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -889,7 +889,7 @@ where
     T::Error: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -929,7 +929,7 @@ where
     T::Error: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -961,7 +961,7 @@ where
     T::Error: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -1356,6 +1356,9 @@ struct MultiTextureInternal {
     size: Size<i32, BufferCoords>,
     format: Option<Fourcc>,
 }
+// SAFETY: We require `Send` for textures of renderers suitable for the MultiRenderer.
+//  Type erasure just forces us to do this instead.
+unsafe impl Send for MultiTextureInternal {}
 
 type DamageAnyTextureMappings = Vec<(Rectangle<i32, BufferCoords>, Box<dyn Any + 'static>)>;
 
@@ -1418,7 +1421,7 @@ impl MultiTexture {
         render: &DrmNode,
     ) -> Option<<<A::Device as ApiDevice>::Renderer as Renderer>::TextureId>
     where
-        <<A::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + 'static,
+        <<A::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send + 'static,
     {
         let tex = self.0.lock().unwrap();
         tex.textures
@@ -1579,7 +1582,7 @@ where
     T::Error: 'static,
     <R::Device as ApiDevice>::Renderer: ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -1685,7 +1688,7 @@ where
     T::Error: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -1723,7 +1726,7 @@ where
     T::Error: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -1780,7 +1783,7 @@ where
     R: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -1816,7 +1819,7 @@ where
     R: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -2328,7 +2331,7 @@ where
     R: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -2525,7 +2528,7 @@ where
     T::Error: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {
@@ -2617,7 +2620,7 @@ where
     T::Error: 'static,
     <R::Device as ApiDevice>::Renderer: Bind<Dmabuf> + ExportMem + ImportDma + ImportMem,
     <T::Device as ApiDevice>::Renderer: ImportDma + ImportMem,
-    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone,
+    <<R::Device as ApiDevice>::Renderer as Renderer>::TextureId: Clone + Send,
     <<R::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
 {

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -451,7 +451,7 @@ impl<A: GraphicsApi> GpuManager<A> {
         <<A::Device as ApiDevice>::Renderer as ExportMem>::TextureMapping: 'static,
     {
         use crate::{
-            backend::renderer::utils::RendererSurfaceState,
+            backend::renderer::utils::RendererSurfaceStateUserData,
             wayland::compositor::{with_surface_tree_upward, TraversalAction},
         };
 
@@ -464,8 +464,8 @@ impl<A: GraphicsApi> GpuManager<A> {
             surface,
             (),
             |_surface, states, _| {
-                if let Some(data) = states.data_map.get::<RefCell<RendererSurfaceState>>() {
-                    let mut data_ref = data.borrow_mut();
+                if let Some(data) = states.data_map.get::<RendererSurfaceStateUserData>() {
+                    let mut data_ref = data.lock().unwrap();
                     let data = &mut *data_ref;
                     if data.textures.is_empty() {
                         // Import a new buffer if available

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -634,7 +634,7 @@ impl<A: GraphicsApi> GpuManager<A> {
                         texture.size(),
                         mappings.into_iter(),
                     );
-                    surface.data_map.insert_if_missing(|| texture.0);
+                    surface.data_map.insert_if_missing_threadsafe(|| texture.0);
                 }
 
                 Ok(())
@@ -1801,7 +1801,7 @@ where
         let res = self.import_dmabuf_internal(dmabuf, texture, Some(damage));
         if res.is_ok() {
             if let Some(surface) = surface {
-                surface.data_map.insert_if_missing(|| texture_ref);
+                surface.data_map.insert_if_missing_threadsafe(|| texture_ref);
             }
         }
         res

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -106,7 +106,8 @@ impl PartialEq<WlBuffer> for &Buffer {
 impl RendererSurfaceState {
     #[profiling::function]
     pub(crate) fn update_buffer(&mut self, states: &SurfaceData) {
-        let mut attrs = states.cached_state.current::<SurfaceAttributes>();
+        let mut attrs_state = states.cached_state.get::<SurfaceAttributes>();
+        let attrs = attrs_state.current();
         self.buffer_delta = attrs.buffer_delta.take();
 
         if let Some(delta) = self.buffer_delta {
@@ -386,13 +387,18 @@ impl SurfaceView {
         buffer_delta: Point<i32, Logical>,
     ) -> SurfaceView {
         viewporter::ensure_viewport_valid(states, surface_size);
-        let viewport = states.cached_state.current::<viewporter::ViewportCachedState>();
+        let mut viewport_state = states.cached_state.get::<viewporter::ViewportCachedState>();
+        let viewport = viewport_state.current();
         let src = viewport
             .src
             .unwrap_or_else(|| Rectangle::from_loc_and_size((0.0, 0.0), surface_size.to_f64()));
         let dst = viewport.size().unwrap_or(surface_size);
         let mut offset = if states.role == Some("subsurface") {
-            states.cached_state.current::<SubsurfaceCachedState>().location
+            states
+                .cached_state
+                .get::<SubsurfaceCachedState>()
+                .current()
+                .location
         } else {
             Default::default()
         };

--- a/src/desktop/space/wayland/mod.rs
+++ b/src/desktop/space/wayland/mod.rs
@@ -33,7 +33,7 @@ pub fn output_update(output: &Output, output_overlap: Option<Rectangle<i32, Logi
             // our children to send a leave events
             if *parent_unmapped {
                 TraversalAction::DoChildren((location, true))
-            } else if let Some(surface_view) = data.and_then(|d| d.borrow().surface_view) {
+            } else if let Some(surface_view) = data.and_then(|d| d.lock().unwrap().surface_view) {
                 location += surface_view.offset;
                 TraversalAction::DoChildren((location, false))
             } else {
@@ -60,7 +60,7 @@ pub fn output_update(output: &Output, output_overlap: Option<Rectangle<i32, Logi
 
             let data = states.data_map.get::<RendererSurfaceStateUserData>();
 
-            if let Some(surface_view) = data.and_then(|d| d.borrow().surface_view) {
+            if let Some(surface_view) = data.and_then(|d| d.lock().unwrap().surface_view) {
                 location += surface_view.offset;
                 let surface_rectangle = Rectangle::from_loc_and_size(location, surface_view.dst);
                 if output_overlap.overlaps(surface_rectangle) {

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -19,9 +19,8 @@ use wayland_server::protocol::wl_surface::{self, WlSurface};
 
 use std::{
     borrow::Cow,
-    cell::{RefCell, RefMut},
     hash::{Hash, Hasher},
-    sync::Arc,
+    sync::{Arc, Mutex, MutexGuard},
     time::Duration,
 };
 
@@ -42,14 +41,14 @@ pub struct LayerMap {
 /// If none existed before a new empty [`LayerMap`] is attached
 /// to the output and returned on subsequent calls.
 ///
-/// Note: This function internally uses a [`RefCell`] per
+/// Note: This function internally uses a [`Mutex`] per
 /// [`Output`] as exposed by its return type. Therefor
 /// trying to hold on to multiple references of a [`LayerMap`]
-/// of the same output using this function *will* result in a panic.
-pub fn layer_map_for_output(o: &Output) -> RefMut<'_, LayerMap> {
+/// of the same output using this function *will* result in a deadlock.
+pub fn layer_map_for_output(o: &Output) -> MutexGuard<'_, LayerMap> {
     let userdata = o.user_data();
-    userdata.insert_if_missing(|| {
-        RefCell::new(LayerMap {
+    userdata.insert_if_missing_threadsafe(|| {
+        Mutex::new(LayerMap {
             layers: IndexSet::new(),
             output: o.downgrade(),
             zone: Rectangle::from_loc_and_size(
@@ -67,7 +66,7 @@ pub fn layer_map_for_output(o: &Output) -> RefMut<'_, LayerMap> {
             ),
         })
     });
-    userdata.get::<RefCell<LayerMap>>().unwrap().borrow_mut()
+    userdata.get::<Mutex<LayerMap>>().unwrap().lock().unwrap()
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -84,7 +83,7 @@ impl LayerMap {
                 .0
                 .userdata
                 .get::<LayerUserdata>()
-                .map(|s| s.borrow().is_some())
+                .map(|s| s.lock().unwrap().location.is_some())
                 .unwrap_or(false)
             {
                 return Err(LayerError::AlreadyMapped);
@@ -99,7 +98,14 @@ impl LayerMap {
     /// Remove a [`LayerSurface`] from this [`LayerMap`].
     pub fn unmap_layer(&mut self, layer: &LayerSurface) {
         if self.layers.shift_remove(layer) {
-            let _ = layer.user_data().get::<LayerUserdata>().take();
+            let _ = layer
+                .user_data()
+                .get::<LayerUserdata>()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .location
+                .take();
             self.arrange();
         }
         if let (Some(output), surface) = (self.output(), layer.wl_surface()) {
@@ -142,7 +148,7 @@ impl LayerMap {
         }
         let mut bbox = layer.bbox();
         let state = layer_state(layer);
-        bbox.loc += state.location;
+        bbox.loc += state.location.unwrap_or_default();
         Some(bbox)
     }
 
@@ -157,7 +163,7 @@ impl LayerMap {
             let bbox_with_popups = {
                 let mut bbox = l.bbox_with_popups();
                 let state = layer_state(l);
-                bbox.loc += state.location;
+                bbox.loc += state.location.unwrap_or_default();
                 bbox
             };
             bbox_with_popups.to_f64().contains(point)
@@ -416,8 +422,8 @@ impl LayerMap {
 
                 {
                     let mut layer_state = layer_state(layer);
-                    if layer_state.location != location {
-                        layer_state.location = location;
+                    if layer_state.location != Some(location) {
+                        layer_state.location = Some(location);
                         changed = true;
                     }
                 }
@@ -452,21 +458,16 @@ impl LayerMap {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct LayerState {
-    pub location: Point<i32, Logical>,
+    pub location: Option<Point<i32, Logical>>,
 }
 
-type LayerUserdata = RefCell<Option<LayerState>>;
-pub fn layer_state(layer: &LayerSurface) -> RefMut<'_, LayerState> {
+type LayerUserdata = Mutex<LayerState>;
+pub fn layer_state(layer: &LayerSurface) -> MutexGuard<'_, LayerState> {
     let userdata = layer.user_data();
-    userdata.insert_if_missing(LayerUserdata::default);
-    RefMut::map(userdata.get::<LayerUserdata>().unwrap().borrow_mut(), |opt| {
-        if opt.is_none() {
-            *opt = Some(LayerState::default());
-        }
-        opt.as_mut().unwrap()
-    })
+    userdata.insert_if_missing_threadsafe(LayerUserdata::default);
+    userdata.get::<LayerUserdata>().unwrap().lock().unwrap()
 }
 
 /// A [`LayerSurface`] represents a single layer surface as given by the wlr-layer-shell protocol.

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -295,7 +295,7 @@ impl LayerMap {
                 }
 
                 let data = with_states(surface, |states| {
-                    *states.cached_state.current::<LayerSurfaceCachedState>()
+                    *states.cached_state.get::<LayerSurfaceCachedState>().current()
                 });
 
                 let mut source = match data.exclusive_zone {
@@ -537,7 +537,7 @@ impl LayerSurface {
     /// Returns the cached protocol state
     pub fn cached_state(&self) -> LayerSurfaceCachedState {
         with_states(self.0.surface.wl_surface(), |states| {
-            *states.cached_state.current::<LayerSurfaceCachedState>()
+            *states.cached_state.get::<LayerSurfaceCachedState>().current()
         })
     }
 
@@ -546,7 +546,8 @@ impl LayerSurface {
         with_states(self.0.surface.wl_surface(), |states| {
             match states
                 .cached_state
-                .current::<LayerSurfaceCachedState>()
+                .get::<LayerSurfaceCachedState>()
+                .current()
                 .keyboard_interactivity
             {
                 KeyboardInteractivity::Exclusive | KeyboardInteractivity::OnDemand => true,
@@ -558,7 +559,11 @@ impl LayerSurface {
     /// Returns the layer this surface resides on, if any yet.
     pub fn layer(&self) -> WlrLayer {
         with_states(self.0.surface.wl_surface(), |states| {
-            states.cached_state.current::<LayerSurfaceCachedState>().layer
+            states
+                .cached_state
+                .get::<LayerSurfaceCachedState>()
+                .current()
+                .layer
         })
     }
 

--- a/src/desktop/wayland/popup/manager.rs
+++ b/src/desktop/wayland/popup/manager.rs
@@ -143,7 +143,7 @@ impl PopupManager {
 
         with_states(&root, |states| {
             let tree = PopupTree::default();
-            if states.data_map.insert_if_missing(|| tree.clone()) {
+            if states.data_map.insert_if_missing_threadsafe(|| tree.clone()) {
                 self.popup_trees.push(tree);
             };
             let tree = states.data_map.get::<PopupTree>().unwrap();

--- a/src/desktop/wayland/popup/mod.rs
+++ b/src/desktop/wayland/popup/mod.rs
@@ -64,7 +64,8 @@ impl PopupKind {
             PopupKind::Xdg(_) => with_states(wl_surface, |states| {
                 states
                     .cached_state
-                    .current::<SurfaceCachedState>()
+                    .get::<SurfaceCachedState>()
+                    .current()
                     .geometry
                     .unwrap_or_default()
             }),

--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -135,7 +135,7 @@ where
                     .map(|data| {
                         data.lock()
                             .unwrap()
-                            .contains_point(&states.cached_state.current(), point - location.to_f64())
+                            .contains_point(&*states.cached_state.get().current(), point - location.to_f64())
                     })
                     .unwrap_or(false);
                 if contains_the_point {
@@ -257,7 +257,8 @@ pub fn send_frames_surface_tree<T, F>(
                 // yet been commited
                 for callback in states
                     .cached_state
-                    .current::<SurfaceAttributes>()
+                    .get::<SurfaceAttributes>()
+                    .current()
                     .frame_callbacks
                     .drain(..)
                 {
@@ -319,8 +320,8 @@ impl SurfacePresentationFeedback {
     ///
     /// Returns `None` if the surface has no stored presentation feedback
     pub fn from_states(states: &SurfaceData, flags: wp_presentation_feedback::Kind) -> Option<Self> {
-        let mut presentation_feedback_state =
-            states.cached_state.current::<PresentationFeedbackCachedState>();
+        let mut guard = states.cached_state.get::<PresentationFeedbackCachedState>();
+        let presentation_feedback_state = guard.current();
         if presentation_feedback_state.callbacks.is_empty() {
             return None;
         }

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -159,7 +159,8 @@ impl Window {
             with_states(&surface, |states| {
                 states
                     .cached_state
-                    .current::<SurfaceCachedState>()
+                    .get::<SurfaceCachedState>()
+                    .current()
                     .geometry
                     .and_then(|geo| geo.intersection(bbox))
             })

--- a/src/wayland/alpha_modifier/dispatch.rs
+++ b/src/wayland/alpha_modifier/dispatch.rs
@@ -106,7 +106,8 @@ where
                 compositor::with_states(&surface, |states| {
                     states
                         .cached_state
-                        .pending::<AlphaModifierSurfaceCachedState>()
+                        .get::<AlphaModifierSurfaceCachedState>()
+                        .pending()
                         .multiplier = Some(factor);
                 })
             }
@@ -129,7 +130,8 @@ where
 
                     states
                         .cached_state
-                        .pending::<AlphaModifierSurfaceCachedState>()
+                        .get::<AlphaModifierSurfaceCachedState>()
+                        .pending()
                         .multiplier = None;
                 });
             }

--- a/src/wayland/alpha_modifier/mod.rs
+++ b/src/wayland/alpha_modifier/mod.rs
@@ -35,8 +35,8 @@
 //!
 //!    fn commit(&mut self, surface: &WlSurface) {
 //!        compositor::with_states(&surface, |states| {
-//!            let current = states.cached_state.current::<AlphaModifierSurfaceCachedState>();
-//!            dbg!(current.multiplier());
+//!            let mut modifier_state = states.cached_state.get::<AlphaModifierSurfaceCachedState>();
+//!            dbg!(modifier_state.current().multiplier());
 //!        });
 //!    }
 //! }
@@ -77,8 +77,8 @@ mod dispatch;
 ///
 /// # let wl_surface = todo!();
 /// compositor::with_states(&wl_surface, |states| {
-///     let current = states.cached_state.current::<AlphaModifierSurfaceCachedState>();
-///     dbg!(current.multiplier());
+///     let mut modifier_state = states.cached_state.get::<AlphaModifierSurfaceCachedState>();
+///     dbg!(modifier_state.current().multiplier());
 /// });
 /// ```
 #[derive(Debug, Clone, Copy, Default)]

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -138,27 +138,17 @@ impl PrivateSurfaceData {
             let mut child_guard = child_mutex.lock().unwrap();
             child_guard.parent = None;
         }
-        if let Some(BufferAssignment::NewBuffer(buffer)) = my_data
-            .public_data
-            .cached_state
-            .current::<SurfaceAttributes>()
-            .buffer
-            .take()
-        {
+        let mut guard = my_data.public_data.cached_state.get::<SurfaceAttributes>();
+        if let Some(BufferAssignment::NewBuffer(buffer)) = guard.current().buffer.take() {
             buffer.release();
         };
-        if let Some(BufferAssignment::NewBuffer(buffer)) = my_data
-            .public_data
-            .cached_state
-            .pending::<SurfaceAttributes>()
-            .buffer
-            .take()
-        {
+        if let Some(BufferAssignment::NewBuffer(buffer)) = guard.pending().buffer.take() {
             buffer.release();
         };
 
         let hooks = my_data.destruction_hooks.clone();
         // don't hold the mutex while the hooks are invoked
+        drop(guard);
         drop(my_data);
         for hook in hooks {
             (hook.cb)(state, surface)

--- a/src/wayland/content_type/dispatch.rs
+++ b/src/wayland/content_type/dispatch.rs
@@ -101,7 +101,8 @@ where
                 compositor::with_states(&surface, |states| {
                     states
                         .cached_state
-                        .pending::<ContentTypeSurfaceCachedState>()
+                        .get::<ContentTypeSurfaceCachedState>()
+                        .pending()
                         .content_type = content_type;
                 })
             }
@@ -122,7 +123,8 @@ where
 
                     states
                         .cached_state
-                        .pending::<ContentTypeSurfaceCachedState>()
+                        .get::<ContentTypeSurfaceCachedState>()
+                        .pending()
                         .content_type = wp_content_type_v1::Type::None;
                 });
             }

--- a/src/wayland/content_type/mod.rs
+++ b/src/wayland/content_type/mod.rs
@@ -32,7 +32,8 @@
 //!
 //!    fn commit(&mut self, surface: &WlSurface) {
 //!        compositor::with_states(&surface, |states| {
-//!            let current = states.cached_state.current::<ContentTypeSurfaceCachedState>();
+//!            let mut guard = states.cached_state.get::<ContentTypeSurfaceCachedState>();
+//!            let current = guard.current();
 //!            dbg!(current.content_type());
 //!        });
 //!    }
@@ -75,7 +76,8 @@ mod dispatch;
 ///
 /// # let wl_surface = todo!();
 /// compositor::with_states(&wl_surface, |states| {
-///     let current = states.cached_state.current::<ContentTypeSurfaceCachedState>();
+///     let mut guard = states.cached_state.get::<ContentTypeSurfaceCachedState>();
+///     let current = guard.current();
 ///     dbg!(current.content_type());
 /// });
 /// ```

--- a/src/wayland/presentation/mod.rs
+++ b/src/wayland/presentation/mod.rs
@@ -57,7 +57,7 @@
 //! // ... render frame ...
 //!
 //! let presentation_feedbacks = with_states(&surface, |states| {
-//!     std::mem::take(&mut states.cached_state.current::<PresentationFeedbackCachedState>().callbacks)
+//!     std::mem::take(&mut states.cached_state.get::<PresentationFeedbackCachedState>().current().callbacks)
 //! });
 //!
 //! // ... send frame callbacks and present frame
@@ -152,7 +152,8 @@ where
                 with_states(&surface, |states| {
                     states
                         .cached_state
-                        .pending::<PresentationFeedbackCachedState>()
+                        .get::<PresentationFeedbackCachedState>()
+                        .pending()
                         .add_callback(surface.clone(), *data, callback);
                 });
             }

--- a/src/wayland/session_lock/lock.rs
+++ b/src/wayland/session_lock/lock.rs
@@ -67,14 +67,9 @@ where
                 // Ensure surface has no existing buffers attached.
                 let has_buffer = compositor::with_states(&surface, |states| {
                     let cached = &states.cached_state;
-                    let pending = matches!(
-                        cached.pending::<SurfaceAttributes>().buffer,
-                        Some(BufferAssignment::NewBuffer(_))
-                    );
-                    let current = matches!(
-                        cached.current::<SurfaceAttributes>().buffer,
-                        Some(BufferAssignment::NewBuffer(_))
-                    );
+                    let mut guard = cached.get::<SurfaceAttributes>();
+                    let pending = matches!(guard.pending().buffer, Some(BufferAssignment::NewBuffer(_)));
+                    let current = matches!(guard.current().buffer, Some(BufferAssignment::NewBuffer(_)));
                     pending || current
                 });
                 if has_buffer {
@@ -120,7 +115,8 @@ where
 
                         // Verify the attached buffer: ext-session-lock requires no NULL buffers
                         // and an exact dimentions match.
-                        let surface_attrs = states.cached_state.pending::<SurfaceAttributes>();
+                        let mut guard = states.cached_state.get::<SurfaceAttributes>();
+                        let surface_attrs = guard.pending();
                         if let Some(assignment) = surface_attrs.buffer.as_ref() {
                             match assignment {
                                 BufferAssignment::Removed => {

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -247,7 +247,7 @@ where
                 }
 
                 compositor::with_states(surface, |states| {
-                    states.cached_state.pending::<SurfaceCachedState>().geometry =
+                    states.cached_state.get::<SurfaceCachedState>().pending().geometry =
                         Some(Rectangle::from_loc_and_size((x, y), (width, height)));
                 });
             }

--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -86,8 +86,10 @@ where
                     .unwrap()
                     .lock()
                     .unwrap() = Default::default();
-                *states.cached_state.pending::<SurfaceCachedState>() = Default::default();
-                *states.cached_state.current::<SurfaceCachedState>() = Default::default();
+
+                let mut guard = states.cached_state.get::<SurfaceCachedState>();
+                *guard.pending() = Default::default();
+                *guard.current() = Default::default();
             })
         }
     }

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -165,8 +165,10 @@ where
                     .unwrap()
                     .lock()
                     .unwrap() = Default::default();
-                *states.cached_state.pending::<SurfaceCachedState>() = Default::default();
-                *states.cached_state.current::<SurfaceCachedState>() = Default::default();
+
+                let mut guard = states.cached_state.get::<SurfaceCachedState>();
+                *guard.pending() = Default::default();
+                *guard.current() = Default::default();
             })
         }
     }
@@ -220,7 +222,7 @@ where
     F: FnOnce(&mut SurfaceCachedState) -> T,
 {
     compositor::with_states(&data.wl_surface, |states| {
-        f(&mut states.cached_state.pending::<SurfaceCachedState>())
+        f(states.cached_state.get::<SurfaceCachedState>().pending())
     })
 }
 

--- a/src/wayland/viewporter/mod.rs
+++ b/src/wayland/viewporter/mod.rs
@@ -32,7 +32,7 @@
 //!
 //! ```no_compile
 //! let viewport = with_states(surface, |states| {
-//!     states.cached_state.current::<ViewportCachedState>();
+//!     states.cached_state.get::<ViewportCachedState>().current()
 //! });
 //! ```
 //!
@@ -204,7 +204,7 @@ where
                             .lock()
                             .unwrap()
                             .take();
-                        *states.cached_state.pending::<ViewportCachedState>() =
+                        *states.cached_state.get::<ViewportCachedState>().pending() =
                             ViewportCachedState::default();
                     });
                 }
@@ -235,7 +235,8 @@ where
                 };
 
                 with_states(&surface, |states| {
-                    let mut viewport_state = states.cached_state.pending::<ViewportCachedState>();
+                    let mut guard = states.cached_state.get::<ViewportCachedState>();
+                    let viewport_state = guard.pending();
                     let src = if is_unset {
                         None
                     } else {
@@ -272,7 +273,8 @@ where
                 };
 
                 with_states(&surface, |states| {
-                    let mut viewport_state = states.cached_state.pending::<ViewportCachedState>();
+                    let mut guard = states.cached_state.get::<ViewportCachedState>();
+                    let viewport_state = guard.pending();
                     let size = if is_unset {
                         None
                     } else {
@@ -308,7 +310,8 @@ fn viewport_commit_hook<D: 'static>(_state: &mut D, _dh: &DisplayHandle, surface
             .lock()
             .unwrap();
         if let Some(viewport) = &*viewport {
-            let viewport_state = states.cached_state.pending::<ViewportCachedState>();
+            let mut guard = states.cached_state.get::<ViewportCachedState>();
+            let viewport_state = guard.pending();
 
             // If src_width or src_height are not integers and destination size is not set,
             // the bad_size protocol error is raised when the surface state is applied.
@@ -343,7 +346,8 @@ pub fn ensure_viewport_valid(states: &SurfaceData, buffer_size: Size<i32, Logica
         .unwrap();
 
     if let Some(viewport) = &*viewport {
-        let state = states.cached_state.pending::<ViewportCachedState>();
+        let mut guard = states.cached_state.get::<ViewportCachedState>();
+        let state = guard.pending();
 
         let buffer_rect = Rectangle::from_loc_and_size((0.0, 0.0), buffer_size.to_f64());
         let src = state.src.unwrap_or(buffer_rect);

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -234,7 +234,11 @@ where
 
                 // Set the serial on the pending state of surface
                 compositor::with_states(&data.wl_surface, |states| {
-                    states.cached_state.pending::<XWaylandShellCachedState>().serial = Some(serial);
+                    states
+                        .cached_state
+                        .get::<XWaylandShellCachedState>()
+                        .pending()
+                        .serial = Some(serial);
                 });
             }
             xwayland_surface_v1::Request::Destroy => {
@@ -251,7 +255,11 @@ fn serial_commit_hook<D: XWaylandShellHandler + XwmHandler + 'static>(
     surface: &WlSurface,
 ) {
     if let Some(serial) = compositor::with_states(surface, |states| {
-        states.cached_state.pending::<XWaylandShellCachedState>().serial
+        states
+            .cached_state
+            .get::<XWaylandShellCachedState>()
+            .pending()
+            .serial
     }) {
         if let Some(client) = surface.client() {
             // We only care about surfaces created by XWayland.

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -873,7 +873,8 @@ impl X11Relatable for WlSurface {
         let serial = compositor::with_states(self, |states| {
             states
                 .cached_state
-                .current::<crate::wayland::xwayland_shell::XWaylandShellCachedState>()
+                .get::<crate::wayland::xwayland_shell::XWaylandShellCachedState>()
+                .current()
                 .serial
         });
 


### PR DESCRIPTION
Best reviewed commit-by-commit.

The biggest is easily 5b2e9193e7316ae38ba6cb958ac551a6b0fb718a, which makes the `CacheMap` thread-safe. A lot of the double buffered state is used to inform rendering, so I am not sure if this can be avoided.

The rest of the changes are most likely less controversial.