### PR TITLE
WIP `fifo` and `commit-timing` protocols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,3 +140,10 @@ harness = false
 [profile.release-with-debug]
 inherits = "release"
 debug = true
+
+[patch.crates-io]
+wayland-protocols = { git = "https://github.com/Smithay/wayland-rs" }
+wayland-client = { git = "https://github.com/Smithay/wayland-rs" }
+wayland-server = { git = "https://github.com/Smithay/wayland-rs" }
+wayland-backend = { git = "https://github.com/Smithay/wayland-rs" }
+wayland-sys = { git = "https://github.com/Smithay/wayland-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ udev = { version = "0.9.0", optional = true }
 wayland-client = { version = "0.31.3", optional = true }
 wayland-cursor = { version = "0.31.3", optional = true }
 wayland-egl = { version = "0.32.0", optional = true }
-wayland-protocols = { version = "0.32.4", features = ["unstable", "staging", "server"], optional = true }
+wayland-protocols = { version = "0.32.5", features = ["unstable", "staging", "server"], optional = true }
 wayland-protocols-wlr = { version = "0.3.1", features = ["server"], optional = true }
 wayland-protocols-misc = { version = "0.3.1", features = ["server"], optional = true }
 wayland-server = { version = "0.31.0", optional = true }
@@ -140,10 +140,3 @@ harness = false
 [profile.release-with-debug]
 inherits = "release"
 debug = true
-
-[patch.crates-io]
-wayland-protocols = { git = "https://github.com/Smithay/wayland-rs" }
-wayland-client = { git = "https://github.com/Smithay/wayland-rs" }
-wayland-server = { git = "https://github.com/Smithay/wayland-rs" }
-wayland-backend = { git = "https://github.com/Smithay/wayland-rs" }
-wayland-sys = { git = "https://github.com/Smithay/wayland-rs" }

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -46,6 +46,7 @@ use smithay::{
     },
     utils::{Clock, Logical, Monotonic, Point, Rectangle},
     wayland::{
+        commit_timing::CommitTimingState,
         compositor::{get_parent, with_states, CompositorClientState, CompositorState},
         dmabuf::DmabufFeedback,
         fifo::FifoState,
@@ -568,6 +569,8 @@ smithay::delegate_single_pixel_buffer!(@<BackendData: Backend + 'static> AnvilSt
 
 smithay::delegate_fifo!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
+smithay::delegate_commit_timing!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+
 impl<BackendData: Backend + 'static> AnvilState<BackendData> {
     pub fn init(
         display: Display<AnvilState<BackendData>>,
@@ -648,6 +651,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                 .map_or(true, |client_state| client_state.security_context.is_none())
         });
         FifoState::new::<Self, _>(&dh, |_| true);
+        CommitTimingState::new::<Self, _>(&dh, |_| true);
 
         // init input
         let seat_name = backend_data.seat_name();

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -48,6 +48,7 @@ use smithay::{
     wayland::{
         compositor::{get_parent, with_states, CompositorClientState, CompositorState},
         dmabuf::DmabufFeedback,
+        fifo::FifoState,
         fractional_scale::{with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState},
         input_method::{InputMethodHandler, InputMethodManagerState, PopupSurface},
         keyboard_shortcuts_inhibit::{
@@ -565,6 +566,8 @@ smithay::delegate_xdg_foreign!(@<BackendData: Backend + 'static> AnvilState<Back
 
 smithay::delegate_single_pixel_buffer!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
+smithay::delegate_fifo!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
+
 impl<BackendData: Backend + 'static> AnvilState<BackendData> {
     pub fn init(
         display: Display<AnvilState<BackendData>>,
@@ -644,6 +647,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
                 .get_data::<ClientState>()
                 .map_or(true, |client_state| client_state.security_context.is_none())
         });
+        FifoState::new::<Self, _>(&dh, |_| true);
 
         // init input
         let seat_name = backend_data.seat_name();

--- a/src/wayland/commit_timing.rs
+++ b/src/wayland/commit_timing.rs
@@ -1,0 +1,143 @@
+use std::time::Duration;
+use wayland_protocols::wp::commit_timing::v1::server::{wp_commit_timer_v1, wp_commit_timing_manager_v1};
+use wayland_server::{
+    backend::GlobalId, protocol::wl_surface, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
+    Resource, WEnum, Weak,
+};
+
+pub struct CommitTimingState {}
+
+impl CommitTimingState {
+    pub fn new<D, F>(display: &DisplayHandle, filter: F) -> Self
+    where
+        D: GlobalDispatch<
+            wp_commit_timing_manager_v1::WpCommitTimingManagerV1,
+            CommitTimingManagerGlobalData,
+        >,
+        D: Dispatch<wp_commit_timing_manager_v1::WpCommitTimingManagerV1, ()>,
+        D: Dispatch<wp_commit_timer_v1::WpCommitTimerV1, CommitTimerData>,
+        D: 'static,
+        F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
+    {
+        let data = CommitTimingManagerGlobalData {
+            filter: Box::new(filter),
+        };
+        display.create_global::<D, wp_commit_timing_manager_v1::WpCommitTimingManagerV1, _>(1, data);
+
+        Self {}
+    }
+}
+
+#[allow(missing_debug_implementations)]
+#[doc(hidden)]
+pub struct CommitTimingManagerGlobalData {
+    /// Filter whether the clients can view global.
+    filter: Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>,
+}
+
+impl<D> GlobalDispatch<wp_commit_timing_manager_v1::WpCommitTimingManagerV1, CommitTimingManagerGlobalData, D>
+    for CommitTimingState
+where
+    D: GlobalDispatch<wp_commit_timing_manager_v1::WpCommitTimingManagerV1, CommitTimingManagerGlobalData>,
+    D: Dispatch<wp_commit_timing_manager_v1::WpCommitTimingManagerV1, ()>,
+    D: 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _display: &DisplayHandle,
+        _client: &Client,
+        manager: New<wp_commit_timing_manager_v1::WpCommitTimingManagerV1>,
+        _global_data: &CommitTimingManagerGlobalData,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(manager, ());
+    }
+
+    fn can_view(client: Client, global_data: &CommitTimingManagerGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+#[doc(hidden)]
+pub struct CommitTimerData {
+    surface: Weak<wl_surface::WlSurface>,
+}
+
+impl<D> Dispatch<wp_commit_timing_manager_v1::WpCommitTimingManagerV1, (), D> for CommitTimingState
+where
+    D: Dispatch<wp_commit_timing_manager_v1::WpCommitTimingManagerV1, ()>,
+    D: Dispatch<wp_commit_timer_v1::WpCommitTimerV1, CommitTimerData>,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &wayland_server::Client,
+        _proxy: &wp_commit_timing_manager_v1::WpCommitTimingManagerV1,
+        request: wp_commit_timing_manager_v1::Request,
+        _data: &(),
+        _dh: &DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            wp_commit_timing_manager_v1::Request::GetTimer { id, surface } => {
+                // TODO CommitTimerExists
+                data_init.init(
+                    id,
+                    CommitTimerData {
+                        surface: surface.downgrade(),
+                    },
+                );
+            }
+            wp_commit_timing_manager_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<wp_commit_timer_v1::WpCommitTimerV1, CommitTimerData, D> for CommitTimingState
+where
+    D: Dispatch<wp_commit_timer_v1::WpCommitTimerV1, CommitTimerData>,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &wayland_server::Client,
+        _proxy: &wp_commit_timer_v1::WpCommitTimerV1,
+        request: wp_commit_timer_v1::Request,
+        _data: &CommitTimerData,
+        _dh: &DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            wp_commit_timer_v1::Request::SetTimestamp {
+                tv_sec_hi,
+                tv_sec_lo,
+                tv_nsec,
+            } => {
+                let secs = (u64::from(tv_sec_hi) << 32) + u64::from(tv_sec_lo);
+                let duration = Duration::new(secs, tv_nsec);
+            }
+            wp_commit_timer_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! delegate_commit_timing {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::commit_timing::v1::server::wp_commit_timing_manager_v1::WpCommitTimingManagerV1: $crate::wayland::commit_timing::CommitTimingManagerGlobalData
+        ] => $crate::wayland::commit_timing::CommitTimingState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::commit_timing::v1::server::wp_commit_timing_manager_v1::WpCommitTimingManagerV1: ()
+        ] => $crate::wayland::commit_timing::CommitTimingState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::commit_timing::v1::server::wp_commit_timer_v1::WpCommitTimerV1: $crate::wayland::commit_timing::CommitTimerData
+        ] => $crate::wayland::commit_timing::CommitTimingState);
+    };
+}
+//use wayland_protocols::wp::commit_timing::v1::server::{wp_commit_timer_v1, wp_commit_timing_manager_v1};

--- a/src/wayland/fifo.rs
+++ b/src/wayland/fifo.rs
@@ -1,0 +1,131 @@
+use wayland_protocols::wp::fifo::v1::server::{wp_fifo_manager_v1, wp_fifo_v1};
+use wayland_server::{
+    backend::GlobalId, protocol::wl_surface, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
+    Resource, WEnum, Weak,
+};
+
+pub struct FifoState {}
+
+impl FifoState {
+    pub fn new<D, F>(display: &DisplayHandle, filter: F) -> Self
+    where
+        D: GlobalDispatch<wp_fifo_manager_v1::WpFifoManagerV1, FifoManagerGlobalData>,
+        D: Dispatch<wp_fifo_manager_v1::WpFifoManagerV1, ()>,
+        D: Dispatch<wp_fifo_v1::WpFifoV1, FifoData>,
+        D: 'static,
+        F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
+    {
+        let data = FifoManagerGlobalData {
+            filter: Box::new(filter),
+        };
+        display.create_global::<D, wp_fifo_manager_v1::WpFifoManagerV1, _>(1, data);
+
+        Self {}
+    }
+}
+
+#[allow(missing_debug_implementations)]
+#[doc(hidden)]
+pub struct FifoManagerGlobalData {
+    /// Filter whether the clients can view global.
+    filter: Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>,
+}
+
+impl<D> GlobalDispatch<wp_fifo_manager_v1::WpFifoManagerV1, FifoManagerGlobalData, D> for FifoState
+where
+    D: GlobalDispatch<wp_fifo_manager_v1::WpFifoManagerV1, FifoManagerGlobalData>,
+    D: Dispatch<wp_fifo_manager_v1::WpFifoManagerV1, ()>,
+    D: 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _display: &DisplayHandle,
+        _client: &Client,
+        manager: New<wp_fifo_manager_v1::WpFifoManagerV1>,
+        _global_data: &FifoManagerGlobalData,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(manager, ());
+    }
+
+    fn can_view(client: Client, global_data: &FifoManagerGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+impl<D> Dispatch<wp_fifo_manager_v1::WpFifoManagerV1, (), D> for FifoState
+where
+    D: Dispatch<wp_fifo_manager_v1::WpFifoManagerV1, ()>,
+    D: Dispatch<wp_fifo_v1::WpFifoV1, FifoData>,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &wayland_server::Client,
+        _proxy: &wp_fifo_manager_v1::WpFifoManagerV1,
+        request: wp_fifo_manager_v1::Request,
+        _data: &(),
+        _dh: &DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            wp_fifo_manager_v1::Request::GetFifo { id, surface } => {
+                // TODO AlreadyExists
+                data_init.init(
+                    id,
+                    FifoData {
+                        surface: surface.downgrade(),
+                    },
+                );
+            }
+            wp_fifo_manager_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct FifoData {
+    surface: Weak<wl_surface::WlSurface>,
+}
+
+impl<D> Dispatch<wp_fifo_v1::WpFifoV1, FifoData, D> for FifoState
+where
+    D: Dispatch<wp_fifo_v1::WpFifoV1, FifoData>,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &wayland_server::Client,
+        _proxy: &wp_fifo_v1::WpFifoV1,
+        request: wp_fifo_v1::Request,
+        _data: &FifoData,
+        _dh: &DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            wp_fifo_v1::Request::SetBarrier => {}
+            wp_fifo_v1::Request::WaitBarrier => {}
+            wp_fifo_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! delegate_fifo {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::fifo::v1::server::wp_fifo_manager_v1::WpFifoManagerV1: $crate::wayland::fifo::FifoManagerGlobalData
+        ] => $crate::wayland::fifo::FifoState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::fifo::v1::server::wp_fifo_manager_v1::WpFifoManagerV1: ()
+        ] => $crate::wayland::fifo::FifoState);
+
+        $crate::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::wayland_protocols::wp::fifo::v1::server::wp_fifo_v1::WpFifoV1: $crate::wayland::fifo::FifoData
+        ] => $crate::wayland::fifo::FifoState);
+    };
+}

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -47,6 +47,7 @@
 
 pub mod alpha_modifier;
 pub mod buffer;
+pub mod commit_timing;
 pub mod compositor;
 pub mod content_type;
 pub mod cursor_shape;

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -55,6 +55,7 @@ pub mod dmabuf;
 pub mod drm_lease;
 #[cfg(feature = "backend_drm")]
 pub mod drm_syncobj;
+pub mod fifo;
 pub mod foreign_toplevel_list;
 pub mod fractional_scale;
 pub mod idle_inhibit;


### PR DESCRIPTION
This doesn't yet implement the correct behavior; it just has the boilerplate to expose the protocol.

I've been meaning to see what implementing `fifo` would take. And now it's provided in `wayland-protocols`. I guess it basically amounts to having a `Blocker` for a transaction that delays a transaction with a  `wait_barrier` until the previous transaction with `set_barrier` has passed? I think that should be easy...

For `commit_timing`, I guess we need a `Blocker` that just checks if a certain monotonic time has passed yet.