### PR TITLE
Update `drm`, `gbm`, `image`; `xkbcommon`/`x11rb` deps of Anvil

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Test features
         env:
           RUST_BACKTRACE: full
-        run: cargo hack check --each-feature --no-dev-deps
+        run: cargo hack check --each-feature --no-dev-deps --exclude-features use_bindgen
 
   smithay-tests:
     needs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ cursor-icon = "1.0.0"
 cgmath = "0.18.0"
 downcast-rs = "1.2.0"
 drm-fourcc = "^2.2.0"
-drm = { version = "0.11.1", optional = true }
-drm-ffi = { version = "0.7.1", optional = true }
+drm = { version = "0.12.0", optional = true }
+drm-ffi = { version = "0.8.0", optional = true }
 errno = "0.3.5"
-gbm = { version = "0.14.2", optional = true, default-features = false, features = ["drm-support"] }
+gbm = { version = "0.15.0", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.12", optional = true }
 input = { version = "0.9.0", default-features = false, features=["libinput_1_19"], optional = true }
 indexmap = "2.0"
@@ -73,7 +73,7 @@ pixman = { version = "0.1.0", features = ["drm-fourcc"], optional = true }
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
 criterion = { version = "0.5" }
-image = "0.24"
+image = "0.25"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
 [build-dependencies]

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -9,13 +9,13 @@ version = "0.0.1"
 [dependencies]
 bitflags = "2.2.1"
 fps_ticker = {version = "1.0.0", optional = true}
-image = {version = "0.24.0", default-features = false, optional = true}
+image = {version = "0.25.1", default-features = false, optional = true}
 rand = "0.8"
 tracing = { version = "0.1.37", features = ["max_level_trace", "release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 thiserror = "1"
 xcursor = {version = "0.3.3", optional = true}
-xkbcommon = "0.6.0"
+xkbcommon = "0.7.0"
 renderdoc = {version = "0.11.0", optional = true}
 smithay-drm-extras = {path = "../smithay-drm-extras", optional = true}
 puffin_http = { version = "0.13", optional = true }
@@ -30,7 +30,7 @@ path = ".."
 default-features = false
 features = ["composite"]
 optional = true
-version = "0.12.0"
+version = "0.13.0"
 
 [build-dependencies]
 gl_generator = "0.14"

--- a/smithay-drm-extras/Cargo.toml
+++ b/smithay-drm-extras/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Bartłomiej Maryńczak <marynczakbartlomiej@gmail.com>"]
 
 [dependencies]
 edid-rs = "0.1.0"
-drm = { version = "0.11.0" }
+drm = { version = "0.12.0" }
 
 [features]
 default = []


### PR DESCRIPTION
There's also a new `ash` release, but that seems to require some changes to use. So I left that for now.