### PR TITLE
shm/pool: Map as writable in `nullify_map`

### DIFF
--- a/src/wayland/shm/pool.rs
+++ b/src/wayland/shm/pool.rs
@@ -295,7 +295,7 @@ unsafe fn nullify_map(ptr: *mut u8, size: usize) -> Result<(), ()> {
         mm::mmap_anonymous(
             ptr as *mut std::ffi::c_void,
             size,
-            mm::ProtFlags::READ,
+            mm::ProtFlags::READ | mm::ProtFlags::WRITE,
             mm::MapFlags::PRIVATE | mm::MapFlags::FIXED,
         )
     };


### PR DESCRIPTION
The actual mapping is mutable, so the placeholder should also be. Or writes will trigger a `SEGV` due to the page being unmapped when execution is resumed after the `BUS` handler.

This fixes uses of `with_buffer_contents_mut` if the file provided by the client isn't large enough. In particular the segfault reported in https://github.com/pop-os/cosmic-comp/issues/48.