### PR TITLE
Multiply alpha modifier with alpha in `WaylandSurfaceRenderElement`

### DIFF
--- a/src/wayland/alpha_modifier/mod.rs
+++ b/src/wayland/alpha_modifier/mod.rs
@@ -1,5 +1,8 @@
 //! Implementation of `wp_alpha_modifier` protocol
 //!
+//! [`WaylandSurfaceRenderElement`][`crate::backend::renderer::element::surface::WaylandSurfaceRenderElement`]
+//! takes the alpha multiplier into account automatically.
+//!
 //! ### Example
 //!
 //! ```no_run


### PR DESCRIPTION
Previously the alpha modifier was not used anywhere within Smithay. The compositor possibly could handle the alpha value itself, but it's not clear how to do that when using `render_elements_from_surface_tree`. Nor is there an obvious reason not to handle this in Smithay.

The protocol leaves the exact blending space undefined. But multiplying here seems like a correct implementation.