### PR TITLE
drm-extras: do not unwrap on scan errors

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -1131,7 +1131,15 @@ impl AnvilState<UdevData> {
             return;
         };
 
-        for event in device.drm_scanner.scan_connectors(&device.drm) {
+        let scan_result = match device.drm_scanner.scan_connectors(&device.drm) {
+            Ok(scan_result) => scan_result,
+            Err(err) => {
+                tracing::warn!(?err, "Failed to scan connectors");
+                return;
+            }
+        };
+
+        for event in scan_result {
             match event {
                 DrmScanEvent::Connected {
                     connector,

--- a/smithay-drm-extras/src/drm_scanner.rs
+++ b/smithay-drm-extras/src/drm_scanner.rs
@@ -90,7 +90,7 @@ where
     /// use smithay_drm_extras::drm_scanner::{DrmScanner, DrmScanEvent};
     ///
     /// let mut scanner: DrmScanner = DrmScanner::new();
-    /// let res = scanner.scan_connectors(&drm_device);
+    /// let res = scanner.scan_connectors(&drm_device).expect("failed to scan connectors");
     ///
     /// // You can extract scan info manually
     /// println!("Plugged {} connectors", res.added.len());
@@ -104,8 +104,8 @@ where
     ///     }
     /// }
     /// ```
-    pub fn scan_connectors(&mut self, drm: &impl ControlDevice) -> DrmScanResult {
-        let scan = self.connectors.scan(drm);
+    pub fn scan_connectors(&mut self, drm: &impl ControlDevice) -> std::io::Result<DrmScanResult> {
+        let scan = self.connectors.scan(drm)?;
 
         let removed = scan
             .disconnected
@@ -128,10 +128,10 @@ where
             })
             .collect();
 
-        DrmScanResult {
+        Ok(DrmScanResult {
             disconnected: removed,
             connected: added,
-        }
+        })
     }
 
     /// Get map of all connectors, connected and disconnected ones.

--- a/smithay-drm-extras/src/drm_scanner/connector_scanner.rs
+++ b/smithay-drm-extras/src/drm_scanner/connector_scanner.rs
@@ -33,8 +33,8 @@ impl ConnectorScanner {
     }
 
     /// Should be called on every device changed event
-    pub fn scan(&mut self, drm: &impl ControlDevice) -> ConnectorScanResult {
-        let res_handles = drm.resource_handles().unwrap();
+    pub fn scan(&mut self, drm: &impl ControlDevice) -> std::io::Result<ConnectorScanResult> {
+        let res_handles = drm.resource_handles()?;
         let connector_handles = res_handles.connectors();
 
         let mut added = Vec::new();
@@ -63,10 +63,10 @@ impl ConnectorScanner {
             }
         }
 
-        ConnectorScanResult {
+        Ok(ConnectorScanResult {
             connected: added,
             disconnected: removed,
-        }
+        })
     }
 
     /// Get map of all connectors, connected and disconnected ones.


### PR DESCRIPTION
this changes scan_connectors to return a result
instead of unwrapping on failing to query the
drm devices resources.