### PR TITLE
drm: Add vrr property helpers

### DIFF
--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -95,7 +95,7 @@ pub use error::Error as DrmError;
 use indexmap::IndexSet;
 #[cfg(feature = "backend_gbm")]
 pub use surface::gbm::{Error as GbmBufferedSurfaceError, GbmBufferedSurface};
-pub use surface::{DrmSurface, PlaneConfig, PlaneDamageClips, PlaneState};
+pub use surface::{DrmSurface, PlaneConfig, PlaneDamageClips, PlaneState, VrrSupport};
 
 use drm::{
     control::{crtc, framebuffer, plane, Device as ControlDevice, PlaneType},


### PR DESCRIPTION
Draft while this is missing docs and more testing.

Adds helper methods to make it possible to set VRR per frame, which makes more dynamic VRR policies like "only enable, when we have a fullscreen application" more easily possible. Also simplifies VRR checks.