### PR TITLE
session_lock: Change surface to Weak

### DIFF
--- a/src/wayland/session_lock/lock.rs
+++ b/src/wayland/session_lock/lock.rs
@@ -79,7 +79,7 @@ where
                 }
 
                 let data = ExtLockSurfaceUserData {
-                    surface: surface.clone(),
+                    surface: surface.downgrade(),
                 };
                 let lock_surface = data_init.init(id, data);
 


### PR DESCRIPTION
Fix the reference cycle.

Found this with Tracy allocation profiling.