### PR TITLE
Check if focus is unchanged in `set_data_device_focus`/`set_primary_focus`

### DIFF
--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -233,6 +233,8 @@ pub fn default_action_chooser(available: DndAction, preferred: DndAction) -> Dnd
 }
 
 /// Set the data device focus to a certain client for a given seat
+///
+/// If the focus is different from the existing focus, the current selection will be offered to the client.
 #[instrument(name = "wayland_data_device", level = "debug", skip(dh, seat, client), fields(seat = seat.name(), client = ?client.as_ref().map(|c| c.id())))]
 pub fn set_data_device_focus<D>(dh: &DisplayHandle, seat: &Seat<D>, client: Option<Client>)
 where

--- a/src/wayland/selection/primary_selection/mod.rs
+++ b/src/wayland/selection/primary_selection/mod.rs
@@ -118,6 +118,8 @@ impl PrimarySelectionState {
 }
 
 /// Set the primary selection focus to a certain client for a given seat
+///
+/// If the focus is different from the existing focus, the current selection will be offered to the client.
 #[instrument(name = "wayland_primary_selection", level = "debug", skip(dh, seat, client), fields(seat = seat.name(), client = ?client.as_ref().map(|c| c.id())))]
 pub fn set_primary_focus<D>(dh: &DisplayHandle, seat: &Seat<D>, client: Option<Client>)
 where

--- a/src/wayland/selection/seat_data.rs
+++ b/src/wayland/selection/seat_data.rs
@@ -44,12 +44,16 @@ impl<U: Clone + Send + Sync + 'static> SeatData<U> {
 
     /// Change focus for the clipboard selection to `new_focus` client. Providing `None` will
     /// remove the focus.
+    ///
+    /// If the focus is different from the existing focus, the current selection will be offered to the client.
     pub fn set_clipboard_focus<D>(&mut self, dh: &DisplayHandle, new_focus: Option<Client>)
     where
         D: SelectionHandler<SelectionUserData = U> + 'static,
     {
-        self.clipboard_selection_focus = new_focus;
-        self.send_selection::<D>(dh, SelectionTarget::Clipboard, None, false)
+        if self.clipboard_selection_focus != new_focus {
+            self.clipboard_selection_focus = new_focus;
+            self.send_selection::<D>(dh, SelectionTarget::Clipboard, None, false)
+        }
     }
 
     /// Set the clipboard selection to the `new_selection`, providing `None` will clear the
@@ -73,12 +77,16 @@ impl<U: Clone + Send + Sync + 'static> SeatData<U> {
 
     /// Change focus for the primary selection to `new_focus` client. Providing `None` will
     /// remove the focus.
+    ///
+    /// If the focus is different from the existing focus, the current selection will be offered to the client.
     pub fn set_primary_focus<D>(&mut self, dh: &DisplayHandle, new_focus: Option<Client>)
     where
         D: SelectionHandler<SelectionUserData = U> + 'static,
     {
-        self.primary_selection_focus = new_focus;
-        self.send_selection::<D>(dh, SelectionTarget::Primary, None, false)
+        if self.primary_selection_focus != new_focus {
+            self.primary_selection_focus = new_focus;
+            self.send_selection::<D>(dh, SelectionTarget::Primary, None, false)
+        }
     }
 
     /// Set the primary selection to the `new_selection`, providing `None` will clear the


### PR DESCRIPTION
I wanted to change where these are called in `cosmic-comp` to workaround an issue. But by not just calling it when keyboard focus changes, it created a flood of `offer` events.

It would be possible to add a getter for the focus, but it seems reasonable just to add a test here to check if it has changed. I assume there's no problem doing noting if the focus is the same as the current one.