### PR TITLE
Avoid unwraping clients from surfaces

### DIFF
--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -124,14 +124,15 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
             });
             if let Some(dmabuf) = maybe_dmabuf {
                 if let Ok((blocker, source)) = dmabuf.generate_blocker(Interest::READ) {
-                    let client = surface.client().unwrap();
-                    let res = state.handle.insert_source(source, move |_, _, data| {
-                        let dh = data.display_handle.clone();
-                        data.client_compositor_state(&client).blocker_cleared(data, &dh);
-                        Ok(())
-                    });
-                    if res.is_ok() {
-                        add_blocker(surface, blocker);
+                    if let Some(client) = surface.client() {
+                        let res = state.handle.insert_source(source, move |_, _, data| {
+                            let dh = data.display_handle.clone();
+                            data.client_compositor_state(&client).blocker_cleared(data, &dh);
+                            Ok(())
+                        });
+                        if res.is_ok() {
+                            add_blocker(surface, blocker);
+                        }
                     }
                 }
             }

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -281,7 +281,10 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
                     .as_ref()
                     .and_then(Output::from_resource)
                     .unwrap_or_else(|| self.space.outputs().next().unwrap().clone());
-                let client = self.display_handle.get_client(wl_surface.id()).unwrap();
+                let client = match self.display_handle.get_client(wl_surface.id()) {
+                    Ok(client) => client,
+                    Err(_) => return,
+                };
                 for output in output.client_outputs(&client) {
                     wl_output = Some(output);
                 }

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -287,9 +287,12 @@ impl PrivateSurfaceData {
             .pending_transaction
             .insert_state(surface.clone(), my_data.current_txid);
         if !is_sync {
+            let client = match surface.client() {
+                Some(client) => client,
+                None => return,
+            };
             // if we are not sync, add the transaction to the queue
             let tx = std::mem::take(&mut my_data.pending_transaction);
-            let client = surface.client().unwrap();
             let mut queue_guard = state.client_compositor_state(&client).queue.lock().unwrap();
             let queue = queue_guard.get_or_insert_with(TransactionQueue::default);
             queue.append(tx.finalize());


### PR DESCRIPTION
Even when handling request for a surface, `surface.client()` may return `None`. This occurs, for example, if a protocol error is signaled; the surface remains alive for some time, but `client()` returns `None` immediately after `post_error` was called.

I just added early returns in the three places I found in the codebase, where a client for a surface was previously being unwrapped.

I didn't add the check, if a surface `is_alive()` before calling the `commit`, discussed in #1407, as I didn't see value in doing the extra check anymore. Let me know if I should still add the check anyways.

Fixes #1407