### PR TITLE
utils: `id_gen!` optimization

### DIFF
--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -43,7 +43,7 @@ pub mod surface;
 pub mod texture;
 pub mod utils;
 
-crate::utils::ids::id_gen!(next_external_id, EXTERNAL_ID, EXTERNAL_IDS);
+crate::utils::ids::id_gen!(external_id);
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 /// A unique id for a [`RenderElement`]
@@ -61,13 +61,13 @@ struct ExternalId(usize);
 
 impl ExternalId {
     fn new() -> Self {
-        ExternalId(next_external_id())
+        ExternalId(external_id::next())
     }
 }
 
 impl Drop for ExternalId {
     fn drop(&mut self) {
-        EXTERNAL_IDS.lock().unwrap().remove(&self.0);
+        external_id::remove(self.0);
     }
 }
 

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -73,11 +73,11 @@ pub mod ffi {
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
 }
 
-crate::utils::ids::id_gen!(next_renderer_id, RENDERER_ID, RENDERER_IDS);
+crate::utils::ids::id_gen!(renderer_id);
 struct RendererId(usize);
 impl Drop for RendererId {
     fn drop(&mut self) {
-        RENDERER_IDS.lock().unwrap().remove(&self.0);
+        renderer_id::remove(self.0);
     }
 }
 
@@ -577,7 +577,7 @@ impl GlesRenderer {
 
         context
             .user_data()
-            .insert_if_missing_threadsafe(|| RendererId(next_renderer_id()));
+            .insert_if_missing_threadsafe(|| RendererId(renderer_id::next()));
         drop(_guard);
 
         let renderer = GlesRenderer {

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -32,7 +32,7 @@ pub use self::element::*;
 use self::output::*;
 pub use self::utils::*;
 
-crate::utils::ids::id_gen!(next_space_id, SPACE_ID, SPACE_IDS);
+crate::utils::ids::id_gen!(space_id);
 
 #[derive(Debug)]
 struct InnerElement<E> {
@@ -66,14 +66,14 @@ impl<E: SpaceElement> PartialEq for Space<E> {
 impl<E: SpaceElement> Drop for Space<E> {
     #[inline]
     fn drop(&mut self) {
-        SPACE_IDS.lock().unwrap().remove(&self.id);
+        space_id::remove(self.id);
     }
 }
 
 impl<E: SpaceElement> Default for Space<E> {
     #[inline]
     fn default() -> Self {
-        let id = next_space_id();
+        let id = space_id::next();
         let span = debug_span!("desktop_space", id);
 
         Self {

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -26,7 +26,7 @@ use std::{
 
 use crate::desktop::WindowSurfaceType;
 
-crate::utils::ids::id_gen!(next_layer_id, LAYER_ID, LAYER_IDS);
+crate::utils::ids::id_gen!(layer_id);
 
 /// Map of [`LayerSurface`]s on an [`Output`]
 #[derive(Debug)]
@@ -501,7 +501,7 @@ pub(crate) struct LayerSurfaceInner {
 impl Drop for LayerSurfaceInner {
     #[inline]
     fn drop(&mut self) {
-        LAYER_IDS.lock().unwrap().remove(&self.id);
+        layer_id::remove(self.id);
     }
 }
 
@@ -516,7 +516,7 @@ impl LayerSurface {
     /// Create a new [`LayerSurface`] from a given [`WlrLayerSurface`] and its namespace.
     pub fn new(surface: WlrLayerSurface, namespace: String) -> LayerSurface {
         LayerSurface(Arc::new(LayerSurfaceInner {
-            id: next_layer_id(),
+            id: layer_id::next(),
             surface,
             namespace,
             userdata: UserDataMap::new(),

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -25,7 +25,7 @@ use wayland_protocols::{
 };
 use wayland_server::protocol::wl_surface;
 
-crate::utils::ids::id_gen!(next_window_id, WINDOW_ID, WINDOW_IDS);
+crate::utils::ids::id_gen!(window_id);
 
 /// Represents the surface of a [`Window`]
 #[derive(Debug)]
@@ -48,7 +48,7 @@ pub(crate) struct WindowInner {
 
 impl Drop for WindowInner {
     fn drop(&mut self) {
-        WINDOW_IDS.lock().unwrap().remove(&self.id);
+        window_id::remove(self.id);
     }
 }
 
@@ -112,7 +112,7 @@ impl Window {
 
     /// Construct a new [`Window`] from a xdg toplevel surface
     pub fn new_wayland_window(toplevel: ToplevelSurface) -> Window {
-        let id = next_window_id();
+        let id = window_id::next();
 
         Window(Arc::new(WindowInner {
             id,
@@ -126,7 +126,7 @@ impl Window {
     /// Construct a new [`Window`] from an X11 surface
     #[cfg(feature = "xwayland")]
     pub fn new_x11_window(surface: X11Surface) -> Window {
-        let id = next_window_id();
+        let id = window_id::next();
 
         Window(Arc::new(WindowInner {
             id,

--- a/src/wayland/compositor/hook.rs
+++ b/src/wayland/compositor/hook.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-crate::utils::ids::id_gen!(next_hooks_id, HOOK_ID, HOOKS_IDS);
+crate::utils::ids::id_gen!(hooks_id);
 
 /// Unique hook identifier used to unregister commit/descruction hooks
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -23,7 +23,7 @@ impl<T: ?Sized> Clone for Hook<T> {
 impl<T: ?Sized> Hook<T> {
     pub fn new(cb: Arc<T>) -> Self {
         Self {
-            id: HookId(next_hooks_id()),
+            id: HookId(hooks_id::next()),
             cb,
         }
     }
@@ -31,6 +31,6 @@ impl<T: ?Sized> Hook<T> {
 
 impl<T: ?Sized> Drop for Hook<T> {
     fn drop(&mut self) {
-        HOOKS_IDS.lock().unwrap().remove(&self.id.0);
+        hooks_id::remove(self.id.0);
     }
 }

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -699,7 +699,7 @@ impl DmabufState {
             + 'static,
         F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
     {
-        let id = next_global_id();
+        let id = global_id::next();
 
         let formats = formats
             .or_else(|| default_feedback.map(|f| f.main_formats()))
@@ -785,7 +785,7 @@ impl DmabufState {
     /// It is highly recommended you disable the global before destroying it and ensure all child objects have
     /// been destroyed.
     pub fn destroy_global<D: 'static>(&mut self, display: &DisplayHandle, global: DmabufGlobal) {
-        if DMABUF_GLOBAL_IDS.lock().unwrap().remove(&global.id) {
+        if global_id::remove(global.id) {
             if let Some(global_state) = self.globals.remove(&global.id) {
                 display.remove_global::<D>(global_state.id);
             }
@@ -1234,4 +1234,4 @@ impl DmabufParamsData {
     }
 }
 
-id_gen!(next_global_id, DMABUF_GLOBAL_ID, DMABUF_GLOBAL_IDS);
+id_gen!(global_id);

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -216,7 +216,7 @@ pub use self::atoms::Atoms;
 
 use super::XWaylandClientData;
 
-crate::utils::ids::id_gen!(next_xwm_id, XWM_ID, XWM_IDS);
+crate::utils::ids::id_gen!(xwm_id);
 
 /// Id of an X11 WM
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -411,7 +411,7 @@ impl Drop for X11Wm {
     fn drop(&mut self) {
         // TODO: Not really needed for Xwayland, but maybe cleanup set root properties?
         let _ = self.conn.destroy_window(self.wm_window);
-        XWM_IDS.lock().unwrap().remove(&self.id.0);
+        xwm_id::remove(self.id.0);
     }
 }
 
@@ -682,7 +682,7 @@ impl X11Wm {
         D: xwayland_shell::XWaylandShellHandler,
         D: 'static,
     {
-        let id = XwmId(next_xwm_id());
+        let id = XwmId(xwm_id::next());
         let span = debug_span!("xwayland_wm", id = id.0);
         let _guard = span.enter();
 


### PR DESCRIPTION
The current id generation logic may return an ID that is already in the HashSet.

I've also simplified the usage of `id_gen!`.