### PR TITLE
session_lock: Verify `BufferAssignment` is `NewBuffer` in attached buffer check

### DIFF
--- a/src/wayland/session_lock/lock.rs
+++ b/src/wayland/session_lock/lock.rs
@@ -67,8 +67,14 @@ where
                 // Ensure surface has no existing buffers attached.
                 let has_buffer = compositor::with_states(&surface, |states| {
                     let cached = &states.cached_state;
-                    let pending = cached.pending::<SurfaceAttributes>().buffer.is_some();
-                    let current = cached.current::<SurfaceAttributes>().buffer.is_some();
+                    let pending = matches!(
+                        cached.pending::<SurfaceAttributes>().buffer,
+                        Some(BufferAssignment::NewBuffer(_))
+                    );
+                    let current = matches!(
+                        cached.current::<SurfaceAttributes>().buffer,
+                        Some(BufferAssignment::NewBuffer(_))
+                    );
                     pending || current
                 });
                 if has_buffer {


### PR DESCRIPTION
gtklock is getting the `already_constructed` protocol error without an attached buffer because it attaches a null one before calling `get_lock_surface`. This causes the `.is_some()` check for the pending buffer to trigger as it becomes `Some(BufferAssignment::Removed)`. This fix explicitly checks for `Some(BufferAssignment::NewBuffer)` before raising the protocol error.

Ref the gtklock part of YaLTeR/niri#341