### PR TITLE
Correct debug tint color

### DIFF
--- a/src/backend/renderer/gles/shaders/implicit/texture.frag
+++ b/src/backend/renderer/gles/shaders/implicit/texture.frag
@@ -31,7 +31,7 @@ void main() {
 
 #if defined(DEBUG_FLAGS)
     if (tint == 1.0)
-        color = vec4(0.0, 0.3, 0.0, 0.2) + color * 0.8;
+        color = vec4(0.0, 0.2, 0.0, 0.2) + color * 0.8;
 #endif
 
     gl_FragColor = color;

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -656,7 +656,7 @@ pub struct PixmanRenderer {
 impl PixmanRenderer {
     /// Creates a new pixman renderer
     pub fn new() -> Result<Self, PixmanError> {
-        let tint = pixman::Solid::new([0.0, 0.3, 0.0, 0.2]).map_err(|_| PixmanError::Unsupported)?;
+        let tint = pixman::Solid::new([0.0, 0.2, 0.0, 0.2]).map_err(|_| PixmanError::Unsupported)?;
         Ok(Self {
             target: None,
             downscale_filter: TextureFilter::Linear,


### PR DESCRIPTION
Not sure if this was intentional, but this color is supposed to be premultiplied, so the color components cannot be above the alpha.