### PR TITLE
Keep dmabuf formats in order

### DIFF
--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -147,7 +147,7 @@ pub fn run_winit() {
 
     let dmabuf_default_feedback = match render_node {
         Ok(Some(node)) => {
-            let dmabuf_formats = backend.renderer().dmabuf_formats().collect::<Vec<_>>();
+            let dmabuf_formats = backend.renderer().dmabuf_formats();
             let dmabuf_default_feedback = DmabufFeedbackBuilder::new(node.dev_id(), dmabuf_formats)
                 .build()
                 .unwrap();
@@ -173,7 +173,7 @@ pub fn run_winit() {
         );
         (dmabuf_state, dmabuf_global, Some(default_feedback))
     } else {
-        let dmabuf_formats = backend.renderer().dmabuf_formats().collect::<Vec<_>>();
+        let dmabuf_formats = backend.renderer().dmabuf_formats();
         let mut dmabuf_state = DmabufState::new();
         let dmabuf_global =
             dmabuf_state.create_global::<AnvilState<WinitData>>(&display.handle(), dmabuf_formats);

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -182,7 +182,7 @@ pub fn run_x11() {
         info!("EGL hardware-acceleration enabled");
     }
 
-    let dmabuf_formats = renderer.dmabuf_formats().collect::<Vec<_>>();
+    let dmabuf_formats = renderer.dmabuf_formats();
     let dmabuf_default_feedback = DmabufFeedbackBuilder::new(node.dev_id(), dmabuf_formats)
         .build()
         .unwrap();

--- a/examples/buffer_test.rs
+++ b/examples/buffer_test.rs
@@ -144,7 +144,7 @@ fn format_test(render: Vec<String>, sample: Vec<String>) {
         }))
         .fold(None, |set, formats| match set {
             None => Some(formats),
-            Some(set) => Some(set.intersection(&formats).cloned().collect()),
+            Some(set) => Some(set.intersection(&formats).copied().collect()),
         })
         .unwrap_or_default()
     {

--- a/src/backend/allocator/format.rs
+++ b/src/backend/allocator/format.rs
@@ -375,7 +375,7 @@ pub struct FormatSet {
 }
 
 impl FormatSet {
-    #[cfg(feature = "backend_egl")]
+    #[cfg(any(feature = "backend_egl", feature = "backend_drm"))]
     pub(crate) fn from_formats(formats: IndexSet<Format>) -> Self {
         FormatSet {
             formats: Arc::new(formats),

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1766,7 +1766,7 @@ where
         code: DrmFourcc,
     ) -> Result<(Swapchain<A>, Frame<A, F>, bool), (A, FrameErrorType<A, F>)> {
         // select a format
-        let mut plane_formats = planes.primary.formats.clone();
+        let mut plane_formats = planes.primary.formats.iter().copied().collect::<IndexSet<_>>();
 
         let opaque_code = get_opaque(code).unwrap_or(code);
         if !plane_formats

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -116,7 +116,13 @@ where
         code: Fourcc,
     ) -> Result<(Slot<GbmBuffer>, Swapchain<A>, bool), (A, Error<A::Error>)> {
         // select a format
-        let mut plane_formats = drm.planes().primary.formats.clone();
+        let mut plane_formats = drm
+            .planes()
+            .primary
+            .formats
+            .iter()
+            .copied()
+            .collect::<IndexSet<_>>();
         let opaque_code = get_opaque(code).unwrap_or(code);
         if !plane_formats
             .iter()

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -1,6 +1,5 @@
 //! EGL context related structs
 use std::{
-    collections::HashSet,
     os::raw::c_int,
     sync::{atomic::Ordering, Arc},
 };
@@ -10,7 +9,7 @@ use libc::c_void;
 use super::{ffi, wrap_egl_call_bool, wrap_egl_call_ptr, EGLError, Error, MakeCurrentError};
 use crate::{
     backend::{
-        allocator::Format as DrmFormat,
+        allocator::format::FormatSet,
         egl::{
             display::{EGLDisplay, PixelFormat},
             EGLSurface,
@@ -454,12 +453,12 @@ impl EGLContext {
     }
 
     /// Returns a list of formats for dmabufs that can be rendered to.
-    pub fn dmabuf_render_formats(&self) -> &HashSet<DrmFormat> {
+    pub fn dmabuf_render_formats(&self) -> &FormatSet {
         self.display.dmabuf_render_formats()
     }
 
     /// Returns a list of formats for dmabufs that can be used as textures.
-    pub fn dmabuf_texture_formats(&self) -> &HashSet<DrmFormat> {
+    pub fn dmabuf_texture_formats(&self) -> &FormatSet {
         self.display.dmabuf_texture_formats()
     }
 

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -11,12 +11,14 @@ use std::{
     os::unix::io::{AsRawFd, FromRawFd, OwnedFd},
 };
 
+use indexmap::IndexSet;
 use libc::c_void;
 #[cfg(all(feature = "use_system_lib", feature = "wayland_frontend"))]
 use wayland_server::{protocol::wl_buffer::WlBuffer, DisplayHandle, Resource};
 #[cfg(feature = "use_system_lib")]
 use wayland_sys::server::wl_display;
 
+use crate::backend::allocator::format::FormatSet;
 #[cfg(feature = "backend_drm")]
 use crate::backend::egl::EGLDevice;
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
@@ -120,8 +122,8 @@ pub struct EGLDisplay {
     display: Arc<EGLDisplayHandle>,
     egl_version: (i32, i32),
     extensions: Vec<String>,
-    dmabuf_import_formats: HashSet<DrmFormat>,
-    dmabuf_render_formats: HashSet<DrmFormat>,
+    dmabuf_import_formats: FormatSet,
+    dmabuf_render_formats: FormatSet,
     surface_type: ffi::EGLint,
     pub(super) has_fences: bool,
     pub(super) supports_native_fences: bool,
@@ -592,12 +594,12 @@ impl EGLDisplay {
     }
 
     /// Returns a list of formats for dmabufs that can be rendered to.
-    pub fn dmabuf_render_formats(&self) -> &HashSet<DrmFormat> {
+    pub fn dmabuf_render_formats(&self) -> &FormatSet {
         &self.dmabuf_render_formats
     }
 
     /// Returns a list of formats for dmabufs that can be used as textures.
-    pub fn dmabuf_texture_formats(&self) -> &HashSet<DrmFormat> {
+    pub fn dmabuf_texture_formats(&self) -> &FormatSet {
         &self.dmabuf_import_formats
     }
 
@@ -870,10 +872,10 @@ impl EGLDisplay {
 fn get_dmabuf_formats(
     display: &ffi::egl::types::EGLDisplay,
     extensions: &[String],
-) -> Result<(HashSet<DrmFormat>, HashSet<DrmFormat>), EGLError> {
+) -> Result<(FormatSet, FormatSet), EGLError> {
     if !extensions.iter().any(|s| s == "EGL_EXT_image_dma_buf_import") {
         warn!("Dmabuf import extension not available");
-        return Ok((HashSet::new(), HashSet::new()));
+        return Ok((FormatSet::default(), FormatSet::default()));
     }
 
     let formats = {
@@ -893,7 +895,7 @@ fn get_dmabuf_formats(
                 ffi::egl::QueryDmaBufFormatsEXT(*display, 0, std::ptr::null_mut(), &mut num as *mut _)
             })?;
             if num == 0 {
-                return Ok((HashSet::new(), HashSet::new()));
+                return Ok((FormatSet::default(), FormatSet::default()));
             }
             let mut formats: Vec<u32> = Vec::with_capacity(num as usize);
             wrap_egl_call_bool(|| unsafe {
@@ -914,8 +916,8 @@ fn get_dmabuf_formats(
         }
     };
 
-    let mut texture_formats = HashSet::new();
-    let mut render_formats = HashSet::new();
+    let mut texture_formats = IndexSet::new();
+    let mut render_formats = IndexSet::new();
 
     for fourcc in formats {
         let mut num = 0i32;
@@ -997,7 +999,10 @@ fn get_dmabuf_formats(
     trace!("Supported dmabuf import formats: {:?}", texture_formats);
     trace!("Supported dmabuf render formats: {:?}", render_formats);
 
-    Ok((texture_formats, render_formats))
+    Ok((
+        FormatSet::from_formats(texture_formats),
+        FormatSet::from_formats(render_formats),
+    ))
 }
 
 /// Type to receive [`EGLBuffer`] for EGL-based [`WlBuffer`]s.

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -3,7 +3,7 @@
 use cgmath::{prelude::*, Matrix3, Vector2};
 use core::slice;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     ffi::{CStr, CString},
     fmt, mem,
     os::raw::c_char,
@@ -42,7 +42,7 @@ use super::{
 use crate::backend::{
     allocator::{
         dmabuf::{Dmabuf, WeakDmabuf},
-        format::{get_bpp, get_opaque, has_alpha},
+        format::{get_bpp, get_opaque, has_alpha, FormatSet},
         Format, Fourcc,
     },
     egl::fence::EGLFence,
@@ -1260,15 +1260,8 @@ impl ImportDma for GlesRenderer {
         })
     }
 
-    fn dmabuf_formats(&self) -> Box<dyn Iterator<Item = Format>> {
-        Box::new(
-            self.egl
-                .dmabuf_texture_formats()
-                .iter()
-                .copied()
-                .collect::<Vec<_>>()
-                .into_iter(),
-        )
+    fn dmabuf_formats(&self) -> FormatSet {
+        self.egl.dmabuf_texture_formats().clone()
     }
 
     fn has_dmabuf_format(&self, format: Format) -> bool {
@@ -1706,7 +1699,7 @@ impl Bind<Dmabuf> for GlesRenderer {
         Ok(())
     }
 
-    fn supported_formats(&self) -> Option<HashSet<Format>> {
+    fn supported_formats(&self) -> Option<FormatSet> {
         Some(self.egl.display().dmabuf_render_formats().clone())
     }
 }

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -11,7 +11,7 @@ use crate::backend::renderer::{ImportDmaWl, ImportMemWl};
 use crate::backend::{egl::display::EGLBufferReader, renderer::ImportEgl};
 use crate::{
     backend::{
-        allocator::{dmabuf::Dmabuf, Format, Fourcc},
+        allocator::{dmabuf::Dmabuf, format::FormatSet, Format, Fourcc},
         egl::EGLContext,
         renderer::{
             element::UnderlyingStorage,
@@ -29,7 +29,6 @@ use wayland_server::protocol::{wl_buffer, wl_shm};
 use glow::Context;
 use std::{
     borrow::{Borrow, BorrowMut},
-    collections::HashSet,
     sync::Arc,
 };
 
@@ -430,7 +429,7 @@ impl ImportDma for GlowRenderer {
     ) -> Result<GlesTexture, GlesError> {
         self.gl.import_dmabuf(buffer, damage)
     }
-    fn dmabuf_formats(&self) -> Box<dyn Iterator<Item = Format>> {
+    fn dmabuf_formats(&self) -> FormatSet {
         self.gl.dmabuf_formats()
     }
     fn has_dmabuf_format(&self, format: Format) -> bool {
@@ -484,7 +483,7 @@ where
     fn bind(&mut self, target: T) -> Result<(), GlesError> {
         self.gl.bind(target)
     }
-    fn supported_formats(&self) -> Option<HashSet<Format>> {
+    fn supported_formats(&self) -> Option<FormatSet> {
         self.gl.supported_formats()
     }
 }

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -7,7 +7,6 @@
 //!
 //! - Raw OpenGL ES 2
 
-use std::collections::HashSet;
 use std::error::Error;
 use std::fmt;
 
@@ -38,6 +37,8 @@ use crate::backend::egl::{
     display::{EGLBufferReader, BUFFER_READER},
     Error as EglError,
 };
+
+use super::allocator::format::FormatSet;
 
 #[cfg(feature = "renderer_multi")]
 pub mod multigpu;
@@ -107,7 +108,7 @@ pub trait Bind<Target>: Unbind {
     /// or throw an error.
     fn bind(&mut self, target: Target) -> Result<(), <Self as Renderer>::Error>;
     /// Supported pixel formats for given targets, if applicable.
-    fn supported_formats(&self) -> Option<HashSet<crate::backend::allocator::Format>> {
+    fn supported_formats(&self) -> Option<FormatSet> {
         None
     }
 }
@@ -486,13 +487,13 @@ pub trait ImportDmaWl: ImportDma {
 /// Trait for Renderers supporting importing dmabufs.
 pub trait ImportDma: Renderer {
     /// Returns supported formats for dmabufs.
-    fn dmabuf_formats(&self) -> Box<dyn Iterator<Item = Format>> {
-        Box::new(std::iter::empty())
+    fn dmabuf_formats(&self) -> FormatSet {
+        FormatSet::default()
     }
 
     /// Test if a specific dmabuf [`Format`] is supported
     fn has_dmabuf_format(&self, format: Format) -> bool {
-        self.dmabuf_formats().any(|f| f == format)
+        self.dmabuf_formats().contains(&format)
     }
 
     /// Import a given raw dmabuf into the renderer.

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -1,6 +1,5 @@
 //! Implementation of the rendering traits using pixman
 use std::{
-    collections::HashSet,
     rc::Rc,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -12,7 +11,7 @@ use tracing::warn;
 use crate::{
     backend::allocator::{
         dmabuf::{Dmabuf, DmabufMapping, DmabufMappingMode, DmabufSyncFailed, DmabufSyncFlags, WeakDmabuf},
-        format::has_alpha,
+        format::{has_alpha, FormatSet},
         Buffer,
     },
     utils::{Buffer as BufferCoords, Physical, Rectangle, Scale, Size, Transform},
@@ -1109,16 +1108,16 @@ impl ImportDma for PixmanRenderer {
         Ok(PixmanTexture(image))
     }
 
-    fn dmabuf_formats(&self) -> Box<dyn Iterator<Item = drm_fourcc::DrmFormat>> {
+    fn dmabuf_formats(&self) -> FormatSet {
         lazy_static::lazy_static! {
-            static ref DMABUF_FORMATS: Vec<DrmFormat> = {
+            static ref DMABUF_FORMATS: FormatSet = {
                 SUPPORTED_FORMATS.iter().copied().map(|code| DrmFormat {
                     code,
                     modifier: drm_fourcc::DrmModifier::Linear,
                 }).collect()
             };
         }
-        Box::new(DMABUF_FORMATS.iter().copied())
+        DMABUF_FORMATS.clone()
     }
 }
 
@@ -1164,9 +1163,9 @@ impl Bind<Dmabuf> for PixmanRenderer {
         Ok(())
     }
 
-    fn supported_formats(&self) -> Option<HashSet<DrmFormat>> {
+    fn supported_formats(&self) -> Option<FormatSet> {
         lazy_static::lazy_static! {
-            static ref DMABUF_FORMATS: HashSet<DrmFormat> = {
+            static ref DMABUF_FORMATS: FormatSet = {
                 SUPPORTED_FORMATS.iter().copied().map(|code| DrmFormat {
                     code,
                     modifier: DrmModifier::Linear,
@@ -1199,9 +1198,9 @@ impl Bind<PixmanRenderBuffer> for PixmanRenderer {
         Ok(())
     }
 
-    fn supported_formats(&self) -> Option<HashSet<DrmFormat>> {
+    fn supported_formats(&self) -> Option<FormatSet> {
         lazy_static::lazy_static! {
-            static ref RENDER_BUFFER_FORMATS: HashSet<DrmFormat> = {
+            static ref RENDER_BUFFER_FORMATS: FormatSet = {
                 SUPPORTED_FORMATS.iter().copied().map(|code| DrmFormat {
                     code,
                     modifier: DrmModifier::Linear,


### PR DESCRIPTION
This PR changes the dmabuf format handling so that the list populated over zwp_dmabuf stays in the same order as returned from the driver. Yes, this should in theory not make a difference, but it does on some drivers.
I noticed this because on a particular binary driver egl clients, using dmabuf v3, misbehaved. Further debugging
has shown that it semi-randomly selected formats, sometimes even YUV formats. This caused everything from wrong
color to performance issues.

Before this PR formats were only stable for a single run of the process as we used a HashSet which internally uses `RandomState`, resulting in different order each time we built the formats.

(Some of the changes are probably not needed, like the change to the plane format ordering, and just me being paranoid after debugging this...)