### PR TITLE
Anvil: fix `LoopHandle` leak

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -308,7 +308,6 @@ pub fn run_udev() {
         })
         .unwrap();
 
-    let handle = event_loop.handle();
     event_loop
         .handle()
         .insert_source(notifier, move |event, &mut (), data| match event {
@@ -354,7 +353,7 @@ pub fn run_udev() {
                             warn!("Failed to reset drm surface state: {}", err);
                         }
                     }
-                    handle.insert_idle(move |data| data.render(node, None));
+                    data.handle.insert_idle(move |data| data.render(node, None));
                 }
             }
         })

--- a/smallvil/src/state.rs
+++ b/smallvil/src/state.rs
@@ -111,10 +111,9 @@ impl Smallvil {
         // Clients will connect to this socket.
         let socket_name = listening_socket.socket_name().to_os_string();
 
-        let handle = event_loop.handle();
+        let loop_handle = event_loop.handle();
 
-        event_loop
-            .handle()
+        loop_handle
             .insert_source(listening_socket, move |client_stream, _, state| {
                 // Inside the callback, you should insert the client into the display.
                 //
@@ -127,7 +126,7 @@ impl Smallvil {
             .expect("Failed to init the wayland event source.");
 
         // You also need to add the display itself to the event loop, so that client events will be processed by wayland-server.
-        handle
+        loop_handle
             .insert_source(
                 Generic::new(display, Interest::READ, Mode::Level),
                 |_, display, state| {


### PR DESCRIPTION
Storing a `LoopHandle` clone in its callback causes "Self-ownership" of `Rc`.