### PR TITLE
Release overriden buffers (again)

### DIFF
--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -60,9 +60,6 @@ impl Drop for InnerBuffer {
 }
 
 /// A wayland buffer
-///
-/// Reference counted, calling `wl_buffer::release` when last reference is
-/// dropped.
 #[derive(Debug, Clone)]
 pub struct Buffer {
     inner: Arc<InnerBuffer>,

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -5,7 +5,7 @@ use super::{
     handlers::{is_effectively_sync, SurfaceUserData},
     hook::{Hook, HookId},
     transaction::{Blocker, PendingTransaction, TransactionQueue},
-    CompositorHandler, SurfaceAttributes, SurfaceData,
+    BufferAssignment, CompositorHandler, SurfaceAttributes, SurfaceData,
 };
 use std::{
     any::Any,
@@ -138,16 +138,24 @@ impl PrivateSurfaceData {
             let mut child_guard = child_mutex.lock().unwrap();
             child_guard.parent = None;
         }
-        my_data
+        if let Some(BufferAssignment::NewBuffer(buffer)) = my_data
             .public_data
             .cached_state
             .current::<SurfaceAttributes>()
-            .buffer = None;
-        my_data
+            .buffer
+            .take()
+        {
+            buffer.release();
+        };
+        if let Some(BufferAssignment::NewBuffer(buffer)) = my_data
             .public_data
             .cached_state
             .pending::<SurfaceAttributes>()
-            .buffer = None;
+            .buffer
+            .take()
+        {
+            buffer.release();
+        };
 
         let hooks = my_data.destruction_hooks.clone();
         // don't hold the mutex while the hooks are invoked


### PR DESCRIPTION
Revert "Call `wl_buffer::release` only in drop impl of `renderer::utils::Buffer`"

`SurfaceAttributes::merge_into` is called during `WlSurface::commit`.
So if no one (like `on_buffer_commit_handler`) processed an existing buffer in the mean time we have to
send a release or no one will do that for a committed buffer.

This reverts commit f25bcd892e6785ec9ce6b57e55843545722921f6.