### PR TITLE
Single pixel buffer (take 2)

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -79,6 +79,7 @@ use smithay::{
             },
         },
         shm::{ShmHandler, ShmState},
+        single_pixel_buffer::SinglePixelBufferState,
         socket::ListeningSocketSource,
         tablet_manager::{TabletManagerState, TabletSeatHandler},
         text_input::TextInputManagerState,
@@ -150,6 +151,7 @@ pub struct AnvilState<BackendData: Backend + 'static> {
     pub xdg_foreign_state: XdgForeignState,
     #[cfg(feature = "xwayland")]
     pub xwayland_shell_state: xwayland_shell::XWaylandShellState,
+    pub single_pixel_buffer_state: SinglePixelBufferState,
 
     pub dnd_icon: Option<WlSurface>,
 
@@ -535,6 +537,8 @@ impl<BackendData: Backend> XdgForeignHandler for AnvilState<BackendData> {
 }
 smithay::delegate_xdg_foreign!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
+smithay::delegate_single_pixel_buffer!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+
 impl<BackendData: Backend + 'static> AnvilState<BackendData> {
     pub fn init(
         display: Display<AnvilState<BackendData>>,
@@ -596,6 +600,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
         let presentation_state = PresentationState::new::<Self>(&dh, clock.id() as u32);
         let fractional_scale_manager_state = FractionalScaleManagerState::new::<Self>(&dh);
         let xdg_foreign_state = XdgForeignState::new::<Self>(&dh);
+        let single_pixel_buffer_state = SinglePixelBufferState::new::<Self>(&dh);
         TextInputManagerState::new::<Self>(&dh);
         InputMethodManagerState::new::<Self, _>(&dh, |_client| true);
         VirtualKeyboardManagerState::new::<Self, _>(&dh, |_client| true);
@@ -654,6 +659,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
             presentation_state,
             fractional_scale_manager_state,
             xdg_foreign_state,
+            single_pixel_buffer_state,
             dnd_icon: None,
             suppressed_keys: Vec::new(),
             cursor_status: CursorImageStatus::default_named(),

--- a/examples/buffer_test.rs
+++ b/examples/buffer_test.rs
@@ -14,7 +14,7 @@ use smithay::{
         egl::{EGLContext, EGLDevice, EGLDisplay},
         renderer::{
             gles::{GlesRenderbuffer, GlesRenderer},
-            Bind, ExportMem, Frame, ImportDma, Offscreen, Renderer,
+            Bind, Color32F, ExportMem, Frame, ImportDma, Offscreen, Renderer,
         },
         vulkan::{version::Version, Instance, PhysicalDevice},
     },
@@ -290,25 +290,25 @@ where
         .expect("Failed to create render frame");
     frame
         .clear(
-            [1.0, 0.0, 0.0, 1.0],
+            Color32F::new(1.0, 0.0, 0.0, 1.0),
             &[Rectangle::from_loc_and_size((0, 0), (w / 2, h / 2))],
         )
         .expect("Render error");
     frame
         .clear(
-            [0.0, 1.0, 0.0, 1.0],
+            Color32F::new(0.0, 1.0, 0.0, 1.0),
             &[Rectangle::from_loc_and_size((w / 2, 0), (w / 2, h / 2))],
         )
         .expect("Render error");
     frame
         .clear(
-            [0.0, 0.0, 1.0, 1.0],
+            Color32F::new(0.0, 0.0, 1.0, 1.0),
             &[Rectangle::from_loc_and_size((0, h / 2), (w / 2, h / 2))],
         )
         .expect("Render error");
     frame
         .clear(
-            [1.0, 1.0, 0.0, 1.0],
+            Color32F::new(1.0, 1.0, 0.0, 1.0),
             &[Rectangle::from_loc_and_size((w / 2, h / 2), (w / 2, h / 2))],
         )
         .expect("Render error");

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -11,7 +11,7 @@ use smithay::{
             },
             gles::GlesRenderer,
             utils::{draw_render_elements, on_commit_buffer_handler},
-            Frame, Renderer,
+            Color32F, Frame, Renderer,
         },
         winit::{self, WinitEvent},
     },
@@ -227,7 +227,7 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
             .collect::<Vec<WaylandSurfaceRenderElement<GlesRenderer>>>();
 
         let mut frame = backend.renderer().render(size, Transform::Flipped180).unwrap();
-        frame.clear([0.1, 0.0, 0.0, 1.0], &[damage]).unwrap();
+        frame.clear(Color32F::new(0.1, 0.0, 0.0, 1.0), &[damage]).unwrap();
         draw_render_elements(&mut frame, 1.0, &elements, &[damage]).unwrap();
         // We rely on the nested compositor to do the sync for us
         let _ = frame.finish().unwrap();

--- a/src/backend/drm/compositor/elements.rs
+++ b/src/backend/drm/compositor/elements.rs
@@ -2,13 +2,11 @@ use crate::{
     backend::renderer::{
         element::{Element, Id, RenderElement},
         utils::{CommitCounter, DamageSet, OpaqueRegions},
-        Frame, Renderer,
+        Color32F, Frame, Renderer,
     },
     render_elements,
     utils::{Buffer, Physical, Point, Rectangle, Scale, Transform},
 };
-
-pub const COLOR_TRANSPARENT: [f32; 4] = [0f32, 0f32, 0f32, 0f32];
 
 render_elements! {
     pub DrmRenderElements<'a, R, E>;
@@ -48,7 +46,7 @@ where
         _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), <R as Renderer>::Error> {
         frame.clear(
-            COLOR_TRANSPARENT,
+            Color32F::TRANSPARENT,
             &damage
                 .iter()
                 .cloned()

--- a/src/backend/renderer/color.rs
+++ b/src/backend/renderer/color.rs
@@ -1,0 +1,77 @@
+use std::ops::Mul;
+
+/// A four-component color representing pre-multiplied RGBA color values
+#[derive(Debug, Copy, Clone, Default, PartialEq)]
+pub struct Color32F([f32; 4]);
+
+impl Color32F {
+    /// Initialize a new [`Color`]
+    #[inline]
+    pub const fn new(r: f32, g: f32, b: f32, a: f32) -> Self {
+        Self([r, g, b, a])
+    }
+}
+
+impl Color32F {
+    /// Transparent color
+    pub const TRANSPARENT: Color32F = Color32F::new(0.0, 0.0, 0.0, 0.0);
+
+    /// Solid black color
+    pub const BLACK: Color32F = Color32F::new(0f32, 0f32, 0f32, 1f32);
+}
+
+impl Color32F {
+    /// Red color component
+    #[inline]
+    pub fn r(&self) -> f32 {
+        self.0[0]
+    }
+
+    /// Green color component
+    #[inline]
+    pub fn g(&self) -> f32 {
+        self.0[1]
+    }
+
+    /// Blue color component
+    #[inline]
+    pub fn b(&self) -> f32 {
+        self.0[2]
+    }
+
+    /// Alpha color component
+    #[inline]
+    pub fn a(&self) -> f32 {
+        self.0[3]
+    }
+
+    /// Color components
+    #[inline]
+    pub fn components(self) -> [f32; 4] {
+        self.0
+    }
+}
+
+impl Color32F {
+    /// Test if the color represents a opaque color
+    #[inline]
+    pub fn is_opaque(&self) -> bool {
+        self.a() == 1f32
+    }
+}
+
+impl From<[f32; 4]> for Color32F {
+    #[inline]
+    fn from(value: [f32; 4]) -> Self {
+        Self(value)
+    }
+}
+
+impl Mul<f32> for Color32F {
+    type Output = Color32F;
+
+    #[inline]
+    fn mul(self, rhs: f32) -> Self::Output {
+        Self::new(self.r() * rhs, self.g() * rhs, self.b() * rhs, self.a() * rhs)
+    }
+}

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -23,7 +23,7 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
+//! #     backend::renderer::{Color32F, DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
 //! #     utils::{Buffer, Physical},
 //! # };
 //! #
@@ -49,14 +49,14 @@
 //! #     type TextureId = FakeTexture;
 //! #
 //! #     fn id(&self) -> usize { unimplemented!() }
-//! #     fn clear(&mut self, _: [f32; 4], _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+//! #     fn clear(&mut self, _: Color32F, _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }
 //! #     fn draw_solid(
 //! #         &mut self,
 //! #         _dst: Rectangle<i32, Physical>,
 //! #         _damage: &[Rectangle<i32, Physical>],
-//! #         _color: [f32; 4],
+//! #         _color: Color32F,
 //! #     ) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -1251,7 +1251,7 @@ macro_rules! render_elements_internal {
 /// # use smithay::{
 /// #     backend::{
 /// #         allocator::Fourcc,
-/// #         renderer::{DebugFlags, Frame, Renderer, Texture, TextureFilter, sync::SyncPoint},
+/// #         renderer::{Color32F, DebugFlags, Frame, Renderer, Texture, TextureFilter, sync::SyncPoint},
 /// #     },
 /// #     utils::{Buffer, Physical, Rectangle, Size, Transform},
 /// # };
@@ -1278,14 +1278,14 @@ macro_rules! render_elements_internal {
 /// #     type TextureId = MyRendererTextureId;
 /// #
 /// #     fn id(&self) -> usize { unimplemented!() }
-/// #     fn clear(&mut self, _: [f32; 4], _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+/// #     fn clear(&mut self, _: Color32F, _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
 /// #         unimplemented!()
 /// #     }
 /// #     fn draw_solid(
 /// #         &mut self,
 /// #         _dst: Rectangle<i32, Physical>,
 /// #         _damage: &[Rectangle<i32, Physical>],
-/// #         _color: [f32; 4],
+/// #         _color: Color32F,
 /// #     ) -> Result<(), Self::Error> {
 /// #         unimplemented!()
 /// #     }

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -23,7 +23,7 @@
 //! # use smithay::{
 //! #     backend::allocator::{Fourcc, dmabuf::Dmabuf},
 //! #     backend::renderer::{
-//! #         DebugFlags, Frame, ImportDma, ImportDmaWl, ImportMem, ImportMemWl, Renderer, Texture,
+//! #         Color32F, DebugFlags, Frame, ImportDma, ImportDmaWl, ImportMem, ImportMemWl, Renderer, Texture,
 //! #         TextureFilter, sync::SyncPoint,
 //! #     },
 //! #     utils::{Buffer, Physical},
@@ -52,14 +52,14 @@
 //! #     type TextureId = FakeTexture;
 //! #
 //! #     fn id(&self) -> usize { unimplemented!() }
-//! #     fn clear(&mut self, _: [f32; 4], _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+//! #     fn clear(&mut self, _: Color32F, _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }
 //! #     fn draw_solid(
 //! #         &mut self,
 //! #         _dst: Rectangle<i32, Physical>,
 //! #         _damage: &[Rectangle<i32, Physical>],
-//! #         _color: [f32; 4],
+//! #         _color: Color32F,
 //! #     ) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -41,7 +41,7 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
+//! #     backend::renderer::{Color32F, DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
 //! #     utils::{Buffer, Physical, Rectangle, Size},
 //! # };
 //! #
@@ -67,14 +67,14 @@
 //! #     type TextureId = FakeTexture;
 //! #
 //! #     fn id(&self) -> usize { unimplemented!() }
-//! #     fn clear(&mut self, _: [f32; 4], _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+//! #     fn clear(&mut self, _: Color32F, _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }
 //! #     fn draw_solid(
 //! #         &mut self,
 //! #         _dst: Rectangle<i32, Physical>,
 //! #         _damage: &[Rectangle<i32, Physical>],
-//! #         _color: [f32; 4],
+//! #         _color: Color32F,
 //! #     ) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }
@@ -201,7 +201,7 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
+//! #     backend::renderer::{Color32F, DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
 //! #     utils::{Buffer, Physical},
 //! # };
 //! #
@@ -227,14 +227,14 @@
 //! #     type TextureId = FakeTexture;
 //! #
 //! #     fn id(&self) -> usize { unimplemented!() }
-//! #     fn clear(&mut self, _: [f32; 4], _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+//! #     fn clear(&mut self, _: Color32F, _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }
 //! #     fn draw_solid(
 //! #         &mut self,
 //! #         _dst: Rectangle<i32, Physical>,
 //! #         _damage: &[Rectangle<i32, Physical>],
-//! #         _color: [f32; 4],
+//! #         _color: Color32F,
 //! #     ) -> Result<(), Self::Error> {
 //! #         unimplemented!()
 //! #     }

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -37,8 +37,8 @@ pub use uniform::*;
 use self::version::GlVersion;
 
 use super::{
-    sync::SyncPoint, Bind, Blit, DebugFlags, ExportMem, Frame, ImportDma, ImportMem, Offscreen, Renderer,
-    Texture, TextureFilter, TextureMapping, Unbind,
+    sync::SyncPoint, Bind, Blit, Color32F, DebugFlags, ExportMem, Frame, ImportDma, ImportMem, Offscreen,
+    Renderer, Texture, TextureFilter, TextureMapping, Unbind,
 };
 use crate::backend::{
     allocator::{
@@ -2190,7 +2190,7 @@ impl<'frame> Frame for GlesFrame<'frame> {
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
     #[profiling::function]
-    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), GlesError> {
+    fn clear(&mut self, color: Color32F, at: &[Rectangle<i32, Physical>]) -> Result<(), GlesError> {
         if at.is_empty() {
             return Ok(());
         }
@@ -2214,13 +2214,13 @@ impl<'frame> Frame for GlesFrame<'frame> {
         &mut self,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
-        color: [f32; 4],
+        color: Color32F,
     ) -> Result<(), Self::Error> {
         if damage.is_empty() {
             return Ok(());
         }
 
-        let is_opaque = color[3] == 1f32;
+        let is_opaque = color.is_opaque();
 
         if is_opaque {
             unsafe {
@@ -2340,7 +2340,7 @@ impl<'frame> GlesFrame<'frame> {
         &mut self,
         dest: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
-        color: [f32; 4],
+        color: Color32F,
     ) -> Result<(), GlesError> {
         if damage.is_empty() {
             return Ok(());
@@ -2399,10 +2399,10 @@ impl<'frame> GlesFrame<'frame> {
             gl.UseProgram(self.renderer.solid_program.program);
             gl.Uniform4f(
                 self.renderer.solid_program.uniform_color,
-                color[0],
-                color[1],
-                color[2],
-                color[3],
+                color.r(),
+                color.g(),
+                color.b(),
+                color.a(),
             );
             gl.UniformMatrix3fv(
                 self.renderer.solid_program.uniform_matrix,

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -16,7 +16,7 @@ use crate::{
         renderer::{
             element::UnderlyingStorage,
             gles::{element::*, *},
-            sync, Bind, Blit, DebugFlags, ExportMem, ImportDma, ImportMem, Offscreen, Renderer,
+            sync, Bind, Blit, Color32F, DebugFlags, ExportMem, ImportDma, ImportMem, Offscreen, Renderer,
             TextureFilter, Unbind,
         },
     },
@@ -254,7 +254,7 @@ impl<'frame> Frame for GlowFrame<'frame> {
     }
 
     #[profiling::function]
-    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+    fn clear(&mut self, color: Color32F, at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
         self.frame.as_mut().unwrap().clear(color, at)
     }
 
@@ -263,7 +263,7 @@ impl<'frame> Frame for GlowFrame<'frame> {
         &mut self,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
-        color: [f32; 4],
+        color: Color32F,
     ) -> Result<(), Self::Error> {
         self.frame.as_mut().unwrap().draw_solid(dst, damage, color)
     }

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -27,6 +27,9 @@ pub mod glow;
 #[cfg(feature = "renderer_pixman")]
 pub mod pixman;
 
+mod color;
+pub use color::Color32F;
+
 use crate::backend::allocator::{dmabuf::Dmabuf, Format, Fourcc};
 #[cfg(all(
     feature = "wayland_frontend",
@@ -176,14 +179,14 @@ pub trait Frame {
     ///
     /// This operation is only valid in between a `begin` and `finish`-call.
     /// If called outside this operation may error-out, do nothing or modify future rendering results in any way.
-    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error>;
+    fn clear(&mut self, color: Color32F, at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error>;
 
     /// Draw a solid color to the current target at the specified destination with the specified color.
     fn draw_solid(
         &mut self,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
-        color: [f32; 4],
+        color: Color32F,
     ) -> Result<(), Self::Error>;
 
     /// Render a texture to the current target as a flat 2d-plane at a given

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -655,6 +655,10 @@ impl<A: GraphicsApi> GpuManager<A> {
                 // we just need to upload in import_shm_buffer
                 Ok(())
             }
+            Some(BufferType::SinglePixel) => {
+                // no need to do anything
+                Ok(())
+            }
             None => {
                 // welp, nothing we can do
                 Ok(())

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -47,8 +47,8 @@ use std::{
 };
 
 use super::{
-    sync::SyncPoint, Bind, Blit, DebugFlags, ExportMem, Frame, ImportDma, ImportMem, Offscreen, Renderer,
-    Texture, TextureFilter, TextureMapping, Unbind,
+    sync::SyncPoint, Bind, Blit, Color32F, DebugFlags, ExportMem, Frame, ImportDma, ImportMem, Offscreen,
+    Renderer, Texture, TextureFilter, TextureMapping, Unbind,
 };
 #[cfg(feature = "wayland_frontend")]
 use super::{ImportDmaWl, ImportMemWl};
@@ -1226,7 +1226,7 @@ where
                         .map_err(Error::Target)?;
                     frame.wait(&sync).map_err(Error::Target)?;
                     frame
-                        .clear([0.0, 0.0, 0.0, 0.0], &damage)
+                        .clear(Color32F::TRANSPARENT, &damage)
                         .map_err(Error::Target)?;
                     frame
                         .render_texture_from_to(
@@ -1329,7 +1329,9 @@ where
                         let src = Rectangle::from_loc_and_size(damage_rect.loc - rect.loc, damage_rect.size)
                             .to_f64();
                         let damage = &[Rectangle::from_loc_and_size((0, 0), dst.size)];
-                        frame.clear([0.0, 0.0, 0.0, 0.0], &[dst]).map_err(Error::Target)?;
+                        frame
+                            .clear(Color32F::TRANSPARENT, &[dst])
+                            .map_err(Error::Target)?;
                         frame
                             .render_texture_from_to(
                                 &texture,
@@ -1628,7 +1630,7 @@ where
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
     #[profiling::function]
-    fn clear(&mut self, color: [f32; 4], at: &[Rectangle<i32, Physical>]) -> Result<(), Error<R, T>> {
+    fn clear(&mut self, color: Color32F, at: &[Rectangle<i32, Physical>]) -> Result<(), Error<R, T>> {
         self.damage.extend(at);
         self.frame
             .as_mut()
@@ -1643,7 +1645,7 @@ where
         &mut self,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
-        color: [f32; 4],
+        color: Color32F,
     ) -> Result<(), Self::Error> {
         self.damage.extend(damage.iter().copied().map(|mut rect| {
             rect.loc += dst.loc;
@@ -2037,7 +2039,9 @@ where
     .filter(|_| !is_new_buffer)
     .unwrap_or(&damage_slice);
 
-    frame.clear([0.0, 0.0, 0.0, 0.0], damage).map_err(Error::Render)?;
+    frame
+        .clear(Color32F::TRANSPARENT, damage)
+        .map_err(Error::Render)?;
     frame
         .render_texture_from_to(
             src_texture,

--- a/src/backend/renderer/test.rs
+++ b/src/backend/renderer/test.rs
@@ -21,6 +21,8 @@ use crate::{
     utils::{Buffer, Physical, Rectangle, Size, Transform},
 };
 
+use super::Color32F;
+
 #[derive(Debug)]
 pub struct DummyRenderer {}
 
@@ -207,7 +209,7 @@ impl Frame for DummyFrame {
         0
     }
 
-    fn clear(&mut self, _color: [f32; 4], _damage: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
+    fn clear(&mut self, _color: Color32F, _damage: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -215,7 +217,7 @@ impl Frame for DummyFrame {
         &mut self,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
-        _color: [f32; 4],
+        _color: Color32F,
     ) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -472,6 +472,14 @@ where
         let buffer_damage = data.damage_since(last_commit.copied());
         if let Entry::Vacant(e) = data.textures.entry(texture_id) {
             if let Some(buffer) = data.buffer.as_ref() {
+                // There is no point in importing a single pixel buffer
+                if matches!(
+                    crate::backend::renderer::buffer_type(buffer),
+                    Some(crate::backend::renderer::BufferType::SinglePixel)
+                ) {
+                    return Ok(());
+                }
+
                 match renderer.import_buffer(buffer, Some(states), &buffer_damage) {
                     Some(Ok(m)) => {
                         e.insert(Box::new(m));

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     backend::renderer::{
         damage::{Error as OutputDamageTrackerError, OutputDamageTracker, RenderOutputResult},
         element::{AsRenderElements, RenderElement, Wrap},
-        Renderer, Texture,
+        Color32F, Renderer, Texture,
     },
     output::{Output, OutputModeSource, OutputNoMode},
     utils::{IsAlive, Logical, Point, Rectangle, Scale, Transform},
@@ -682,7 +682,7 @@ pub fn render_output<
     spaces: S,
     custom_elements: &'a [C],
     damage_tracker: &'d mut OutputDamageTracker,
-    clear_color: [f32; 4],
+    clear_color: impl Into<Color32F>,
 ) -> Result<RenderOutputResult<'d>, OutputDamageTrackerError<R>>
 where
     <R as Renderer>::TextureId: Clone + Texture + 'static,

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -69,6 +69,7 @@ pub mod selection;
 pub mod session_lock;
 pub mod shell;
 pub mod shm;
+pub mod single_pixel_buffer;
 pub mod socket;
 pub mod tablet_manager;
 pub mod text_input;

--- a/src/wayland/single_pixel_buffer/handlers.rs
+++ b/src/wayland/single_pixel_buffer/handlers.rs
@@ -1,0 +1,82 @@
+use crate::wayland::buffer::BufferHandler;
+
+use super::{SinglePixelBufferState, SinglePixelBufferUserData};
+use wayland_protocols::wp::single_pixel_buffer::v1::server::wp_single_pixel_buffer_manager_v1::{
+    self, WpSinglePixelBufferManagerV1,
+};
+use wayland_server::{
+    protocol::wl_buffer::{self, WlBuffer},
+    DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
+};
+
+impl<D> GlobalDispatch<WpSinglePixelBufferManagerV1, (), D> for SinglePixelBufferState
+where
+    D: GlobalDispatch<WpSinglePixelBufferManagerV1, ()>,
+    D: Dispatch<WpSinglePixelBufferManagerV1, ()>,
+    D: 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _dh: &DisplayHandle,
+        _client: &wayland_server::Client,
+        resource: New<WpSinglePixelBufferManagerV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(resource, ());
+    }
+}
+
+impl<D> Dispatch<WpSinglePixelBufferManagerV1, (), D> for SinglePixelBufferState
+where
+    D: Dispatch<WpSinglePixelBufferManagerV1, ()>,
+    D: Dispatch<WlBuffer, SinglePixelBufferUserData>,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &wayland_server::Client,
+        _manager: &WpSinglePixelBufferManagerV1,
+        request: wp_single_pixel_buffer_manager_v1::Request,
+        _data: &(),
+        _dh: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            wp_single_pixel_buffer_manager_v1::Request::CreateU32RgbaBuffer {
+                id: buffer,
+                r,
+                g,
+                b,
+                a,
+            } => {
+                data_init.init(buffer, SinglePixelBufferUserData { r, g, b, a });
+            }
+            wp_single_pixel_buffer_manager_v1::Request::Destroy => {}
+            _ => todo!(),
+        }
+    }
+}
+
+impl<D> Dispatch<WlBuffer, SinglePixelBufferUserData, D> for SinglePixelBufferState
+where
+    D: Dispatch<WlBuffer, SinglePixelBufferUserData>,
+    D: BufferHandler,
+{
+    fn request(
+        data: &mut D,
+        _client: &wayland_server::Client,
+        buffer: &wl_buffer::WlBuffer,
+        request: wl_buffer::Request,
+        _udata: &SinglePixelBufferUserData,
+        _dh: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            wl_buffer::Request::Destroy => {
+                data.buffer_destroyed(buffer);
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/wayland/single_pixel_buffer/mod.rs
+++ b/src/wayland/single_pixel_buffer/mod.rs
@@ -112,6 +112,20 @@ impl SinglePixelBufferUserData {
             (self.a / divisor) as u8,
         ]
     }
+
+    /// Color represented as rgba32f
+    ///
+    /// Ranges from `0f32` to `1f32`
+    pub fn rgba32f(&self) -> [f32; 4] {
+        let divisor = u32::MAX as f32;
+
+        [
+            self.r as f32 / divisor,
+            self.g as f32 / divisor,
+            self.b as f32 / divisor,
+            self.a as f32 / divisor,
+        ]
+    }
 }
 
 /// Error that can occur when accessing an SinglePixelBuffer

--- a/src/wayland/single_pixel_buffer/mod.rs
+++ b/src/wayland/single_pixel_buffer/mod.rs
@@ -1,0 +1,147 @@
+//! Utilities for handling the `wp_single_pixel_buffer` protocol
+//!
+//! ## How to use it
+//!
+//! ### Initialization
+//!
+//! To initialize this implementation, create [`SinglePixelBufferState`], store it in your `State` struct and
+//! implement the required traits, as shown in this example:
+//!
+//! ```
+//! use smithay::wayland::{
+//!     buffer::BufferHandler,
+//!     single_pixel_buffer::SinglePixelBufferState
+//! };
+//! use smithay::delegate_single_pixel_buffer;
+//!
+//! # struct State;
+//! # let mut display = wayland_server::Display::<State>::new().unwrap();
+//!
+//! // Create the single pixel buffer state:
+//! let single_pixel_buffer_state = SinglePixelBufferState::new::<State>(
+//!     &display.handle(), // the display
+//! );
+//!
+//! // Smithay's "SinglePixelBufferState" also requires the buffer management utilities, you need to implement
+//! // "BufferHandler".
+//! impl BufferHandler for State {
+//!     fn buffer_destroyed(&mut self, buffer: &wayland_server::protocol::wl_buffer::WlBuffer) {
+//!         // All renderers can handle buffer destruction at this point. Some parts of window management may
+//!         // also use this function.
+//!     }
+//! }
+//!
+//! // implement Dispatch for the SinglePixelBuffer types
+//! delegate_single_pixel_buffer!(State);
+//!
+//! // You're now ready to go!
+//! ```
+//!
+//! ### Access the single pixel buffer data
+//!
+//! The buffer data stores the color as RGBA values which can be retrieved by calling [`get_single_pixel_buffer`].
+//!
+//! ```no_run
+//! use smithay::wayland::single_pixel_buffer;
+//! # let buffer: smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer = { todo!() };
+//! let single_pixel_buffer_data = single_pixel_buffer::get_single_pixel_buffer(&buffer).unwrap();
+//! ```
+
+use wayland_protocols::wp::single_pixel_buffer::v1::server::wp_single_pixel_buffer_manager_v1::WpSinglePixelBufferManagerV1;
+use wayland_server::{
+    backend::GlobalId, protocol::wl_buffer::WlBuffer, Dispatch, DisplayHandle, GlobalDispatch, Resource,
+};
+
+mod handlers;
+
+/// Delegate state of WpSinglePixelBuffer protocol
+#[derive(Debug)]
+pub struct SinglePixelBufferState {
+    global: GlobalId,
+}
+
+impl SinglePixelBufferState {
+    /// Create a new [`WpSinglePixelBufferManagerV1`] global
+    //
+    /// The id provided by [`SinglePixelBufferState::global`] may be used to
+    /// remove or disable this global in the future.
+    pub fn new<D>(display: &DisplayHandle) -> Self
+    where
+        D: GlobalDispatch<WpSinglePixelBufferManagerV1, ()>,
+        D: Dispatch<WpSinglePixelBufferManagerV1, ()>,
+        D: 'static,
+    {
+        let global = display.create_global::<D, WpSinglePixelBufferManagerV1, _>(1, ());
+
+        Self { global }
+    }
+
+    /// Returns the id of the [`WpSinglePixelBufferManagerV1`] global.
+    pub fn global(&self) -> GlobalId {
+        self.global.clone()
+    }
+}
+
+/// User data of `WlBuffer` backed by single pixel
+#[derive(Debug)]
+pub struct SinglePixelBufferUserData {
+    /// Value of the buffer's red channel
+    pub r: u32,
+    /// Value of the buffer's green channel
+    pub g: u32,
+    /// Value of the buffer's blue channel
+    pub b: u32,
+    /// Value of the buffer's alpha channel
+    pub a: u32,
+}
+
+impl SinglePixelBufferUserData {
+    /// Check if pixel has alpha
+    pub fn has_alpha(&self) -> bool {
+        self.a != u32::MAX
+    }
+
+    /// RGAB8888 color buffer
+    pub fn rgba8888(&self) -> [u8; 4] {
+        let divisor = u32::MAX / 255;
+
+        [
+            (self.r / divisor) as u8,
+            (self.g / divisor) as u8,
+            (self.b / divisor) as u8,
+            (self.a / divisor) as u8,
+        ]
+    }
+}
+
+/// Error that can occur when accessing an SinglePixelBuffer
+#[derive(Debug, thiserror::Error)]
+pub enum BufferAccessError {
+    /// This buffer is not managed by the SinglePixelBuffer handler
+    #[error("non-single-pixel buffer")]
+    NotManaged,
+}
+
+/// Gets the data of a `SinglePixelBuffer` backed [`WlBuffer`].
+pub fn get_single_pixel_buffer(buffer: &WlBuffer) -> Result<&SinglePixelBufferUserData, BufferAccessError> {
+    buffer
+        .data::<SinglePixelBufferUserData>()
+        .ok_or(BufferAccessError::NotManaged)
+}
+
+/// Macro used to delegate `WpSinglePixelBuffer` events
+#[macro_export]
+macro_rules! delegate_single_pixel_buffer {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::single_pixel_buffer::v1::server::wp_single_pixel_buffer_manager_v1::WpSinglePixelBufferManagerV1: ()
+        ] => $crate::wayland::single_pixel_buffer::SinglePixelBufferState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::single_pixel_buffer::v1::server::wp_single_pixel_buffer_manager_v1::WpSinglePixelBufferManagerV1: ()
+        ] => $crate::wayland::single_pixel_buffer::SinglePixelBufferState);
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_server::protocol::wl_buffer::WlBuffer: $crate::wayland::single_pixel_buffer::SinglePixelBufferUserData
+        ] => $crate::wayland::single_pixel_buffer::SinglePixelBufferState);
+    };
+}


### PR DESCRIPTION
This PR adds support for the `wp_single_pixel_buffer` protocol, based on #719 and  #988

Main difference to #988 is that this PR leaves the `WaylandSurfaceRenderElement` in tact instead of replacing it
with an enum holding a `TextureRenderElement` and `SolidRenderElement`. Some code might already depend
on the `WaylandSurfaceRenderElement` and moving everything over to the `TextureRenderElement` in a generic
way would just complicate the code. This also allows us to keep the wayland surface specific rounding while we
could lift that for the other render elements.