### PR TITLE
Use `WeakOutput` in `OutputUserData`, `Output` in `WlOutputData`

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -240,7 +240,7 @@ pub(crate) struct Inner {
 /// about any change in the properties of this output.
 #[derive(Debug, Clone)]
 pub struct Output {
-    pub(crate) inner: OutputData,
+    pub(crate) inner: Arc<(Mutex<Inner>, UserDataMap)>,
 }
 
 /// Weak variant of an [`Output`]
@@ -251,9 +251,6 @@ pub struct Output {
 pub struct WeakOutput {
     pub(crate) inner: Weak<(Mutex<Inner>, UserDataMap)>,
 }
-
-/// Data of an Output
-pub(crate) type OutputData = Arc<(Mutex<Inner>, UserDataMap)>;
 
 impl Output {
     /// Create a new output with given name and physical properties.

--- a/src/wayland/output/handlers.rs
+++ b/src/wayland/output/handlers.rs
@@ -41,7 +41,7 @@ where
         let output = data_init.init(
             resource,
             OutputUserData {
-                output: global_data.output.clone(),
+                output: global_data.output.downgrade(),
                 last_client_scale: AtomicU32::new(client_scale.load(Ordering::Acquire)),
                 client_scale,
             },
@@ -124,13 +124,14 @@ where
         output: &WlOutput,
         data: &OutputUserData,
     ) {
-        data.output
-            .inner
-            .0
-            .lock()
-            .unwrap()
-            .instances
-            .retain(|o| o.id() != output.id());
+        if let Some(o) = data.output.upgrade() {
+            o.inner
+                .0
+                .lock()
+                .unwrap()
+                .instances
+                .retain(|o| o.id() != output.id());
+        }
     }
 }
 

--- a/src/wayland/output/handlers.rs
+++ b/src/wayland/output/handlers.rs
@@ -41,13 +41,13 @@ where
         let output = data_init.init(
             resource,
             OutputUserData {
-                global_data: global_data.inner.clone(),
+                output: global_data.output.clone(),
                 last_client_scale: AtomicU32::new(client_scale.load(Ordering::Acquire)),
                 client_scale,
             },
         );
 
-        let mut inner = global_data.inner.0.lock().unwrap();
+        let mut inner = global_data.output.inner.0.lock().unwrap();
 
         let span = warn_span!("output_bind", name = inner.name);
         let _enter = span.enter();
@@ -99,10 +99,7 @@ where
         inner.instances.push(output.downgrade());
 
         drop(inner);
-        let o = Output {
-            inner: global_data.inner.clone(),
-        };
-        state.output_bound(o, output);
+        state.output_bound(global_data.output.clone(), output);
     }
 }
 
@@ -127,7 +124,8 @@ where
         output: &WlOutput,
         data: &OutputUserData,
     ) {
-        data.global_data
+        data.output
+            .inner
             .0
             .lock()
             .unwrap()

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -78,7 +78,7 @@ use std::sync::{
     Arc,
 };
 
-use crate::output::{Inner, Mode, Output, Scale, Subpixel};
+use crate::output::{Inner, Mode, Output, Scale, Subpixel, WeakOutput};
 
 use tracing::info;
 use wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_manager_v1::ZxdgOutputManagerV1;
@@ -144,7 +144,7 @@ impl OutputManagerState {
 /// User data for WlOutput
 #[derive(Debug)]
 pub struct OutputUserData {
-    pub(crate) output: Output,
+    pub(crate) output: WeakOutput,
     last_client_scale: AtomicU32,
     client_scale: Arc<AtomicU32>,
 }
@@ -209,7 +209,7 @@ impl Output {
 
     /// Attempt to retrieve a [`Output`] from an existing resource
     pub fn from_resource(output: &WlOutput) -> Option<Output> {
-        output.data::<OutputUserData>().map(|ud| ud.output.clone())
+        output.data::<OutputUserData>().and_then(|ud| ud.output.upgrade())
     }
 
     pub(crate) fn wl_change_current_state(


### PR DESCRIPTION
Generally it's best not to hold strong references like this in user data, and it's definitely important if we use `WeakOutput::is_alive` for anything (https://github.com/Smithay/smithay/issues/1584). In any case, making it weak seems to be easy.

This alone didn't solve the issue I was seeing in cosmic-comp (which https://github.com/pop-os/cosmic-comp/pull/990 addresses, at least for now), so there may be more `Output` strong references to deal with somewhere...