### PR TITLE
xwm: Fix missing map_window_notify callback

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1449,6 +1449,8 @@ where
                         AtomEnum::WINDOW,
                         &[surface.window_id()],
                     )?;
+                    drop(_guard);
+                    state.map_window_notify(xwm_id, surface);
                 }
             }
         }


### PR DESCRIPTION
https://github.com/Smithay/smithay/pull/1351 accidentally dropped the `XwmHandler::map_window_notify` (which admittedly was at a very unintuitive place, this is now much cleaner), breaking compositors making use of it. Lets reintroduce it.