### PR TITLE
gbm: Force implicit modifiers for old api

### DIFF
--- a/src/backend/drm/gbm.rs
+++ b/src/backend/drm/gbm.rs
@@ -96,7 +96,7 @@ pub fn framebuffer_from_wayland_buffer<A: AsFd + 'static>(
     ) {
         let bo = gbm
             .import_buffer_object_from_wayland::<()>(buffer, gbm::BufferObjectFlags::SCANOUT)
-            .map(GbmBuffer::from_bo)
+            .map(|bo| GbmBuffer::from_bo(bo, true))
             .map_err(Error::Import)?;
         let (fb, format) = framebuffer_from_bo_internal(
             drm,


### PR DESCRIPTION
Buffers created via `gbm_bo_create` might return (errornous or actual) modifiers, which can then lead to errors trying to attach them to drm or exporting in dmabuf, which will then suddenly have modifiers.

So lets track if the creation method allows for modifiers or not.

This fixes a current bug with virgl, that zero-initializes the modifier field and thus returns `LINEAR`. This has been previously been bugs in multiple drivers and some drivers are intentionally returning the internally used modifier.

This proposed solution is equivalent to what other compositors are doing, e.g.: https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/bf86110fc5615bfd1af46e95cf81ac720ecac307