### PR TITLE
xwm: Rename HIDDEN state from minimized to suspended

### DIFF
--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -492,11 +492,11 @@ impl X11Surface {
         Ok(())
     }
 
-    /// Sets the window as minimized or not.
+    /// Sets the window as suspended/hidden or not.
     ///
-    /// Allows the client to e.g. stop rendering while minimized.
-    pub fn set_minimized(&self, minimized: bool) -> Result<(), ConnectionError> {
-        if minimized {
+    /// Allows the client to e.g. stop rendering.
+    pub fn set_suspended(&self, suspended: bool) -> Result<(), ConnectionError> {
+        if suspended {
             self.change_net_state(&[self.atoms._NET_WM_STATE_HIDDEN], &[])?;
         } else {
             self.change_net_state(&[], &[self.atoms._NET_WM_STATE_HIDDEN])?;


### PR DESCRIPTION
`NET_WM_STATE_HIDDEN` represents what xdg-shell calls `suspended`, not minimized. X11 windows typically expect to be unmapped and remapped, when asking for a specific minimized state, not for `_NET_WM_STATE_HIDDEN`. So lets rename this to be less confusing and more consistent.