### PR TITLE
fix deadlock in AtomicDrmDevice

### DIFF
--- a/src/backend/drm/device/atomic.rs
+++ b/src/backend/drm/device/atomic.rs
@@ -138,6 +138,8 @@ impl AtomicDrmDevice {
         dev.old_state = old_state;
         trace!("Mapping: {:#?}", mapping);
 
+        drop(mapping);
+
         // If the user does not explicitly requests us to skip this,
         // we clear out the complete connector<->crtc mapping on device creation.
         //
@@ -154,7 +156,6 @@ impl AtomicDrmDevice {
             dev.reset_state()?;
         }
 
-        drop(mapping);
         drop(_guard);
         Ok(dev)
     }


### PR DESCRIPTION
https://github.com/Smithay/smithay/commit/88cdf9bd7d9c3550d16aa7b291486b9b4471e1c0 introduced a deadlock when creating AtomicDrmDevice, as https://github.com/Smithay/smithay/blob/88cdf9bd7d9c3550d16aa7b291486b9b4471e1c0/src/backend/drm/device/atomic.rs#L122 causes a deadlock in https://github.com/Smithay/smithay/blob/88cdf9bd7d9c3550d16aa7b291486b9b4471e1c0/src/backend/drm/device/atomic.rs#L185, since the `mapping` is dropped too late. this changes it to be dropped earlier.