### PR TITLE
utils: Fix debug_assert for converting `Time`

### DIFF
--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -77,8 +77,8 @@ impl<Kind> Copy for Time<Kind> {}
 impl<Kind: NonNegativeClockSource> From<Time<Kind>> for Duration {
     #[inline]
     fn from(time: Time<Kind>) -> Self {
-        debug_assert!(time.tp.tv_sec > 0);
-        debug_assert!(time.tp.tv_nsec > 0);
+        debug_assert!(time.tp.tv_sec >= 0);
+        debug_assert!(time.tp.tv_nsec >= 0);
         Duration::new(time.tp.tv_sec as u64, time.tp.tv_nsec as u32)
     }
 }


### PR DESCRIPTION
`0` is a valid value