### PR TITLE
Add Pointer/Touch/KeyboardHandle::with_grab() and downcasting

### DIFF
--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use downcast_rs::{impl_downcast, Downcast};
+
 use crate::{
     backend::input::ButtonState,
     input::SeatHandler,
@@ -32,7 +34,7 @@ use super::{
 /// When your grab ends (either as you requested it or if it was forcefully cancelled by the server),
 /// the struct implementing this trait will be dropped. As such you should put clean-up logic in the destructor,
 /// rather than trying to guess when the grab will end.
-pub trait PointerGrab<D: SeatHandler>: Send {
+pub trait PointerGrab<D: SeatHandler>: Send + Downcast {
     /// A motion was reported
     ///
     /// This method allows you attach additional behavior to a motion event, possibly altering it.
@@ -169,6 +171,8 @@ pub trait PointerGrab<D: SeatHandler>: Send {
     /// The grab has been unset or replaced with another grab.
     fn unset(&mut self, data: &mut D);
 }
+
+impl_downcast!(PointerGrab<D> where D: SeatHandler);
 
 /// Data about the event that started the grab.
 pub struct GrabStartData<D: SeatHandler> {

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -336,13 +336,21 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
     fn unset(&mut self, _data: &mut D) {}
 }
 
-// A click grab, basic grab started when an user clicks a surface
-// to maintain it focused until the user releases the click.
-//
-// In case the user maintains several simultaneous clicks, release
-// the grab once all are released.
-struct ClickGrab<D: SeatHandler> {
+/// A click grab, basic grab started when an user clicks a surface
+/// to maintain it focused until the user releases the click.
+///
+/// In case the user maintains several simultaneous clicks, release
+/// the grab once all are released.
+pub struct ClickGrab<D: SeatHandler> {
     start_data: GrabStartData<D>,
+}
+
+impl<D: SeatHandler + 'static> fmt::Debug for ClickGrab<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClickGrab")
+            .field("start_data", &self.start_data)
+            .finish()
+    }
 }
 
 impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -18,7 +18,7 @@ pub use cursor_image::{CursorImageAttributes, CursorImageStatus, CursorImageSurf
 
 mod grab;
 use grab::DefaultGrab;
-pub use grab::{GrabStartData, PointerGrab};
+pub use grab::{ClickGrab, GrabStartData, PointerGrab};
 use tracing::{info_span, instrument};
 
 /// An handle to a pointer handler

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -207,6 +207,16 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
         }
     }
 
+    /// Calls `f` with the active grab, if any.
+    pub fn with_grab<T>(&self, f: impl FnOnce(Serial, &dyn PointerGrab<D>) -> T) -> Option<T> {
+        let guard = self.inner.lock().unwrap();
+        if let GrabStatus::Active(s, g) = &guard.grab {
+            Some(f(*s, &**g))
+        } else {
+            None
+        }
+    }
+
     /// Notify that the pointer moved
     ///
     /// You provide the new location of the pointer, in the form of:

--- a/src/input/touch/grab.rs
+++ b/src/input/touch/grab.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use downcast_rs::{impl_downcast, Downcast};
+
 use crate::{
     backend::input::TouchSlot,
     input::SeatHandler,
@@ -28,7 +30,7 @@ use super::{DownEvent, MotionEvent, OrientationEvent, ShapeEvent, TouchInnerHand
 /// When your grab ends (either as you requested it or if it was forcefully cancelled by the server),
 /// the struct implementing this trait will be dropped. As such you should put clean-up logic in the destructor,
 /// rather than trying to guess when the grab will end.
-pub trait TouchGrab<D: SeatHandler>: Send {
+pub trait TouchGrab<D: SeatHandler>: Send + Downcast {
     /// A new touch point appeared
     ///
     /// This method allows you attach additional behavior to a down event, possibly altering it.
@@ -109,6 +111,8 @@ pub trait TouchGrab<D: SeatHandler>: Send {
     /// The grab has been unset or replaced with another grab.
     fn unset(&mut self, data: &mut D);
 }
+
+impl_downcast!(TouchGrab<D> where D: SeatHandler);
 
 /// Data about the event that started the grab.
 pub struct GrabStartData<D: SeatHandler> {

--- a/src/input/touch/mod.rs
+++ b/src/input/touch/mod.rs
@@ -269,6 +269,16 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
         }
     }
 
+    /// Calls `f` with the active grab, if any.
+    pub fn with_grab<T>(&self, f: impl FnOnce(Serial, &dyn TouchGrab<D>) -> T) -> Option<T> {
+        let guard = self.inner.lock().unwrap();
+        if let GrabStatus::Active(s, g) = &guard.grab {
+            Some(f(*s, &**g))
+        } else {
+            None
+        }
+    }
+
     /// Notify that a new touch point appeared
     ///
     /// You provide the location of the touch, in the form of:

--- a/src/wayland/input_method/mod.rs
+++ b/src/wayland/input_method/mod.rs
@@ -81,7 +81,7 @@ use crate::{
 };
 
 pub use input_method_handle::{InputMethodHandle, InputMethodUserData};
-pub use input_method_keyboard_grab::InputMethodKeyboardUserData;
+pub use input_method_keyboard_grab::{InputMethodKeyboardGrab, InputMethodKeyboardUserData};
 pub use input_method_popup_surface::InputMethodPopupSurfaceUserData;
 
 use super::text_input::TextInputHandle;

--- a/src/wayland/selection/data_device/dnd_grab.rs
+++ b/src/wayland/selection/data_device/dnd_grab.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::RefCell,
+    fmt,
     os::unix::io::{AsFd, OwnedFd},
     sync::{Arc, Mutex},
 };
@@ -32,7 +33,8 @@ use crate::{
 
 use super::{with_source_metadata, ClientDndGrabHandler, DataDeviceHandler};
 
-pub(crate) struct DnDGrab<D: SeatHandler> {
+/// Grab during a client-initiated DnD operation.
+pub struct DnDGrab<D: SeatHandler> {
     dh: DisplayHandle,
     pointer_start_data: Option<PointerGrabStartData<D>>,
     touch_start_data: Option<TouchGrabStartData<D>>,
@@ -43,6 +45,23 @@ pub(crate) struct DnDGrab<D: SeatHandler> {
     icon: Option<WlSurface>,
     origin: WlSurface,
     seat: Seat<D>,
+}
+
+impl<D: SeatHandler + 'static> fmt::Debug for DnDGrab<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DnDGrab")
+            .field("dh", &self.dh)
+            .field("pointer_start_data", &self.pointer_start_data)
+            .field("touch_start_data", &self.touch_start_data)
+            .field("data_source", &self.data_source)
+            .field("current_focus", &self.current_focus)
+            .field("pending_offers", &self.pending_offers)
+            .field("offer_data", &self.offer_data)
+            .field("icon", &self.icon)
+            .field("origin", &self.origin)
+            .field("seat", &self.seat)
+            .finish()
+    }
 }
 
 impl<D: SeatHandler> DnDGrab<D> {

--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -100,6 +100,8 @@ mod server_dnd_grab;
 mod source;
 
 pub use device::{DataDeviceUserData, DND_ICON_ROLE};
+pub use dnd_grab::DnDGrab;
+pub use server_dnd_grab::ServerDnDGrab;
 pub use source::{with_source_metadata, DataSourceUserData, SourceMetadata};
 
 use super::{

--- a/src/wayland/selection/data_device/server_dnd_grab.rs
+++ b/src/wayland/selection/data_device/server_dnd_grab.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::RefCell,
+    fmt,
     os::unix::io::OwnedFd,
     sync::{Arc, Mutex},
 };
@@ -33,7 +34,8 @@ use crate::{
 
 use super::{DataDeviceHandler, DataDeviceUserData, ServerDndGrabHandler, SourceMetadata};
 
-pub(crate) struct ServerDnDGrab<D: SeatHandler> {
+/// Grab during a compositor-initiated DnD operation.
+pub struct ServerDnDGrab<D: SeatHandler> {
     dh: DisplayHandle,
     pointer_start_data: Option<PointerGrabStartData<D>>,
     touch_start_data: Option<TouchGrabStartData<D>>,
@@ -42,6 +44,21 @@ pub(crate) struct ServerDnDGrab<D: SeatHandler> {
     pending_offers: Vec<wl_data_offer::WlDataOffer>,
     offer_data: Option<Arc<Mutex<ServerDndOfferData>>>,
     seat: Seat<D>,
+}
+
+impl<D: SeatHandler + 'static> fmt::Debug for ServerDnDGrab<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServerDnDGrab")
+            .field("dh", &self.dh)
+            .field("pointer_start_data", &self.pointer_start_data)
+            .field("touch_start_data", &self.touch_start_data)
+            .field("metadata", &self.metadata)
+            .field("current_focus", &self.current_focus)
+            .field("pending_offers", &self.pending_offers)
+            .field("offer_data", &self.offer_data)
+            .field("seat", &self.seat)
+            .finish()
+    }
 }
 
 impl<D: SeatHandler> ServerDnDGrab<D> {


### PR DESCRIPTION
Allows the compositor to inspect which grab is currently active.

Use case 1: in niri I want to scroll the workspace left and right when hovering the mouse close to output edges with a DnD grab, but not with a regular click grab.

Use case 2: avoiding a weird case with libadwaita DnD/move conflict https://gitlab.gnome.org/GNOME/gtk/-/issues/7113 by checking if the active grab is a DnD grab specifically and denying the move request in that case.

```rust
let mut is_dnd_grab = false;
pointer.with_grab(|_, grab| {
    is_dnd_grab = grab.as_any().downcast_ref::<DnDGrab<Self>>().is_some();
});
```

Debug impls are auto-generated with rust-analyzer (they want `D: 'static`).