### PR TITLE
xwayland: Make hook implementation-detail

### DIFF
--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
 #[cfg(feature = "xwayland")]
-use smithay::xwayland::{X11Wm, XWaylandClientData};
+use smithay::xwayland::XWaylandClientData;
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
     desktop::{
@@ -140,9 +140,6 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
     }
 
     fn commit(&mut self, surface: &WlSurface) {
-        #[cfg(feature = "xwayland")]
-        X11Wm::commit_hook(self, surface);
-
         on_commit_buffer_handler::<Self>(surface);
         self.backend_data.early_import(surface);
 


### PR DESCRIPTION
Also fixes, that the commit hook is added on every SetSerial call (xwayland re-uses surfaces).

cc @PapyElGringo, @colinmarc 