### PR TITLE
Fix the xwayland shell - X11Window to WlSurface association

### DIFF
--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -1,8 +1,7 @@
 use std::cell::RefCell;
 
 #[cfg(feature = "xwayland")]
-use smithay::xwayland::XWaylandClientData;
-
+use smithay::xwayland::{X11Wm, XWaylandClientData};
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
     desktop::{
@@ -34,7 +33,6 @@ use smithay::{
             xdg::{XdgPopupSurfaceData, XdgToplevelSurfaceData},
         },
     },
-    xwayland::X11Wm,
 };
 
 use crate::{

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -33,7 +33,8 @@ use smithay::{
             },
             xdg::{XdgPopupSurfaceData, XdgToplevelSurfaceData},
         },
-    }, xwayland::X11Wm,
+    },
+    xwayland::X11Wm,
 };
 
 use crate::{
@@ -143,7 +144,7 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
     fn commit(&mut self, surface: &WlSurface) {
         #[cfg(feature = "xwayland")]
         X11Wm::commit_hook(self, surface);
-        
+
         on_commit_buffer_handler::<Self>(surface);
         self.backend_data.early_import(surface);
 

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -141,9 +141,6 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
     }
 
     fn commit(&mut self, surface: &WlSurface) {
-        #[cfg(feature = "xwayland")]
-        X11Wm::commit_hook(self, surface);
-
         on_commit_buffer_handler::<Self>(surface);
         self.backend_data.early_import(surface);
 

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -33,7 +33,7 @@ use smithay::{
             },
             xdg::{XdgPopupSurfaceData, XdgToplevelSurfaceData},
         },
-    },
+    }, xwayland::X11Wm,
 };
 
 use crate::{
@@ -141,6 +141,9 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
     }
 
     fn commit(&mut self, surface: &WlSurface) {
+        #[cfg(feature = "xwayland")]
+        X11Wm::commit_hook(self, surface);
+        
         on_commit_buffer_handler::<Self>(surface);
         self.backend_data.early_import(surface);
 

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
 #[cfg(feature = "xwayland")]
-use smithay::xwayland::{X11Wm, XWaylandClientData};
+use smithay::xwayland::XWaylandClientData;
 
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -30,7 +30,7 @@
 //!         todo!()
 //!     }
 //! }
-//! 
+//!
 //! impl XwmHandler for State {
 //! }
 //!

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -31,7 +31,28 @@
 //!     }
 //! }
 //!
+//! #  use smithay::wayland::selection::SelectionTarget;
+//! #  use smithay::xwayland::{XWayland, XWaylandEvent, X11Wm, X11Surface, XwmHandler, xwm::{XwmId, ResizeEdge, Reorder}};
+//! #  use smithay::utils::{Rectangle, Logical};
+//! #  use std::os::unix::io::OwnedFd;
+//! #  use std::process::Stdio;
+//!
 //! impl XwmHandler for State {
+//!     fn xwm_state(&mut self, xwm: XwmId) -> &mut X11Wm {
+//!         // ...
+//! #       unreachable!()
+//!     }
+//!     fn new_window(&mut self, xwm: XwmId, window: X11Surface) { /* ... */ }
+//!     fn new_override_redirect_window(&mut self, xwm: XwmId, window: X11Surface) { /* ... */ }
+//!     fn map_window_request(&mut self, xwm: XwmId, window: X11Surface) { /* ... */ }
+//!     fn mapped_override_redirect_window(&mut self, xwm: XwmId, window: X11Surface) { /* ... */ }
+//!     fn unmapped_window(&mut self, xwm: XwmId, window: X11Surface) { /* ... */ }
+//!     fn destroyed_window(&mut self, xwm: XwmId, window: X11Surface) { /* ... */ }
+//!     fn configure_request(&mut self, xwm: XwmId, window: X11Surface, x: Option<i32>, y: Option<i32>, w: Option<u32>, h: Option<u32>, reorder: Option<Reorder>) { /* ... */ }
+//!     fn configure_notify(&mut self, xwm: XwmId, window: X11Surface, geometry: Rectangle<i32, Logical>, above: Option<u32>) { /* ... */ }
+//!     fn resize_request(&mut self, xwm: XwmId, window: X11Surface, button: u32, resize_edge: ResizeEdge) { /* ... */ }
+//!     fn move_request(&mut self, xwm: XwmId, window: X11Surface, button: u32) { /* ... */ }
+//!     fn send_selection(&mut self, xwm: XwmId, selection: SelectionTarget, mime_type: String, fd: OwnedFd) { /* ... */ }
 //! }
 //!
 //! // implement Dispatch for your state.

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -245,11 +245,11 @@ where
 
                     xwm_id.and_then(|xwm_id| {
                         let xwm = XwmHandler::xwm_state(state, *xwm_id);
-                        let window = xwm.unpaired_surfaces.remove(&serial);
+                        let window = xwm.unpaired_surfaces.get(&serial);
                         window.and_then(|window| {
                             xwm.windows
                                 .iter()
-                                .find(|x| x.window_id() == window || x.mapped_window_id() == Some(window))
+                                .find(|x| x.window_id() == *window || x.mapped_window_id() == Some(*window))
                         })
                     })
                 } {
@@ -257,10 +257,8 @@ where
                         mapped_window_id = xsurface.mapped_window_id(),
                         window_id = xsurface.window_id(),
                         wl_surface = ?data.wl_surface.id().protocol_id(),
-                        "associated X11 window to wl_surface in commit hook",
+                        "associated X11 window to wl_surface in SetSerial request",
                     );
-
-                    xsurface.state.lock().unwrap().wl_surface = Some(data.wl_surface.clone());
                     let window_id = xsurface.window_id();
                     XWaylandShellHandler::surface_associated(state, data.wl_surface.clone(), window_id);
                 } else {

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -8,6 +8,7 @@
 //!     XWaylandShellState,
 //! };
 //! use smithay::delegate_xwayland_shell;
+//! use x11rb::protocol::xproto::Window as X11Window;
 //!
 //! # struct State;
 //! # let mut display = wayland_server::Display::<State>::new().unwrap();

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -30,6 +30,9 @@
 //!         todo!()
 //!     }
 //! }
+//! 
+//! impl XwmHandler for State {
+//! }
 //!
 //! // implement Dispatch for your state.
 //! delegate_xwayland_shell!(State);

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -278,7 +278,7 @@ pub trait XwmHandler {
     ///
     /// To grant the wish you have to call `X11Surface::set_mapped(true)` for the window to become visible.
     fn map_window_request(&mut self, xwm: XwmId, window: X11Surface);
-    /// Notification a window was mapped sucessfully and now has a usable `wl_surface` attached.
+    /// Notification a window was mapped sucessfully
     fn map_window_notify(&mut self, xwm: XwmId, window: X11Surface) {
         let _ = (xwm, window);
     }
@@ -388,7 +388,7 @@ pub struct X11Wm {
     wm_window: X11Window,
     atoms: Atoms,
 
-    unpaired_surfaces: HashMap<u64, X11Window>,
+    pub(crate) unpaired_surfaces: HashMap<u64, X11Window>,
     sequences_to_ignore: BinaryHeap<Reverse<u16>>,
 
     // selections

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -94,7 +94,9 @@
 use crate::{
     utils::{x11rb::X11Source, Logical, Point, Rectangle, Size},
     wayland::{
-        compositor, selection::SelectionTarget, xwayland_shell::{self, XWaylandShellHandler}
+        compositor,
+        selection::SelectionTarget,
+        xwayland_shell::{self, XWaylandShellHandler},
     },
 };
 use calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction, RegistrationToken};

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -94,7 +94,6 @@
 use crate::{
     utils::{x11rb::X11Source, Logical, Point, Rectangle, Size},
     wayland::{
-        compositor,
         selection::SelectionTarget,
         xwayland_shell::{self, XWaylandShellHandler},
     },
@@ -112,7 +111,7 @@ use std::{
     sync::Arc,
 };
 use tracing::{debug, debug_span, error, info, trace, warn};
-use wayland_server::{protocol::wl_surface::WlSurface, Client, Resource};
+use wayland_server::{Client, Resource};
 
 use x11rb::{
     connection::Connection as _,


### PR DESCRIPTION
Since the `map_window_notify` doesn't ensure that a valid association is made between a X11Surface and a WlSurface we need to have a new way to associate them. But currently the `surface_associated` doesn't provide arguments that allow this association in the implementation side.]

This PR aim to fix thoses issues.

Note: It's currently doesn't work as expected since the execution order seems to be odd