### PR TITLE
WIP Enable `clippy::same_name_method` lint

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -2460,7 +2460,7 @@ impl<'frame> GlesFrame<'frame> {
     /// Optionally allows a custom texture program and matching additional uniforms to be passed in.
     #[instrument(level = "trace", skip(self), parent = &self.span)]
     #[profiling::function]
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::same_name_method, clippy::too_many_arguments)]
     pub fn render_texture_from_to(
         &mut self,
         texture: &GlesTexture,

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -530,6 +530,7 @@ impl LayerSurface {
 
     /// Returns the underlying [`WlSurface`]
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn wl_surface(&self) -> &WlSurface {
         self.0.surface.wl_surface()
     }
@@ -721,6 +722,6 @@ impl LayerSurface {
 impl WaylandFocus for LayerSurface {
     #[inline]
     fn wl_surface(&self) -> Option<Cow<'_, wl_surface::WlSurface>> {
-        Some(Cow::Borrowed(self.0.surface.wl_surface()))
+        Some(Cow::Borrowed(self.wl_surface()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, clippy::same_name_method)]
 // Allow acronyms like EGL
 #![allow(clippy::upper_case_acronyms)]
 

--- a/src/wayland/drm_syncobj/sync_point.rs
+++ b/src/wayland/drm_syncobj/sync_point.rs
@@ -79,6 +79,7 @@ impl DrmSyncPoint {
     }
 
     /// Wait for sync point.
+    #[allow(clippy::same_name_method)]
     pub fn wait(&self, timeout_nsec: i64) -> io::Result<()> {
         self.timeline.0.device.syncobj_timeline_wait(
             &[self.timeline.0.syncobj],


### PR DESCRIPTION
It is confusing and error prone to have a method on a type and a trait implemented by that type with the same name.

This is particularly bad for something like `<Window as SpaceElement>::bbox`, which actually calls `Window::bbox_with_popups`. Which is different from `Window::box`. But these three functions have the same type signature.

It seems good to disallow this lint in general, but it can be allowed where the methods do the same thing.

Not sure how we want to resolve this. Is there a better way to name `bbox`/`geometry` to avoid duplication? "Geometry" seems like a problematically overloaded term in general...

I guess it's probably not intentional that `xwm::X11Surface` has two definitions of `alive()`, once as `self.state.lock().unwrap().alive` and once as `self.state.lock().unwrap().alive && self.conn.strong_count() != 0`?