### PR TITLE
Notify when InputMethod::PopupSurface changes location

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -293,6 +293,8 @@ impl<BackendData: Backend> InputMethodHandler for AnvilState<BackendData> {
         }
     }
 
+    fn popup_repositioned(&mut self, _: PopupSurface) {}
+
     fn dismiss_popup(&mut self, surface: PopupSurface) {
         if let Some(parent) = surface.get_parent().map(|parent| parent.surface.clone()) {
             let _ = PopupManager::dismiss_popup(&parent, &PopupKind::from(surface));

--- a/src/wayland/input_method/mod.rs
+++ b/src/wayland/input_method/mod.rs
@@ -20,6 +20,7 @@
 //! impl InputMethodHandler for State {
 //!     fn new_popup(&mut self, surface: PopupSurface) {}
 //!     fn dismiss_popup(&mut self, surface: PopupSurface) {}
+//!     fn popup_repositioned(&mut self, surface: PopupSurface) {}
 //!     fn parent_geometry(&self, parent: &WlSurface) -> Rectangle<i32, Logical> {
 //!         Rectangle::default()
 //!     }
@@ -92,6 +93,9 @@ pub trait InputMethodHandler {
 
     /// Dismiss a popup surface from the compositor state.
     fn dismiss_popup(&mut self, surface: PopupSurface);
+
+    /// Popup location has changed.
+    fn popup_repositioned(&mut self, surface: PopupSurface);
 
     /// Sets the parent location so the popup surface can be placed correctly
     fn parent_geometry(&self, parent: &WlSurface) -> Rectangle<i32, Logical>;
@@ -208,6 +212,7 @@ where
                         text_input_handle: text_input_handle.clone(),
                         keyboard_handle,
                         popup_geometry_callback: D::parent_geometry,
+                        popup_repositioned: D::popup_repositioned,
                         new_popup: D::new_popup,
                         dismiss_popup: D::dismiss_popup,
                     },

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -210,7 +210,7 @@ where
             }
             zwp_text_input_v3::Request::SetCursorRectangle { x, y, width, height } => {
                 data.input_method_handle
-                    .set_text_input_rectangle(x, y, width, height);
+                    .set_text_input_rectangle::<D>(state, x, y, width, height);
             }
             zwp_text_input_v3::Request::Commit => {
                 data.input_method_handle.with_instance(|input_method| {


### PR DESCRIPTION
Each call to `set_text_input_rectangle` changes the position of the popup and also will result in popup repositioning, thus notify users when such request occurs.

The location and text cursor area where separated, since one is used for the rendering, and the other one is original location.

--

Use case: https://github.com/YaLTeR/niri/pull/295 