### PR TITLE
Revert "xwm: Don't reparent on unmap"

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1583,6 +1583,12 @@ where
                     )?;
                     {
                         let mut state = surface.state.lock().unwrap();
+                        conn.reparent_window(
+                            n.window,
+                            xwm.screen.root,
+                            state.geometry.loc.x as i16,
+                            state.geometry.loc.y as i16,
+                        )?;
                         if let Some(frame) = state.mapped_onto.take() {
                             conn.destroy_window(frame)?;
                         }


### PR DESCRIPTION
This reverts commit c6aab182a3c9f106d9c7a0ea34187f90403e59e7.

@ids1024 pointed out that this is likely responsible for https://github.com/pop-os/cosmic-epoch/issues/835 and similar issues.

I remember the reason for this fix being some misbehaving clients on minimize, that would immediately restore themselves again. I can't reproduce this reverting just this commit with current cosmic-comp. Even if there is 1 in 10 clients, this is clearly an improvement to killing X11 clients and further issues should probably be debugged separately.