### PR TITLE
Make input focus store f64 Logical global coords

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -345,7 +345,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
     pub fn surface_under(
         &self,
         pos: Point<f64, Logical>,
-    ) -> Option<(PointerFocusTarget, Point<i32, Logical>)> {
+    ) -> Option<(PointerFocusTarget, Point<f64, Logical>)> {
         let output = self.space.outputs().find(|o| {
             let geometry = self.space.output_geometry(o).unwrap();
             geometry.contains(pos.to_i32_round())
@@ -406,7 +406,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         {
             under = Some(focus)
         };
-        under
+        under.map(|(s, l)| (s, l.to_f64()))
     }
 
     fn on_pointer_axis<B: InputBackend>(&mut self, evt: B::PointerAxisEvent) {
@@ -806,7 +806,7 @@ impl AnvilState<UdevData> {
                 Some(constraint) if constraint.is_active() => {
                     // Constraint does not apply if not within region
                     if !constraint.region().map_or(true, |x| {
-                        x.contains(pointer_location.to_i32_round() - *surface_loc)
+                        x.contains((pointer_location - *surface_loc).to_i32_round())
                     }) {
                         return;
                     }
@@ -856,7 +856,7 @@ impl AnvilState<UdevData> {
                     return;
                 }
                 if let Some(region) = confine_region {
-                    if !region.contains(pointer_location.to_i32_round() - *surface_loc) {
+                    if !region.contains((pointer_location - *surface_loc).to_i32_round()) {
                         pointer.frame(self);
                         return;
                     }
@@ -882,7 +882,7 @@ impl AnvilState<UdevData> {
         {
             with_pointer_constraint(&under, &pointer, |constraint| match constraint {
                 Some(constraint) if !constraint.is_active() => {
-                    let point = pointer_location.to_i32_round() - surface_location;
+                    let point = (pointer_location - surface_location).to_i32_round();
                     if constraint.region().map_or(true, |region| region.contains(point)) {
                         constraint.activate();
                     }

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -35,7 +35,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerMoveS
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        _focus: Option<(PointerFocusTarget, Point<i32, Logical>)>,
+        _focus: Option<(PointerFocusTarget, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -52,7 +52,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerMoveS
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        focus: Option<(PointerFocusTarget, Point<i32, Logical>)>,
+        focus: Option<(PointerFocusTarget, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);
@@ -180,7 +180,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
         _handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
         _focus: Option<(
             <AnvilState<BackendData> as smithay::input::SeatHandler>::TouchFocus,
-            Point<i32, Logical>,
+            Point<f64, Logical>,
         )>,
         _event: &smithay::input::touch::DownEvent,
         _seq: Serial,
@@ -208,7 +208,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
         _handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
         _focus: Option<(
             <AnvilState<BackendData> as smithay::input::SeatHandler>::TouchFocus,
-            Point<i32, Logical>,
+            Point<f64, Logical>,
         )>,
         event: &smithay::input::touch::MotionEvent,
         _seq: Serial,
@@ -353,7 +353,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerResiz
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        _focus: Option<(PointerFocusTarget, Point<i32, Logical>)>,
+        _focus: Option<(PointerFocusTarget, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -437,7 +437,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerResiz
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut PointerInnerHandle<'_, AnvilState<BackendData>>,
-        focus: Option<(PointerFocusTarget, Point<i32, Logical>)>,
+        focus: Option<(PointerFocusTarget, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);
@@ -648,7 +648,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
         _handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
         _focus: Option<(
             <AnvilState<BackendData> as smithay::input::SeatHandler>::TouchFocus,
-            Point<i32, Logical>,
+            Point<f64, Logical>,
         )>,
         _event: &smithay::input::touch::DownEvent,
         _seq: Serial,
@@ -754,7 +754,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
         handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
         _focus: Option<(
             <AnvilState<BackendData> as smithay::input::SeatHandler>::TouchFocus,
-            Point<i32, Logical>,
+            Point<f64, Logical>,
         )>,
         event: &smithay::input::touch::MotionEvent,
         _seq: Serial,

--- a/smallvil/src/grabs/move_grab.rs
+++ b/smallvil/src/grabs/move_grab.rs
@@ -22,7 +22,7 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
         &mut self,
         data: &mut Smallvil,
         handle: &mut PointerInnerHandle<'_, Smallvil>,
-        _focus: Option<(WlSurface, Point<i32, Logical>)>,
+        _focus: Option<(WlSurface, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -38,7 +38,7 @@ impl PointerGrab<Smallvil> for MoveSurfaceGrab {
         &mut self,
         data: &mut Smallvil,
         handle: &mut PointerInnerHandle<'_, Smallvil>,
-        focus: Option<(WlSurface, Point<i32, Logical>)>,
+        focus: Option<(WlSurface, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -76,7 +76,7 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
         &mut self,
         data: &mut Smallvil,
         handle: &mut PointerInnerHandle<'_, Smallvil>,
-        _focus: Option<(WlSurface, Point<i32, Logical>)>,
+        _focus: Option<(WlSurface, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -133,7 +133,7 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
         &mut self,
         data: &mut Smallvil,
         handle: &mut PointerInnerHandle<'_, Smallvil>,
-        focus: Option<(WlSurface, Point<i32, Logical>)>,
+        focus: Option<(WlSurface, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);

--- a/smallvil/src/state.rs
+++ b/smallvil/src/state.rs
@@ -143,11 +143,11 @@ impl Smallvil {
         socket_name
     }
 
-    pub fn surface_under(&self, pos: Point<f64, Logical>) -> Option<(WlSurface, Point<i32, Logical>)> {
+    pub fn surface_under(&self, pos: Point<f64, Logical>) -> Option<(WlSurface, Point<f64, Logical>)> {
         self.space.element_under(pos).and_then(|(window, location)| {
             window
                 .surface_under(pos - location.to_f64(), WindowSurfaceType::ALL)
-                .map(|(s, p)| (s, p + location))
+                .map(|(s, p)| (s, (p + location).to_f64()))
         })
     }
 }

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -303,7 +303,7 @@ where
                 // We set the focus to root as this will make
                 // sure the grab will stay alive until the
                 // toplevel is destroyed or the grab is unset
-                focus: Some((root.into(), (0, 0).into())),
+                focus: Some((root.into(), (0f64, 0f64).into())),
                 location: (0f64, 0f64).into(),
             },
         }
@@ -549,7 +549,7 @@ where
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         if self.popup_grab.has_ended() {
@@ -580,7 +580,7 @@ where
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -45,7 +45,7 @@ pub trait PointerGrab<D: SeatHandler>: Send {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     );
     /// Relative motion was reported
@@ -57,7 +57,7 @@ pub trait PointerGrab<D: SeatHandler>: Send {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     );
     /// A button press was reported
@@ -175,7 +175,7 @@ pub struct GrabStartData<D: SeatHandler> {
     /// The focused surface and its location, if any, at the start of the grab.
     ///
     /// The location coordinates are in the global compositor space.
-    pub focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+    pub focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
     /// The button that initiated the grab.
     pub button: u32,
     /// The location of the click that initiated the grab, in the global compositor space.
@@ -210,7 +210,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         handle.motion(data, focus, event);
@@ -220,7 +220,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);
@@ -346,7 +346,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        _focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        _focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         handle.motion(data, self.start_data.focus.clone(), event);
@@ -356,7 +356,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -222,7 +222,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     pub fn motion(
         &self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         let mut inner = self.inner.lock().unwrap();
@@ -242,7 +242,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     pub fn relative_motion(
         &self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         let mut inner = self.inner.lock().unwrap();
@@ -515,7 +515,7 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     }
 
     /// Access the current focus of this pointer
-    pub fn current_focus(&self) -> Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)> {
+    pub fn current_focus(&self) -> Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)> {
         self.inner.focus.clone()
     }
 
@@ -546,7 +546,7 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     pub fn motion(
         &mut self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         self.inner.motion(data, self.seat, focus, event);
@@ -560,7 +560,7 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
     pub fn relative_motion(
         &mut self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         self.inner.relative_motion(data, self.seat, focus, event);
@@ -670,8 +670,8 @@ impl<'a, D: SeatHandler + 'static> PointerInnerHandle<'a, D> {
 }
 
 pub(crate) struct PointerInternal<D: SeatHandler> {
-    pub(crate) focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
-    pending_focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+    pub(crate) focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
+    pending_focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
     location: Point<f64, Logical>,
     grab: GrabStatus<dyn PointerGrab<D>>,
     pressed_buttons: Vec<u32>,
@@ -756,13 +756,13 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
         &mut self,
         data: &mut D,
         seat: &Seat<D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         self.location = event.location;
         if let Some((focus, loc)) = focus {
             let event = MotionEvent {
-                location: event.location - loc.to_f64(),
+                location: event.location - loc,
                 serial: event.serial,
                 time: event.time,
             };
@@ -791,7 +791,7 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
         &mut self,
         data: &mut D,
         seat: &Seat<D>,
-        _focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        _focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         if let Some((focused, _)) = self.focus.as_mut() {

--- a/src/input/touch/grab.rs
+++ b/src/input/touch/grab.rs
@@ -41,7 +41,7 @@ pub trait TouchGrab<D: SeatHandler>: Send {
         &mut self,
         data: &mut D,
         handle: &mut TouchInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
         seq: Serial,
     );
@@ -68,7 +68,7 @@ pub trait TouchGrab<D: SeatHandler>: Send {
         &mut self,
         data: &mut D,
         handle: &mut TouchInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
         seq: Serial,
     );
@@ -115,7 +115,7 @@ pub struct GrabStartData<D: SeatHandler> {
     /// The focused surface and its location, if any, at the start of the grab.
     ///
     /// The location coordinates are in the global compositor space.
-    pub focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+    pub focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
     /// The touch point that initiated the grab.
     pub slot: TouchSlot,
     /// The location of the down event that initiated the grab, in the global compositor space.
@@ -151,7 +151,7 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
         &mut self,
         data: &mut D,
         handle: &mut TouchInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
         seq: Serial,
     ) {
@@ -179,7 +179,7 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
         &mut self,
         data: &mut D,
         handle: &mut TouchInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
         seq: Serial,
     ) {
@@ -241,7 +241,7 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for TouchDownGrab<D> {
         &mut self,
         data: &mut D,
         handle: &mut TouchInnerHandle<'_, D>,
-        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
         seq: Serial,
     ) {
@@ -261,7 +261,7 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for TouchDownGrab<D> {
         &mut self,
         data: &mut D,
         handle: &mut TouchInnerHandle<'_, D>,
-        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
         seq: Serial,
     ) {

--- a/src/input/touch/mod.rs
+++ b/src/input/touch/mod.rs
@@ -85,7 +85,7 @@ pub(crate) struct TouchInternal<D: SeatHandler> {
 }
 
 struct TouchSlotState<D: SeatHandler> {
-    focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+    focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
     frame_pending: Option<<D as SeatHandler>::TouchFocus>,
     pending: Serial,
     current: Option<Serial>,
@@ -278,7 +278,7 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
     pub fn down(
         &self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
     ) {
         let mut inner = self.inner.lock().unwrap();
@@ -314,7 +314,7 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
     pub fn motion(
         &self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         let mut inner = self.inner.lock().unwrap();
@@ -433,7 +433,7 @@ impl<'a, D: SeatHandler + 'static> TouchInnerHandle<'a, D> {
     pub fn down(
         &mut self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
         seq: Serial,
     ) {
@@ -460,7 +460,7 @@ impl<'a, D: SeatHandler + 'static> TouchInnerHandle<'a, D> {
     pub fn motion(
         &mut self,
         data: &mut D,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
         seq: Serial,
     ) {
@@ -531,7 +531,7 @@ impl<D: SeatHandler + 'static> TouchInternal<D> {
         &mut self,
         data: &mut D,
         seat: &Seat<D>,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
         seq: Serial,
     ) {
@@ -551,7 +551,7 @@ impl<D: SeatHandler + 'static> TouchInternal<D> {
         let state = self.focus.get(&event.slot).unwrap();
         if let Some((focus, loc)) = state.focus.as_ref() {
             let mut new_event = event.clone();
-            new_event.location -= loc.to_f64();
+            new_event.location -= *loc;
             focus.down(seat, data, &new_event, seq);
         }
     }
@@ -574,7 +574,7 @@ impl<D: SeatHandler + 'static> TouchInternal<D> {
         &mut self,
         data: &mut D,
         seat: &Seat<D>,
-        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
         seq: Serial,
     ) {
@@ -584,7 +584,7 @@ impl<D: SeatHandler + 'static> TouchInternal<D> {
         state.pending = seq;
         if let Some((focus, loc)) = state.focus.as_ref() {
             let mut new_event = event.clone();
-            new_event.location -= loc.to_f64();
+            new_event.location -= *loc;
             focus.motion(seat, data, &new_event, seq);
         }
     }

--- a/src/wayland/selection/data_device/dnd_grab.rs
+++ b/src/wayland/selection/data_device/dnd_grab.rs
@@ -99,7 +99,7 @@ where
 {
     fn update_focus<F: WaylandFocus>(
         &mut self,
-        focus: Option<(F, Point<i32, Logical>)>,
+        focus: Option<(F, Point<f64, Logical>)>,
         location: Point<f64, Logical>,
         serial: Serial,
         time: u32,
@@ -137,7 +137,7 @@ where
                 Ok(c) => c,
                 Err(_) => return,
             };
-            let (x, y) = (location - surface_location.to_f64()).into();
+            let (x, y) = (location - *surface_location).into();
             if self.current_focus.is_none() {
                 // We entered a new surface, send the data offer if appropriate
                 if let Some(ref source) = self.data_source {
@@ -270,7 +270,7 @@ where
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         // While the grab is active, no client has pointer focus
@@ -283,7 +283,7 @@ where
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);
@@ -397,7 +397,7 @@ where
         &mut self,
         _data: &mut D,
         _handle: &mut crate::input::touch::TouchInnerHandle<'_, D>,
-        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         _event: &crate::input::touch::DownEvent,
         _seq: crate::utils::Serial,
     ) {
@@ -422,7 +422,7 @@ where
         &mut self,
         _data: &mut D,
         _handle: &mut crate::input::touch::TouchInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &crate::input::touch::MotionEvent,
         _seq: crate::utils::Serial,
     ) {

--- a/src/wayland/selection/data_device/server_dnd_grab.rs
+++ b/src/wayland/selection/data_device/server_dnd_grab.rs
@@ -90,7 +90,7 @@ where
 {
     fn update_focus<F: WaylandFocus>(
         &mut self,
-        focus: Option<(F, Point<i32, Logical>)>,
+        focus: Option<(F, Point<f64, Logical>)>,
         location: Point<f64, Logical>,
         serial: Serial,
         time: u32,
@@ -125,7 +125,7 @@ where
                 Ok(c) => c,
                 _ => return,
             };
-            let (x, y) = (location - surface_location.to_f64()).into();
+            let (x, y) = (location - *surface_location).into();
             if self.current_focus.is_none() {
                 // We entered a new surface, send the data offer
                 let offer_data = Arc::new(Mutex::new(ServerDndOfferData {
@@ -237,7 +237,7 @@ where
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
         let location = event.location;
@@ -254,7 +254,7 @@ where
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::PointerFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &RelativeMotionEvent,
     ) {
         handle.relative_motion(data, focus, event);
@@ -371,7 +371,7 @@ where
         &mut self,
         _data: &mut D,
         _handle: &mut crate::input::touch::TouchInnerHandle<'_, D>,
-        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        _focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         _event: &crate::input::touch::DownEvent,
         _seq: Serial,
     ) {
@@ -397,7 +397,7 @@ where
         &mut self,
         _data: &mut D,
         _handle: &mut crate::input::touch::TouchInnerHandle<'_, D>,
-        focus: Option<(<D as SeatHandler>::TouchFocus, Point<i32, Logical>)>,
+        focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &crate::input::touch::MotionEvent,
         _seq: Serial,
     ) {

--- a/src/wayland/tablet_manager/tablet_tool.rs
+++ b/src/wayland/tablet_manager/tablet_tool.rs
@@ -37,7 +37,7 @@ impl TabletTool {
     fn proximity_in(
         &mut self,
         loc: Point<f64, Logical>,
-        (focus, sloc): (WlSurface, Point<i32, Logical>),
+        (focus, sloc): (WlSurface, Point<f64, Logical>),
         tablet: &TabletHandle,
         serial: Serial,
         time: u32,
@@ -48,7 +48,7 @@ impl TabletTool {
             tablet.with_focused_tablet(&focus, |wl_tablet| {
                 wl_tool.proximity_in(serial.into(), wl_tablet, &focus);
                 // proximity_in has to be followed by motion event (required by protocol)
-                let srel_loc = loc - sloc.to_f64();
+                let srel_loc = loc - sloc;
                 wl_tool.motion(srel_loc.x, srel_loc.y);
                 wl_tool.frame(time);
             });
@@ -103,7 +103,7 @@ impl TabletTool {
     fn motion(
         &mut self,
         pos: Point<f64, Logical>,
-        focus: Option<(WlSurface, Point<i32, Logical>)>,
+        focus: Option<(WlSurface, Point<f64, Logical>)>,
         tablet: &TabletHandle,
         serial: Serial,
         time: u32,
@@ -116,7 +116,7 @@ impl TabletTool {
                         .iter()
                         .find(|i| i.id().same_client_as(&focus.0.id()))
                     {
-                        let srel_loc = pos - focus.1.to_f64();
+                        let srel_loc = pos - focus.1;
                         wl_tool.motion(srel_loc.x, srel_loc.y);
 
                         if let Some(pressure) = self.pending_pressure.take() {
@@ -290,7 +290,7 @@ impl TabletToolHandle {
     pub fn proximity_in(
         &self,
         pos: Point<f64, Logical>,
-        focus: (WlSurface, Point<i32, Logical>),
+        focus: (WlSurface, Point<f64, Logical>),
         tablet: &TabletHandle,
         serial: Serial,
         time: u32,
@@ -330,7 +330,7 @@ impl TabletToolHandle {
     pub fn motion(
         &self,
         pos: Point<f64, Logical>,
-        focus: Option<(WlSurface, Point<i32, Logical>)>,
+        focus: Option<(WlSurface, Point<f64, Logical>)>,
         tablet: &TabletHandle,
         serial: Serial,
         time: u32,


### PR DESCRIPTION
Surface position in global compositor space is not required to be rounded to logical integers. The compositor is free to put surfaces wherever. So, do not require an integer-logical position.

Not to be confused with:

* A subsurface can only be at an integer-logical offset from its parent surface (for now, at least). However, this is unrelated to the subsurface position in the global compositor space.
* A surface buffer is (generally expected to be) at an integer *physical* pixel position. However, this is unrelated to, and frequently isn't, an integer *logical* pixel position.