### PR TITLE
Add a new scalable client coordinate-space

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -1007,7 +1007,7 @@ impl AnvilState<UdevData> {
 
         if let Some(rect) = output_geometry {
             let tool = evt.tool();
-            tablet_seat.add_tool::<Self>(dh, &tool);
+            tablet_seat.add_tool::<Self>(self, dh, &tool);
 
             let pointer_location = evt.position_transformed(rect.size) + rect.loc.to_f64();
 

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -684,6 +684,8 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
     pub fn start_xwayland(&mut self) {
         use std::process::Stdio;
 
+        use smithay::wayland::compositor::CompositorHandler;
+
         let (xwayland, client) = XWayland::spawn(
             &self.display_handle,
             None,
@@ -702,6 +704,12 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                     x11_socket,
                     display_number,
                 } => {
+                    let xwayland_scale = std::env::var("ANVIL_XWAYLAND_SCALE")
+                        .ok()
+                        .and_then(|s| s.parse::<u32>().ok())
+                        .unwrap_or(1);
+                    data.client_compositor_state(&client)
+                        .set_client_scale(xwayland_scale);
                     let mut wm = X11Wm::start_wm(data.handle.clone(), x11_socket, client.clone())
                         .expect("Failed to attach X11 Window Manager");
 

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -8,6 +8,11 @@ use wayland_server::protocol::wl_output::Transform as WlTransform;
 #[derive(Debug)]
 pub struct Logical;
 
+/// Type-level marker for the client logical coordinate space
+#[derive(Debug)]
+#[cfg(feature = "wayland_frontend")]
+pub(crate) struct Client;
+
 /// Type-level marker for the physical coordinate space
 #[derive(Debug)]
 pub struct Physical;
@@ -454,6 +459,17 @@ impl<N: fmt::Debug, S> fmt::Debug for Point<N, S> {
 
 impl<N: Coordinate> Point<N, Logical> {
     #[inline]
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) fn to_client(self, scale: impl Into<Scale<N>>) -> Point<N, Client> {
+        let scale: Scale<N> = scale.into();
+        Point {
+            x: self.x.upscale(scale.x),
+            y: self.y.upscale(scale.y),
+            _kind: std::marker::PhantomData,
+        }
+    }
+
+    #[inline]
     /// Convert this logical point to physical coordinate space according to given scale factor
     pub fn to_physical(self, scale: impl Into<Scale<N>>) -> Point<N, Physical> {
         let scale = scale.into();
@@ -507,6 +523,19 @@ impl<N: Coordinate> Point<N, Logical> {
         Point {
             x: point.x.upscale(scale.x),
             y: point.y.upscale(scale.y),
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl<N: Coordinate> Point<N, Client> {
+    #[inline]
+    pub(crate) fn to_logical(self, scale: impl Into<Scale<N>>) -> Point<N, Logical> {
+        let scale = scale.into();
+        Point {
+            x: self.x.downscale(scale.x),
+            y: self.y.downscale(scale.y),
             _kind: std::marker::PhantomData,
         }
     }
@@ -769,6 +798,17 @@ impl<N: fmt::Debug, S> fmt::Debug for Size<N, S> {
 
 impl<N: Coordinate> Size<N, Logical> {
     #[inline]
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) fn to_client(self, scale: impl Into<Scale<N>>) -> Size<N, Client> {
+        let scale = scale.into();
+        Size {
+            w: self.w.upscale(scale.x),
+            h: self.h.upscale(scale.y),
+            _kind: std::marker::PhantomData,
+        }
+    }
+
+    #[inline]
     /// Convert this logical size to physical coordinate space according to given scale factor
     pub fn to_physical(self, scale: impl Into<Scale<N>>) -> Size<N, Physical> {
         let scale = scale.into();
@@ -818,6 +858,19 @@ impl<N: Coordinate> Size<N, Logical> {
             h: self.h.upscale(scale.y),
             _kind: std::marker::PhantomData,
         })
+    }
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl<N: Coordinate> Size<N, Client> {
+    #[inline]
+    pub(crate) fn to_logical(self, scale: impl Into<Scale<N>>) -> Size<N, Logical> {
+        let scale = scale.into();
+        Size {
+            w: self.w.downscale(scale.x),
+            h: self.h.downscale(scale.y),
+            _kind: std::marker::PhantomData,
+        }
     }
 }
 
@@ -1273,6 +1326,16 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
 }
 
 impl<N: Coordinate> Rectangle<N, Logical> {
+    #[inline]
+    #[cfg(feature = "xwayland")]
+    pub(crate) fn to_client(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Client> {
+        let scale = scale.into();
+        Rectangle {
+            loc: self.loc.to_client(scale),
+            size: self.size.to_client(scale),
+        }
+    }
+
     /// Convert this logical rectangle to physical coordinate space according to given scale factor
     #[inline]
     pub fn to_physical(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Physical> {
@@ -1338,6 +1401,18 @@ impl<N: Coordinate> Rectangle<N, Logical> {
                 h: rect.size.h.upscale(scale.y),
                 _kind: std::marker::PhantomData,
             },
+        }
+    }
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl<N: Coordinate> Rectangle<N, Client> {
+    #[inline]
+    pub(crate) fn to_logical(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Logical> {
+        let scale = scale.into();
+        Rectangle {
+            loc: self.loc.to_logical(scale),
+            size: self.size.to_logical(scale),
         }
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -18,6 +18,8 @@ pub use fd::*;
 #[cfg(feature = "wayland_frontend")]
 pub(crate) mod sealed_file;
 
+#[cfg(feature = "wayland_frontend")]
+pub(crate) use self::geometry::Client;
 pub use self::geometry::{
     Buffer, Coordinate, Logical, Physical, Point, Raw, Rectangle, Scale, Size, Transform,
 };

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -17,7 +17,7 @@ use wayland_server::{
 
 use crate::utils::{
     alive_tracker::{AliveTracker, IsAlive},
-    Logical, Point,
+    Client, Logical, Point,
 };
 
 use super::{
@@ -119,6 +119,7 @@ impl Cacheable for SurfaceAttributes {
             opaque_region: self.opaque_region.clone(),
             input_region: self.input_region.clone(),
             frame_callbacks: std::mem::take(&mut self.frame_callbacks),
+            client_scale: self.client_scale,
         }
     }
     fn merge_into(self, into: &mut Self, _dh: &DisplayHandle) {
@@ -143,6 +144,7 @@ impl Cacheable for SurfaceAttributes {
         into.opaque_region = self.opaque_region;
         into.input_region = self.input_region;
         into.frame_callbacks.extend(self.frame_callbacks);
+        into.client_scale = self.client_scale;
     }
 }
 
@@ -163,7 +165,7 @@ where
 {
     fn request(
         state: &mut D,
-        _client: &wayland_server::Client,
+        client: &wayland_server::Client,
         surface: &WlSurface,
         request: wl_surface::Request,
         _data: &SurfaceUserData,
@@ -172,7 +174,7 @@ where
     ) {
         match request {
             wl_surface::Request::Attach { buffer, x, y } => {
-                let offset: Point<i32, Logical> = (x, y).into();
+                let offset: Point<i32, Client> = (x, y).into();
                 let offset = (x != 0 || y != 0).then_some(offset);
 
                 // If version predates 5 just use the offset
@@ -190,6 +192,9 @@ where
                     None
                 };
 
+                let client_scale = state.client_compositor_state(client).client_scale() as i32;
+                let offset = offset.map(|p| p.to_logical(client_scale));
+
                 PrivateSurfaceData::with_states(surface, |states| {
                     let mut guard = states.cached_state.get::<SurfaceAttributes>();
                     let pending = guard.pending();
@@ -206,16 +211,17 @@ where
                 });
             }
             wl_surface::Request::Damage { x, y, width, height } => {
+                let client_scale = state.client_compositor_state(client).client_scale() as i32;
                 PrivateSurfaceData::with_states(surface, |states| {
                     states
                         .cached_state
                         .get::<SurfaceAttributes>()
                         .pending()
                         .damage
-                        .push(Damage::Surface(Rectangle::from_loc_and_size(
-                            (x, y),
-                            (width, height),
-                        )));
+                        .push(Damage::Surface(
+                            Rectangle::<i32, Client>::from_loc_and_size((x, y), (width, height))
+                                .to_logical(client_scale),
+                        ));
                 });
             }
             wl_surface::Request::Frame { callback } => {
@@ -257,6 +263,15 @@ where
                 });
             }
             wl_surface::Request::Commit => {
+                let client_scale = state.client_compositor_state(client).client_scale();
+                PrivateSurfaceData::with_states(surface, |states| {
+                    states
+                        .cached_state
+                        .get::<SurfaceAttributes>()
+                        .pending()
+                        .client_scale = client_scale;
+                });
+
                 PrivateSurfaceData::invoke_pre_commit_hooks(state, handle, surface);
 
                 PrivateSurfaceData::commit(surface, handle, state);
@@ -299,12 +314,13 @@ where
                 });
             }
             wl_surface::Request::Offset { x, y } => {
+                let client_scale = state.client_compositor_state(client).client_scale() as i32;
                 PrivateSurfaceData::with_states(surface, |states| {
                     states
                         .cached_state
                         .get::<SurfaceAttributes>()
                         .pending()
-                        .buffer_delta = Some((x, y).into());
+                        .buffer_delta = Some(Point::<i32, Client>::from((x, y)).to_logical(client_scale));
                 });
             }
             wl_surface::Request::Destroy => {
@@ -358,8 +374,8 @@ where
     D: CompositorHandler,
 {
     fn request(
-        _state: &mut D,
-        _client: &wayland_server::Client,
+        state: &mut D,
+        client: &wayland_server::Client,
         _resource: &WlRegion,
         request: wl_region::Request,
         data: &RegionUserData,
@@ -367,14 +383,16 @@ where
         _init: &mut wayland_server::DataInit<'_, D>,
     ) {
         let mut guard = data.inner.lock().unwrap();
+        let client_scale = state.client_compositor_state(client).client_scale() as i32;
+
         match request {
             wl_region::Request::Add { x, y, width, height } => guard.rects.push((
                 RectangleKind::Add,
-                Rectangle::from_loc_and_size((x, y), (width, height)),
+                Rectangle::<i32, Client>::from_loc_and_size((x, y), (width, height)).to_logical(client_scale),
             )),
             wl_region::Request::Subtract { x, y, width, height } => guard.rects.push((
                 RectangleKind::Subtract,
-                Rectangle::from_loc_and_size((x, y), (width, height)),
+                Rectangle::<i32, Client>::from_loc_and_size((x, y), (width, height)).to_logical(client_scale),
             )),
             wl_region::Request::Destroy => {
                 // all is handled by our destructor
@@ -533,8 +551,8 @@ where
     D: 'static,
 {
     fn request(
-        _state: &mut D,
-        _client: &wayland_server::Client,
+        state: &mut D,
+        client: &wayland_server::Client,
         subsurface: &WlSubsurface,
         request: wl_subsurface::Request,
         data: &SubsurfaceUserData,
@@ -543,12 +561,13 @@ where
     ) {
         match request {
             wl_subsurface::Request::SetPosition { x, y } => {
+                let client_scale = state.client_compositor_state(client).client_scale() as i32;
                 PrivateSurfaceData::with_states(&data.surface, |state| {
                     state
                         .cached_state
                         .get::<SubsurfaceCachedState>()
                         .pending()
-                        .location = (x, y).into();
+                        .location = Point::<i32, Client>::from((x, y)).to_logical(client_scale);
                 })
             }
             wl_subsurface::Request::PlaceAbove { sibling } => {

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -246,6 +246,8 @@ pub struct SurfaceAttributes {
     /// An example possibility would be to trigger it once the frame
     /// associated with this commit has been displayed on the screen.
     pub frame_callbacks: Vec<wl_callback::WlCallback>,
+
+    pub(crate) client_scale: u32,
 }
 
 impl Default for SurfaceAttributes {
@@ -259,6 +261,7 @@ impl Default for SurfaceAttributes {
             input_region: None,
             damage: Vec::new(),
             frame_callbacks: Vec::new(),
+            client_scale: 1,
         }
     }
 }

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -112,6 +112,8 @@ mod transaction;
 mod tree;
 
 use std::cell::RefCell;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
 use std::{any::Any, sync::Mutex};
 
 pub use self::cache::{Cacheable, MultiCache};
@@ -606,9 +608,19 @@ pub struct CompositorState {
 }
 
 /// Per-client state of a compositor
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct CompositorClientState {
     queue: Mutex<Option<TransactionQueue>>,
+    scale_override: Arc<AtomicU32>,
+}
+
+impl Default for CompositorClientState {
+    fn default() -> Self {
+        CompositorClientState {
+            queue: Mutex::new(None),
+            scale_override: Arc::new(AtomicU32::new(1)),
+        }
+    }
 }
 
 impl CompositorClientState {
@@ -625,6 +637,32 @@ impl CompositorClientState {
         for transaction in transactions {
             transaction.apply(dh, state)
         }
+    }
+
+    /// Set an additionally mapping between smithay's `Logical` coordinate space
+    /// and this clients logical coordinate space.
+    ///
+    /// This is used in the same way as if the client was setting the
+    /// surface.buffer_scale on every surface i.e a value of 2.0 will make
+    /// the windows appear smaller on a regular DPI monitor.
+    ///
+    /// Only the minimal set of protocols used by xwayland are guaranteed to be supported.
+    ///
+    /// Buffer sizes are unaffected.
+    pub fn set_client_scale(&self, new_scale: u32) {
+        self.scale_override.store(new_scale, Ordering::Release);
+    }
+
+    /// Get the scale factor of the additional mapping between smithay's `Logical`
+    /// coordinate space and this clients logical coordinate space.
+    ///
+    /// This is mainly intended to support out-of-tree protocol implementations.
+    pub fn client_scale(&self) -> u32 {
+        self.scale_override.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn clone_client_scale(&self) -> Arc<AtomicU32> {
+        self.scale_override.clone()
     }
 }
 

--- a/src/wayland/input_method/mod.rs
+++ b/src/wayland/input_method/mod.rs
@@ -6,16 +6,20 @@
 //! ```
 //! use smithay::{
 //!     delegate_seat, delegate_input_method_manager, delegate_text_input_manager,
+//! #   delegate_compositor,
 //! };
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::wayland::input_method::{InputMethodManagerState, InputMethodHandler, PopupSurface};
 //! use smithay::wayland::text_input::TextInputManagerState;
 //! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
+//! # use smithay::reexports::wayland_server::Client;
 //! use smithay::utils::{Rectangle, Logical};
 //!
 //! # struct State { seat_state: SeatState<Self> };
 //!
 //! delegate_seat!(State);
+//! # delegate_compositor!(State);
 //!
 //! impl InputMethodHandler for State {
 //!     fn new_popup(&mut self, surface: PopupSurface) {}
@@ -47,6 +51,12 @@
 //!     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //!     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
 //! }
+//!
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &WlSurface) {}
+//! # }
 //!
 //! // Add the seat state to your state and create manager globals
 //! InputMethodManagerState::new::<State, _>(&display_handle, |_client| true);

--- a/src/wayland/text_input/mod.rs
+++ b/src/wayland/text_input/mod.rs
@@ -8,10 +8,13 @@
 //! ```
 //! use smithay::{
 //!     delegate_seat, delegate_text_input_manager,
+//! #   delegate_compositor,
 //! };
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::wayland::text_input::TextInputManagerState;
 //! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
+//! # use smithay::reexports::wayland_server::Client;
 //!
 //! # struct State { seat_state: SeatState<Self> };
 //!
@@ -39,6 +42,12 @@
 //! // Add the seat state to your state and create manager global
 //! TextInputManagerState::new::<State>(&display_handle);
 //!
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &WlSurface) {}
+//! # }
+//! # delegate_compositor!(State);
 //! ```
 //!
 

--- a/src/wayland/virtual_keyboard/mod.rs
+++ b/src/wayland/virtual_keyboard/mod.rs
@@ -7,10 +7,13 @@
 //! ```
 //! use smithay::{
 //!     delegate_seat, delegate_virtual_keyboard_manager,
+//! #   delegate_compositor
 //! };
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::wayland::virtual_keyboard::VirtualKeyboardManagerState;
 //! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
+//! # use smithay::reexports::wayland_server::Client;
 //!
 //! # struct State { seat_state: SeatState<Self> };
 //!
@@ -39,6 +42,12 @@
 //! // to avoid untrusted clients requesting a new keyboard
 //! VirtualKeyboardManagerState::new::<State, _>(&display_handle, |_client| true);
 //!
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &WlSurface) {}
+//! # }
+//! # delegate_compositor!(State);
 //! ```
 //!
 

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -92,7 +92,7 @@
 //! ```
 
 use crate::{
-    utils::{x11rb::X11Source, Logical, Point, Rectangle, Size},
+    utils::{x11rb::X11Source, Client, Coordinate, Logical, Point, Rectangle, Size},
     wayland::{
         selection::SelectionTarget,
         xwayland_shell::{self, XWaylandShellHandler},
@@ -108,10 +108,13 @@ use std::{
         io::{AsFd, BorrowedFd, OwnedFd},
         net::UnixStream,
     },
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
 };
 use tracing::{debug, debug_span, error, info, trace, warn};
-use wayland_server::{Client, Resource};
+use wayland_server::Resource;
 
 pub use x11rb::protocol::xproto::Window as X11Window;
 use x11rb::{
@@ -386,6 +389,7 @@ pub trait XwmHandler {
 pub struct X11Wm {
     id: XwmId,
     conn: Arc<RustConnection>,
+    client_scale: Arc<AtomicU32>,
     screen: Screen,
     wm_window: X11Window,
     atoms: Atoms,
@@ -675,7 +679,7 @@ impl X11Wm {
     pub fn start_wm<D>(
         handle: LoopHandle<'static, D>,
         connection: UnixStream,
-        client: Client,
+        client: wayland_server::Client,
     ) -> Result<Self, Box<dyn std::error::Error>>
     where
         D: XwmHandler,
@@ -813,12 +817,11 @@ impl X11Wm {
         let conn = Arc::new(conn);
         let source = X11Source::new(Arc::clone(&conn), win, atoms._SMITHAY_CLOSE_CONNECTION);
 
+        let client_data = client.get_data::<XWaylandClientData>().unwrap();
+        let client_scale = client_data.compositor_state.clone_client_scale();
+
         // We need this for the commit hook.
-        client
-            .get_data::<XWaylandClientData>()
-            .unwrap()
-            .user_data()
-            .insert_if_missing(|| id);
+        client_data.user_data().insert_if_missing(|| id);
 
         let _xfixes_data = conn
             .query_extension(x11rb::protocol::xfixes::X11_EXTENSION_NAME.as_bytes())?
@@ -836,6 +839,7 @@ impl X11Wm {
         let wm = Self {
             id,
             conn,
+            client_scale,
             screen,
             atoms,
             wm_window: win,
@@ -1300,17 +1304,19 @@ where
             }
 
             let geo = conn.get_geometry(n.window)?.reply()?;
+            let geometry = Rectangle::<i32, Client>::from_loc_and_size(
+                (geo.x as i32, geo.y as i32),
+                (geo.width as i32, geo.height as i32),
+            )
+            .to_logical(xwm.client_scale.load(Ordering::Acquire) as i32);
 
             let surface = X11Surface::new(
-                xwm_id,
+                Some(xwm),
                 n.window,
                 n.override_redirect,
                 Arc::downgrade(&conn),
                 xwm.atoms,
-                Rectangle::from_loc_and_size(
-                    (geo.x as i32, geo.y as i32),
-                    (geo.width as i32, geo.height as i32),
-                ),
+                geometry,
             );
             surface.update_properties()?;
             xwm.windows.push(surface.clone());
@@ -1412,27 +1418,30 @@ where
         Event::ConfigureRequest(r) => {
             if let Some(surface) = xwm.windows.iter().find(|x| x.window_id() == r.window).cloned() {
                 drop(_guard);
+
+                let client_scale = xwm.client_scale.load(Ordering::Acquire);
+
                 // Pass the request to downstream to decide
                 state.configure_request(
                     xwm_id,
                     surface.clone(),
                     if u16::from(r.value_mask) & u16::from(ConfigWindow::X) != 0 {
-                        Some(i32::from(r.x))
+                        Some((r.x as i32).downscale(client_scale as i32))
                     } else {
                         None
                     },
                     if u16::from(r.value_mask) & u16::from(ConfigWindow::Y) != 0 {
-                        Some(i32::from(r.y))
+                        Some((r.y as i32).downscale(client_scale as i32))
                     } else {
                         None
                     },
                     if u16::from(r.value_mask) & u16::from(ConfigWindow::WIDTH) != 0 {
-                        Some(u32::from(r.width))
+                        Some((r.width as u32).downscale(client_scale))
                     } else {
                         None
                     },
                     if u16::from(r.value_mask) & u16::from(ConfigWindow::HEIGHT) != 0 {
-                        Some(u32::from(r.height))
+                        Some((r.height as u32).downscale(client_scale))
                     } else {
                         None
                     },
@@ -1467,6 +1476,14 @@ where
         }
         Event::ConfigureNotify(n) => {
             trace!(window = ?n, "configured X11 Window");
+
+            let client_scale = xwm.client_scale.load(Ordering::Acquire);
+            let geometry = Rectangle::<i32, Client>::from_loc_and_size(
+                (n.x as i32, n.y as i32),
+                (n.width as i32, n.height as i32),
+            )
+            .to_logical(client_scale as i32);
+
             if let Some(surface) = xwm
                 .windows
                 .iter()
@@ -1477,7 +1494,7 @@ where
                 state.configure_notify(
                     xwm_id,
                     surface,
-                    Rectangle::from_loc_and_size((n.x as i32, n.y as i32), (n.width as i32, n.height as i32)),
+                    geometry,
                     if n.above_sibling == x11rb::NONE {
                         None
                     } else {
@@ -1486,10 +1503,6 @@ where
                 );
             } else if let Some(surface) = xwm.windows.iter().find(|x| x.window_id() == n.window).cloned() {
                 if surface.is_override_redirect() {
-                    let geometry = Rectangle::from_loc_and_size(
-                        (n.x as i32, n.y as i32),
-                        (n.width as i32, n.height as i32),
-                    );
                     surface.state.lock().unwrap().geometry = geometry;
                     drop(_guard);
                     state.configure_notify(
@@ -2418,7 +2431,7 @@ fn send_selection_notify_resp(
 fn send_configure_notify(
     conn: &RustConnection,
     win: &X11Window,
-    geometry: Rectangle<i32, Logical>,
+    geometry: Rectangle<i32, Client>,
     override_redirect: bool,
 ) -> Result<(), ConnectionError> {
     conn.send_event(

--- a/src/xwayland/xwm/settings.rs
+++ b/src/xwayland/xwm/settings.rs
@@ -1,0 +1,239 @@
+//! Types related to XSETTINGS handling
+//!
+//! See https://specifications.freedesktop.org/xsettings-spec/0.5/
+
+use std::{borrow::Borrow, collections::HashMap, hash::Hash};
+
+use tracing::debug;
+use x11rb::{
+    connection::Connection,
+    errors::{ConnectionError, ReplyOrIdError},
+    protocol::xproto::{ConnectionExt as _, PropMode, Window, WindowClass},
+    rust_connection::RustConnection,
+    wrapper::ConnectionExt as _,
+};
+// use std::{borrow::Borrow, hash::Hash};
+
+#[derive(Debug)]
+pub(super) struct XSettings {
+    pub(super) window: Window,
+    atoms: super::Atoms,
+    values: HashMap<String, Setting>,
+    current_serial: u32,
+}
+
+#[derive(Debug)]
+struct Setting {
+    val: Value,
+    last_changed_serial: u32,
+}
+
+#[derive(Debug)]
+/// XSETTINGS value
+pub enum Value {
+    /// String value
+    String(String),
+    /// Integer value
+    Integer(i32),
+    /// Color value
+    Color([u16; 4]),
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Value::String(value)
+    }
+}
+impl From<i32> for Value {
+    fn from(value: i32) -> Self {
+        Value::Integer(value)
+    }
+}
+impl From<[u16; 4]> for Value {
+    fn from(value: [u16; 4]) -> Self {
+        Value::Color(value)
+    }
+}
+
+const fn pad(len: usize) -> usize {
+    (4 - (len % 4)) % 4
+}
+
+/// XSETTINGS Name validation error
+#[derive(Debug, thiserror::Error)]
+pub enum NameError {
+    /// Name contained an invalid character. Only a-z, A-Z, 0-9, /, _ are allowed.
+    #[error("Name contained an invalid character. Only a-z, A-Z, 0-9, /, _ are allowed.")]
+    DisallowedCharacter,
+    /// Name started or ended on a slash.
+    #[error("Name started or ended on a slash.")]
+    SlashAtStartOrEnd,
+    /// Name contained two consecutive slashes.
+    #[error("Name contained two consecutive slashes.")]
+    DoubleSlash,
+    /// Name contained a number at the start or immediately following a slash.
+    #[error("Name contained a number at the start or immediately following a slash.")]
+    LeadingNumber,
+    /// Name was empty.
+    #[error("Name was empty.")]
+    EmptyName,
+}
+
+impl XSettings {
+    pub(super) fn new(
+        conn: &RustConnection,
+        depth: u8,
+        root: Window,
+        atoms: &super::Atoms,
+    ) -> Result<XSettings, ReplyOrIdError> {
+        let win = conn.generate_id()?;
+        conn.create_window(
+            depth,
+            win,
+            root,
+            // x, y, width, height, border width
+            0,
+            0,
+            1,
+            1,
+            0,
+            WindowClass::INPUT_OUTPUT,
+            x11rb::COPY_FROM_PARENT,
+            &Default::default(),
+        )?;
+        conn.set_selection_owner(win, atoms._XSETTINGS_S0, x11rb::CURRENT_TIME)?;
+        debug!(window = win, "Created XSettings window");
+
+        let mut this = XSettings {
+            window: win,
+            atoms: *atoms,
+            values: HashMap::default(),
+            current_serial: 0,
+        };
+        this.update(conn)?;
+        Ok(this)
+    }
+
+    pub fn set(&mut self, name: impl Into<String>, value: impl Into<Value>) -> Result<(), NameError> {
+        let name = name.into();
+        if name
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '/' || c == '_'))
+            .is_some()
+        {
+            return Err(NameError::DisallowedCharacter);
+        }
+        if name.is_empty() {
+            return Err(NameError::EmptyName);
+        }
+        if name.starts_with('/') || name.ends_with('/') {
+            return Err(NameError::SlashAtStartOrEnd);
+        }
+        if name.split('/').any(str::is_empty) {
+            return Err(NameError::DoubleSlash);
+        }
+        if name
+            .split('/')
+            .any(|s| str::starts_with(s, |c: char| c.is_ascii_digit()))
+        {
+            return Err(NameError::LeadingNumber);
+        }
+
+        self.values.insert(
+            name,
+            Setting {
+                val: value.into(),
+                last_changed_serial: self.current_serial,
+            },
+        );
+
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn get<Q>(&self, name: &Q) -> Option<&Value>
+    where
+        Q: Hash + Eq + ?Sized,
+        String: Borrow<Q>,
+    {
+        self.values.get(name).map(|setting| &setting.val)
+    }
+
+    #[allow(dead_code)]
+    pub fn remove<Q>(&mut self, name: &Q) -> Option<Value>
+    where
+        Q: Hash + Eq + ?Sized,
+        String: Borrow<Q>,
+    {
+        self.values.remove(name).map(|setting| setting.val)
+    }
+
+    fn serialize(&mut self) -> Vec<u8> {
+        let mut data = Vec::new();
+
+        if cfg!(target_endian = "little") {
+            data.push(0);
+        } else {
+            data.push(1);
+        }
+        data.extend_from_slice(&[0u8; 3]);
+        data.extend_from_slice(&self.current_serial.to_ne_bytes());
+        data.extend_from_slice(&(self.values.len() as i32).to_ne_bytes());
+
+        for (name, setting) in self.values.iter() {
+            debug_assert!(name.is_ascii());
+            let name = name.as_bytes();
+
+            data.extend(&setting.val._type().to_ne_bytes());
+            data.push(0u8);
+            data.extend(&(name.len() as u16).to_ne_bytes());
+            data.extend(name);
+            data.extend(std::iter::repeat(0u8).take(pad(name.len())));
+            data.extend(&setting.last_changed_serial.to_ne_bytes());
+
+            setting.val.serialize(&mut data);
+        }
+
+        self.current_serial = self.current_serial.wrapping_add(1);
+
+        data
+    }
+
+    pub(super) fn update(&mut self, conn: &RustConnection) -> Result<(), ConnectionError> {
+        conn.change_property8(
+            PropMode::REPLACE,
+            self.window,
+            self.atoms._XSETTINGS_SETTINGS,
+            self.atoms._XSETTINGS_SETTINGS,
+            &self.serialize(),
+        )
+        .map(|_| ())
+    }
+}
+
+impl Value {
+    fn _type(&self) -> i8 {
+        match self {
+            Value::Integer(_) => 0,
+            Value::String(_) => 1,
+            Value::Color(_) => 2,
+        }
+    }
+
+    fn serialize(&self, data: &mut Vec<u8>) {
+        match self {
+            Value::Integer(val) => {
+                data.extend(&val.to_ne_bytes());
+            }
+            Value::String(val) => {
+                let val = val.as_bytes();
+                data.extend(&(val.len() as u32).to_ne_bytes());
+                data.extend(val)
+            }
+            Value::Color(val) => {
+                for component in val {
+                    data.extend(&component.to_ne_bytes());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Alright, so this is an attempt at allowing Xwayland to be scaled similar to what KDE does.

The approach is quite generic though (and very similar in concept to what kwin does internally: https://invent.kde.org/plasma/kwin/-/merge_requests/2288).

We basically introduce a differentiation between the client's coordinate space and our `Logical` coordinate space. On every value reaching us from wayland or x11 we undo any scaling factor (saved in the `CompositorClientState`) and reapply it when sending values back.

This way we can pretend a client has an additional e.g. 2x scaling factor, decoupling the scale each client has from what it is telling us and allowing the compositor to override that seamlessly (without doing a bunch of annoying calculations itself).

To do these calculations somewhat sanely internally, this introduces a new (private) `Client`-coordinate space, which all incoming and outgoing values should be serialized into. This obviously still isn't 100% type-safe as wayland-server is just using primitive values, but can catch a few bugs this way at least.

Last but not least we use the `surface_view` infrastructure to automatically descale any buffers before rendering via smithay's infrastructure. (A compositor handling wl_buffers on it's own will obviously have to handle the larger buffers itself.)

Anvil now gains a new env-variable to override the scale factor of Xwayland. (Mainly because I didn't want to deal with making this properly dynamic in anvil, which requires to also update all `Output`s and set `Xft.dpi` on the xresources database. So for now use something like `GDK_SCALE=2` to test.)

Xwayland handling in anvil still seems a bit broken, often mismatching window dimensions resulting in missed input. This seems to be the same no matter if this PR is used or not, so unrelated, but I'll leave this a draft until other compositors make use of this as well. It is very much ready for review though. (Best commit-by-commit.)