### PR TITLE
Perf/tiled renderers

### DIFF
--- a/anvil/README.md
+++ b/anvil/README.md
@@ -40,3 +40,16 @@ The currently available backends are:
 - `--tty-udev`: start anvil in a tty with udev support. This is the "traditional" launch of a Wayland
   compositor. Note that this requires you to start anvil as root if your system does not have logind
   available.
+
+### Supported Environment Variables
+
+| Variable                      | Example         | Backends  |
+|-------------------------------|-----------------|-----------|
+| ANVIL_DRM_DEVICE              | /dev/dri/card0  | tty-udev  |
+| ANVIL_DISABLE_10BIT           | any             | tty-udev  |
+| ANVIL_DISABLE_COLOR_TRANSFORM | any             | tty-udev  |
+| ANVIL_DISABLE_DIRECT_SCANOUT  | any             | tty-udev  |
+| ANVIL_DISABLE_DRM_COMPOSITOR  | any             | tty-udev  |
+| ANVIL_NO_VULKAN               | 1,true,yes,y    | x11       |
+| SMITHAY_USE_LEGACY            | 1,true,yes,y    | tty-udev  |
+| SMITHAY_VK_VERSION            | 1.3             |           |

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -202,6 +202,7 @@ where
         _src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), R::Error> {
         // FIXME: respect the src for cropping
         let scale = dst.size.to_f64() / self.src().size;
@@ -243,6 +244,7 @@ where
                 texture_src.to_f64(),
                 dst,
                 &damage,
+                &[],
                 Transform::Normal,
                 1.0,
             )?;

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -1059,6 +1059,9 @@ impl AnvilState<UdevData> {
                     }
                 };
                 compositor.set_debug_flags(self.backend_data.debug_flags);
+
+                let disable_direct_scanout = std::env::var("ANVIL_DISABLE_DIRECT_SCANOUT").is_ok();
+                compositor.use_direct_scanout(!disable_direct_scanout);
                 SurfaceComposition::Compositor(compositor)
             };
 

--- a/examples/buffer_test.rs
+++ b/examples/buffer_test.rs
@@ -340,6 +340,7 @@ where
             1.,
             Transform::Normal,
             &[Rectangle::from_loc_and_size((0, 0), (w, h))],
+            &[],
             1.0,
         )
         .expect("Failed to sample dmabuf");

--- a/src/backend/drm/compositor/elements.rs
+++ b/src/backend/drm/compositor/elements.rs
@@ -45,6 +45,7 @@ where
         _src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
         frame.clear(
             COLOR_TRANSPARENT,
@@ -177,6 +178,7 @@ where
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
         // We do not actually draw anything here
         Ok(())

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1324,7 +1324,7 @@ where
                 trace!("drawing frame element with damage: {:#?}", element_damage);
 
                 element
-                    .draw(&mut frame, src, dst, &element_damage)
+                    .draw(&mut frame, src, dst, &element_damage, &[])
                     .map_err(BlitFrameResultError::Rendering)?;
             }
 
@@ -3308,6 +3308,7 @@ where
                             src,
                             dst,
                             &[dst],
+                            &[],
                             element.transform(),
                             element.alpha(),
                         )?;

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -66,6 +66,7 @@
 //! #         _: Rectangle<f64, Buffer>,
 //! #         _: Rectangle<i32, Physical>,
 //! #         _: &[Rectangle<i32, Physical>],
+//! #         _: &[Rectangle<i32, Physical>],
 //! #         _: Transform,
 //! #         _: f32,
 //! #     ) -> Result<(), Self::Error> {
@@ -751,8 +752,17 @@ where
         src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
-        frame.render_texture_from_to(&self.texture, src, dst, damage, self.buffer_transform, self.alpha)
+        frame.render_texture_from_to(
+            &self.texture,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            self.buffer_transform,
+            self.alpha,
+        )
     }
 
     #[inline]

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -389,6 +389,7 @@ pub trait RenderElement<R: Renderer>: Element {
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), R::Error>;
 
     /// Get the underlying storage of this element, may be used to optimize rendering (eg. drm planes)
@@ -477,8 +478,9 @@ where
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), R::Error> {
-        (*self).draw(frame, src, dst, damage)
+        (*self).draw(frame, src, dst, damage, opaque_regions)
     }
 }
 
@@ -760,6 +762,7 @@ macro_rules! render_elements_internal {
             src: $crate::utils::Rectangle<f64, $crate::utils::Buffer>,
             dst: $crate::utils::Rectangle<i32, $crate::utils::Physical>,
             damage: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
+            opaque_regions: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
         ) -> Result<(), <$renderer as $crate::backend::renderer::Renderer>::Error>
         where
         $(
@@ -776,7 +779,7 @@ macro_rules! render_elements_internal {
                     $(
                         #[$meta]
                     )*
-                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, frame, src, dst, damage)
+                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, frame, src, dst, damage, opaque_regions)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -804,6 +807,7 @@ macro_rules! render_elements_internal {
             src: $crate::utils::Rectangle<f64, $crate::utils::Buffer>,
             dst: $crate::utils::Rectangle<i32, $crate::utils::Physical>,
             damage: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
+            opaque_regions: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
         ) -> Result<(), <$renderer as $crate::backend::renderer::Renderer>::Error>
         {
             match self {
@@ -812,7 +816,7 @@ macro_rules! render_elements_internal {
                     $(
                         #[$meta]
                     )*
-                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, frame, src, dst, damage)
+                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, frame, src, dst, damage, opaque_regions)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -1146,6 +1150,7 @@ macro_rules! render_elements_internal {
 /// #         _src: Rectangle<f64, Buffer>,
 /// #         _dst: Rectangle<i32, Physical>,
 /// #         _damage: &[Rectangle<i32, Physical>],
+/// #         _opaque_regions: &[Rectangle<i32, Physical>],
 /// #     ) -> Result<(), <R as Renderer>::Error> {
 /// #         unimplemented!()
 /// #     }
@@ -1176,6 +1181,7 @@ macro_rules! render_elements_internal {
 /// #         _src: Rectangle<f64, Buffer>,
 /// #         _dst: Rectangle<i32, Physical>,
 /// #         _damage: &[Rectangle<i32, Physical>],
+/// #         _opaque_regions: &[Rectangle<i32, Physical>],
 /// #     ) -> Result<(), <R as Renderer>::Error> {
 /// #         unimplemented!()
 /// #     }
@@ -1288,6 +1294,7 @@ macro_rules! render_elements_internal {
 /// #         _: &Self::TextureId,
 /// #         _: Rectangle<f64, Buffer>,
 /// #         _: Rectangle<i32, Physical>,
+/// #         _: &[Rectangle<i32, Physical>],
 /// #         _: &[Rectangle<i32, Physical>],
 /// #         _: Transform,
 /// #         _: f32,
@@ -1472,8 +1479,9 @@ where
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
-        self.0.draw(frame, src, dst, damage)
+        self.0.draw(frame, src, dst, damage, opaque_regions)
     }
 
     #[inline]

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -51,6 +51,7 @@
 //! #         _: Rectangle<f64, Buffer>,
 //! #         _: Rectangle<i32, Physical>,
 //! #         _: &[Rectangle<i32, Physical>],
+//! #         _: &[Rectangle<i32, Physical>],
 //! #         _: Transform,
 //! #         _: f32,
 //! #     ) -> Result<(), Self::Error> {
@@ -330,6 +331,7 @@ impl<R: Renderer> RenderElement<R> for SolidColorRenderElement {
         _src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
         frame.draw_solid(dst, damage, self.color)
     }

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -69,6 +69,7 @@
 //! #         _: Rectangle<f64, Buffer>,
 //! #         _: Rectangle<i32, Physical>,
 //! #         _: &[Rectangle<i32, Physical>],
+//! #         _: &[Rectangle<i32, Physical>],
 //! #         _: Transform,
 //! #         _: f32,
 //! #     ) -> Result<(), Self::Error> {
@@ -529,7 +530,16 @@ where
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), R::Error> {
-        frame.render_texture_from_to(&self.texture, src, dst, damage, self.buffer_transform, self.alpha)
+        frame.render_texture_from_to(
+            &self.texture,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            self.buffer_transform,
+            self.alpha,
+        )
     }
 }

--- a/src/backend/renderer/element/tests.rs
+++ b/src/backend/renderer/element/tests.rs
@@ -149,6 +149,7 @@ where
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
         todo!()
     }
@@ -186,6 +187,7 @@ where
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
         todo!()
     }
@@ -232,6 +234,7 @@ where
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
         todo!()
     }
@@ -277,6 +280,7 @@ where
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
         todo!()
     }

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -84,6 +84,7 @@
 //! #         _: Rectangle<f64, Buffer>,
 //! #         _: Rectangle<i32, Physical>,
 //! #         _: &[Rectangle<i32, Physical>],
+//! #         _: &[Rectangle<i32, Physical>],
 //! #         _: Transform,
 //! #         _: f32,
 //! #     ) -> Result<(), Self::Error> {
@@ -242,6 +243,7 @@
 //! #         _: &Self::TextureId,
 //! #         _: Rectangle<f64, Buffer>,
 //! #         _: Rectangle<i32, Physical>,
+//! #         _: &[Rectangle<i32, Physical>],
 //! #         _: &[Rectangle<i32, Physical>],
 //! #         _: Transform,
 //! #         _: f32,
@@ -903,12 +905,21 @@ where
         src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
         if frame.id() != self.renderer_id {
             warn!("trying to render texture from different renderer");
             return Ok(());
         }
 
-        frame.render_texture_from_to(&self.texture, src, dst, damage, self.transform, self.alpha)
+        frame.render_texture_from_to(
+            &self.texture,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            self.transform,
+            self.alpha,
+        )
     }
 }

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -99,8 +99,9 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RescaleRenderElement
         src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
         dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
         damage: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
+        opaque_regions: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
-        self.element.draw(frame, src, dst, damage)
+        self.element.draw(frame, src, dst, damage, opaque_regions)
     }
 
     #[inline]
@@ -282,8 +283,9 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for CropRenderElement<E>
         src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
         dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
         damage: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
+        opaque_regions: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
-        self.element.draw(frame, src, dst, damage)
+        self.element.draw(frame, src, dst, damage, opaque_regions)
     }
 
     #[inline]
@@ -383,8 +385,9 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RelocateRenderElemen
         src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
         dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
         damage: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
+        opaque_regions: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
-        self.element.draw(frame, src, dst, damage)
+        self.element.draw(frame, src, dst, damage, opaque_regions)
     }
 
     #[inline]

--- a/src/backend/renderer/gles/element.rs
+++ b/src/backend/renderer/gles/element.rs
@@ -113,6 +113,7 @@ impl RenderElement<GlesRenderer> for PixelShaderElement {
         _src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), GlesError> {
         frame.render_pixel_shader_to(
             &self.shader,

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -271,6 +271,7 @@ impl<'frame> Frame for GlowFrame<'frame> {
         src: Rectangle<f64, BufferCoord>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
         src_transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error> {
@@ -280,6 +281,7 @@ impl<'frame> Frame for GlowFrame<'frame> {
             src,
             dst,
             damage,
+            opaque_regions,
             src_transform,
             alpha,
         )
@@ -298,6 +300,7 @@ impl<'frame> Frame for GlowFrame<'frame> {
         output_scale: impl Into<crate::utils::Scale<f64>>,
         src_transform: Transform,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
         alpha: f32,
     ) -> Result<(), Self::Error> {
         self.frame.as_mut().unwrap().render_texture_at(
@@ -307,6 +310,7 @@ impl<'frame> Frame for GlowFrame<'frame> {
             output_scale,
             src_transform,
             damage,
+            opaque_regions,
             alpha,
         )
     }
@@ -536,8 +540,9 @@ impl RenderElement<GlowRenderer> for PixelShaderElement {
         src: Rectangle<f64, BufferCoord>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), GlesError> {
-        RenderElement::<GlesRenderer>::draw(self, frame.borrow_mut(), src, dst, damage)
+        RenderElement::<GlesRenderer>::draw(self, frame.borrow_mut(), src, dst, damage, opaque_regions)
     }
 
     fn underlying_storage(&self, renderer: &mut GlowRenderer) -> Option<UnderlyingStorage<'_>> {

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -194,6 +194,7 @@ pub trait Frame {
         output_scale: impl Into<Scale<f64>>,
         src_transform: Transform,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
         alpha: f32,
     ) -> Result<(), Self::Error> {
         self.render_texture_from_to(
@@ -207,6 +208,7 @@ pub trait Frame {
                     .to_physical_precise_round(output_scale),
             ),
             damage,
+            opaque_regions,
             src_transform,
             alpha,
         )
@@ -215,12 +217,14 @@ pub trait Frame {
     /// Render part of a texture as given by src to the current target into the rectangle described by dst
     /// as a flat 2d-plane after applying the inverse of the given transformation.
     /// (Meaning `src_transform` should match the orientation of surface being rendered).
+    #[allow(clippy::too_many_arguments)]
     fn render_texture_from_to(
         &mut self,
         texture: &Self::TextureId,
         src: Rectangle<f64, BufferCoord>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
         src_transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error>;

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1212,6 +1212,7 @@ where
                             Rectangle::from_loc_and_size((0, 0), buffer_size).to_f64(),
                             Rectangle::from_loc_and_size((0, 0), self.size),
                             &damage,
+                            &[Rectangle::from_loc_and_size((0, 0), self.size)],
                             Transform::Normal,
                             1.0,
                         )
@@ -1300,7 +1301,15 @@ where
                         let damage = &[Rectangle::from_loc_and_size((0, 0), dst.size)];
                         frame.clear([0.0, 0.0, 0.0, 0.0], &[dst]).map_err(Error::Target)?;
                         frame
-                            .render_texture_from_to(&texture, src, dst, damage, Transform::Normal, 1.0)
+                            .render_texture_from_to(
+                                &texture,
+                                src,
+                                dst,
+                                damage,
+                                &[Rectangle::from_loc_and_size((0, 0), self.size)],
+                                Transform::Normal,
+                                1.0,
+                            )
                             .map_err(Error::Target)?;
                     }
                 }
@@ -1614,6 +1623,7 @@ where
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
         src_transform: Transform,
         alpha: f32,
     ) -> Result<(), Error<R, T>> {
@@ -1632,7 +1642,7 @@ where
             self.frame
                 .as_mut()
                 .unwrap()
-                .render_texture_from_to(&texture, src, dst, damage, src_transform, alpha)
+                .render_texture_from_to(&texture, src, dst, damage, opaque_regions, src_transform, alpha)
                 .map_err(Error::Render)
         } else {
             warn!(
@@ -1986,6 +1996,7 @@ where
             Rectangle::from_loc_and_size((0, 0), src_texture.size()).to_f64(),
             Rectangle::from_loc_and_size((0, 0), shadow_size),
             damage,
+            &[],
             Transform::Normal,
             1.0,
         )

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -348,6 +348,7 @@ impl<'frame> Frame for PixmanFrame<'frame> {
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
         src_transform: Transform,
         alpha: f32,
     ) -> Result<(), Self::Error> {

--- a/src/backend/renderer/test.rs
+++ b/src/backend/renderer/test.rs
@@ -226,6 +226,7 @@ impl Frame for DummyFrame {
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
         _src_transform: Transform,
         _alpha: f32,
     ) -> Result<(), Self::Error> {

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -625,7 +625,7 @@ where
             continue;
         }
 
-        element.draw(frame, element.src(), element_geometry, &element_damage)?;
+        element.draw(frame, element.src(), element_geometry, &element_damage, &[])?;
     }
 
     Ok(Some(render_damage))


### PR DESCRIPTION
This extends the renderer api to take the opaque regions which can be used to optimize rendering.
On certain hardware it is important to disable blending when not necessary to achieve the full potential.
This is especially important on tile based renderer which might otherwise have to do an expensive read-back
from dram to the tile cache.