### PR TITLE
Move pointer protocol extensions logic to their corresponding modules

### DIFF
--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -266,7 +266,7 @@ where
                 );
 
                 if let Some(ref ptr_handle) = inner.pointer {
-                    ptr_handle.new_pointer(pointer);
+                    ptr_handle.wl_pointer.new_pointer(pointer);
                 } else {
                     // we should send a protocol error... but the protocol does not allow
                     // us, so this pointer will just remain inactive ¯\_(ツ)_/¯


### PR DESCRIPTION
Maybe it's just a personal preference, but every time I open seat logic code, and see some new protocol extension added in there it starts to overwhelm me a bit.
So spliting it up per protocol seems resonable.

Also this adresses my other main problem with reading seat code, the fact that data of the protocol is defined in `input::` module rather than next to the protocol implementation, which leads to constant jumping around. With this change state type definition is stored next to the logic.