### PR TITLE
Add accessor for FormatSet's underlying storage 

### DIFF
--- a/src/backend/allocator/format.rs
+++ b/src/backend/allocator/format.rs
@@ -402,6 +402,11 @@ impl FormatSet {
             inner: self.formats.intersection(&other.formats),
         }
     }
+
+    /// Get access to the underlying storage.
+    pub fn indexset(&self) -> &IndexSet<Format> {
+        &self.formats
+    }
 }
 
 /// A lazy iterator producing elements in the intersection of [`FormatSet`]s.


### PR DESCRIPTION
This gives read-only access to the underlying storage of `FormatSet`, to make it simpler for consumers to combine formats without having to reallocate.