### PR TITLE
Add a `disable` method to `DrmSurface`/`DrmCompositor` for implementing DPMS

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -4216,6 +4216,24 @@ where
             Err(Some(RenderingReason::ScanoutFailed))
         }
     }
+
+    /// Clear the surface, setting DPMS state to off, disabling all planes,
+    /// and clearing the pending frame.
+    ///
+    /// Calling [`queue_frame`][Self::queue_frame] will re-enable.
+    pub fn clear(&mut self) -> Result<(), DrmError> {
+        self.surface.clear()?;
+
+        self.current_frame
+            .planes
+            .iter_mut()
+            .for_each(|(_, state)| *state = Default::default());
+        self.pending_frame = None;
+        self.queued_frame = None;
+        self.next_frame = None;
+
+        Ok(())
+    }
 }
 
 #[inline]

--- a/src/backend/drm/device/legacy.rs
+++ b/src/backend/drm/device/legacy.rs
@@ -202,9 +202,9 @@ where
                         conn,
                         *handle,
                         if enabled {
-                            0 /*DRM_MODE_DPMS_ON*/
+                            drm_ffi::DRM_MODE_DPMS_ON.into()
                         } else {
-                            3 /*DRM_MODE_DPMS_OFF*/
+                            drm_ffi::DRM_MODE_DPMS_OFF.into()
                         },
                     )
                     .map_err(|source| {

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -1081,6 +1081,10 @@ impl AtomicDrmSurface {
     pub(crate) fn device_fd(&self) -> &DrmDeviceFd {
         self.fd.device_fd()
     }
+
+    pub fn clear(&self) -> Result<(), Error> {
+        self.clear_state()
+    }
 }
 
 struct TestBuffer {

--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -18,7 +18,6 @@ use tracing::{debug, info, info_span, instrument, trace};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct State {
-    pub active: bool,
     pub mode: Mode,
     pub connectors: HashSet<connector::Handle>,
 }
@@ -74,9 +73,6 @@ impl State {
         // we need to be sure, we require a mode to always be set without relying on the compiler.
         // So we cheat, because it works and is easier to handle later.
         Ok(State {
-            // On legacy there is not (reliable) way to read-back the dpms state.
-            // So we just always assume it is off.
-            active: false,
             mode: current_mode.unwrap_or_else(|| unsafe { std::mem::zeroed() }),
             connectors: current_connectors,
         })
@@ -107,7 +103,6 @@ impl LegacyDrmSurface {
 
         let state = State::current_state(&*fd, crtc)?;
         let pending = State {
-            active: true,
             mode,
             connectors: connectors.iter().copied().collect(),
         };

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -441,6 +441,17 @@ impl DrmSurface {
             DrmSurfaceInternal::Legacy(surf) => &surf.span,
         }
     }
+
+    /// Clear the surface, setting DPMS state to off and disabling all planes.
+    ///
+    /// The surface will be re-enabled on the next [`page_flip`][Self::page_flip] or
+    /// [`commit`][Self::commit].
+    pub fn clear(&self) -> Result<(), Error> {
+        match &*self.internal {
+            DrmSurfaceInternal::Atomic(surf) => surf.clear(),
+            DrmSurfaceInternal::Legacy(surf) => surf.clear(),
+        }
+    }
 }
 
 fn ensure_legacy_planes<'a>(


### PR DESCRIPTION
As discussed in https://github.com/Smithay/smithay/issues/1553.

This seems to be working okay, on atomic or legacy DRM. I'm still finishing the cosmic-comp support.

Not sure if `DrmCompositor::disable` should clear any other state. Or if `AtomicDrmSurface::clear_state` does anything that is unneeded here. Other compositors appear to vary slightly in which properties their atomic backends set/unset for DPMS.