### PR TITLE
zero-saturating size sub

### DIFF
--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -943,6 +943,25 @@ impl<N: Coordinate, Kind> AddAssign for Size<N, Kind> {
     }
 }
 
+impl<N: Coordinate, Kind> Sub for Size<N, Kind> {
+    type Output = Size<N, Kind>;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        debug_assert!(
+            self.w >= rhs.w && self.h >= rhs.h,
+            "Attempting to subtract bigger from smaller size: {:?} - {:?}",
+            (&self.w, &self.h),
+            (&rhs.w, &rhs.h),
+        );
+
+        Size {
+            w: self.w.saturating_sub(rhs.w),
+            h: self.h.saturating_sub(rhs.h),
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
 impl<N: Coordinate, Kind> SubAssign for Size<N, Kind> {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {


### PR DESCRIPTION
this pr is two commits

- in [b5b9410409f2de6eb42084754451fa7fcbf37e17] i `impl Sub for Size`, that just mirrors what the `SubAssign` already does

- [ecb3f8565594bbdbd325ce54c6cd345e8072e186] might be a little controvertial: `Sub` and `SubAssign` operations on `Size` are already saturating, but they saturate to `i32::MIN`, which i don't personally think is very useful, because a `Size` can (should) not be negative, which means that i always have to check before subtracting two sizes. i changed it so they saturate to `0`.

to saturate to 0, i added an assossiated `const ZERO: Self` to the `Coordinate` trait.

if you prefer, i could move them to a `Size::saturating_sub(other: Size)` instead, but i think that this change makes `Size` more convenient to use.