### PR TITLE
Apply protocol state in post-commit hooks

### DIFF
--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -299,7 +299,7 @@ fn add_constraint<D: SeatHandler + 'static>(
     });
 
     if added {
-        compositor::add_pre_commit_hook(surface, commit_hook::<D>);
+        compositor::add_post_commit_hook(surface, commit_hook::<D>);
     }
 }
 

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -124,7 +124,7 @@ where
                 if initial {
                     compositor::add_pre_commit_hook::<D, _>(&wl_surface, |_state, _dh, surface| {
                         compositor::with_states(surface, |states| {
-                            let mut guard = states
+                            let guard = states
                                 .data_map
                                 .get::<Mutex<LayerSurfaceAttributes>>()
                                 .unwrap()
@@ -147,8 +147,18 @@ where
                                     zwlr_layer_surface_v1::Error::InvalidSize,
                                     "height 0 requested without setting top and bottom anchors",
                                 );
-                                return;
                             }
+                        });
+                    });
+
+                    compositor::add_post_commit_hook::<D, _>(&wl_surface, |_state, _dh, surface| {
+                        compositor::with_states(surface, |states| {
+                            let mut guard = states
+                                .data_map
+                                .get::<Mutex<LayerSurfaceAttributes>>()
+                                .unwrap()
+                                .lock()
+                                .unwrap();
 
                             if let Some(state) = guard.last_acked.clone() {
                                 guard.current = state;

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -121,7 +121,7 @@ where
                 });
 
                 if initial {
-                    compositor::add_pre_commit_hook::<D, _>(
+                    compositor::add_post_commit_hook::<D, _>(
                         surface,
                         super::super::ToplevelSurface::commit_hook,
                     );
@@ -199,7 +199,14 @@ where
                 });
 
                 if initial {
-                    compositor::add_pre_commit_hook::<D, _>(surface, super::super::PopupSurface::commit_hook);
+                    compositor::add_pre_commit_hook::<D, _>(
+                        surface,
+                        super::super::PopupSurface::pre_commit_hook,
+                    );
+                    compositor::add_post_commit_hook::<D, _>(
+                        surface,
+                        super::super::PopupSurface::post_commit_hook,
+                    );
                 }
 
                 let popup = data_init.init(

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1851,11 +1851,11 @@ impl PopupSurface {
         self.send_configure_internal(Some(token))
     }
 
-    /// Handles the role specific commit logic
+    /// Handles the role specific commit error checking
     ///
     /// This should be called when the underlying WlSurface
     /// handles a wl_surface.commit request.
-    pub(crate) fn commit_hook<D: 'static>(
+    pub(crate) fn pre_commit_hook<D: 'static>(
         _state: &mut D,
         _dh: &DisplayHandle,
         surface: &wl_surface::WlSurface,
@@ -1879,9 +1879,18 @@ impl PopupSurface {
                 xdg_surface::Error::NotConstructed,
                 "Surface has not been configured yet.",
             );
-            return;
         }
+    }
 
+    /// Handles the role specific commit state application
+    ///
+    /// This should be called when the underlying WlSurface
+    /// applies a wl_surface.commit state.
+    pub(crate) fn post_commit_hook<D: 'static>(
+        _state: &mut D,
+        _dh: &DisplayHandle,
+        surface: &wl_surface::WlSurface,
+    ) {
         compositor::with_states(surface, |states| {
             let mut attributes = states
                 .data_map
@@ -1897,7 +1906,6 @@ impl PopupSurface {
                     }
                 }
             }
-            !attributes.initial_configure_sent
         });
     }
 

--- a/src/wayland/viewporter/mod.rs
+++ b/src/wayland/viewporter/mod.rs
@@ -167,7 +167,7 @@ where
 
                 // only add the pre-commit hook once for the surface
                 if initial {
-                    compositor::add_pre_commit_hook::<D, _>(&surface, viewport_commit_hook);
+                    compositor::add_pre_commit_hook::<D, _>(&surface, viewport_pre_commit_hook);
                 }
             }
             wp_viewporter::Request::Destroy => {
@@ -298,7 +298,11 @@ pub struct ViewportState {
 
 pub(crate) struct ViewportMarker(Weak<wp_viewport::WpViewport>);
 
-fn viewport_commit_hook<D: 'static>(_state: &mut D, _dh: &DisplayHandle, surface: &wl_surface::WlSurface) {
+fn viewport_pre_commit_hook<D: 'static>(
+    _state: &mut D,
+    _dh: &DisplayHandle,
+    surface: &wl_surface::WlSurface,
+) {
     with_states(surface, |states| {
         states
             .data_map


### PR DESCRIPTION
State should be applied on the actual commit. Pre-commit is too early, because the actual commit can and will be delayed by blockers. This would lead to inconsistent state where the current surface state is still old, but the protocol surface state is already new. Post-commit hook is the right place for this, it runs right after the current surface state is updated, and before the compositor commit handler is called.

After this change, my resize transactions impl in niri seems to work. Also, haven't run into any issues yet I think. But would be good for someone else to give this a try before merging. No compositor side changes are needed.