### PR TITLE
add pointer location hint

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -365,6 +365,29 @@ impl<BackendData: Backend> PointerConstraintsHandler for AnvilState<BackendData>
             });
         }
     }
+
+    fn cursor_position_hint(
+        &mut self,
+        surface: &WlSurface,
+        pointer: &PointerHandle<Self>,
+        location: Point<f64, Logical>,
+    ) {
+        if with_pointer_constraint(surface, pointer, |constraint| {
+            constraint.map_or(false, |c| c.is_active())
+        }) {
+            let origin = self
+                .space
+                .elements()
+                .find_map(|window| {
+                    (window.wl_surface().as_deref() == Some(surface)).then(|| window.geometry())
+                })
+                .unwrap_or_default()
+                .loc
+                .to_f64();
+
+            pointer.set_location_hint(origin + location);
+        }
+    }
 }
 delegate_pointer_constraints!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -385,7 +385,7 @@ impl<BackendData: Backend> PointerConstraintsHandler for AnvilState<BackendData>
                 .loc
                 .to_f64();
 
-            pointer.set_location_hint(origin + location);
+            pointer.set_location(origin + location);
         }
     }
 }

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -435,6 +435,23 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
         self.inner.lock().unwrap().location
     }
 
+    /// Update the current location of this pointer in the global space,
+    /// without sending any event and without updating the focus.
+    ///
+    /// This is useful when the pointer is only moved by relative events,
+    /// such as when a pointer lock is held by the focused surface.
+    /// The client can give us a cursor position hint, which corresponds to
+    /// the actual location the client may be rendering a pointer at.
+    /// This position hint should be used as the initial location
+    /// when the pointer lock is deactivated.
+    ///
+    /// The next time [Self::motion] is called, the focus will be
+    /// updated accordingly as if this function was never called.
+    /// Clients will never be notified of a location hint.
+    pub fn set_location_hint(&self, location: Point<f64, Logical>) {
+        self.inner.lock().unwrap().location = location;
+    }
+
     /// Access the [`Serial`] of the last `pointer_enter` event, if that focus is still active.
     ///
     /// In other words this will return `None` again, once a `pointer_leave` event occurred.

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -438,6 +438,9 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     /// Update the current location of this pointer in the global space,
     /// without sending any event and without updating the focus.
     ///
+    /// If you want to update the location, and update the focus,
+    /// and send events, use [Self::motion] instead of this.
+    ///
     /// This is useful when the pointer is only moved by relative events,
     /// such as when a pointer lock is held by the focused surface.
     /// The client can give us a cursor position hint, which corresponds to

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -448,7 +448,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
     /// The next time [Self::motion] is called, the focus will be
     /// updated accordingly as if this function was never called.
     /// Clients will never be notified of a location hint.
-    pub fn set_location_hint(&self, location: Point<f64, Logical>) {
+    pub fn set_location(&self, location: Point<f64, Logical>) {
         self.inner.lock().unwrap().location = location;
     }
 

--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -183,6 +183,7 @@ impl PointerConstraint {
         }
     }
 
+    /// Commits the pending state of the constraint, and returns the cursor position hint if it has changed.
     fn commit(&mut self) -> Option<Point<f64, Logical>> {
         match self {
             Self::Confined(confined) => {


### PR DESCRIPTION
I noticed that at the moment, there seems to be absolutely no way to utilize the value of [zwp_locked_pointer_v1::set_cursor_position_hint](https://wayland.app/protocols/pointer-constraints-unstable-v1#zwp_locked_pointer_v1:request:set_cursor_position_hint), not least because there is no good way to be notified of when its state changes, but Smithay's pointer handling seems to have no way to actually inform it about a cursor position hint.

This PR fixes that, by adding a method to `PointerConstraintsHandler` to notify the downstream compositor, and a method to `PointerHandle` to update the location field. Because it keeps track of the old focus as a separate field, i reckon this isn't going to cause any issues, and if it does cause issues, it's entirely opt-in.

`PointerConstrainsHandler::cursor_position_hint` receives surface-local coordinates. `PointerHandle::set_location_hint` expects global coordinates. It is up to the compositor to correctly map the surface-local coordinates to global coordinates.

I've already implemented this in niri. That pull request contains a video comparison of a real client (which also happens to be niri) and a concrete benefit to having the pointer location hints in Smithay.
- https://github.com/YaLTeR/niri/pull/685

Some care had to be taken when calling `PointerConstraintsHandler::cursor_position_hint` to make sure we don't deadlock. I may or may not have caused deadlocks several times when implementing this, where the only remedy was a hard reset of my hardware. Oops.