### PR TITLE
xwayland: Some improvements for handling of xserver crashes

### DIFF
--- a/src/backend/x11/mod.rs
+++ b/src/backend/x11/mod.rs
@@ -578,8 +578,11 @@ impl EventSource for X11Backend {
 
         let post_action = self
             .source
-            .process_events(readiness, token, |event, _| {
-                X11Inner::process_event(&inner, event, &mut callback);
+            .process_events(readiness, token, |event, _| match event {
+                calloop::channel::Event::Msg(event) => {
+                    X11Inner::process_event(&inner, event, &mut callback);
+                }
+                calloop::channel::Event::Closed => {}
             })
             .map_err(|_| X11Error::ConnectionLost)?;
 

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -11,9 +11,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use tracing::{info, trace};
-use wayland_server::backend::ClientData;
-use wayland_server::backend::DisconnectReason;
+use tracing::{error, info, trace};
+use wayland_server::backend::{ClientData, ClientId, DisconnectReason};
 use wayland_server::{Client, DisplayHandle};
 
 use crate::{utils::user_data::UserDataMap, wayland::compositor::CompositorClientState};
@@ -367,7 +366,13 @@ pub struct XWaylandClientData {
     data_map: UserDataMap,
 }
 
-impl ClientData for XWaylandClientData {}
+impl ClientData for XWaylandClientData {
+    fn disconnected(&self, _client_id: ClientId, reason: DisconnectReason) {
+        if let DisconnectReason::ProtocolError(err) = reason {
+            error!("Xwayland disconnected: {}", err);
+        }
+    }
+}
 
 impl XWaylandClientData {
     /// Access user_data map for a xwayland client


### PR DESCRIPTION
This logs a tracing error if the X server is disconnected with a protocol  error, and logs the return status of the `Xwayland` subprocess (which also means properly reaping the pid). Having these logged (and logged alongside any other compositor errors) will hopefully help with debugging some issues.

This also adds a `disconnected` method to `XwmHandler` so the compositor knows when we lose connection to the X server. (See https://github.com/pop-os/cosmic-comp/pull/823 for a use case.)