### PR TITLE
wayland.shm: Add support for wl_shm version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ udev = { version = "0.9.0", optional = true }
 wayland-client = { version = "0.31.3", optional = true }
 wayland-cursor = { version = "0.31.3", optional = true }
 wayland-egl = { version = "0.32.0", optional = true }
-wayland-protocols = { version = "0.32.4", features = ["unstable", "staging", "server"], optional = true }
+wayland-protocols = { version = "0.32.5", features = ["unstable", "staging", "server"], optional = true }
 wayland-protocols-wlr = { version = "0.3.1", features = ["server"], optional = true }
 wayland-protocols-misc = { version = "0.3.1", features = ["server"], optional = true }
 wayland-server = { version = "0.31.0", optional = true }

--- a/src/wayland/shm/handlers.rs
+++ b/src/wayland/shm/handlers.rs
@@ -61,6 +61,7 @@ where
 
         let (pool, fd, size) = match request {
             Request::CreatePool { id: pool, fd, size } => (pool, fd, size),
+            Request::Release => return,
             _ => unreachable!(),
         };
 

--- a/src/wayland/shm/mod.rs
+++ b/src/wayland/shm/mod.rs
@@ -154,7 +154,7 @@ impl ShmState {
         formats.insert(wl_shm::Format::Argb8888);
         formats.insert(wl_shm::Format::Xrgb8888);
 
-        let shm = display.create_global::<D, WlShm, _>(1, ());
+        let shm = display.create_global::<D, WlShm, _>(2, ());
 
         ShmState { formats, shm }
     }


### PR DESCRIPTION
Version 2 adds [release](https://wayland.app/protocols/wayland#wl_shm:request:release) request, we don't have to do anything with it in Smithay as it is marked as destructor.

Draft until next wayland-rs release