### PR TITLE
expose multitexture get method

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1449,7 +1449,7 @@ impl MultiTexture {
         })))
     }
 
-    fn get<A: GraphicsApi + 'static>(
+    pub fn get<A: GraphicsApi + 'static>(
         &self,
         render: &DrmNode,
     ) -> Option<<<A::Device as ApiDevice>::Renderer as Renderer>::TextureId>

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1449,6 +1449,12 @@ impl MultiTexture {
         })))
     }
 
+    /// Attempt to get a texture of type `T: Renderer::TextureId` given the renderer type `A` for the given `DrmNode`.
+    ///
+    /// Will return `None` if either:
+    ///
+    /// - No textures are available for the Renderer type `A``
+    /// - No texture of type `T` is available for the given `DrmNode`
     pub fn get<A: GraphicsApi + 'static>(
         &self,
         render: &DrmNode,


### PR DESCRIPTION
The Multitexture get method, is useful for accessing the internal texture reference for a given DrmNode and a specific Renderer.
Exposing this method will allow Custom Renders to leverage the smithay automatic import of buffer while implementing their own rendering logic on the output elements