### PR TITLE
wayland.pointer_constraints: Remove constraints in the destructor

### DIFF
--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -482,11 +482,22 @@ where
                     }
                 });
             }
-            zwp_confined_pointer_v1::Request::Destroy => {
-                remove_constraint(&data.surface, pointer);
-            }
+            zwp_confined_pointer_v1::Request::Destroy => {}
             _ => unreachable!(),
         }
+    }
+
+    fn destroyed(
+        _state: &mut D,
+        _client: wayland_server::backend::ClientId,
+        _resource: &ZwpConfinedPointerV1,
+        data: &PointerConstraintUserData<D>,
+    ) {
+        let Some(pointer) = &data.pointer else {
+            return;
+        };
+
+        remove_constraint(&data.surface, pointer);
     }
 }
 
@@ -524,11 +535,22 @@ where
                     }
                 });
             }
-            zwp_locked_pointer_v1::Request::Destroy => {
-                remove_constraint(&data.surface, pointer);
-            }
+            zwp_locked_pointer_v1::Request::Destroy => {}
             _ => unreachable!(),
         }
+    }
+
+    fn destroyed(
+        _state: &mut D,
+        _client: wayland_server::backend::ClientId,
+        _resource: &ZwpLockedPointerV1,
+        data: &PointerConstraintUserData<D>,
+    ) {
+        let Some(pointer) = &data.pointer else {
+            return;
+        };
+
+        remove_constraint(&data.surface, pointer);
     }
 }
 


### PR DESCRIPTION
I'm pretty sure this works fine as is, but just to be 100% sure that the reference cycle (see  #1552) gets broken properly, let's remove the constraint in the destructor rather than on event.

`remove_constraint` removes the constraint object from `wlsurface` user data, and as the constraint object contains the surface in its own user data this makes sure that the cycle is broken properly.