### PR TITLE
Call `wl_buffer::release` only in drop impl of `renderer::utils::Buffer`

### DIFF
--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -59,6 +59,9 @@ impl Drop for InnerBuffer {
 }
 
 /// A wayland buffer
+///
+/// Reference counted, calling `wl_buffer::release` when last reference is
+/// dropped.
 #[derive(Debug, Clone)]
 pub struct Buffer {
     inner: Arc<InnerBuffer>,

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -123,18 +123,7 @@ impl Cacheable for SurfaceAttributes {
     }
     fn merge_into(self, into: &mut Self, _dh: &DisplayHandle) {
         if self.buffer.is_some() {
-            if let Some(BufferAssignment::NewBuffer(buffer)) =
-                std::mem::replace(&mut into.buffer, self.buffer)
-            {
-                let new_buffer = into.buffer.as_ref().and_then(|b| match b {
-                    BufferAssignment::Removed => None,
-                    BufferAssignment::NewBuffer(buffer) => Some(buffer),
-                });
-
-                if Some(&buffer) != new_buffer {
-                    buffer.release();
-                }
-            }
+            into.buffer = self.buffer;
         }
         into.buffer_delta = self.buffer_delta;
         into.buffer_scale = self.buffer_scale;

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -5,7 +5,7 @@ use super::{
     handlers::{is_effectively_sync, SurfaceUserData},
     hook::{Hook, HookId},
     transaction::{Blocker, PendingTransaction, TransactionQueue},
-    BufferAssignment, CompositorHandler, SurfaceAttributes, SurfaceData,
+    CompositorHandler, SurfaceAttributes, SurfaceData,
 };
 use std::{
     any::Any,
@@ -138,24 +138,16 @@ impl PrivateSurfaceData {
             let mut child_guard = child_mutex.lock().unwrap();
             child_guard.parent = None;
         }
-        if let Some(BufferAssignment::NewBuffer(buffer)) = my_data
+        my_data
             .public_data
             .cached_state
             .current::<SurfaceAttributes>()
-            .buffer
-            .take()
-        {
-            buffer.release();
-        };
-        if let Some(BufferAssignment::NewBuffer(buffer)) = my_data
+            .buffer = None;
+        my_data
             .public_data
             .cached_state
             .pending::<SurfaceAttributes>()
-            .buffer
-            .take()
-        {
-            buffer.release();
-        };
+            .buffer = None;
 
         let hooks = my_data.destruction_hooks.clone();
         // don't hold the mutex while the hooks are invoked


### PR DESCRIPTION
The protocol says a buffer that is attached but then replaced without being committed should not get `release`. So there shouldn't be any reason to call `release` in `merge_into` or `cleanup`.

Once the surface is comitted, `RenderSurfaceState::update_buffer` will create a `Buffer`. So it seems everything should be correct to ensure a buffer is released once and only once, when there are no references.