### PR TITLE
virtual_keyboard: Remove unused instance tracking

### DIFF
--- a/src/wayland/virtual_keyboard/mod.rs
+++ b/src/wayland/virtual_keyboard/mod.rs
@@ -158,8 +158,6 @@ where
                         seat: seat.clone(),
                     },
                 );
-
-                virtual_keyboard_handle.count_instance();
             }
             _ => unreachable!(),
         }

--- a/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
+++ b/src/wayland/virtual_keyboard/virtual_keyboard_handle.rs
@@ -27,7 +27,6 @@ use super::VirtualKeyboardManagerState;
 
 #[derive(Debug, Default)]
 pub(crate) struct VirtualKeyboard {
-    instances: u8,
     state: Option<VirtualKeyboardState>,
 }
 
@@ -55,13 +54,6 @@ unsafe impl Send for VirtualKeyboard {}
 #[derive(Debug, Clone, Default)]
 pub(crate) struct VirtualKeyboardHandle {
     pub(crate) inner: Arc<Mutex<VirtualKeyboard>>,
-}
-
-impl VirtualKeyboardHandle {
-    pub(super) fn count_instance(&self) {
-        let mut inner = self.inner.lock().unwrap();
-        inner.instances += 1;
-    }
 }
 
 /// User data of ZwpVirtualKeyboardV1 object


### PR DESCRIPTION
Remnants of this commit: https://github.com/Smithay/smithay/commit/5a0b08c804d5f7ea045b1beddf7fe8a4870fb2a7

It removed the code that decremented or even just accessed the counter, leaving it to overflow, which causes panics with overflow checks.

Intended to fix https://github.com/YaLTeR/niri/issues/316.

cc @chrisduerr 