### PR TITLE
seat/kbd: Allow overriding replace behaviour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
       - name: Build Documentation
         env: 
           RUSTDOCFLAGS: --cfg=docsrs
-        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.14.0 -p drm -p gbm -p input -p udev -p wayland-server -p wayland-backend -p wayland-protocols@0.32.1 -p winit -p x11rb -p tracing
+        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.14.0 -p drm -p gbm -p input -p udev -p wayland-server -p wayland-backend -p wayland-protocols@0.32.2 -p winit -p x11rb -p tracing
         
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html


### PR DESCRIPTION
Similar to `PointerTarget::replace` this allows overriding the behaviour for custom targets.