### PR TITLE
Expose `SerializedMods` type publicly in API

### DIFF
--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -24,7 +24,7 @@ mod keymap_file;
 pub use keymap_file::KeymapFile;
 
 mod modifiers_state;
-pub use modifiers_state::ModifiersState;
+pub use modifiers_state::{ModifiersState, SerializedMods};
 
 mod xkb_config;
 pub use xkb_config::XkbConfig;

--- a/src/input/keyboard/modifiers_state.rs
+++ b/src/input/keyboard/modifiers_state.rs
@@ -50,11 +50,16 @@ impl ModifiersState {
     }
 }
 
+/// Serialized modifier state
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct SerializedMods {
+    /// Depressed modifiers
     pub depressed: u32,
+    /// Latched modifiers
     pub latched: u32,
+    /// Locked modifiers
     pub locked: u32,
+    /// Effective keyboard layout
     pub layout_effective: u32,
 }
 


### PR DESCRIPTION
The type is used as a public member of `ModifiersState`, and was public but not nameable. It seems better to add a `pub use` for the type.