### PR TITLE
Add `from_resource` to `KeyboardHandle`/`PointerHandle`/`TouchHandle`

### DIFF
--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -21,7 +21,7 @@ use crate::{
     wayland::{input_method::InputMethodSeat, text_input::TextInputSeat},
 };
 
-impl<D: SeatHandler + 'static> KeyboardHandle<D>
+impl<D> KeyboardHandle<D>
 where
     D: SeatHandler + 'static,
     <D as SeatHandler>::KeyboardFocus: WaylandFocus,
@@ -79,6 +79,16 @@ where
             }
         }
         self.arc.known_kbds.lock().unwrap().push(kbd);
+    }
+}
+
+impl<D: SeatHandler + 'static> KeyboardHandle<D> {
+    /// Attempt to retrieve a [`KeyboardHandle`] from an existing resource
+    ///
+    /// May return `None` for a valid `WlKeyboard` that was created without
+    /// the keyboard capability.
+    pub fn from_resource(seat: &WlKeyboard) -> Option<Self> {
+        seat.data::<KeyboardUserData<D>>()?.handle.clone()
     }
 }
 

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -39,6 +39,16 @@ struct V120UserData {
 /// WlSurface role of a cursor image icon
 pub const CURSOR_IMAGE_ROLE: &str = "cursor_image";
 
+impl<D: SeatHandler + 'static> PointerHandle<D> {
+    /// Attempt to retrieve a [`PointerHandle`] from an existing resource
+    ///
+    /// May return `None` for a valid `WlPointer` that was created without
+    /// the keyboard capability.
+    pub fn from_resource(seat: &WlPointer) -> Option<Self> {
+        seat.data::<PointerUserData<D>>()?.handle.clone()
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct WlPointerHandle {
     pub(crate) last_enter: Mutex<Option<Serial>>,

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -22,6 +22,16 @@ impl<D: SeatHandler> TouchHandle<D> {
     }
 }
 
+impl<D: SeatHandler + 'static> TouchHandle<D> {
+    /// Attempt to retrieve a [`TouchHandle`] from an existing resource
+    ///
+    /// May return `None` for a valid `WlTouch` that was created without
+    /// the keyboard capability.
+    pub fn from_resource(seat: &WlTouch) -> Option<Self> {
+        seat.data::<TouchUserData<D>>()?.handle.clone()
+    }
+}
+
 fn for_each_focused_touch<D: SeatHandler + 'static>(
     seat: &Seat<D>,
     surface: &WlSurface,


### PR DESCRIPTION
It seems most protocols take a `wl_seat` as an argument rather than a capability type, but it seems reasonable for Smithay to expose this in some way to compositors still.