### PR TITLE
Remove unused format specifier

### DIFF
--- a/src/backend/drm/device/atomic.rs
+++ b/src/backend/drm/device/atomic.rs
@@ -338,7 +338,7 @@ where
         })
         .map_err(|source| {
             Error::Access(AccessError {
-                errmsg: "Error reading properties on {:?}",
+                errmsg: "Error reading properties",
                 dev: fd.dev_path(),
                 source,
             })


### PR DESCRIPTION
Guess it got left over from refactoring.