### PR TITLE
drm: Update for NetBSD

### DIFF
--- a/src/backend/drm/node/constants.rs
+++ b/src/backend/drm/node/constants.rs
@@ -6,7 +6,7 @@
 pub const DRM_MAJOR: u32 = 145;
 
 #[cfg(target_os = "netbsd")]
-pub const DRM_MAJOR: u32 = 34;
+pub const DRM_MAJOR: u32 = 180;
 
 #[cfg(all(target_os = "openbsd", target_arch = "x86"))]
 pub const DRM_MAJOR: u32 = 88;

--- a/src/backend/drm/node/mod.rs
+++ b/src/backend/drm/node/mod.rs
@@ -340,7 +340,7 @@ fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
     ))
 }
 
-#[cfg(target_os = "openbsd")]
+#[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
 fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
     use std::io::ErrorKind;
 
@@ -380,7 +380,7 @@ fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
     ))
 }
 
-#[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 fn get_minor_base(type_: NodeType) -> u32 {
     match type_ {
         NodeType::Primary => 0,


### PR DESCRIPTION
Fairly straightforward. `DRM_MAJOR` matched libdrm... but that is wrong: https://gitlab.freedesktop.org/mesa/drm/-/issues/1.

NetBSD still lacks libinput, libudev, or a way to use Smithay (non-nested) practically without those.