### PR TITLE
wayland.selection: Introduce ext data control protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,15 +53,15 @@ thiserror = "1.0.25"
 udev = { version = "0.9.0", optional = true }
 # Require never `wayland-client`/`wayland-cursor` than winit uses to fix `-Z minimal-versions`
 # due to issue in older version.
-wayland-client = { version = "0.31.3", optional = true }
-wayland-cursor = { version = "0.31.3", optional = true }
-wayland-egl = { version = "0.32.0", optional = true }
-wayland-protocols = { version = "0.32.5", features = ["unstable", "staging", "server"], optional = true }
-wayland-protocols-wlr = { version = "0.3.1", features = ["server"], optional = true }
-wayland-protocols-misc = { version = "0.3.1", features = ["server"], optional = true }
-wayland-server = { version = "0.31.0", optional = true }
-wayland-sys = { version = "0.31", optional = true }
-wayland-backend = { version = "0.3.5", optional = true }
+wayland-client = { version = "0.31.8", optional = true }
+wayland-cursor = { version = "0.31.8", optional = true }
+wayland-egl = { version = "0.32.5", optional = true }
+wayland-protocols = { version = "0.32.6", features = ["unstable", "staging", "server"], optional = true }
+wayland-protocols-wlr = { version = "0.3.6", features = ["server"], optional = true }
+wayland-protocols-misc = { version = "0.3.6", features = ["server"], optional = true }
+wayland-server = { version = "0.31.7", optional = true }
+wayland-sys = { version = "0.31.6", optional = true }
+wayland-backend = { version = "0.3.8", optional = true }
 winit = { version = "0.30.0", default-features = false, features = ["wayland", "wayland-dlopen", "x11", "rwh_06"], optional = true }
 x11rb = { version = "0.13.0", optional = true }
 xkbcommon = { version = "0.8.0", features = ["wayland"]}

--- a/src/wayland/selection/device.rs
+++ b/src/wayland/selection/device.rs
@@ -1,6 +1,3 @@
-use std::any::Any;
-use std::any::TypeId;
-
 use wayland_protocols::ext::data_control::v1::server::ext_data_control_device_v1::ExtDataControlDeviceV1;
 use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1 as PrimaryDevice;
 use wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_device_v1::ZwlrDataControlDeviceV1;
@@ -16,6 +13,14 @@ use super::offer::SelectionOffer;
 use super::primary_selection::PrimaryDeviceUserData;
 use super::private::selection_dispatch;
 use super::wlr_data_control::DataControlDeviceUserData;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum DataDeviceKind {
+    Core,
+    Primary,
+    WlrDataControl,
+    ExtDataControl,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DataControlDevice {
@@ -100,13 +105,12 @@ impl SelectionDevice {
         selection_dispatch!(self; Self(device) => device.id())
     }
 
-    /// Get the [`TypeId`] of the underlying data device provider.
-    pub fn inner_type_id(&self) -> TypeId {
+    pub fn device_kind(&self) -> DataDeviceKind {
         match self {
-            Self::DataDevice(device) => device.type_id(),
-            Self::Primary(device) => device.type_id(),
-            Self::DataControl(DataControlDevice::Wlr(device)) => device.type_id(),
-            Self::DataControl(DataControlDevice::Ext(device)) => device.type_id(),
+            Self::DataDevice(_) => DataDeviceKind::Core,
+            Self::Primary(_) => DataDeviceKind::Primary,
+            Self::DataControl(DataControlDevice::Wlr(_)) => DataDeviceKind::WlrDataControl,
+            Self::DataControl(DataControlDevice::Ext(_)) => DataDeviceKind::ExtDataControl,
         }
     }
 

--- a/src/wayland/selection/ext_data_control/device.rs
+++ b/src/wayland/selection/ext_data_control/device.rs
@@ -1,8 +1,7 @@
 use std::cell::RefCell;
-use std::sync::Arc;
 
-use wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_device_v1::{
-    self, ZwlrDataControlDeviceV1,
+use wayland_protocols::ext::data_control::v1::server::ext_data_control_device_v1::{
+    self, ExtDataControlDeviceV1,
 };
 use wayland_server::protocol::wl_seat::WlSeat;
 use wayland_server::{Client, Dispatch, DisplayHandle};
@@ -16,25 +15,25 @@ use crate::wayland::selection::{SelectionSource, SelectionTarget};
 
 use super::{DataControlHandler, DataControlState};
 
-#[allow(missing_debug_implementations)]
 #[doc(hidden)]
-pub struct DataControlDeviceUserData {
-    pub(crate) primary_selection_filter: Arc<Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>>,
+#[derive(Debug)]
+pub struct ExtDataControlDeviceUserData {
+    pub(crate) primary: bool,
     pub(crate) wl_seat: WlSeat,
 }
 
-impl<D> Dispatch<ZwlrDataControlDeviceV1, DataControlDeviceUserData, D> for DataControlState
+impl<D> Dispatch<ExtDataControlDeviceV1, ExtDataControlDeviceUserData, D> for DataControlState
 where
-    D: Dispatch<ZwlrDataControlDeviceV1, DataControlDeviceUserData>,
+    D: Dispatch<ExtDataControlDeviceV1, ExtDataControlDeviceUserData>,
     D: DataControlHandler,
     D: 'static,
 {
     fn request(
         handler: &mut D,
-        client: &Client,
-        resource: &ZwlrDataControlDeviceV1,
-        request: <ZwlrDataControlDeviceV1 as wayland_server::Resource>::Request,
-        data: &DataControlDeviceUserData,
+        _client: &Client,
+        resource: &ExtDataControlDeviceV1,
+        request: <ExtDataControlDeviceV1 as wayland_server::Resource>::Request,
+        data: &ExtDataControlDeviceUserData,
         dh: &DisplayHandle,
         _: &mut wayland_server::DataInit<'_, D>,
     ) {
@@ -44,12 +43,12 @@ where
         };
 
         match request {
-            zwlr_data_control_device_v1::Request::SetSelection { source, .. } => {
+            ext_data_control_device_v1::Request::SetSelection { source, .. } => {
                 seat.user_data()
                     .insert_if_missing(|| RefCell::new(SeatData::<D::SelectionUserData>::new()));
 
                 let source = source
-                    .map(DataControlSource::Wlr)
+                    .map(DataControlSource::Ext)
                     .map(SelectionSourceProvider::DataControl);
 
                 handler.new_selection(
@@ -64,9 +63,9 @@ where
                     .borrow_mut()
                     .set_clipboard_selection::<D>(dh, source.map(OfferReplySource::Client));
             }
-            zwlr_data_control_device_v1::Request::SetPrimarySelection { source, .. } => {
+            ext_data_control_device_v1::Request::SetPrimarySelection { source, .. } => {
                 // When the primary selection is disabled, we should simply ignore the requests.
-                if !(*data.primary_selection_filter)(client) {
+                if !data.primary {
                     return;
                 }
 
@@ -74,7 +73,7 @@ where
                     .insert_if_missing(|| RefCell::new(SeatData::<D::SelectionUserData>::new()));
 
                 let source = source
-                    .map(DataControlSource::Wlr)
+                    .map(DataControlSource::Ext)
                     .map(SelectionSourceProvider::DataControl);
 
                 handler.new_selection(
@@ -89,13 +88,13 @@ where
                     .borrow_mut()
                     .set_primary_selection::<D>(dh, source.map(OfferReplySource::Client));
             }
-            zwlr_data_control_device_v1::Request::Destroy => seat
+            ext_data_control_device_v1::Request::Destroy => seat
                 .user_data()
                 .get::<RefCell<SeatData<D::SelectionUserData>>>()
                 .unwrap()
                 .borrow_mut()
                 .retain_devices(|ndd| match ndd {
-                    SelectionDevice::DataControl(DataControlDevice::Wlr(ndd)) => ndd != resource,
+                    SelectionDevice::DataControl(DataControlDevice::Ext(ndd)) => ndd != resource,
                     _ => true,
                 }),
 

--- a/src/wayland/selection/ext_data_control/device.rs
+++ b/src/wayland/selection/ext_data_control/device.rs
@@ -7,10 +7,10 @@ use wayland_server::protocol::wl_seat::WlSeat;
 use wayland_server::{Client, Dispatch, DisplayHandle};
 
 use crate::input::Seat;
-use crate::wayland::selection::device::{DataControlDevice, SelectionDevice};
+use crate::wayland::selection::device::SelectionDevice;
 use crate::wayland::selection::offer::OfferReplySource;
 use crate::wayland::selection::seat_data::SeatData;
-use crate::wayland::selection::source::{DataControlSource, SelectionSourceProvider};
+use crate::wayland::selection::source::SelectionSourceProvider;
 use crate::wayland::selection::{SelectionSource, SelectionTarget};
 
 use super::{DataControlHandler, DataControlState};
@@ -47,9 +47,7 @@ where
                 seat.user_data()
                     .insert_if_missing(|| RefCell::new(SeatData::<D::SelectionUserData>::new()));
 
-                let source = source
-                    .map(DataControlSource::Ext)
-                    .map(SelectionSourceProvider::DataControl);
+                let source = source.map(SelectionSourceProvider::ExtDataControl);
 
                 handler.new_selection(
                     SelectionTarget::Clipboard,
@@ -72,9 +70,7 @@ where
                 seat.user_data()
                     .insert_if_missing(|| RefCell::new(SeatData::<D::SelectionUserData>::new()));
 
-                let source = source
-                    .map(DataControlSource::Ext)
-                    .map(SelectionSourceProvider::DataControl);
+                let source = source.map(SelectionSourceProvider::ExtDataControl);
 
                 handler.new_selection(
                     SelectionTarget::Primary,
@@ -94,7 +90,7 @@ where
                 .unwrap()
                 .borrow_mut()
                 .retain_devices(|ndd| match ndd {
-                    SelectionDevice::DataControl(DataControlDevice::Ext(ndd)) => ndd != resource,
+                    SelectionDevice::ExtDataControl(ndd) => ndd != resource,
                     _ => true,
                 }),
 

--- a/src/wayland/selection/ext_data_control/mod.rs
+++ b/src/wayland/selection/ext_data_control/mod.rs
@@ -119,7 +119,6 @@ pub struct ExtDataControlManagerUserData {
 mod handlers {
     use std::cell::RefCell;
 
-    use crate::wayland::selection::device::DataControlDevice;
     use tracing::error;
     use wayland_protocols::ext::data_control::v1::server::{
         ext_data_control_device_v1::ExtDataControlDeviceV1,
@@ -197,14 +196,13 @@ mod handlers {
                             seat.user_data()
                                 .insert_if_missing(|| RefCell::new(SeatData::<D::SelectionUserData>::new()));
 
-                            let device =
-                                SelectionDevice::DataControl(DataControlDevice::Ext(data_init.init(
-                                    id,
-                                    ExtDataControlDeviceUserData {
-                                        wl_seat,
-                                        primary: data.primary,
-                                    },
-                                )));
+                            let device = SelectionDevice::ExtDataControl(data_init.init(
+                                id,
+                                ExtDataControlDeviceUserData {
+                                    wl_seat,
+                                    primary: data.primary,
+                                },
+                            ));
 
                             let mut seat_data = seat
                                 .user_data()

--- a/src/wayland/selection/ext_data_control/source.rs
+++ b/src/wayland/selection/ext_data_control/source.rs
@@ -1,0 +1,76 @@
+use std::sync::Mutex;
+
+use wayland_server::backend::ClientId;
+use wayland_server::{Dispatch, DisplayHandle, Resource};
+
+use crate::utils::alive_tracker::AliveTracker;
+use crate::utils::IsAlive;
+
+use wayland_protocols::ext::data_control::v1::server::ext_data_control_source_v1::{
+    self, ExtDataControlSourceV1,
+};
+
+use super::{DataControlHandler, DataControlState};
+
+#[doc(hidden)]
+#[derive(Default, Debug)]
+pub struct ExtDataControlSourceUserData {
+    pub(crate) inner: Mutex<SourceMetadata>,
+    alive_tracker: AliveTracker,
+}
+
+impl ExtDataControlSourceUserData {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// The metadata describing a data source
+#[derive(Debug, Default, Clone)]
+pub struct SourceMetadata {
+    /// The MIME types supported by this source
+    pub mime_types: Vec<String>,
+}
+
+impl<D> Dispatch<ExtDataControlSourceV1, ExtDataControlSourceUserData, D> for DataControlState
+where
+    D: Dispatch<ExtDataControlSourceV1, ExtDataControlSourceUserData>,
+    D: DataControlHandler,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &wayland_server::Client,
+        _resource: &ExtDataControlSourceV1,
+        request: <ExtDataControlSourceV1 as wayland_server::Resource>::Request,
+        data: &ExtDataControlSourceUserData,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            ext_data_control_source_v1::Request::Offer { mime_type } => {
+                let mut data = data.inner.lock().unwrap();
+                data.mime_types.push(mime_type);
+            }
+            ext_data_control_source_v1::Request::Destroy => (),
+            _ => unreachable!(),
+        }
+    }
+
+    fn destroyed(
+        _state: &mut D,
+        _client: ClientId,
+        _resource: &ExtDataControlSourceV1,
+        data: &ExtDataControlSourceUserData,
+    ) {
+        data.alive_tracker.destroy_notify();
+    }
+}
+
+impl IsAlive for ExtDataControlSourceV1 {
+    #[inline]
+    fn alive(&self) -> bool {
+        let data: &ExtDataControlSourceUserData = self.data().unwrap();
+        data.alive_tracker.alive()
+    }
+}

--- a/src/wayland/selection/mod.rs
+++ b/src/wayland/selection/mod.rs
@@ -16,6 +16,7 @@ use std::os::unix::io::OwnedFd;
 use crate::input::{Seat, SeatHandler};
 
 pub mod data_device;
+pub mod ext_data_control;
 pub mod primary_selection;
 pub mod wlr_data_control;
 

--- a/src/wayland/selection/mod.rs
+++ b/src/wayland/selection/mod.rs
@@ -68,7 +68,8 @@ pub(crate) mod private {
     /// match self {
     ///    Enum::DataDevice(foo) => foo.something(),
     ///    Enum::Primary(foo) => foo.something(),
-    ///    Enum::DataControl(foo) => foo.something(),
+    ///    Enum::WlrDataControl(foo) => foo.something(),
+    ///    Enum::ExtDataControl(foo) => foo.something(),
     /// }
     /// ```
     ///
@@ -78,7 +79,8 @@ pub(crate) mod private {
     /// match (self, other) {
     ///    (Enum::DataDevice(foo), EnumNext::DataDevice(zoo))  => foo.something(zoo),
     ///    (Enum::Primary(foo), EnumNext::Primary(zoo))  => foo.something(zoo),
-    ///    (Enum::DataControl(foo), EnumNext::DataControl(zoo))  => foo.something(zoo),
+    ///    (Enum::WlrDataControl(foo), EnumNext::WlrDataControl(zoo))  => foo.something(zoo),
+    ///    (Enum::ExtDataControl(foo), EnumNext::ExtDataControl(zoo))  => foo.something(zoo),
     ///    _ => unreachable!(),
     /// }
     /// ```
@@ -89,14 +91,16 @@ pub(crate) mod private {
             match $what {
                 $enum::DataDevice($($c1)*) => $x,
                 $enum::Primary($($c1)*) => $x,
-                $enum::DataControl($($c1)*) => $x,
+                $enum::WlrDataControl($($c1)*) => $x,
+                $enum::ExtDataControl($($c1)*) => $x,
             }
         };
         ($what:ident$(, $what_next:ident)+; $enum:ident ( $($c1:tt)*) $(, $enum_next:ident ( $($c2:tt)* ) )+ => $x:expr) => {
             match ($what$(, $what_next)*) {
                 ($enum::DataDevice($($c1)*)$(, $enum_next::DataDevice($($c2)*))*) => $x,
                 ($enum::Primary($($c1)*)$(, $enum_next::Primary($($c2)*))*) => $x,
-                ($enum::DataControl($($c1)*)$(, $enum_next::DataControl($($c2)*))*) => $x,
+                ($enum::WlrDataControl($($c1)*)$(, $enum_next::WlrDataControl($($c2)*))*) => $x,
+                ($enum::ExtDataControl($($c1)*)$(, $enum_next::ExtDataControl($($c2)*))*) => $x,
                 _ => unreachable!(),
             }
         };

--- a/src/wayland/selection/offer.rs
+++ b/src/wayland/selection/offer.rs
@@ -55,30 +55,13 @@ impl<U: Clone + Send + Sync + 'static> OfferReplySource<U> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DataControlOffer {
-    Wlr(ZwlrDataControlOfferV1),
-    Ext(ExtDataControlOfferV1),
-}
-
-impl DataControlOffer {
-    /// Advertise offered MIME type
-    ///
-    /// Sent immediately after creating the wlr_data_control_offer object. One event per offered MIME type.
-    fn offer(&self, mime_type: String) {
-        match self {
-            Self::Wlr(obj) => obj.offer(mime_type),
-            Self::Ext(obj) => obj.offer(mime_type),
-        }
-    }
-}
-
 /// Offer representing various selection offers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SelectionOffer {
     DataDevice(WlDataOffer),
     Primary(PrimaryOffer),
-    DataControl(DataControlOffer),
+    WlrDataControl(ZwlrDataControlOfferV1),
+    ExtDataControl(ExtDataControlOfferV1),
 }
 
 impl SelectionOffer {
@@ -116,12 +99,12 @@ impl SelectionOffer {
         match device_kind {
             DataDeviceKind::Core => Self::DataDevice(WlDataOffer::from_id(dh, offer).unwrap()),
             DataDeviceKind::Primary => Self::Primary(PrimaryOffer::from_id(dh, offer).unwrap()),
-            DataDeviceKind::WlrDataControl => Self::DataControl(DataControlOffer::Wlr(
-                ZwlrDataControlOfferV1::from_id(dh, offer).unwrap(),
-            )),
-            DataDeviceKind::ExtDataControl => Self::DataControl(DataControlOffer::Ext(
-                ExtDataControlOfferV1::from_id(dh, offer).unwrap(),
-            )),
+            DataDeviceKind::WlrDataControl => {
+                Self::WlrDataControl(ZwlrDataControlOfferV1::from_id(dh, offer).unwrap())
+            }
+            DataDeviceKind::ExtDataControl => {
+                Self::ExtDataControl(ExtDataControlOfferV1::from_id(dh, offer).unwrap())
+            }
         }
     }
 

--- a/src/wayland/selection/wlr_data_control/device.rs
+++ b/src/wayland/selection/wlr_data_control/device.rs
@@ -8,10 +8,10 @@ use wayland_server::protocol::wl_seat::WlSeat;
 use wayland_server::{Client, Dispatch, DisplayHandle};
 
 use crate::input::Seat;
-use crate::wayland::selection::device::{DataControlDevice, SelectionDevice};
+use crate::wayland::selection::device::SelectionDevice;
 use crate::wayland::selection::offer::OfferReplySource;
 use crate::wayland::selection::seat_data::SeatData;
-use crate::wayland::selection::source::{DataControlSource, SelectionSourceProvider};
+use crate::wayland::selection::source::SelectionSourceProvider;
 use crate::wayland::selection::{SelectionSource, SelectionTarget};
 
 use super::{DataControlHandler, DataControlState};
@@ -48,9 +48,7 @@ where
                 seat.user_data()
                     .insert_if_missing(|| RefCell::new(SeatData::<D::SelectionUserData>::new()));
 
-                let source = source
-                    .map(DataControlSource::Wlr)
-                    .map(SelectionSourceProvider::DataControl);
+                let source = source.map(SelectionSourceProvider::WlrDataControl);
 
                 handler.new_selection(
                     SelectionTarget::Clipboard,
@@ -73,9 +71,7 @@ where
                 seat.user_data()
                     .insert_if_missing(|| RefCell::new(SeatData::<D::SelectionUserData>::new()));
 
-                let source = source
-                    .map(DataControlSource::Wlr)
-                    .map(SelectionSourceProvider::DataControl);
+                let source = source.map(SelectionSourceProvider::WlrDataControl);
 
                 handler.new_selection(
                     SelectionTarget::Primary,
@@ -95,7 +91,7 @@ where
                 .unwrap()
                 .borrow_mut()
                 .retain_devices(|ndd| match ndd {
-                    SelectionDevice::DataControl(DataControlDevice::Wlr(ndd)) => ndd != resource,
+                    SelectionDevice::WlrDataControl(ndd) => ndd != resource,
                     _ => true,
                 }),
 

--- a/src/wayland/selection/wlr_data_control/mod.rs
+++ b/src/wayland/selection/wlr_data_control/mod.rs
@@ -133,7 +133,6 @@ mod handlers {
     use wayland_server::{Client, Dispatch, DisplayHandle, GlobalDispatch};
 
     use crate::input::Seat;
-    use crate::wayland::selection::device::DataControlDevice;
     use crate::wayland::selection::device::SelectionDevice;
     use crate::wayland::selection::seat_data::SeatData;
     use crate::wayland::selection::SelectionTarget;
@@ -202,14 +201,13 @@ mod handlers {
                             seat.user_data()
                                 .insert_if_missing(|| RefCell::new(SeatData::<D::SelectionUserData>::new()));
 
-                            let device =
-                                SelectionDevice::DataControl(DataControlDevice::Wlr(data_init.init(
-                                    id,
-                                    DataControlDeviceUserData {
-                                        wl_seat,
-                                        primary_selection_filter: Arc::clone(&data.primary_selection_filter),
-                                    },
-                                )));
+                            let device = SelectionDevice::WlrDataControl(data_init.init(
+                                id,
+                                DataControlDeviceUserData {
+                                    wl_seat,
+                                    primary_selection_filter: Arc::clone(&data.primary_selection_filter),
+                                },
+                            ));
 
                             let mut seat_data = seat
                                 .user_data()


### PR DESCRIPTION
- `wayland.selection: ExtDataControl` Adds support for the new ext data control protocol
- `wayland.selection: Introduce DataDeviceKind` Removes `TypeId` in favor of `DataDeviceKind` enum