### PR TITLE
shm: guard against pool destruction race condition

### DIFF
--- a/src/wayland/shm/pool.rs
+++ b/src/wayland/shm/pool.rs
@@ -116,6 +116,13 @@ impl InnerPool {
 
         let pool_guard = self.map.read().unwrap();
 
+        // This should not happen, but in case a pool resize failed (which result in a protocol error
+        // and will kill the client) and the buffer got cached somewhere it is possible that we try to access
+        // a dead pool.
+        if pool_guard.ptr.is_null() {
+            return Err(());
+        }
+
         trace!(fd = ?self.fd, "Buffer access on shm pool");
 
         // Prepare the access
@@ -151,6 +158,13 @@ impl InnerPool {
         });
 
         let pool_guard = self.map.write().unwrap();
+
+        // This should not happen, but in case a pool resize failed (which result in a protocol error
+        // and will kill the client) and the buffer got cached somewhere it is possible that we try to access
+        // a dead pool.
+        if pool_guard.ptr.is_null() {
+            return Err(());
+        }
 
         trace!(fd = ?self.fd, "Mutable buffer access on shm pool");
 


### PR DESCRIPTION
It might happen that a buffer is cached somewhere while the pool has been set to null after a resize failed