### PR TITLE
drm: pick one primary plane if we have multiple

### DIFF
--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -124,8 +124,8 @@ pub trait Framebuffer: AsRef<framebuffer::Handle> {
 /// A set of planes as supported by a crtc
 #[derive(Debug, Clone)]
 pub struct Planes {
-    /// The primary plane of the crtc (automatically selected for [DrmDevice::create_surface])
-    pub primary: PlaneInfo,
+    /// The primary plane(s) of the crtc
+    pub primary: Vec<PlaneInfo>,
     /// The cursor plane of the crtc, if available
     pub cursor: Option<PlaneInfo>,
     /// Overlay planes supported by the crtc, if available
@@ -150,7 +150,7 @@ fn planes(
     crtc: &crtc::Handle,
     has_universal_planes: bool,
 ) -> Result<Planes, DrmError> {
-    let mut primary = None;
+    let mut primary = Vec::with_capacity(1);
     let mut cursor = None;
     let mut overlay = Vec::new();
 
@@ -191,7 +191,7 @@ fn planes(
             };
             match type_ {
                 PlaneType::Primary => {
-                    primary = Some(plane_info);
+                    primary.push(plane_info);
                 }
                 PlaneType::Cursor => {
                     cursor = Some(plane_info);
@@ -204,7 +204,7 @@ fn planes(
     }
 
     Ok(Planes {
-        primary: primary.expect("Crtc has no primary plane"),
+        primary,
         cursor: if has_universal_planes { cursor } else { None },
         overlay: if has_universal_planes { overlay } else { Vec::new() },
     })

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -116,13 +116,7 @@ where
         code: Fourcc,
     ) -> Result<(Slot<GbmBuffer>, Swapchain<A>, bool), (A, Error<A::Error>)> {
         // select a format
-        let mut plane_formats = drm
-            .planes()
-            .primary
-            .formats
-            .iter()
-            .copied()
-            .collect::<IndexSet<_>>();
+        let mut plane_formats = drm.plane_info().formats.iter().copied().collect::<IndexSet<_>>();
         let opaque_code = get_opaque(code).unwrap_or(code);
         if !plane_formats
             .iter()

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -13,7 +13,8 @@ pub(super) mod atomic;
 pub(super) mod gbm;
 pub(super) mod legacy;
 use super::{
-    device::PlaneClaimStorage, error::Error, plane_type, DrmDeviceFd, PlaneClaim, PlaneType, Planes,
+    device::PlaneClaimStorage, error::Error, plane_type, DrmDeviceFd, PlaneClaim, PlaneInfo, PlaneType,
+    Planes,
 };
 use crate::utils::DevPath;
 use crate::utils::{Buffer, Physical, Point, Rectangle, Transform};
@@ -30,6 +31,7 @@ pub struct DrmSurface {
     pub(super) planes: Planes,
     pub(super) internal: Arc<DrmSurfaceInternal>,
     pub(super) plane_claim_storage: PlaneClaimStorage,
+    pub(super) primary_plane: (PlaneInfo, PlaneClaim),
 }
 
 #[derive(Debug)]
@@ -194,7 +196,12 @@ impl DrmSurface {
 
     /// Returns the underlying primary [`plane`](drm::control::plane) of this surface
     pub fn plane(&self) -> plane::Handle {
-        self.planes.primary.handle
+        self.primary_plane.0.handle
+    }
+
+    /// Returns the [`PlaneInfo`] of the underlying primary [`plane`](drm::control::plane) of this surface
+    pub fn plane_info(&self) -> &PlaneInfo {
+        &self.primary_plane.0
     }
 
     /// Currently used [`connector`](drm::control::connector)s of this surface
@@ -394,7 +401,7 @@ impl DrmSurface {
     /// Returns `None` if the plane could not be claimed
     pub fn claim_plane(&self, plane: plane::Handle) -> Option<PlaneClaim> {
         // Validate that we are called with an plane that belongs to us
-        if self.planes.primary.handle == plane
+        if self.planes.primary.iter().any(|p| p.handle == plane)
             || self
                 .planes
                 .cursor


### PR DESCRIPTION
some drivers might offer multiple candidates as the primary plane for a CRTC. pick one and claim it so that we do not accidentially select the same plane multiple times.

fixes #1462 