### PR TITLE
xdg-shell: `is_initial_configure_sent` getter

### DIFF
--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -27,10 +27,7 @@ use smithay::{
         compositor::with_states,
         input_method::InputMethodSeat,
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
-        shell::{
-            wlr_layer::{KeyboardInteractivity, Layer as WlrLayer, LayerSurfaceCachedState},
-            xdg::XdgToplevelSurfaceData,
-        },
+        shell::wlr_layer::{KeyboardInteractivity, Layer as WlrLayer, LayerSurfaceCachedState},
     },
 };
 
@@ -122,16 +119,8 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                                 false
                             }
                         });
-                        let initial_configure_sent = with_states(toplevel.wl_surface(), |states| {
-                            states
-                                .data_map
-                                .get::<XdgToplevelSurfaceData>()
-                                .unwrap()
-                                .lock()
-                                .unwrap()
-                                .initial_configure_sent
-                        });
-                        if mode_changed && initial_configure_sent {
+
+                        if mode_changed && toplevel.is_initial_configure_sent() {
                             toplevel.send_pending_configure();
                         }
                     }

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -31,7 +31,7 @@ use smithay::{
                 Layer, LayerSurface as WlrLayerSurface, LayerSurfaceData, WlrLayerShellHandler,
                 WlrLayerShellState,
             },
-            xdg::{XdgPopupSurfaceData, XdgToplevelSurfaceData},
+            xdg::XdgToplevelSurfaceData,
         },
     },
 };
@@ -322,16 +322,7 @@ fn ensure_initial_configure(surface: &WlSurface, space: &Space<WindowElement>, p
             }
         };
 
-        let initial_configure_sent = with_states(surface, |states| {
-            states
-                .data_map
-                .get::<XdgPopupSurfaceData>()
-                .unwrap()
-                .lock()
-                .unwrap()
-                .initial_configure_sent
-        });
-        if !initial_configure_sent {
+        if !popup.is_initial_configure_sent() {
             // NOTE: This should never fail as the initial configure is always
             // allowed.
             popup.send_configure().expect("initial configure failed");

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -311,7 +311,11 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
 
         // The protocol demands us to always reply with a configure,
         // regardless of we fulfilled the request or not
-        surface.send_configure();
+        if surface.is_initial_configure_sent() {
+            surface.send_configure();
+        } else {
+            // Will be sent during initial configure
+        }
     }
 
     fn unfullscreen_request(&mut self, surface: ToplevelSurface) {
@@ -367,7 +371,11 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
 
         // The protocol demands us to always reply with a configure,
         // regardless of we fulfilled the request or not
-        surface.send_configure();
+        if surface.is_initial_configure_sent() {
+            surface.send_configure();
+        } else {
+            // Will be sent during initial configure
+        }
     }
 
     fn unmaximize_request(&mut self, surface: ToplevelSurface) {

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -75,7 +75,7 @@ use smithay::{
             wlr_layer::WlrLayerShellState,
             xdg::{
                 decoration::{XdgDecorationHandler, XdgDecorationState},
-                ToplevelSurface, XdgShellState, XdgToplevelSurfaceData,
+                ToplevelSurface, XdgShellState,
             },
         },
         shm::{ShmHandler, ShmState},
@@ -427,16 +427,7 @@ impl<BackendData: Backend> XdgDecorationHandler for AnvilState<BackendData> {
             });
         });
 
-        let initial_configure_sent = with_states(toplevel.wl_surface(), |states| {
-            states
-                .data_map
-                .get::<XdgToplevelSurfaceData>()
-                .unwrap()
-                .lock()
-                .unwrap()
-                .initial_configure_sent
-        });
-        if initial_configure_sent {
+        if toplevel.is_initial_configure_sent() {
             toplevel.send_pending_configure();
         }
     }
@@ -445,16 +436,8 @@ impl<BackendData: Backend> XdgDecorationHandler for AnvilState<BackendData> {
         toplevel.with_pending_state(|state| {
             state.decoration_mode = Some(Mode::ClientSide);
         });
-        let initial_configure_sent = with_states(toplevel.wl_surface(), |states| {
-            states
-                .data_map
-                .get::<XdgToplevelSurfaceData>()
-                .unwrap()
-                .lock()
-                .unwrap()
-                .initial_configure_sent
-        });
-        if initial_configure_sent {
+
+        if toplevel.is_initial_configure_sent() {
             toplevel.send_pending_configure();
         }
     }

--- a/smallvil/src/handlers/xdg_shell.rs
+++ b/smallvil/src/handlers/xdg_shell.rs
@@ -16,8 +16,8 @@ use smithay::{
     wayland::{
         compositor::with_states,
         shell::xdg::{
-            PopupSurface, PositionerState, ToplevelSurface, XdgPopupSurfaceData, XdgShellHandler,
-            XdgShellState, XdgToplevelSurfaceData,
+            PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler, XdgShellState,
+            XdgToplevelSurfaceData,
         },
     },
 };
@@ -177,16 +177,7 @@ pub fn handle_commit(popups: &mut PopupManager, space: &Space<Window>, surface: 
     if let Some(popup) = popups.find_popup(surface) {
         match popup {
             PopupKind::Xdg(ref xdg) => {
-                let initial_configure_sent = with_states(surface, |states| {
-                    states
-                        .data_map
-                        .get::<XdgPopupSurfaceData>()
-                        .unwrap()
-                        .lock()
-                        .unwrap()
-                        .initial_configure_sent
-                });
-                if !initial_configure_sent {
+                if !xdg.is_initial_configure_sent() {
                     // NOTE: This should never fail as the initial configure is always
                     // allowed.
                     xdg.send_configure().expect("initial configure failed");

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1527,6 +1527,22 @@ impl ToplevelSurface {
         serial
     }
 
+    /// Did the surface sent the initial
+    /// configure event to the client.
+    ///
+    /// Calls [`compositor::with_states`] internally.
+    pub fn is_initial_configure_sent(&self) -> bool {
+        compositor::with_states(&self.wl_surface, |states| {
+            states
+                .data_map
+                .get::<XdgToplevelSurfaceData>()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .initial_configure_sent
+        })
+    }
+
     /// Handles the role specific commit logic
     ///
     /// This should be called when the underlying WlSurface
@@ -1841,6 +1857,22 @@ impl PopupSurface {
         let serial = self.send_configure_internal(None);
 
         Ok(serial)
+    }
+
+    /// Did the surface sent the initial
+    /// configure event to the client.
+    ///
+    /// Calls [`compositor::with_states`] internally.
+    pub fn is_initial_configure_sent(&self) -> bool {
+        compositor::with_states(&self.wl_surface, |states| {
+            states
+                .data_map
+                .get::<XdgPopupSurfaceData>()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .initial_configure_sent
+        })
     }
 
     /// Send a configure event, including the `repositioned` event to the client


### PR DESCRIPTION
Just a simple helper to reduce typemap magic a little bit.

Technically, this needlessly hides deadlocky `compositor::with_states`, but I doubt it matters if `send_configure`  usually called right after this check hides `with_states` already, if anything this reduces the chance of someone calling `send_configure` in `with_states` callback where needed initial configure value is available.

This also fixes Anvil sending configure to early during initial configure dance, whenever fullscreen/maximize requests are retrieved, but guarding the configure with `if is_initial_configure_sent`.