### PR TITLE
Derive `Default` for `WeakOutput`

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -246,8 +246,8 @@ pub struct Output {
 /// Weak variant of an [`Output`]
 ///
 /// Does not keep associated user data alive,
-/// and can be used to referr to a potentially already destroyed output.
-#[derive(Debug, Clone)]
+/// and can be used to refer to a potentially already destroyed output.
+#[derive(Debug, Default, Clone)]
 pub struct WeakOutput {
     pub(crate) inner: Weak<(Mutex<Inner>, UserDataMap)>,
 }


### PR DESCRIPTION
Provides a way to construct a `WeakOutput` that doesn't point to any output. Useful when `Output::from_resource` returns `None`, but the `WeakOutput` needs to be stored in a user data.