### PR TITLE
Don't hold lock in `input_intercept` callback and don't expose `xkb::` types in safe API

### DIFF
--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -788,7 +788,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         // Construct the Keymap internally instead of accepting one as input
         // because libxkbcommon is not thread-safe.
         let keymap = xkb::Keymap::new_from_string(
-            &xkb::Context::new(0),
+            &self.arc.internal.lock().unwrap().xkb.context,
             keymap,
             xkb::KEYMAP_FORMAT_TEXT_V1,
             xkb::KEYMAP_COMPILE_NO_FLAGS,

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -177,8 +177,8 @@ impl Xkb {
     }
 
     /// Iterate over layouts present in the keymap.
-    pub fn layouts(&self) -> Box<dyn Iterator<Item = Layout>> {
-        Box::new((0..self.keymap.num_layouts()).map(Layout))
+    pub fn layouts(&self) -> impl Iterator<Item = Layout> {
+        (0..self.keymap.num_layouts()).map(Layout)
     }
 
     /// Returns the syms for the underlying keycode without any modifications by the current keymap


### PR DESCRIPTION
See commits messages for descriptions of the changes here. The last commit is potentially more controversial than the earlier ones; if it's an issue, I think the `Xkb` changes in the others are a good improvement at least.