### PR TITLE
Update to `pixman` 0.2, and make `PixmanTexture` thread-safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ xkbcommon = { version = "0.8.0", features = ["wayland"]}
 encoding_rs = { version = "0.8.33", optional = true }
 profiling = "1.0.13"
 smallvec = "1.11"
-pixman = { version = "0.1.0", features = ["drm-fourcc"], optional = true }
+pixman = { version = "0.2.0", features = ["drm-fourcc", "sync"], optional = true }
 
 
 [dev-dependencies]

--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -434,6 +434,12 @@ impl DmabufMapping {
     }
 }
 
+// SAFETY: The caller is responsible for accessing the data without assuming
+// another process isn't mutating it, regardless of how many threads this is
+// referenced in.
+unsafe impl Send for DmabufMapping {}
+unsafe impl Sync for DmabufMapping {}
+
 impl Drop for DmabufMapping {
     fn drop(&mut self) {
         let _ = unsafe { rustix::mm::munmap(self.ptr, self.len) };


### PR DESCRIPTION
Needs testing. Compiles, but I haven't checked that the `borrow_mut` calls can't panic.

Requires https://github.com/cmeissl/pixman-rs/pull/19.