### PR TITLE
Add `GpuManager::devices` methods

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -231,6 +231,14 @@ impl<A: GraphicsApi> GpuManager<A> {
         })
     }
 
+    /// Get all devices enumerated by the API.
+    pub fn devices(&mut self) -> Result<&[A::Device], A::Error> {
+        if self.api.needs_enumeration() {
+            self.api.enumerate(&mut self.devices)?;
+        }
+        Ok(&self.devices)
+    }
+
     /// Create a [`MultiRenderer`] from a single device.
     ///
     /// This a convenience function to deal with the same types even, if you only need one device.


### PR DESCRIPTION
It doesn't seem `GpuManager` has a way to get a list of all backend renders; or other information about devices. (Calling `GraphicsApi::enumerate` in multiple places would not be correct.)

This seems useful in some cases, and easy to support.

(My use case is to dynamically configure a shader, and compile the shader on all GPUs when the shader is changed. Which needs a way to iterate over the `GlesRenderer`s).