### PR TITLE
Fixup Seat ref count cycles

### DIFF
--- a/src/input/touch/mod.rs
+++ b/src/input/touch/mod.rs
@@ -5,6 +5,8 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 
 use tracing::{info_span, instrument};
+#[cfg(feature = "wayland_frontend")]
+use wayland_server::Weak;
 
 use crate::backend::input::TouchSlot;
 use crate::utils::{IsAlive, Logical, Point, Serial, SerialCounter};
@@ -28,7 +30,7 @@ pub struct TouchHandle<D: SeatHandler> {
     pub(crate) inner: Arc<Mutex<TouchInternal<D>>>,
     #[cfg(feature = "wayland_frontend")]
     pub(crate) known_instances:
-        Arc<Mutex<Vec<(wayland_server::protocol::wl_touch::WlTouch, Option<Serial>)>>>,
+        Arc<Mutex<Vec<(Weak<wayland_server::protocol::wl_touch::WlTouch>, Option<Serial>)>>>,
     pub(crate) span: tracing::Span,
 }
 

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -78,7 +78,7 @@ where
                 );
             }
         }
-        self.arc.known_kbds.lock().unwrap().push(kbd);
+        self.arc.known_kbds.lock().unwrap().push(kbd.downgrade());
     }
 }
 
@@ -141,6 +141,10 @@ pub(crate) fn for_each_focused_kbds<D: SeatHandler + 'static>(
     if let Some(keyboard) = seat.get_keyboard() {
         let inner = keyboard.arc.known_kbds.lock().unwrap();
         for kbd in &*inner {
+            let Ok(kbd) = kbd.upgrade() else {
+                continue;
+            };
+
             if kbd.id().same_client_as(&surface.id()) {
                 f(kbd.clone())
             }


### PR DESCRIPTION
Before:
```mermaid
flowchart TD
    WlKeyboard ---> KeyboardUserData --> KeyboardHandle --> KbdRc --> WlKeyboard
    WlPointer ---> PointerUserData --> PointerHandle --> WlPointerHandle  --> WlPointer
    WlTouch ---> TouchUserData --> TouchHandle ---> WlTouch
```
After:
```mermaid
flowchart TD
    WlKeyboard ---> KeyboardUserData --> KeyboardHandle --> KbdRc -.-> |Weak| WlKeyboard
    WlPointer ---> PointerUserData --> PointerHandle --> WlPointerHandle  -.-> |Weak| WlPointer
    WlTouch ---> TouchUserData --> TouchHandle -.-> |Weak| WlTouch
```