### PR TITLE
renderer/multigpu: Don't unwrap renderer error in `import_shm_buffer`

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1704,7 +1704,7 @@ where
             .render
             .renderer_mut()
             .import_shm_buffer(buffer, surface, damage)
-            .expect("import_shm_buffer without checking buffer type?");
+            .map_err(Error::Render)?;
         let dimensions = shm::with_buffer_contents(buffer, |_, _, data| (data.width, data.height).into())
             .map_err(|_| Error::ImportFailed)?;
         let mut texture = MultiTexture::from_surface(surface, dimensions);


### PR DESCRIPTION
This can error due to the buffer type being something other than an shm buffer, but it can also error for other reasons, like `BufferAccessError::BadMap`.

This fixes a panic when a client tries to use a buffer wit a file that isn't large enough. With this, there's no longer a panic and the client gets a protocol error as it is supposed to.

Fixes https://github.com/Smithay/smithay/issues/834.