### PR TITLE
drm: pick one cursor plane if we have multiple

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -523,7 +523,7 @@ impl DrmLeaseHandler for AnvilState<UdevData> {
                     })
                     .ok_or_else(LeaseRejected::default)?;
                 builder.add_plane(primary_plane.handle, primary_plane_claim);
-                if let Some((cursor, claim)) = planes.cursor.and_then(|plane| {
+                if let Some((cursor, claim)) = planes.cursor.iter().find_map(|plane| {
                     backend
                         .drm
                         .claim_plane(plane.handle, *crtc)

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -126,8 +126,8 @@ pub trait Framebuffer: AsRef<framebuffer::Handle> {
 pub struct Planes {
     /// The primary plane(s) of the crtc
     pub primary: Vec<PlaneInfo>,
-    /// The cursor plane of the crtc, if available
-    pub cursor: Option<PlaneInfo>,
+    /// The cursor plane(s) of the crtc, if available
+    pub cursor: Vec<PlaneInfo>,
     /// Overlay planes supported by the crtc, if available
     pub overlay: Vec<PlaneInfo>,
 }
@@ -151,7 +151,7 @@ fn planes(
     has_universal_planes: bool,
 ) -> Result<Planes, DrmError> {
     let mut primary = Vec::with_capacity(1);
-    let mut cursor = None;
+    let mut cursor = Vec::new();
     let mut overlay = Vec::new();
 
     let planes = dev.plane_handles().map_err(|source| {
@@ -194,7 +194,7 @@ fn planes(
                     primary.push(plane_info);
                 }
                 PlaneType::Cursor => {
-                    cursor = Some(plane_info);
+                    cursor.push(plane_info);
                 }
                 PlaneType::Overlay => {
                     overlay.push(plane_info);
@@ -205,7 +205,7 @@ fn planes(
 
     Ok(Planes {
         primary,
-        cursor: if has_universal_planes { cursor } else { None },
+        cursor: if has_universal_planes { cursor } else { Vec::new() },
         overlay: if has_universal_planes { overlay } else { Vec::new() },
     })
 }

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -402,12 +402,7 @@ impl DrmSurface {
     pub fn claim_plane(&self, plane: plane::Handle) -> Option<PlaneClaim> {
         // Validate that we are called with an plane that belongs to us
         if self.planes.primary.iter().any(|p| p.handle == plane)
-            || self
-                .planes
-                .cursor
-                .as_ref()
-                .map(|p| p.handle == plane)
-                .unwrap_or(false)
+            || self.planes.cursor.iter().any(|p| p.handle == plane)
             || self.planes.overlay.iter().any(|p| p.handle == plane)
         {
             self.plane_claim_storage.claim(plane, self.crtc)


### PR DESCRIPTION
some drivers might offer multiple cursor planes per CRTC. in this case try to use the first unclaimed plane and try to keep the same for as long as possible