### PR TITLE
multigpu: reset texture on surface buffer format change

### DIFF
--- a/src/backend/renderer/multigpu/gbm.rs
+++ b/src/backend/renderer/multigpu/gbm.rs
@@ -310,7 +310,7 @@ where
                     .find_map(|renderer| Self::try_import_egl(renderer.renderer_mut(), buffer).ok())
             })
         {
-            let texture = MultiTexture::from_surface(surface, dmabuf.size());
+            let texture = MultiTexture::from_surface(surface, dmabuf.size(), dmabuf.format());
             let texture_ref = texture.0.clone();
             let res = self.import_dmabuf_internal(&dmabuf, texture, Some(damage));
             if res.is_ok() {


### PR DESCRIPTION
A surface itself does not have a format, it is implicitly defined by the currently attached buffer. So whenever we cache something that depends on that format we have to clear the cache if the format changes.

~~This might explain all kind of strange issues when going between direct scan-out and composition where it is not
unlikely that the format changes.~~ Might not happen so often as mesa does not implicitly change format afaik

@YaLTeR Thanks for reporting the detailed reproduction in `#smithay`