### PR TITLE
perf: use WlWeak::is_alive instead of upgrading

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -324,7 +324,7 @@ impl ElementFramebufferCacheKey {
     #[inline]
     fn is_alive(&self) -> bool {
         match self.buffer {
-            ElementFramebufferCacheBuffer::Wayland(ref buffer) => buffer.upgrade().is_ok(),
+            ElementFramebufferCacheBuffer::Wayland(ref buffer) => buffer.is_alive(),
         }
     }
 }

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -305,7 +305,7 @@ impl Output {
 
     pub(crate) fn cleanup_surfaces(&self) {
         let mut inner = self.inner.0.lock().unwrap();
-        inner.surfaces.retain(|s| s.upgrade().is_ok());
+        inner.surfaces.retain(|s| s.is_alive());
     }
 }
 


### PR DESCRIPTION
this has been introduced in the latest wayland-rs release and can safe a few cycles, especially for lists holding a lot of weak resources.