### PR TITLE
Return real alpha in SolidColorRenderElement

### DIFF
--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -315,7 +315,7 @@ impl Element for SolidColorRenderElement {
     }
 
     fn alpha(&self) -> f32 {
-        1.0
+        self.color[3]
     }
 
     fn kind(&self) -> Kind {


### PR DESCRIPTION
Without this, changing just the alpha in SolidColorRenderElement::from_buffer() doesn't damage the element.

I didn't test this in Smithay, but I bumped into this problem in my in-tree copy in niri.