### PR TITLE
input: add iso_level5_shift modifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ wayland-sys = { version = "0.31", optional = true }
 wayland-backend = { version = "0.3.0", optional = true }
 winit = { version = "0.30.0", default-features = false, features = ["wayland", "wayland-dlopen", "x11", "rwh_06"], optional = true }
 x11rb = { version = "0.13.0", optional = true }
-xkbcommon = { version = "0.7.0", features = ["wayland"]}
+xkbcommon = { version = "0.8.0", features = ["wayland"]}
 scan_fmt = { version = "0.2.3", default-features = false }
 encoding_rs = { version = "0.8.33", optional = true }
 profiling = "1.0"

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -15,7 +15,7 @@ tracing = { version = "0.1.37", features = ["max_level_trace", "release_max_leve
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 thiserror = "1"
 xcursor = {version = "0.3.3", optional = true}
-xkbcommon = "0.7.0"
+xkbcommon = "0.8.0"
 renderdoc = {version = "0.11.0", optional = true}
 smithay-drm-extras = {path = "../smithay-drm-extras", optional = true}
 puffin_http = { version = "0.13", optional = true }

--- a/src/input/keyboard/modifiers_state.rs
+++ b/src/input/keyboard/modifiers_state.rs
@@ -27,6 +27,9 @@ pub struct ModifiersState {
     /// Also known as the "AltGr" key
     pub iso_level3_shift: bool,
 
+    /// The "ISO level 5 shift" key
+    pub iso_level5_shift: bool,
+
     /// Serialized modifier state, as send e.g. by the wl_keyboard protocol
     pub serialized: SerializedMods,
 }
@@ -42,6 +45,7 @@ impl ModifiersState {
         self.num_lock = state.mod_name_is_active(&xkb::MOD_NAME_NUM, xkb::STATE_MODS_EFFECTIVE);
         self.iso_level3_shift =
             state.mod_name_is_active(&xkb::MOD_NAME_ISO_LEVEL3_SHIFT, xkb::STATE_MODS_EFFECTIVE);
+        self.iso_level5_shift = state.mod_name_is_active(&xkb::MOD_NAME_MOD3, xkb::STATE_MODS_EFFECTIVE);
         self.serialized = serialize_modifiers(state);
     }
 }


### PR DESCRIPTION
This follows https://github.com/Smithay/smithay/pull/1365 in adding support for mod3. It doesn't appear that [the upstream PR](https://github.com/rust-x-bindings/xkbcommon-rs/pull/52) will be accepted anytime soon. I'm hoping that since this is basically a string constant addition this PR can go ahead and be merged to enable support.

(Closes #1464)