### PR TITLE
Replace `lazy_static` with `once_cell::sync::Lazy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ gbm = { version = "0.15.0", optional = true, default-features = false, features 
 glow = { version = "0.12", optional = true }
 input = { version = "0.9.0", default-features = false, features=["libinput_1_19"], optional = true }
 indexmap = "2.0"
-lazy_static = "1"
 libc = "0.2.103"
 libseat = { version = "0.2.1", optional = true, default-features = false }
 libloading = { version="0.8.0", optional = true }

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -13,6 +13,7 @@ use std::{
 
 use indexmap::IndexSet;
 use libc::c_void;
+use once_cell::sync::Lazy;
 #[cfg(all(feature = "use_system_lib", feature = "wayland_frontend"))]
 use wayland_server::{protocol::wl_buffer::WlBuffer, DisplayHandle, Resource};
 #[cfg(all(feature = "use_system_lib", feature = "wayland_frontend"))]
@@ -40,12 +41,8 @@ use crate::{
 use tracing::{debug, error, info, info_span, instrument, trace, warn};
 
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
-lazy_static::lazy_static! {
-    pub(crate) static ref BUFFER_READER: Mutex<Option<WeakBufferReader>> = Mutex::new(None);
-}
-lazy_static::lazy_static! {
-    static ref DISPLAYS: Mutex<HashSet<WeakEGLDisplayHandle>> = Mutex::new(HashSet::new());
-}
+pub(crate) static BUFFER_READER: Mutex<Option<WeakBufferReader>> = Mutex::new(None);
+static DISPLAYS: Lazy<Mutex<HashSet<WeakEGLDisplayHandle>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
 /// Wrapper around [`ffi::EGLDisplay`](ffi::egl::types::EGLDisplay) to ensure display is only destroyed
 /// once all resources bound to it have been dropped.

--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -142,11 +142,11 @@ pub fn make_sure_egl_is_loaded() -> Result<Vec<String>, Error> {
 pub mod egl {
     use super::*;
     use libloading::Library;
+    use once_cell::sync::Lazy;
     use std::sync::Once;
 
-    lazy_static::lazy_static! {
-        pub static ref LIB: Library = unsafe { Library::new("libEGL.so.1") }.expect("Failed to load LibEGL");
-    }
+    pub static LIB: Lazy<Library> =
+        Lazy::new(|| unsafe { Library::new("libEGL.so.1") }.expect("Failed to load LibEGL"));
 
     pub static LOAD: Once = Once::new();
     pub static DEBUG: Once = Once::new();


### PR DESCRIPTION
`once_cell::sync::Lazy` can be further replaced by `std::sync::LazyLock` once MSRV is bumped above 1.80.