### PR TITLE
Various little xwm fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
       - name: Build Documentation
         env: 
           RUSTDOCFLAGS: --cfg=docsrs
-        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.14.0 -p drm -p gbm -p input -p udev -p wayland-server -p wayland-backend -p wayland-protocols@0.32.2 -p winit -p x11rb -p tracing
+        run: cargo doc --no-deps --features "test_all_features" -p smithay -p calloop:0.14.0 -p drm -p gbm -p input -p udev -p wayland-server -p wayland-backend -p wayland-protocols@0.32.3 -p winit -p x11rb -p tracing
         
       - name: Setup index
         run: cp ./doc_index.html ./target/doc/index.html

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1530,12 +1530,6 @@ where
                     )?;
                     {
                         let mut state = surface.state.lock().unwrap();
-                        conn.reparent_window(
-                            n.window,
-                            xwm.screen.root,
-                            state.geometry.loc.x as i16,
-                            state.geometry.loc.y as i16,
-                        )?;
                         if let Some(frame) = state.mapped_onto.take() {
                             conn.destroy_window(frame)?;
                         }

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -2143,6 +2143,7 @@ where
                             );
 
                             guard.wl_surface = Some(wl_surface.clone());
+                            std::mem::drop(guard);
                             XWaylandShellHandler::surface_associated(state, wl_surface, window_id);
                         } else {
                             debug!(

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -113,6 +113,7 @@ use std::{
 use tracing::{debug, debug_span, error, info, trace, warn};
 use wayland_server::{Client, Resource};
 
+pub use x11rb::protocol::xproto::Window as X11Window;
 use x11rb::{
     connection::Connection as _,
     errors::ReplyOrIdError,
@@ -124,8 +125,8 @@ use x11rb::{
             Atom, AtomEnum, ChangeWindowAttributesAux, ConfigWindow, ConfigureNotifyEvent,
             ConfigureWindowAux, ConnectionExt as _, CreateGCAux, CreateWindowAux, CursorWrapper, EventMask,
             FontWrapper, GcontextWrapper, GetPropertyReply, ImageFormat, PixmapWrapper, PropMode, Property,
-            QueryExtensionReply, Screen, SelectionNotifyEvent, SelectionRequestEvent, StackMode,
-            Window as X11Window, WindowClass, CONFIGURE_NOTIFY_EVENT, SELECTION_NOTIFY_EVENT,
+            QueryExtensionReply, Screen, SelectionNotifyEvent, SelectionRequestEvent, StackMode, WindowClass,
+            CONFIGURE_NOTIFY_EVENT, SELECTION_NOTIFY_EVENT,
         },
         Event,
     },


### PR DESCRIPTION
Best reviewed commit-by-commit.

- We previously didn't re-export our renamed `X11Window` for the window id. This wasn't critical, because we reexport the whole `x11rb` crate, but it is needlessly confusing and breaks links in rustdoc.

- `surface_associated` is called in two places, one locks the surface state, the other doesn't. This is just asking for deadlocks.

- `surface_associated` is the only handler not taking a `XwmId`, making it unusable running multiple Xwayland servers. Lets fix that and also pass the whole `X11Surface` instead of just the window id to not force compositors to retrieve that manually.

- CI fix

- Reparenting apparently has the side-effect of mapping a window again, causing endless loops. So let's not do that.