### PR TITLE
Use `CLOCK_MONOTONIC` instead of `0` for synthetic input events

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -612,7 +612,7 @@ impl AnvilState<UdevData> {
                             &MotionEvent {
                                 location,
                                 serial: SCOUNTER.next_serial(),
-                                time: 0,
+                                time: self.clock.now().as_millis(),
                             },
                         );
                         pointer.frame(self);
@@ -650,7 +650,7 @@ impl AnvilState<UdevData> {
                             &MotionEvent {
                                 location: pointer_location,
                                 serial: SCOUNTER.next_serial(),
-                                time: 0,
+                                time: self.clock.now().as_millis(),
                             },
                         );
                         pointer.frame(self);
@@ -689,7 +689,7 @@ impl AnvilState<UdevData> {
                             &MotionEvent {
                                 location: pointer_location,
                                 serial: SCOUNTER.next_serial(),
-                                time: 0,
+                                time: self.clock.now().as_millis(),
                             },
                         );
                         pointer.frame(self);
@@ -955,7 +955,7 @@ impl AnvilState<UdevData> {
                 &MotionEvent {
                     location: pointer_location,
                     serial: SCOUNTER.next_serial(),
-                    time: 0,
+                    time: self.clock.now().as_millis(),
                 },
             );
 
@@ -1022,7 +1022,7 @@ impl AnvilState<UdevData> {
                 &MotionEvent {
                     location: pointer_location,
                     serial: SCOUNTER.next_serial(),
-                    time: 0,
+                    time: evt.time_msec(),
                 },
             );
             pointer.frame(self);

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -21,7 +21,7 @@
 use std::io::Error as IoError;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use calloop::generic::Generic;
 use calloop::{EventSource, Interest, PostAction, Readiness, Token};
@@ -52,7 +52,7 @@ use crate::{
             Bind,
         },
     },
-    utils::{Physical, Rectangle, Size},
+    utils::{Clock, Monotonic, Physical, Rectangle, Size},
 };
 
 mod input;
@@ -204,7 +204,7 @@ where
         WinitEventLoop {
             inner: WinitEventLoopInner {
                 scale_factor: window.scale_factor(),
-                start_time: Instant::now(),
+                clock: Clock::<Monotonic>::new(),
                 key_counter: 0,
                 window,
                 is_x11,
@@ -360,7 +360,7 @@ where
 #[derive(Debug)]
 struct WinitEventLoopInner {
     window: Arc<WinitWindow>,
-    start_time: Instant,
+    clock: Clock<Monotonic>,
     key_counter: u32,
     is_x11: bool,
     scale_factor: f64,
@@ -418,7 +418,7 @@ struct WinitEventLoopApp<'a, F: FnMut(WinitEvent)> {
 
 impl<'a, F: FnMut(WinitEvent)> WinitEventLoopApp<'a, F> {
     fn timestamp(&self) -> u64 {
-        self.inner.start_time.elapsed().as_micros() as u64
+        self.inner.clock.now().as_micros()
     }
 }
 

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     backend::input::{Axis, AxisRelativeDirection, AxisSource, ButtonState},
     input::{GrabStatus, Seat, SeatHandler},
     utils::Serial,
-    utils::{IsAlive, Logical, Point},
+    utils::{Clock, IsAlive, Logical, Monotonic, Point},
 };
 
 mod cursor_image;
@@ -724,7 +724,7 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
                 &MotionEvent {
                     location,
                     serial,
-                    time: 0,
+                    time: Clock::<Monotonic>::new().now().as_millis(),
                 },
             );
         }

--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -65,6 +65,30 @@ impl<Kind> Time<Kind> {
     }
 }
 
+impl Time<Monotonic> {
+    /// Returns the time in milliseconds
+    ///
+    /// This should match timestamps from libinput:
+    /// https://wayland.freedesktop.org/libinput/doc/latest/timestamps.html
+    pub fn as_millis(&self) -> u32 {
+        // Assume monotonic clock (but not realitime) fits as milliseconds in 32-bit
+        debug_assert!(self.tp.tv_sec >= 0);
+        debug_assert!(self.tp.tv_nsec >= 0);
+        self.tp.tv_sec as u32 * 1000 + self.tp.tv_nsec as u32 / 1000000
+    }
+
+    /// Returns the time in microseconds
+    ///
+    /// This should match timestamps from libinput:
+    /// https://wayland.freedesktop.org/libinput/doc/latest/timestamps.html
+    pub fn as_micros(&self) -> u64 {
+        // Assume monotonic clock (but not realitime) fits as microseconds in 64-bit
+        debug_assert!(self.tp.tv_sec >= 0);
+        debug_assert!(self.tp.tv_nsec >= 0);
+        self.tp.tv_sec as u64 * 1000000 + self.tp.tv_nsec as u64 / 1000
+    }
+}
+
 impl<Kind> Clone for Time<Kind> {
     #[inline]
     fn clone(&self) -> Self {


### PR DESCRIPTION
This should match the timestamp on input events from libinput. As far as I'm aware, this is more correct than using `0`.