### PR TITLE
Fix read_window_property_u32

### DIFF
--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -862,7 +862,7 @@ impl X11Surface {
             Err(err) => return Err(err),
         };
 
-        if let Some(value32) = reply.value32() {
+        if let Some(mut value32) = reply.value32() {
             if let Some(value) = value32.next() {
                 return Ok(Some(value));
             }

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -862,11 +862,13 @@ impl X11Surface {
             Err(err) => return Err(err),
         };
 
-        let Some(value) = reply.value32().unwrap().next() else {
-            return Ok(None);
-        };
+        if let Some(value32) = reply.value32() {
+            if let Some(value) = value32.next() {
+                return Ok(Some(value));
+            }
+        }
 
-        Ok(Some(value))
+        Ok(None)
     }
 
     /// Retrieve user_data associated with this X11 window


### PR DESCRIPTION
Fix the `read_window_property_u32` because it's currently panic if `value32` is `None`