### PR TITLE
output: fix scale clamping

### DIFF
--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -254,7 +254,7 @@ impl Output {
                 inner.send_geometry_to(&output);
             }
             if (new_scale.is_some() || scale_changed) && output.version() >= 2 {
-                let scale = (inner.scale.integer_scale() / client_scale as i32).min(1);
+                let scale = (inner.scale.integer_scale() / client_scale as i32).max(1);
                 output.scale(scale);
             }
             if output.version() >= 2 {


### PR DESCRIPTION
we want to make sure the output integer scale
is always >= 1 after applying the client scale.
using min will do the opposite, so change to max
which will make sure we always return at least 1
or whatever scale we calculated

fixes #1559 