### PR TITLE
style: Use `AnvilState<BackendData>` everywhere

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -451,7 +451,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
 }
 
 #[cfg(any(feature = "winit", feature = "x11"))]
-impl<Backend: crate::state::Backend> AnvilState<Backend> {
+impl<BackendData: Backend> AnvilState<BackendData> {
     pub fn process_input_event_windowed<B: InputBackend>(&mut self, event: InputEvent<B>, output_name: &str) {
         match event {
             InputEvent::Keyboard { event } => match self.keyboard_key_to_action::<B>(event) {

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -28,7 +28,7 @@ use smithay::{
 };
 
 use super::ssd::HEADER_BAR_HEIGHT;
-use crate::{focus::PointerFocusTarget, AnvilState};
+use crate::{focus::PointerFocusTarget, state::Backend, AnvilState};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct WindowElement(pub Window);
@@ -157,8 +157,13 @@ impl WaylandFocus for SSD {
     }
 }
 
-impl<Backend: crate::state::Backend> PointerTarget<AnvilState<Backend>> for SSD {
-    fn enter(&self, _seat: &Seat<AnvilState<Backend>>, _data: &mut AnvilState<Backend>, event: &MotionEvent) {
+impl<BackendData: Backend> PointerTarget<AnvilState<BackendData>> for SSD {
+    fn enter(
+        &self,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
+        event: &MotionEvent,
+    ) {
         let mut state = self.0.decoration_state();
         if state.is_ssd {
             state.header_bar.pointer_enter(event.location);
@@ -166,8 +171,8 @@ impl<Backend: crate::state::Backend> PointerTarget<AnvilState<Backend>> for SSD 
     }
     fn motion(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         event: &MotionEvent,
     ) {
         let mut state = self.0.decoration_state();
@@ -177,23 +182,34 @@ impl<Backend: crate::state::Backend> PointerTarget<AnvilState<Backend>> for SSD 
     }
     fn relative_motion(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &RelativeMotionEvent,
     ) {
     }
-    fn button(&self, seat: &Seat<AnvilState<Backend>>, data: &mut AnvilState<Backend>, event: &ButtonEvent) {
+    fn button(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        event: &ButtonEvent,
+    ) {
         let mut state = self.0.decoration_state();
         if state.is_ssd {
             state.header_bar.clicked(seat, data, &self.0, event.serial);
         }
     }
-    fn axis(&self, _seat: &Seat<AnvilState<Backend>>, _data: &mut AnvilState<Backend>, _frame: AxisFrame) {}
-    fn frame(&self, _seat: &Seat<AnvilState<Backend>>, _data: &mut AnvilState<Backend>) {}
+    fn axis(
+        &self,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
+        _frame: AxisFrame,
+    ) {
+    }
+    fn frame(&self, _seat: &Seat<AnvilState<BackendData>>, _data: &mut AnvilState<BackendData>) {}
     fn leave(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _serial: Serial,
         _time: u32,
     ) {
@@ -204,67 +220,67 @@ impl<Backend: crate::state::Backend> PointerTarget<AnvilState<Backend>> for SSD 
     }
     fn gesture_swipe_begin(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &GestureSwipeBeginEvent,
     ) {
     }
     fn gesture_swipe_update(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &GestureSwipeUpdateEvent,
     ) {
     }
     fn gesture_swipe_end(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &GestureSwipeEndEvent,
     ) {
     }
     fn gesture_pinch_begin(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &GesturePinchBeginEvent,
     ) {
     }
     fn gesture_pinch_update(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &GesturePinchUpdateEvent,
     ) {
     }
     fn gesture_pinch_end(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &GesturePinchEndEvent,
     ) {
     }
     fn gesture_hold_begin(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &GestureHoldBeginEvent,
     ) {
     }
     fn gesture_hold_end(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &GestureHoldEndEvent,
     ) {
     }
 }
 
-impl<Backend: crate::state::Backend> TouchTarget<AnvilState<Backend>> for SSD {
+impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for SSD {
     fn down(
         &self,
-        seat: &Seat<AnvilState<Backend>>,
-        data: &mut AnvilState<Backend>,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::DownEvent,
         _seq: Serial,
     ) {
@@ -277,8 +293,8 @@ impl<Backend: crate::state::Backend> TouchTarget<AnvilState<Backend>> for SSD {
 
     fn up(
         &self,
-        seat: &Seat<AnvilState<Backend>>,
-        data: &mut AnvilState<Backend>,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::UpEvent,
         _seq: Serial,
     ) {
@@ -290,8 +306,8 @@ impl<Backend: crate::state::Backend> TouchTarget<AnvilState<Backend>> for SSD {
 
     fn motion(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::MotionEvent,
         _seq: Serial,
     ) {
@@ -301,14 +317,26 @@ impl<Backend: crate::state::Backend> TouchTarget<AnvilState<Backend>> for SSD {
         }
     }
 
-    fn frame(&self, _seat: &Seat<AnvilState<Backend>>, _data: &mut AnvilState<Backend>, _seq: Serial) {}
+    fn frame(
+        &self,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
+        _seq: Serial,
+    ) {
+    }
 
-    fn cancel(&self, _seat: &Seat<AnvilState<Backend>>, _data: &mut AnvilState<Backend>, _seq: Serial) {}
+    fn cancel(
+        &self,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
+        _seq: Serial,
+    ) {
+    }
 
     fn shape(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &smithay::input::touch::ShapeEvent,
         _seq: Serial,
     ) {
@@ -316,8 +344,8 @@ impl<Backend: crate::state::Backend> TouchTarget<AnvilState<Backend>> for SSD {
 
     fn orientation(
         &self,
-        _seat: &Seat<AnvilState<Backend>>,
-        _data: &mut AnvilState<Backend>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
         _event: &smithay::input::touch::OrientationEvent,
         _seq: Serial,
     ) {

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -24,8 +24,8 @@ use crate::{
     state::{AnvilState, Backend},
 };
 
-pub struct PointerMoveSurfaceGrab<B: Backend + 'static> {
-    pub start_data: PointerGrabStartData<AnvilState<B>>,
+pub struct PointerMoveSurfaceGrab<BackendData: Backend + 'static> {
+    pub start_data: PointerGrabStartData<AnvilState<BackendData>>,
     pub window: WindowElement,
     pub initial_window_location: Point<i32, Logical>,
 }
@@ -167,8 +167,8 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerMoveS
     fn unset(&mut self, _data: &mut AnvilState<BackendData>) {}
 }
 
-pub struct TouchMoveSurfaceGrab<B: Backend + 'static> {
-    pub start_data: TouchGrabStartData<AnvilState<B>>,
+pub struct TouchMoveSurfaceGrab<BackendData: Backend + 'static> {
+    pub start_data: TouchGrabStartData<AnvilState<BackendData>>,
     pub window: WindowElement,
     pub initial_window_location: Point<i32, Logical>,
 }
@@ -339,8 +339,8 @@ pub enum ResizeState {
     WaitingForCommit(ResizeData),
 }
 
-pub struct PointerResizeSurfaceGrab<B: Backend + 'static> {
-    pub start_data: PointerGrabStartData<AnvilState<B>>,
+pub struct PointerResizeSurfaceGrab<BackendData: Backend + 'static> {
+    pub start_data: PointerGrabStartData<AnvilState<BackendData>>,
     pub window: WindowElement,
     pub edges: ResizeEdge,
     pub initial_window_location: Point<i32, Logical>,
@@ -632,8 +632,8 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerResiz
     fn unset(&mut self, _data: &mut AnvilState<BackendData>) {}
 }
 
-pub struct TouchResizeSurfaceGrab<B: Backend + 'static> {
-    pub start_data: TouchGrabStartData<AnvilState<B>>,
+pub struct TouchResizeSurfaceGrab<BackendData: Backend + 'static> {
+    pub start_data: TouchGrabStartData<AnvilState<BackendData>>,
     pub window: WindowElement,
     pub edges: ResizeEdge,
     pub initial_window_location: Point<i32, Logical>,

--- a/anvil/src/shell/ssd.rs
+++ b/anvil/src/shell/ssd.rs
@@ -14,7 +14,7 @@ use smithay::{
 
 use std::cell::{RefCell, RefMut};
 
-use crate::AnvilState;
+use crate::{state::Backend, AnvilState};
 
 use super::WindowElement;
 
@@ -53,10 +53,10 @@ impl HeaderBar {
         self.pointer_loc = None;
     }
 
-    pub fn clicked<B: crate::state::Backend>(
+    pub fn clicked<BackendData: Backend>(
         &mut self,
-        seat: &Seat<AnvilState<B>>,
-        state: &mut AnvilState<B>,
+        seat: &Seat<AnvilState<BackendData>>,
+        state: &mut AnvilState<BackendData>,
         window: &WindowElement,
         serial: Serial,
     ) {
@@ -104,10 +104,10 @@ impl HeaderBar {
         };
     }
 
-    pub fn touch_down<B: crate::state::Backend>(
+    pub fn touch_down<BackendData: Backend>(
         &mut self,
-        seat: &Seat<AnvilState<B>>,
-        state: &mut AnvilState<B>,
+        seat: &Seat<AnvilState<BackendData>>,
+        state: &mut AnvilState<BackendData>,
         window: &WindowElement,
         serial: Serial,
     ) {
@@ -136,10 +136,10 @@ impl HeaderBar {
         };
     }
 
-    pub fn touch_up<B: crate::state::Backend>(
+    pub fn touch_up<BackendData: Backend>(
         &mut self,
-        _seat: &Seat<AnvilState<B>>,
-        state: &mut AnvilState<B>,
+        _seat: &Seat<AnvilState<BackendData>>,
+        state: &mut AnvilState<BackendData>,
         window: &WindowElement,
         _serial: Serial,
     ) {


### PR DESCRIPTION
Before this patch, `AnvilState<BackendData>`,
`AnvilState<Backend: crate::state::Backend>`, and `AnvilState<B>` are mixed up. This patch uses `AnvilState<BackendData>` for consistency.