### PR TITLE
Mark constants functions with const

### DIFF
--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -424,12 +424,12 @@ pub struct DmabufMapping {
 
 impl DmabufMapping {
     /// Access the raw pointer of the mapping
-    pub fn ptr(&self) -> *mut std::ffi::c_void {
+    pub const fn ptr(&self) -> *mut std::ffi::c_void {
         self.ptr
     }
 
     /// Access the length of the mapping
-    pub fn length(&self) -> usize {
+    pub const fn length(&self) -> usize {
         self.len
     }
 }

--- a/src/backend/allocator/dumb.rs
+++ b/src/backend/allocator/dumb.rs
@@ -37,7 +37,7 @@ pub struct DumbAllocator {
 
 impl DumbAllocator {
     /// Create a new [`DumbAllocator`] from a [`DrmDeviceFd`].
-    pub fn new(fd: DrmDeviceFd) -> Self {
+    pub const fn new(fd: DrmDeviceFd) -> Self {
         DumbAllocator { fd }
     }
 }
@@ -96,7 +96,7 @@ impl DumbBuffer {
     ///
     /// Note: This handle will become invalid, once the `DumbBuffer` wrapper is dropped
     /// or the device used to create is closed. Do not copy this handle and assume it keeps being valid.
-    pub fn handle(&self) -> &Handle {
+    pub const fn handle(&self) -> &Handle {
         &self.handle
     }
 }

--- a/src/backend/allocator/format.rs
+++ b/src/backend/allocator/format.rs
@@ -127,7 +127,7 @@ macro_rules! format_tables {
             }
         }
 
-        fn _impl_formats() -> &'static [$crate::backend::allocator::Fourcc] {
+        const fn _impl_formats() -> &'static [$crate::backend::allocator::Fourcc] {
             &[
                 $(
                     $crate::backend::allocator::Fourcc::$fourcc,

--- a/src/backend/allocator/gbm.rs
+++ b/src/backend/allocator/gbm.rs
@@ -154,7 +154,7 @@ impl<A: AsFd + 'static> AsFd for GbmAllocator<A> {
 impl<A: AsFd + 'static> GbmAllocator<A> {
     /// Create a new [`GbmAllocator`] from a [`GbmDevice`] with some default usage flags,
     /// to be used when [`Allocator::create_buffer`] is invoked.
-    pub fn new(device: GbmDevice<A>, default_flags: GbmBufferFlags) -> GbmAllocator<A> {
+    pub const fn new(device: GbmDevice<A>, default_flags: GbmBufferFlags) -> GbmAllocator<A> {
         GbmAllocator {
             device,
             default_flags,

--- a/src/backend/allocator/swapchain.rs
+++ b/src/backend/allocator/swapchain.rs
@@ -255,7 +255,7 @@ where
     }
 
     /// Get set format
-    pub fn format(&self) -> Fourcc {
+    pub const fn format(&self) -> Fourcc {
         self.fourcc
     }
 }

--- a/src/backend/allocator/vulkan/mod.rs
+++ b/src/backend/allocator/vulkan/mod.rs
@@ -345,7 +345,7 @@ impl VulkanAllocator {
     }
 
     /// Returns the [`PhysicalDevice`] this allocator was created with.
-    pub fn physical_device(&self) -> &PhysicalDevice {
+    pub const fn physical_device(&self) -> &PhysicalDevice {
         &self.phd
     }
 }

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -180,14 +180,14 @@ pub mod gbm;
 use elements::*;
 
 impl RenderElementState {
-    pub(crate) fn zero_copy(visible_area: usize) -> Self {
+    pub(crate) const fn zero_copy(visible_area: usize) -> Self {
         RenderElementState {
             visible_area,
             presentation_state: RenderElementPresentationState::ZeroCopy,
         }
     }
 
-    pub(crate) fn rendering_with_reason(reason: RenderingReason) -> Self {
+    pub(crate) const fn rendering_with_reason(reason: RenderingReason) -> Self {
         RenderElementState {
             visible_area: 0,
             presentation_state: RenderElementPresentationState::Rendering { reason: Some(reason) },
@@ -2905,7 +2905,7 @@ where
     }
 
     /// Returns the current enabled [`DebugFlags`]
-    pub fn debug_flags(&self) -> DebugFlags {
+    pub const fn debug_flags(&self) -> DebugFlags {
         self.debug_flags
     }
 
@@ -2915,7 +2915,7 @@ where
     }
 
     /// Get the format of the underlying swapchain
-    pub fn format(&self) -> DrmFourcc {
+    pub const fn format(&self) -> DrmFourcc {
         self.swapchain.format()
     }
 
@@ -4205,7 +4205,7 @@ fn apply_underlying_storage_transform(
 }
 
 #[inline]
-fn apply_output_transform(transform: Transform, output_transform: Transform) -> Transform {
+const fn apply_output_transform(transform: Transform, output_transform: Transform) -> Transform {
     match (transform, output_transform) {
         (Transform::Normal, output_transform) => output_transform,
 

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -139,14 +139,14 @@ pub enum DrmDeviceInternal {
 }
 
 impl DrmDeviceInternal {
-    pub(crate) fn device_fd(&self) -> &DrmDeviceFd {
+    pub(crate) const fn device_fd(&self) -> &DrmDeviceFd {
         match self {
             DrmDeviceInternal::Atomic(dev) => &dev.fd,
             DrmDeviceInternal::Legacy(dev) => &dev.fd,
         }
     }
 
-    fn span(&self) -> &tracing::Span {
+    const fn span(&self) -> &tracing::Span {
         match self {
             DrmDeviceInternal::Atomic(internal) => &internal.span,
             DrmDeviceInternal::Legacy(internal) => &internal.span,
@@ -281,7 +281,7 @@ impl DrmDevice {
     }
 
     /// Claim a plane so that it won't be used by a different crtc
-    ///  
+    ///
     /// Returns `None` if the plane could not be claimed
     pub fn claim_plane(&self, plane: plane::Handle, crtc: crtc::Handle) -> Option<PlaneClaim> {
         self.plane_claim_storage.claim(plane, crtc)
@@ -292,7 +292,7 @@ impl DrmDevice {
     /// Note: In case of universal planes this is the
     /// maximum size of a buffer that can be used on
     /// the cursor plane.
-    pub fn cursor_size(&self) -> Size<u32, Buffer> {
+    pub const fn cursor_size(&self) -> Size<u32, Buffer> {
         self.cursor_size
     }
 
@@ -401,7 +401,7 @@ impl DrmDevice {
     }
 
     /// Returns the device_id of the underlying drm node
-    pub fn device_id(&self) -> dev_t {
+    pub const fn device_id(&self) -> dev_t {
         self.dev_id
     }
 

--- a/src/backend/drm/node/mod.rs
+++ b/src/backend/drm/node/mod.rs
@@ -65,12 +65,12 @@ impl DrmNode {
     }
 
     /// Returns the type of the DRM node.
-    pub fn ty(&self) -> NodeType {
+    pub const fn ty(&self) -> NodeType {
         self.ty
     }
 
     /// Returns the device_id of the underlying DRM node.
-    pub fn dev_id(&self) -> dev_t {
+    pub const fn dev_id(&self) -> dev_t {
         self.dev
     }
 
@@ -148,7 +148,7 @@ impl NodeType {
     /// Returns a string representing the prefix of a minor device's name.
     ///
     /// For example, on Linux with a primary node, the returned string would be `card`.
-    pub fn minor_name_prefix(&self) -> &str {
+    pub const fn minor_name_prefix(&self) -> &str {
         match self {
             NodeType::Primary => PRIMARY_NAME,
             NodeType::Control => CONTROL_NAME,

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -460,7 +460,7 @@ where
     }
 
     /// Tries to mark a [`connector`](drm::control::connector)
-    /// for removal on the next commit.    
+    /// for removal on the next commit.
     pub fn remove_connector(&self, connector: connector::Handle) -> Result<(), Error<A::Error>> {
         self.drm.remove_connector(connector).map_err(Error::DrmError)
     }
@@ -470,19 +470,19 @@ where
     /// Fails if one new `connector` is not compatible with the underlying [`crtc`](drm::control::crtc)
     /// (e.g. no suitable [`encoder`](drm::control::encoder) may be found)
     /// or is not compatible with the currently pending
-    /// [`Mode`](drm::control::Mode).    
+    /// [`Mode`](drm::control::Mode).
     pub fn set_connectors(&self, connectors: &[connector::Handle]) -> Result<(), Error<A::Error>> {
         self.drm.set_connectors(connectors).map_err(Error::DrmError)
     }
 
     /// Returns the currently active [`Mode`](drm::control::Mode)
-    /// of the underlying [`crtc`](drm::control::crtc)    
+    /// of the underlying [`crtc`](drm::control::crtc)
     pub fn current_mode(&self) -> Mode {
         self.drm.current_mode()
     }
 
     /// Returns the currently pending [`Mode`](drm::control::Mode)
-    /// to be used after the next commit.    
+    /// to be used after the next commit.
     pub fn pending_mode(&self) -> Mode {
         self.drm.pending_mode()
     }
@@ -506,7 +506,7 @@ where
     }
 
     /// Get the format of the underlying swapchain
-    pub fn format(&self) -> Fourcc {
+    pub const fn format(&self) -> Fourcc {
         self.swapchain.format()
     }
 }

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -190,17 +190,17 @@ impl DrmSurface {
     }
 
     /// Returns the underlying [`crtc`](drm::control::crtc) of this surface
-    pub fn crtc(&self) -> crtc::Handle {
+    pub const fn crtc(&self) -> crtc::Handle {
         self.crtc
     }
 
     /// Returns the underlying primary [`plane`](drm::control::plane) of this surface
-    pub fn plane(&self) -> plane::Handle {
+    pub const fn plane(&self) -> plane::Handle {
         self.primary_plane.0.handle
     }
 
     /// Returns the [`PlaneInfo`] of the underlying primary [`plane`](drm::control::plane) of this surface
-    pub fn plane_info(&self) -> &PlaneInfo {
+    pub const fn plane_info(&self) -> &PlaneInfo {
         &self.primary_plane.0
     }
 
@@ -392,12 +392,12 @@ impl DrmSurface {
     }
 
     /// Returns a set of available planes for this surface
-    pub fn planes(&self) -> &Planes {
+    pub const fn planes(&self) -> &Planes {
         &self.planes
     }
 
     /// Claim a plane so that it won't be used by a different crtc
-    ///  
+    ///
     /// Returns `None` if the plane could not be claimed
     pub fn claim_plane(&self, plane: plane::Handle) -> Option<PlaneClaim> {
         // Validate that we are called with an plane that belongs to us

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -419,12 +419,12 @@ impl EGLContext {
     }
 
     /// Returns the egl config for this context
-    pub fn config_id(&self) -> ffi::egl::types::EGLConfig {
+    pub const fn config_id(&self) -> ffi::egl::types::EGLConfig {
         self.config_id
     }
 
     /// Returns the pixel format of the main framebuffer of the context.
-    pub fn pixel_format(&self) -> Option<PixelFormat> {
+    pub const fn pixel_format(&self) -> Option<PixelFormat> {
         self.pixel_format
     }
 
@@ -448,17 +448,17 @@ impl EGLContext {
     }
 
     /// Returns the display which created this context.
-    pub fn display(&self) -> &EGLDisplay {
+    pub const fn display(&self) -> &EGLDisplay {
         &self.display
     }
 
     /// Returns a list of formats for dmabufs that can be rendered to.
-    pub fn dmabuf_render_formats(&self) -> &FormatSet {
+    pub const fn dmabuf_render_formats(&self) -> &FormatSet {
         self.display.dmabuf_render_formats()
     }
 
     /// Returns a list of formats for dmabufs that can be used as textures.
-    pub fn dmabuf_texture_formats(&self) -> &FormatSet {
+    pub const fn dmabuf_texture_formats(&self) -> &FormatSet {
         self.display.dmabuf_texture_formats()
     }
 
@@ -473,7 +473,7 @@ impl EGLContext {
     /// Get a raw handle to the underlying context.
     ///
     /// The pointer will become invalid, when this struct is destroyed.
-    pub fn get_context_handle(&self) -> ffi::egl::types::EGLContext {
+    pub const fn get_context_handle(&self) -> ffi::egl::types::EGLContext {
         self.context
     }
 }
@@ -545,7 +545,7 @@ pub struct PixelFormatRequirements {
 
 impl PixelFormatRequirements {
     /// Format selection to get a 8-bit color format with alpha, depth and stencil bits
-    pub fn _8_bit() -> Self {
+    pub const fn _8_bit() -> Self {
         PixelFormatRequirements {
             hardware_accelerated: Some(true),
             color_bits: Some(24),
@@ -558,7 +558,7 @@ impl PixelFormatRequirements {
     }
 
     /// Format selection to get a 10-bit color format with alpha, depth and stencil bits
-    pub fn _10_bit() -> Self {
+    pub const fn _10_bit() -> Self {
         PixelFormatRequirements {
             hardware_accelerated: Some(true),
             color_bits: Some(30),
@@ -571,7 +571,7 @@ impl PixelFormatRequirements {
     }
 
     /// Format selection to get a 10-bit color format based on floating point values with alpha, depth and stencil bits
-    pub fn _10f_bit() -> Self {
+    pub const fn _10f_bit() -> Self {
         PixelFormatRequirements {
             hardware_accelerated: Some(true),
             color_bits: Some(48),

--- a/src/backend/egl/device.rs
+++ b/src/backend/egl/device.rs
@@ -237,7 +237,7 @@ impl EGLDevice {
     /// Returns the pointer to the raw [`EGLDevice`].
     ///
     /// The pointer will become invalid, when this struct is destroyed.
-    pub fn get_device_handle(&self) -> *const c_void {
+    pub const fn get_device_handle(&self) -> *const c_void {
         self.inner
     }
 }

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -584,7 +584,7 @@ impl EGLDisplay {
     }
 
     /// Returns the runtime egl version of this display
-    pub fn get_egl_version(&self) -> (i32, i32) {
+    pub const fn get_egl_version(&self) -> (i32, i32) {
         self.egl_version
     }
 
@@ -594,12 +594,12 @@ impl EGLDisplay {
     }
 
     /// Returns a list of formats for dmabufs that can be rendered to.
-    pub fn dmabuf_render_formats(&self) -> &FormatSet {
+    pub const fn dmabuf_render_formats(&self) -> &FormatSet {
         &self.dmabuf_render_formats
     }
 
     /// Returns a list of formats for dmabufs that can be used as textures.
-    pub fn dmabuf_texture_formats(&self) -> &FormatSet {
+    pub const fn dmabuf_texture_formats(&self) -> &FormatSet {
         &self.dmabuf_import_formats
     }
 

--- a/src/backend/egl/fence.rs
+++ b/src/backend/egl/fence.rs
@@ -32,7 +32,7 @@ pub struct EGLFence(Arc<InnerEGLFence>);
 
 impl EGLFence {
     /// Returns whether the display supports creating fences from native fences
-    pub fn supports_importing(display: &EGLDisplay) -> bool {
+    pub const fn supports_importing(display: &EGLDisplay) -> bool {
         display.supports_native_fences
     }
 

--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -18,7 +18,7 @@ pub type NativeDisplayType = *const c_void;
 pub type NativePixmapType = *const c_void;
 pub type NativeWindowType = *const c_void;
 
-fn error_str(error: egl::types::EGLenum) -> &'static str {
+const fn error_str(error: egl::types::EGLenum) -> &'static str {
     match error {
         egl::SUCCESS => "SUCCESS",
         egl::NOT_INITIALIZED => "NOT_INITIALIZED",
@@ -77,7 +77,7 @@ pub fn make_sure_egl_is_loaded() -> Result<Vec<String>, Error> {
         ptr,
     };
 
-    fn constrain<F>(f: F) -> F
+    const fn constrain<F>(f: F) -> F
     where
         F: for<'a> Fn(&'a str) -> *const ::std::os::raw::c_void,
     {

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -219,7 +219,7 @@ pub enum Format {
 impl Format {
     /// Amount of planes this format uses
     #[inline]
-    pub fn num_planes(&self) -> usize {
+    pub const fn num_planes(&self) -> usize {
         match *self {
             Format::RGB | Format::RGBA | Format::External => 1,
             Format::Y_UV | Format::Y_XUXV => 2,

--- a/src/backend/egl/surface.rs
+++ b/src/backend/egl/surface.rs
@@ -218,12 +218,12 @@ impl EGLSurface {
     }
 
     /// Returns the egl config for this context
-    pub fn config_id(&self) -> ffi::egl::types::EGLConfig {
+    pub const fn config_id(&self) -> ffi::egl::types::EGLConfig {
         self.config_id
     }
 
     /// Returns the pixel format of the main framebuffer of the context.
-    pub fn pixel_format(&self) -> PixelFormat {
+    pub const fn pixel_format(&self) -> PixelFormat {
         self.pixel_format
     }
 

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -812,7 +812,7 @@ pub enum InputEvent<B: InputBackend> {
 ///
 /// Taken from https://sources.debian.org/src/xserver-xorg-input-libinput/1.1.0-1/src/xf86libinput.c/?hl=1508#L236-L252
 #[cfg(any(feature = "backend_winit", feature = "backend_x11"))]
-pub(crate) fn xorg_mouse_to_libinput(xorg: u32) -> u32 {
+pub(crate) const fn xorg_mouse_to_libinput(xorg: u32) -> u32 {
     match xorg {
         0 => 0,
         1 => 0x110,            // BTN_LEFT

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -51,7 +51,7 @@ impl LibinputInputBackend {
     }
 
     /// Returns a reference to the underlying libinput context
-    pub fn context(&self) -> &libinput::Libinput {
+    pub const fn context(&self) -> &libinput::Libinput {
         &self.context
     }
 }

--- a/src/backend/renderer/color.rs
+++ b/src/backend/renderer/color.rs
@@ -23,31 +23,31 @@ impl Color32F {
 impl Color32F {
     /// Red color component
     #[inline]
-    pub fn r(&self) -> f32 {
+    pub const fn r(&self) -> f32 {
         self.0[0]
     }
 
     /// Green color component
     #[inline]
-    pub fn g(&self) -> f32 {
+    pub const fn g(&self) -> f32 {
         self.0[1]
     }
 
     /// Blue color component
     #[inline]
-    pub fn b(&self) -> f32 {
+    pub const fn b(&self) -> f32 {
         self.0[2]
     }
 
     /// Alpha color component
     #[inline]
-    pub fn a(&self) -> f32 {
+    pub const fn a(&self) -> f32 {
         self.0[3]
     }
 
     /// Color components
     #[inline]
-    pub fn components(self) -> [f32; 4] {
+    pub const fn components(self) -> [f32; 4] {
         self.0
     }
 }

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -407,7 +407,7 @@ impl OutputDamageTracker {
     }
 
     /// Get the [`OutputModeSource`] of the [`OutputDamageTracker`]
-    pub fn mode(&self) -> &OutputModeSource {
+    pub const fn mode(&self) -> &OutputModeSource {
         &self.mode
     }
 

--- a/src/backend/renderer/damage/shaper.rs
+++ b/src/backend/renderer/damage/shaper.rs
@@ -273,7 +273,7 @@ enum DamageSplitAxis {
 
 impl DamageSplitAxis {
     /// Invert the split direction.
-    fn invert(self) -> Self {
+    const fn invert(self) -> Self {
         match self {
             DamageSplitAxis::X => DamageSplitAxis::Y,
             DamageSplitAxis::Y => DamageSplitAxis::X,

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -277,17 +277,17 @@ impl MemoryBuffer {
     }
 
     /// Get the size of this buffer
-    pub fn size(&self) -> Size<i32, Buffer> {
+    pub const fn size(&self) -> Size<i32, Buffer> {
         self.size
     }
 
     /// Get the format of this buffer
-    pub fn format(&self) -> Fourcc {
+    pub const fn format(&self) -> Fourcc {
         self.format
     }
 
     /// Get the stride of this buffer
-    pub fn stride(&self) -> i32 {
+    pub const fn stride(&self) -> i32 {
         self.stride
     }
 

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -139,7 +139,7 @@ pub enum RenderElementPresentationState {
 #[derive(Debug, Clone, Copy)]
 pub struct RenderElementState {
     /// Holds the physical visible area of the element on the output in pixels.
-    ///  
+    ///
     /// Note: If the presentation_state is [`RenderElementPresentationState::Skipped`] this will be zero.
     pub visible_area: usize,
     /// Holds the presentation state of the element on the output
@@ -154,7 +154,7 @@ impl RenderElementState {
         }
     }
 
-    pub(crate) fn rendered(visible_area: usize) -> Self {
+    pub(crate) const fn rendered(visible_area: usize) -> Self {
         RenderElementState {
             visible_area,
             presentation_state: RenderElementPresentationState::Rendering { reason: None },

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -225,7 +225,7 @@ impl SolidColorBuffer {
     }
 
     /// Get the current color of this buffer
-    pub fn color(&self) -> Color32F {
+    pub const fn color(&self) -> Color32F {
         self.color
     }
 }
@@ -286,7 +286,7 @@ impl SolidColorRenderElement {
     }
 
     /// Get the current color of this element
-    pub fn color(&self) -> Color32F {
+    pub const fn color(&self) -> Color32F {
         self.color
     }
 }

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -429,12 +429,12 @@ impl<R: Renderer + ImportAll> WaylandSurfaceRenderElement<R> {
     }
 
     /// Get the view into the surface
-    pub fn view(&self) -> SurfaceView {
+    pub const fn view(&self) -> SurfaceView {
         self.view
     }
 
     /// Get the buffer texture
-    pub fn texture(&self) -> &WaylandSurfaceTexture<R> {
+    pub const fn texture(&self) -> &WaylandSurfaceTexture<R> {
         &self.texture
     }
 }

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1794,7 +1794,7 @@ impl GlesRenderer {
     /// and no guarantee is made about what can or cannot be changed.
     /// To make sure a certain modification does not interfere with
     /// the renderer's behaviour, check the source.
-    pub fn egl_context(&self) -> &EGLContext {
+    pub const fn egl_context(&self) -> &EGLContext {
         &self.egl
     }
 

--- a/src/backend/renderer/gles/uniform.rs
+++ b/src/backend/renderer/gles/uniform.rs
@@ -236,7 +236,7 @@ impl UniformValue {
     }
 
     /// Returns the type of this uniform value
-    pub fn type_(&self) -> UniformType {
+    pub const fn type_(&self) -> UniformType {
         match self {
             UniformValue::_1f(_) => UniformType::_1f,
             UniformValue::_2f(_, _) => UniformType::_2f,

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -69,7 +69,7 @@ pub enum TextureFilter {
 impl Transform {
     /// A projection matrix to apply this transformation
     #[inline]
-    pub fn matrix(&self) -> Matrix3<f32> {
+    pub const fn matrix(&self) -> Matrix3<f32> {
         match self {
             Transform::Normal => Matrix3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
             Transform::_90 => Matrix3::new(0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0),

--- a/src/backend/renderer/utils/mod.rs
+++ b/src/backend/renderer/utils/mod.rs
@@ -177,7 +177,7 @@ impl<N: Clone, Kind> DamageSnapshot<N, Kind> {
     /// and provided to the next call of [`damage_since`](DamageSnapshot::damage_since)
     /// to query the damage between these two [`CommitCounter`]s.
     #[inline]
-    pub fn current_commit(&self) -> CommitCounter {
+    pub const fn current_commit(&self) -> CommitCounter {
         self.commit_counter
     }
 
@@ -248,7 +248,7 @@ impl<N: Clone, Kind> DamageBag<N, Kind> {
 
     /// Gets the current [`CommitCounter`] of this tracker
     #[inline]
-    pub fn current_commit(&self) -> CommitCounter {
+    pub const fn current_commit(&self) -> CommitCounter {
         self.state.current_commit()
     }
 

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -227,7 +227,7 @@ impl RendererSurfaceState {
     ///
     /// The position should be saved after calling [`damage_since`](RendererSurfaceState::damage_since) and
     /// provided as the commit in the next call.
-    pub fn current_commit(&self) -> CommitCounter {
+    pub const fn current_commit(&self) -> CommitCounter {
         self.damage.current_commit()
     }
 
@@ -257,12 +257,12 @@ impl RendererSurfaceState {
     }
 
     /// Returns the scale of the current attached buffer
-    pub fn buffer_scale(&self) -> i32 {
+    pub const fn buffer_scale(&self) -> i32 {
         self.buffer_scale
     }
 
     /// Returns the transform of the current attached buffer
-    pub fn buffer_transform(&self) -> Transform {
+    pub const fn buffer_transform(&self) -> Transform {
         self.buffer_transform
     }
 
@@ -276,7 +276,7 @@ impl RendererSurfaceState {
 
     /// Get the attached buffer.
     /// Can be used to check if surface is mapped
-    pub fn buffer(&self) -> Option<&Buffer> {
+    pub const fn buffer(&self) -> Option<&Buffer> {
         self.buffer.as_ref()
     }
 
@@ -316,7 +316,7 @@ impl RendererSurfaceState {
     }
 
     /// Gets the [`SurfaceView`] of this surface
-    pub fn view(&self) -> Option<SurfaceView> {
+    pub const fn view(&self) -> Option<SurfaceView> {
         self.surface_view
     }
 

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -427,19 +427,19 @@ impl PhysicalDevice {
     /// returns the version the device can actually support, based on the instance’s, `api_version`.
     ///
     /// The Vulkan specification provides more information about the version requirements: <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-validusage-versions>
-    pub fn api_version(&self) -> Version {
+    pub const fn api_version(&self) -> Version {
         self.info.api_version
     }
 
     /// Returns the device type.
     ///
     /// This may be used during device selection to choose a higher performance GPU.
-    pub fn ty(&self) -> vk::PhysicalDeviceType {
+    pub const fn ty(&self) -> vk::PhysicalDeviceType {
         self.info.properties.device_type
     }
 
     /// Returns the Vulkan 1.0 physical device features.
-    pub fn features(&self) -> vk::PhysicalDeviceFeatures {
+    pub const fn features(&self) -> vk::PhysicalDeviceFeatures {
         self.info.features
     }
 
@@ -447,24 +447,24 @@ impl PhysicalDevice {
     ///
     /// Some properties such as the device name can be obtained using other functions defined on
     /// [`PhysicalDevice`].
-    pub fn properties(&self) -> vk::PhysicalDeviceProperties {
+    pub const fn properties(&self) -> vk::PhysicalDeviceProperties {
         self.info.properties
     }
 
     /// Returns the device's descriptor set properties.
     ///
     /// This also describes the maximum memory allocation size.
-    pub fn properties_maintenance_3(&self) -> vk::PhysicalDeviceMaintenance3Properties<'_> {
+    pub const fn properties_maintenance_3(&self) -> vk::PhysicalDeviceMaintenance3Properties<'_> {
         self.info.maintenance_3
     }
 
     /// Information about universally unique identifiers (UUIDs) that identify this device.
-    pub fn id_properties(&self) -> vk::PhysicalDeviceIDProperties<'_> {
+    pub const fn id_properties(&self) -> vk::PhysicalDeviceIDProperties<'_> {
         self.info.id
     }
 
     /// Returns the physical device limits.
-    pub fn limits(&self) -> vk::PhysicalDeviceLimits {
+    pub const fn limits(&self) -> vk::PhysicalDeviceLimits {
         self.info.properties.limits
     }
 
@@ -474,7 +474,7 @@ impl PhysicalDevice {
     /// * The Vulkan implementation is not at least 1.2
     /// * If the Vulkan implementation is not at least Vulkan 1.2, the `VK_KHR_driver_properties` device
     ///   extension is not available.
-    pub fn driver(&self) -> Option<&DriverInfo> {
+    pub const fn driver(&self) -> Option<&DriverInfo> {
         self.info.driver.as_ref()
     }
 
@@ -601,12 +601,12 @@ impl PhysicalDevice {
     ///
     /// The handle refers to a specific physical device advertised by the instance. This handle is only valid
     /// for the lifetime of the instance.
-    pub fn handle(&self) -> vk::PhysicalDevice {
+    pub const fn handle(&self) -> vk::PhysicalDevice {
         self.phd
     }
 
     /// The instance which provided this physical device.
-    pub fn instance(&self) -> &Instance {
+    pub const fn instance(&self) -> &Instance {
         &self.instance
     }
 }

--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -376,7 +376,7 @@ pub(crate) struct RelativePosition {
 }
 
 impl RelativePosition {
-    pub(crate) fn new(x: f64, y: f64) -> Self {
+    pub(crate) const fn new(x: f64, y: f64) -> Self {
         Self { x, y }
     }
 }

--- a/src/backend/x11/mod.rs
+++ b/src/backend/x11/mod.rs
@@ -435,7 +435,7 @@ pub struct WindowBuilder<'a> {
 impl<'a> WindowBuilder<'a> {
     #[allow(clippy::new_without_default)]
     /// Returns a new builder.
-    pub fn new() -> WindowBuilder<'a> {
+    pub const fn new() -> WindowBuilder<'a> {
         WindowBuilder {
             name: None,
             size: None,
@@ -443,7 +443,7 @@ impl<'a> WindowBuilder<'a> {
     }
 
     /// Sets the title of the window that will be created by the builder.
-    pub fn title(self, name: &'a str) -> Self {
+    pub const fn title(self, name: &'a str) -> Self {
         Self {
             name: Some(name),
             ..self
@@ -454,7 +454,7 @@ impl<'a> WindowBuilder<'a> {
     ///
     /// There is no guarantee the size specified here will be the actual size of the window when it is
     /// presented.
-    pub fn size(self, size: Size<u16, Logical>) -> Self {
+    pub const fn size(self, size: Size<u16, Logical>) -> Self {
         Self {
             size: Some(size),
             ..self

--- a/src/backend/x11/surface.rs
+++ b/src/backend/x11/surface.rs
@@ -59,7 +59,7 @@ impl X11Surface {
     }
 
     /// Returns the format of the buffers the surface accepts.
-    pub fn format(&self) -> DrmFourcc {
+    pub const fn format(&self) -> DrmFourcc {
         self.format
     }
 

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -87,7 +87,7 @@ impl<E: SpaceElement> Default for Space<E> {
 
 impl<E: SpaceElement + PartialEq> Space<E> {
     /// Gets the id of this space
-    pub fn id(&self) -> usize {
+    pub const fn id(&self) -> usize {
         self.id
     }
 

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -134,7 +134,7 @@ impl LayerMap {
     }
 
     /// Return the area of this output, that is not exclusive to any [`LayerSurface`]s.
-    pub fn non_exclusive_zone(&self) -> Rectangle<i32, Logical> {
+    pub const fn non_exclusive_zone(&self) -> Rectangle<i32, Logical> {
         self.zone
     }
 

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -310,13 +310,13 @@ where
     }
 
     /// Returns the serial that was used to grab the popup
-    pub fn serial(&self) -> Serial {
+    pub const fn serial(&self) -> Serial {
         self.serial
     }
 
     /// Returns the previous serial that was used to grab
     /// the parent popup in case of nested grabs
-    pub fn previous_serial(&self) -> Option<Serial> {
+    pub const fn previous_serial(&self) -> Option<Serial> {
         self.previous_serial
     }
 
@@ -363,7 +363,7 @@ where
     /// The focus of the [`KeyboardGrabStartData`] will always be the root
     /// of the popup grab, e.g. the surface of the toplevel, to make sure
     /// the grab is not automatically unset.
-    pub fn keyboard_grab_start_data(&self) -> &KeyboardGrabStartData<D> {
+    pub const fn keyboard_grab_start_data(&self) -> &KeyboardGrabStartData<D> {
         &self.keyboard_grab_start_data
     }
 
@@ -372,7 +372,7 @@ where
     /// The focus of the [`PointerGrabStartData`] will always be the root
     /// of the popup grab, e.g. the surface of the toplevel, to make sure
     /// the grab is not automatically unset.
-    pub fn pointer_grab_start_data(&self) -> &PointerGrabStartData<D> {
+    pub const fn pointer_grab_start_data(&self) -> &PointerGrabStartData<D> {
         &self.pointer_grab_start_data
     }
 

--- a/src/desktop/wayland/popup/mod.rs
+++ b/src/desktop/wayland/popup/mod.rs
@@ -43,7 +43,7 @@ impl From<PopupKind> for WlSurface {
 impl PopupKind {
     /// Retrieves the underlying [`WlSurface`]
     #[inline]
-    pub fn wl_surface(&self) -> &WlSurface {
+    pub const fn wl_surface(&self) -> &WlSurface {
         match *self {
             PopupKind::Xdg(ref t) => t.wl_surface(),
             PopupKind::InputMethod(ref t) => t.wl_surface(),

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -91,7 +91,7 @@ impl KeymapFile {
     }
 
     /// Get this keymap's unique ID.
-    pub(crate) fn id(&self) -> usize {
+    pub(crate) const fn id(&self) -> usize {
         self.id
     }
 }

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -384,7 +384,7 @@ impl<'a> KeysymHandle<'a> {
     }
 
     /// Returns the raw code in X keycode system (shifted by 8)
-    pub fn raw_code(&'a self) -> Keycode {
+    pub const fn raw_code(&'a self) -> Keycode {
         self.keycode
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -278,7 +278,7 @@ impl<D: SeatHandler> Default for SeatState<D> {
 
 impl<D: SeatHandler> SeatState<D> {
     /// Create new delegate SeatState
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { seats: Vec::new() }
     }
 

--- a/src/input/pointer/cursor_image.rs
+++ b/src/input/pointer/cursor_image.rs
@@ -13,7 +13,7 @@ pub struct CursorImageAttributes {
     pub hotspot: Point<i32, Logical>,
 }
 
-/// Data associated with XDG toplevel surface  
+/// Data associated with XDG toplevel surface
 ///
 /// ```no_run
 /// # #[cfg(feature = "wayland_frontend")]
@@ -44,7 +44,7 @@ pub enum CursorImageStatus {
 
 impl CursorImageStatus {
     /// Get default `Named` cursor.
-    pub fn default_named() -> Self {
+    pub const fn default_named() -> Self {
         Self::Named(CursorIcon::Default)
     }
 }

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -1063,7 +1063,7 @@ pub struct GestureHoldEndEvent {
 
 impl AxisFrame {
     /// Create a new frame of axis events
-    pub fn new(time: u32) -> Self {
+    pub const fn new(time: u32) -> Self {
         AxisFrame {
             source: None,
             relative_direction: (AxisRelativeDirection::Identical, AxisRelativeDirection::Identical),
@@ -1081,13 +1081,13 @@ impl AxisFrame {
     ///
     /// Using the [`AxisSource::Finger`] requires a stop event to be send,
     /// when the user lifts off the finger (not necessarily in the same frame).
-    pub fn source(mut self, source: AxisSource) -> Self {
+    pub const fn source(mut self, source: AxisSource) -> Self {
         self.source = Some(source);
         self
     }
 
     /// Specify the direction of the physical motion, relative to axis direction
-    pub fn relative_direction(mut self, axis: Axis, relative_direction: AxisRelativeDirection) -> Self {
+    pub const fn relative_direction(mut self, axis: Axis, relative_direction: AxisRelativeDirection) -> Self {
         match axis {
             Axis::Horizontal => {
                 self.relative_direction.0 = relative_direction;
@@ -1135,7 +1135,7 @@ impl AxisFrame {
     ///
     /// This event is required for sources of the [`AxisSource::Finger`] type
     /// and otherwise optional.
-    pub fn stop(mut self, axis: Axis) -> Self {
+    pub const fn stop(mut self, axis: Axis) -> Self {
         match axis {
             Axis::Horizontal => {
                 self.stop.0 = true;

--- a/src/output.rs
+++ b/src/output.rs
@@ -202,7 +202,7 @@ impl Scale {
     }
 
     /// Returns the fractional scale (calculated if necessary)
-    pub fn fractional_scale(&self) -> f64 {
+    pub const fn fractional_scale(&self) -> f64 {
         match self {
             Scale::Integer(scale) => *scale as f64,
             Scale::Fractional(scale) => *scale,

--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -37,7 +37,7 @@ pub struct Clock<Kind: ClockSource> {
 impl<Kind: ClockSource> Clock<Kind> {
     /// Initialize a new clock
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Clock { _kind: PhantomData }
     }
 
@@ -47,7 +47,7 @@ impl<Kind: ClockSource> Clock<Kind> {
     }
 
     /// Gets the id of the clock
-    pub fn id(&self) -> ClockId {
+    pub const fn id(&self) -> ClockId {
         Kind::ID
     }
 }

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -687,7 +687,7 @@ pub struct Size<N, Kind> {
 impl<N: Coordinate, Kind> Size<N, Kind> {
     /// Convert this [`Size`] to a [`Point`] with the same coordinates
     #[inline]
-    pub fn to_point(self) -> Point<N, Kind> {
+    pub const fn to_point(self) -> Point<N, Kind> {
         Point {
             x: self.w,
             y: self.h,
@@ -1526,7 +1526,7 @@ impl Transform {
     ///
     /// Flipping is preserved and 180/Normal transformation are uneffected.
     #[inline]
-    pub fn invert(&self) -> Transform {
+    pub const fn invert(&self) -> Transform {
         match self {
             Transform::Normal => Transform::Normal,
             Transform::Flipped => Transform::Flipped,
@@ -1601,7 +1601,7 @@ impl Transform {
     }
 
     /// Returns true if the transformation would flip contents
-    pub fn flipped(&self) -> bool {
+    pub const fn flipped(&self) -> bool {
         !matches!(
             self,
             Transform::Normal | Transform::_90 | Transform::_180 | Transform::_270
@@ -1610,7 +1610,7 @@ impl Transform {
 
     /// Returns the angle (in degrees) of the transformation
     #[inline]
-    pub fn degrees(&self) -> u32 {
+    pub const fn degrees(&self) -> u32 {
         match self {
             Transform::Normal | Transform::Flipped => 0,
             Transform::_90 | Transform::Flipped90 => 90,

--- a/src/utils/sealed_file.rs
+++ b/src/utils/sealed_file.rs
@@ -90,7 +90,7 @@ impl SealedFile {
     }
 
     // Only used in KeymapFile which is under the wayland_frontend feature
-    pub fn size(&self) -> usize {
+    pub const fn size(&self) -> usize {
         self.size
     }
 }

--- a/src/utils/user_data.rs
+++ b/src/utils/user_data.rs
@@ -294,7 +294,7 @@ mod list {
             unsafe { self.append_ptr(p) };
         }
 
-        pub fn iter(&self) -> AppendListIterator<'_, T> {
+        pub const fn iter(&self) -> AppendListIterator<'_, T> {
             AppendListIterator(&self.0)
         }
 

--- a/src/wayland/alpha_modifier/mod.rs
+++ b/src/wayland/alpha_modifier/mod.rs
@@ -30,7 +30,7 @@
 //!    }
 //!
 //!    fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState {
-//!        &client.get_data::<ClientState>().unwrap().compositor_state    
+//!        &client.get_data::<ClientState>().unwrap().compositor_state
 //!    }
 //!
 //!    fn commit(&mut self, surface: &WlSurface) {
@@ -88,7 +88,7 @@ pub struct AlphaModifierSurfaceCachedState {
 
 impl AlphaModifierSurfaceCachedState {
     /// Alpha multiplier for the surface
-    pub fn multiplier(&self) -> Option<u32> {
+    pub const fn multiplier(&self) -> Option<u32> {
         self.multiplier
     }
 
@@ -121,7 +121,7 @@ struct AlphaModifierSurfaceData {
 }
 
 impl AlphaModifierSurfaceData {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             is_resource_attached: AtomicBool::new(false),
         }

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -481,7 +481,7 @@ pub struct SubsurfaceUserData {
 
 impl SubsurfaceUserData {
     /// Returns the surface for this subsurface (not to be confused with the parent surface).
-    pub fn surface(&self) -> &WlSurface {
+    pub const fn surface(&self) -> &WlSurface {
         &self.surface
     }
 }
@@ -518,7 +518,7 @@ pub(crate) struct SubsurfaceState {
 }
 
 impl SubsurfaceState {
-    fn new() -> SubsurfaceState {
+    const fn new() -> SubsurfaceState {
         SubsurfaceState {
             sync: AtomicBool::new(true),
         }

--- a/src/wayland/content_type/mod.rs
+++ b/src/wayland/content_type/mod.rs
@@ -27,7 +27,7 @@
 //!    }
 //!
 //!    fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState {
-//!        &client.get_data::<ClientState>().unwrap().compositor_state    
+//!        &client.get_data::<ClientState>().unwrap().compositor_state
 //!    }
 //!
 //!    fn commit(&mut self, surface: &WlSurface) {
@@ -88,7 +88,7 @@ pub struct ContentTypeSurfaceCachedState {
 
 impl ContentTypeSurfaceCachedState {
     /// This informs the compositor that the client believes it is displaying buffers matching this content type.
-    pub fn content_type(&self) -> &wp_content_type_v1::Type {
+    pub const fn content_type(&self) -> &wp_content_type_v1::Type {
         &self.content_type
     }
 }
@@ -117,7 +117,7 @@ struct ContentTypeSurfaceData {
 }
 
 impl ContentTypeSurfaceData {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             is_resource_attached: AtomicBool::new(false),
         }

--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -295,7 +295,7 @@ where
     }
 }
 
-fn shape_to_cursor_icon(shape: Shape) -> CursorIcon {
+const fn shape_to_cursor_icon(shape: Shape) -> CursorIcon {
     match shape {
         Shape::Default => CursorIcon::Default,
         Shape::ContextMenu => CursorIcon::ContextMenu,

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -271,7 +271,7 @@ struct DmabufFeedbackFormat {
 }
 
 impl DmabufFeedbackFormat {
-    fn to_ne_bytes(self) -> [u8; 16] {
+    const fn to_ne_bytes(self) -> [u8; 16] {
         let format: [u8; 4] = self.format.to_ne_bytes();
         let reserved: [u8; 4] = self._reserved.to_ne_bytes();
         let modifier: [u8; 8] = self.modifier.to_ne_bytes();
@@ -967,7 +967,12 @@ impl ImportNotifier {
         self.drop_ignore = true;
     }
 
-    fn new(params: ZwpLinuxBufferParamsV1, display: DisplayHandle, dmabuf: Dmabuf, import: Import) -> Self {
+    const fn new(
+        params: ZwpLinuxBufferParamsV1,
+        display: DisplayHandle,
+        dmabuf: Dmabuf,
+        import: Import,
+    ) -> Self {
         Self {
             inner: params,
             display,

--- a/src/wayland/drm_lease/mod.rs
+++ b/src/wayland/drm_lease/mod.rs
@@ -217,7 +217,7 @@ impl DrmLease {
         self.planes.keys()
     }
     /// Lease Id
-    pub fn id(&self) -> u32 {
+    pub const fn id(&self) -> u32 {
         self.lease_id.get()
     }
 
@@ -620,7 +620,7 @@ impl DrmLeaseState {
     }
 
     /// [`DrmNode`] belonging to this DRM lease global
-    pub fn node(&self) -> DrmNode {
+    pub const fn node(&self) -> DrmNode {
         self.node
     }
 

--- a/src/wayland/fractional_scale/mod.rs
+++ b/src/wayland/fractional_scale/mod.rs
@@ -245,7 +245,7 @@ impl FractionalScaleState {
     }
 
     /// Returns the current preferred scale
-    pub fn preferred_scale(&self) -> Option<f64> {
+    pub const fn preferred_scale(&self) -> Option<f64> {
         self.preferred_scale
     }
 }

--- a/src/wayland/idle_inhibit/inhibitor.rs
+++ b/src/wayland/idle_inhibit/inhibitor.rs
@@ -15,7 +15,7 @@ pub struct IdleInhibitorState {
 
 impl IdleInhibitorState {
     /// Create `zwp_idle_inhibitor_v1` state.
-    pub fn new(surface: WlSurface) -> Self {
+    pub const fn new(surface: WlSurface) -> Self {
         Self { surface }
     }
 }

--- a/src/wayland/input_method/input_method_popup_surface.rs
+++ b/src/wayland/input_method/input_method_popup_surface.rs
@@ -60,12 +60,12 @@ impl PopupSurface {
 
     /// Access to the underlying `wl_surface` of this popup
     #[inline]
-    pub fn wl_surface(&self) -> &WlSurface {
+    pub const fn wl_surface(&self) -> &WlSurface {
         &self.surface
     }
 
     /// Access to the parent surface associated with this popup
-    pub fn get_parent(&self) -> Option<&PopupParent> {
+    pub const fn get_parent(&self) -> Option<&PopupParent> {
         self.parent.as_ref()
     }
 

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -115,7 +115,7 @@ pub trait OutputHandler {
 
 impl OutputManagerState {
     /// Create new output manager
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             xdg_output_manager: None,
         }

--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -50,7 +50,7 @@ pub struct ConfinedPointer {
 
 impl ConfinedPointer {
     /// Region in which to confine the pointer
-    pub fn region(&self) -> Option<&RegionAttributes> {
+    pub const fn region(&self) -> Option<&RegionAttributes> {
         self.region.as_ref()
     }
 }
@@ -69,12 +69,12 @@ pub struct LockedPointer {
 
 impl LockedPointer {
     /// Region in which to activate the lock
-    pub fn region(&self) -> Option<&RegionAttributes> {
+    pub const fn region(&self) -> Option<&RegionAttributes> {
         self.region.as_ref()
     }
 
     /// Position the client is rendering a cursor, if any
-    pub fn cursor_position_hint(&self) -> Option<Point<f64, Logical>> {
+    pub const fn cursor_position_hint(&self) -> Option<Point<f64, Logical>> {
         self.cursor_position_hint
     }
 }
@@ -157,14 +157,14 @@ impl PointerConstraint {
     }
 
     /// Region in which to lock or confine the pointer
-    pub fn region(&self) -> Option<&RegionAttributes> {
+    pub const fn region(&self) -> Option<&RegionAttributes> {
         match self {
             PointerConstraint::Confined(confined) => confined.region(),
             PointerConstraint::Locked(locked) => locked.region(),
         }
     }
 
-    fn lifetime(&self) -> WEnum<Lifetime> {
+    const fn lifetime(&self) -> WEnum<Lifetime> {
         match self {
             PointerConstraint::Confined(confined) => confined.lifetime,
             PointerConstraint::Locked(locked) => locked.lifetime,

--- a/src/wayland/presentation/mod.rs
+++ b/src/wayland/presentation/mod.rs
@@ -198,7 +198,7 @@ pub struct PresentationFeedbackCallback {
 
 impl PresentationFeedbackCallback {
     /// Get the id of the clock that was used at bind
-    pub fn clk_id(&self) -> u32 {
+    pub const fn clk_id(&self) -> u32 {
         self.clk_id
     }
 

--- a/src/wayland/selection/seat_data.rs
+++ b/src/wayland/selection/seat_data.rs
@@ -106,12 +106,12 @@ impl<U: Clone + Send + Sync + 'static> SeatData<U> {
     }
 
     /// Get the current selection which will be used as a clipboard selection.
-    pub fn get_clipboard_selection(&self) -> Option<&OfferReplySource<U>> {
+    pub const fn get_clipboard_selection(&self) -> Option<&OfferReplySource<U>> {
         self.clipboard_selection.as_ref()
     }
 
     /// Get the current selection which will be used as a primary selection.
-    pub fn get_primary_selection(&self) -> Option<&OfferReplySource<U>> {
+    pub const fn get_primary_selection(&self) -> Option<&OfferReplySource<U>> {
         self.primary_selection.as_ref()
     }
 

--- a/src/wayland/session_lock/surface.rs
+++ b/src/wayland/session_lock/surface.rs
@@ -123,7 +123,7 @@ impl PartialEq for LockSurface {
 }
 
 impl LockSurface {
-    pub(crate) fn new(surface: WlSurface, shell_surface: ExtSessionLockSurfaceV1) -> Self {
+    pub(crate) const fn new(surface: WlSurface, shell_surface: ExtSessionLockSurfaceV1) -> Self {
         Self {
             surface,
             shell_surface,
@@ -185,7 +185,7 @@ impl LockSurface {
 
     /// Access the underlying [`WlSurface`].
     #[inline]
-    pub fn wl_surface(&self) -> &WlSurface {
+    pub const fn wl_surface(&self) -> &WlSurface {
         &self.surface
     }
 

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -74,7 +74,7 @@ pub use types::{Anchor, ExclusiveZone, KeyboardInteractivity, Layer, Margins};
 /// The role of a wlr_layer_shell_surface
 pub const LAYER_SURFACE_ROLE: &str = "zwlr_layer_surface_v1";
 
-/// Data associated with XDG popup surface  
+/// Data associated with XDG popup surface
 ///
 /// ```no_run
 /// use smithay::wayland::compositor;
@@ -431,7 +431,7 @@ impl LayerSurface {
     ///
     /// Returns `None` if the layer surface actually no longer exists.
     #[inline]
-    pub fn wl_surface(&self) -> &wl_surface::WlSurface {
+    pub const fn wl_surface(&self) -> &wl_surface::WlSurface {
         &self.wl_surface
     }
 

--- a/src/wayland/shell/wlr_layer/types.rs
+++ b/src/wayland/shell/wlr_layer/types.rs
@@ -139,14 +139,14 @@ impl Anchor {
     ///
     /// If it is anchored to `left` and `right` anchor at the same time
     /// it returns `true`
-    pub fn anchored_horizontally(&self) -> bool {
+    pub const fn anchored_horizontally(&self) -> bool {
         self.contains(Self::LEFT) && self.contains(Self::RIGHT)
     }
     /// Check if anchored vertically
     ///
     /// If it is anchored to `top` and `bottom` anchor at the same time
     /// it returns `true`
-    pub fn anchored_vertically(&self) -> bool {
+    pub const fn anchored_vertically(&self) -> bool {
         self.contains(Self::TOP) && self.contains(Self::BOTTOM)
     }
 }

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -365,7 +365,7 @@ xdg_role!(
     }
 );
 
-/// Data associated with XDG toplevel surface  
+/// Data associated with XDG toplevel surface
 ///
 /// ```no_run
 /// use smithay::wayland::compositor;
@@ -439,7 +439,7 @@ xdg_role!(
     }
 );
 
-/// Data associated with XDG popup surface  
+/// Data associated with XDG popup surface
 ///
 /// ```no_run
 /// use smithay::wayland::compositor;
@@ -769,7 +769,10 @@ impl PositionerState {
     }
 }
 
-fn compute_offsets(target: Rectangle<i32, Logical>, popup: Rectangle<i32, Logical>) -> (i32, i32, i32, i32) {
+const fn compute_offsets(
+    target: Rectangle<i32, Logical>,
+    popup: Rectangle<i32, Logical>,
+) -> (i32, i32, i32, i32) {
     let off_left = target.loc.x - popup.loc.x;
     let off_right = (popup.loc.x + popup.size.w) - (target.loc.x + target.size.w);
     let off_top = target.loc.y - popup.loc.y;
@@ -777,7 +780,7 @@ fn compute_offsets(target: Rectangle<i32, Logical>, popup: Rectangle<i32, Logica
     (off_left, off_right, off_top, off_bottom)
 }
 
-fn invert_anchor_x(anchor: Anchor) -> Anchor {
+const fn invert_anchor_x(anchor: Anchor) -> Anchor {
     match anchor {
         Anchor::Left => Anchor::Right,
         Anchor::Right => Anchor::Left,
@@ -789,7 +792,7 @@ fn invert_anchor_x(anchor: Anchor) -> Anchor {
     }
 }
 
-fn invert_anchor_y(anchor: Anchor) -> Anchor {
+const fn invert_anchor_y(anchor: Anchor) -> Anchor {
     match anchor {
         Anchor::Top => Anchor::Bottom,
         Anchor::Bottom => Anchor::Top,
@@ -801,7 +804,7 @@ fn invert_anchor_y(anchor: Anchor) -> Anchor {
     }
 }
 
-fn invert_gravity_x(gravity: Gravity) -> Gravity {
+const fn invert_gravity_x(gravity: Gravity) -> Gravity {
     match gravity {
         Gravity::Left => Gravity::Right,
         Gravity::Right => Gravity::Left,
@@ -813,7 +816,7 @@ fn invert_gravity_x(gravity: Gravity) -> Gravity {
     }
 }
 
-fn invert_gravity_y(gravity: Gravity) -> Gravity {
+const fn invert_gravity_y(gravity: Gravity) -> Gravity {
     match gravity {
         Gravity::Top => Gravity::Bottom,
         Gravity::Bottom => Gravity::Top,
@@ -1587,12 +1590,12 @@ impl ToplevelSurface {
 
     /// Access the underlying `wl_surface` of this toplevel surface
     #[inline]
-    pub fn wl_surface(&self) -> &wl_surface::WlSurface {
+    pub const fn wl_surface(&self) -> &wl_surface::WlSurface {
         &self.wl_surface
     }
 
     /// Access the underlying `xdg_toplevel` of this toplevel surface
-    pub fn xdg_toplevel(&self) -> &xdg_toplevel::XdgToplevel {
+    pub const fn xdg_toplevel(&self) -> &xdg_toplevel::XdgToplevel {
         &self.shell_surface
     }
 
@@ -1950,12 +1953,12 @@ impl PopupSurface {
 
     /// Access the underlying `wl_surface` of this popup surface
     #[inline]
-    pub fn wl_surface(&self) -> &wl_surface::WlSurface {
+    pub const fn wl_surface(&self) -> &wl_surface::WlSurface {
         &self.wl_surface
     }
 
     /// Access the underlying `xdg_popup` of this popup surface
-    pub fn xdg_popup(&self) -> &xdg_popup::XdgPopup {
+    pub const fn xdg_popup(&self) -> &xdg_popup::XdgPopup {
         &self.shell_surface
     }
 

--- a/src/wayland/shm/pool.rs
+++ b/src/wayland/shm/pool.rs
@@ -247,7 +247,7 @@ impl MemMap {
         }
     }
 
-    fn size(&self) -> usize {
+    const fn size(&self) -> usize {
         self.size
     }
 

--- a/src/wayland/single_pixel_buffer/mod.rs
+++ b/src/wayland/single_pixel_buffer/mod.rs
@@ -97,12 +97,12 @@ pub struct SinglePixelBufferUserData {
 
 impl SinglePixelBufferUserData {
     /// Check if pixel has alpha
-    pub fn has_alpha(&self) -> bool {
+    pub const fn has_alpha(&self) -> bool {
         self.a != u32::MAX
     }
 
     /// RGAB8888 color buffer
-    pub fn rgba8888(&self) -> [u8; 4] {
+    pub const fn rgba8888(&self) -> [u8; 4] {
         let divisor = u32::MAX / 255;
 
         [

--- a/src/xwayland/x11_sockets.rs
+++ b/src/xwayland/x11_sockets.rs
@@ -115,7 +115,7 @@ impl X11Lock {
         }
     }
 
-    pub(crate) fn display_number(&self) -> u32 {
+    pub(crate) const fn display_number(&self) -> u32 {
         self.display
     }
 }

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -371,7 +371,7 @@ impl ClientData for XWaylandClientData {}
 
 impl XWaylandClientData {
     /// Access user_data map for a xwayland client
-    pub fn user_data(&self) -> &UserDataMap {
+    pub const fn user_data(&self) -> &UserDataMap {
         &self.data_map
     }
 }

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -83,7 +83,7 @@
 //!             client.clone(),
 //!         )
 //!         .expect("Failed to attach X11 Window Manager");
-//!         
+//!
 //!         // store the WM somewhere
 //!     }
 //!     XWaylandEvent::Error => eprintln!("XWayland failed to start!"),
@@ -248,14 +248,14 @@ enum StackingDirection {
 }
 
 impl StackingDirection {
-    fn pos_comparator(&self, pos: usize, last_pos: usize) -> bool {
+    const fn pos_comparator(&self, pos: usize, last_pos: usize) -> bool {
         match self {
             Self::Downwards => last_pos < pos,
             Self::Upwards => last_pos > pos,
         }
     }
 
-    fn stack_mode(&self) -> StackMode {
+    const fn stack_mode(&self) -> StackMode {
         match self {
             Self::Downwards => StackMode::BELOW,
             Self::Upwards => StackMode::ABOVE,
@@ -887,7 +887,7 @@ impl X11Wm {
     }
 
     /// Id of this X11 WM
-    pub fn id(&self) -> XwmId {
+    pub const fn id(&self) -> XwmId {
         self.id
     }
 
@@ -1033,7 +1033,7 @@ impl X11Wm {
     ///
     /// So if windows `A -> C` are given in order and the internal stack is `C -> B -> A`,
     /// no reordering will occur.
-    ///  
+    ///
     /// See [`X11Wm::update_stacking_order_downwards`] for a variant of this algorithm,
     /// which works from the top down or [`X11Wm::raise_window`] for an easier but
     /// much more limited way to reorder.

--- a/src/xwayland/xwm/settings.rs
+++ b/src/xwayland/xwm/settings.rs
@@ -211,7 +211,7 @@ impl XSettings {
 }
 
 impl Value {
-    fn _type(&self) -> i8 {
+    const fn _type(&self) -> i8 {
         match self {
             Value::Integer(_) => 0,
             Value::String(_) => 1,

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -198,12 +198,12 @@ impl X11Surface {
     }
 
     /// Returns the id of the X11Wm responsible for this surface, if any
-    pub fn xwm_id(&self) -> Option<XwmId> {
+    pub const fn xwm_id(&self) -> Option<XwmId> {
         self.xwm
     }
 
     /// X11 protocol id of the underlying window
-    pub fn window_id(&self) -> X11Window {
+    pub const fn window_id(&self) -> X11Window {
         self.window
     }
 
@@ -250,7 +250,7 @@ impl X11Surface {
     }
 
     /// Returns if this window has the override redirect flag set or not
-    pub fn is_override_redirect(&self) -> bool {
+    pub const fn is_override_redirect(&self) -> bool {
         self.override_redirect
     }
 


### PR DESCRIPTION
Using `const` for constant functions allows the compiler to evaluate them at compile-time, and allows the calling functions to be `const`, too.

These functions were detected with the clippy lint:
https://rust-lang.github.io/rust-clippy/master/index.html#/missing_const_for_fn
