### PR TITLE
winit, x11: Fix scroll direction

### DIFF
--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -142,8 +142,8 @@ impl PointerAxisEvent<WinitInput> for WinitMouseWheelEvent {
 
     fn amount(&self, axis: Axis) -> Option<f64> {
         match (axis, self.delta) {
-            (Axis::Horizontal, MouseScrollDelta::PixelDelta(delta)) => Some(delta.x),
-            (Axis::Vertical, MouseScrollDelta::PixelDelta(delta)) => Some(delta.y),
+            (Axis::Horizontal, MouseScrollDelta::PixelDelta(delta)) => Some(-delta.x),
+            (Axis::Vertical, MouseScrollDelta::PixelDelta(delta)) => Some(-delta.y),
             (_, MouseScrollDelta::LineDelta(_, _)) => None,
         }
     }
@@ -151,8 +151,8 @@ impl PointerAxisEvent<WinitInput> for WinitMouseWheelEvent {
     // TODO: Use high-res scroll where backend supports it
     fn amount_v120(&self, axis: Axis) -> Option<f64> {
         match (axis, self.delta) {
-            (Axis::Horizontal, MouseScrollDelta::LineDelta(x, _)) => Some(x as f64 * 120.),
-            (Axis::Vertical, MouseScrollDelta::LineDelta(_, y)) => Some(y as f64 * 120.),
+            (Axis::Horizontal, MouseScrollDelta::LineDelta(x, _)) => Some(-x as f64 * 120.),
+            (Axis::Vertical, MouseScrollDelta::LineDelta(_, y)) => Some(-y as f64 * 120.),
             (_, MouseScrollDelta::PixelDelta(_)) => None,
         }
     }

--- a/src/backend/x11/input.rs
+++ b/src/backend/x11/input.rs
@@ -122,7 +122,10 @@ impl PointerAxisEvent<X11Input> for X11MouseWheelEvent {
 
     fn amount_v120(&self, axis: Axis) -> Option<f64> {
         if self.axis == axis {
-            Some(self.amount * 120.)
+            match axis {
+                Axis::Vertical => Some(-self.amount * 120.),
+                Axis::Horizontal => Some(self.amount * 120.),
+            }
         } else {
             Some(0.0)
         }


### PR DESCRIPTION
Testing with this, horizontal and vertical scroll now seems to work expected on both winit and X11.

Fixes https://github.com/Smithay/smithay/issues/1524.