### PR TITLE
Add getters for some `WaylandSurfaceRenderElement` properties

### DIFF
--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -379,10 +379,21 @@ impl<R: Renderer + ImportAll> WaylandSurfaceRenderElement<R> {
             .unwrap_or_default()
     }
 
-    fn buffer_size(&self) -> Option<Size<i32, Logical>> {
+    /// Get the buffer dimensions in logical coordinates
+    pub fn buffer_size(&self) -> Option<Size<i32, Logical>> {
         self.buffer_dimensions
             .as_ref()
             .map(|dim| dim.to_logical(self.buffer_scale, self.buffer_transform))
+    }
+
+    /// Get the view into the surface
+    pub fn view(&self) -> Option<SurfaceView> {
+        self.view
+    }
+
+    /// Get the buffer texture
+    pub fn texture(&self) -> Option<&R::TextureId> {
+        self.texture.as_ref()
     }
 }
 

--- a/src/backend/renderer/gles/texture.rs
+++ b/src/backend/renderer/gles/texture.rs
@@ -39,6 +39,11 @@ impl GlesTexture {
     pub fn tex_id(&self) -> ffi::types::GLuint {
         self.0.texture
     }
+
+    /// Whether the texture is upside down
+    pub fn is_y_inverted(&self) -> bool {
+        self.0.y_inverted
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
These seem to be sufficient for me in niri to build a matrix that transforms the shader coordinate space to the geometry coordinate space, taking viewporter src and buffer transform into account.