### PR TITLE
Add `shape`/`orientation` to `TouchHandle` and `TouchGrab`

### DIFF
--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -241,6 +241,26 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
         handle.unset_grab(self, data);
     }
 
+    fn shape(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
+        event: &smithay::input::touch::ShapeEvent,
+        seq: Serial,
+    ) {
+        handle.shape(data, event, seq);
+    }
+
+    fn orientation(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
+        event: &smithay::input::touch::OrientationEvent,
+        seq: Serial,
+    ) {
+        handle.orientation(data, event, seq);
+    }
+
     fn start_data(&self) -> &smithay::input::touch::GrabStartData<AnvilState<BackendData>> {
         &self.start_data
     }
@@ -832,6 +852,26 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
     ) {
         handle.cancel(data, seq);
         handle.unset_grab(self, data);
+    }
+
+    fn shape(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
+        event: &smithay::input::touch::ShapeEvent,
+        seq: Serial,
+    ) {
+        handle.shape(data, event, seq);
+    }
+
+    fn orientation(
+        &mut self,
+        data: &mut AnvilState<BackendData>,
+        handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
+        event: &smithay::input::touch::OrientationEvent,
+        seq: Serial,
+    ) {
+        handle.orientation(data, event, seq);
     }
 
     fn start_data(&self) -> &smithay::input::touch::GrabStartData<AnvilState<BackendData>> {

--- a/src/input/touch/grab.rs
+++ b/src/input/touch/grab.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::{Logical, Point, Serial},
 };
 
-use super::{DownEvent, MotionEvent, TouchInnerHandle, UpEvent};
+use super::{DownEvent, MotionEvent, OrientationEvent, ShapeEvent, TouchInnerHandle, UpEvent};
 
 /// A trait to implement a touch grab
 ///
@@ -90,6 +90,18 @@ pub trait TouchGrab<D: SeatHandler>: Send {
     ///
     /// Usually called in case the compositor decides the touch stream is a global gesture.
     fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial);
+
+    /// A touch point has changed its shape.
+    fn shape(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &ShapeEvent, seq: Serial);
+
+    /// A touch point has changed its orientation.
+    fn orientation(
+        &mut self,
+        data: &mut D,
+        handle: &mut TouchInnerHandle<'_, D>,
+        event: &OrientationEvent,
+        seq: Serial,
+    );
 
     /// The data about the event that started the grab.
     fn start_data(&self) -> &GrabStartData<D>;
@@ -182,6 +194,20 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
         handle.cancel(data, seq)
     }
 
+    fn shape(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &ShapeEvent, seq: Serial) {
+        handle.shape(data, event, seq)
+    }
+
+    fn orientation(
+        &mut self,
+        data: &mut D,
+        handle: &mut TouchInnerHandle<'_, D>,
+        event: &OrientationEvent,
+        seq: Serial,
+    ) {
+        handle.orientation(data, event, seq)
+    }
+
     fn start_data(&self) -> &GrabStartData<D> {
         unreachable!()
     }
@@ -249,6 +275,20 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for TouchDownGrab<D> {
     fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
         handle.cancel(data, seq);
         handle.unset_grab(self, data);
+    }
+
+    fn shape(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &ShapeEvent, seq: Serial) {
+        handle.shape(data, event, seq)
+    }
+
+    fn orientation(
+        &mut self,
+        data: &mut D,
+        handle: &mut TouchInnerHandle<'_, D>,
+        event: &OrientationEvent,
+        seq: Serial,
+    ) {
+        handle.orientation(data, event, seq)
     }
 
     fn start_data(&self) -> &GrabStartData<D> {

--- a/src/wayland/selection/data_device/dnd_grab.rs
+++ b/src/wayland/selection/data_device/dnd_grab.rs
@@ -451,6 +451,24 @@ where
         handle.unset_grab(self, data);
     }
 
+    fn shape(
+        &mut self,
+        _data: &mut D,
+        _handle: &mut crate::input::touch::TouchInnerHandle<'_, D>,
+        _event: &crate::input::touch::ShapeEvent,
+        _seq: Serial,
+    ) {
+    }
+
+    fn orientation(
+        &mut self,
+        _data: &mut D,
+        _handle: &mut crate::input::touch::TouchInnerHandle<'_, D>,
+        _event: &crate::input::touch::OrientationEvent,
+        _seq: Serial,
+    ) {
+    }
+
     fn start_data(&self) -> &TouchGrabStartData<D> {
         self.touch_start_data.as_ref().unwrap()
     }

--- a/src/wayland/selection/data_device/server_dnd_grab.rs
+++ b/src/wayland/selection/data_device/server_dnd_grab.rs
@@ -429,6 +429,24 @@ where
         handle.unset_grab(self, data);
     }
 
+    fn shape(
+        &mut self,
+        _data: &mut D,
+        _handle: &mut crate::input::touch::TouchInnerHandle<'_, D>,
+        _event: &crate::input::touch::ShapeEvent,
+        _seq: Serial,
+    ) {
+    }
+
+    fn orientation(
+        &mut self,
+        _data: &mut D,
+        _handle: &mut crate::input::touch::TouchInnerHandle<'_, D>,
+        _event: &crate::input::touch::OrientationEvent,
+        _seq: Serial,
+    ) {
+    }
+
     fn start_data(&self) -> &TouchGrabStartData<D> {
         self.touch_start_data.as_ref().unwrap()
     }


### PR DESCRIPTION
The event structs were already defined and used in `TouchTarget`, but there was no way to actually send them.

I would also add backend support for getting these events from libinput, but apparently that still doesn't exist:
https://gitlab.freedesktop.org/libinput/libinput/-/issues/746.