### PR TITLE
Pixman (and gles) renderer fixes

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -627,7 +627,6 @@ impl GlesRenderer {
 
     #[profiling::function]
     fn cleanup(&mut self) {
-        #[cfg(feature = "wayland_frontend")]
         self.dmabuf_cache.retain(|entry, _tex| !entry.is_gone());
         // Free outdated buffer resources
         // TODO: Replace with `drain_filter` once it lands

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -739,6 +739,9 @@ impl PixmanRenderer {
             });
         }
 
+        dmabuf.sync_plane(0, DmabufSyncFlags::START | DmabufSyncFlags::READ)?;
+        dmabuf.sync_plane(0, DmabufSyncFlags::END | DmabufSyncFlags::READ)?;
+
         let image: Image<'_, '_> = unsafe {
             pixman::Image::from_raw_mut(
                 format,


### PR DESCRIPTION
This fixes an error I noticed in https://github.com/Smithay/smithay/pull/1497 where it the renderer couldn't access an shm buffer that had been destroyed. I believe using a strong reference to the `WlBuffer` won't cause issues here.

For dmabuf buffers, retaining a strong `Dmabuf` would not be correct, since the caching is based on strong references to the `Dmabuf`. I've tested that the same error doesn't occur with dmabufs though. I guess as long as there is a strong reference in the `WaylandSurfaceRenderElement`, the user data of the `WlBuffer` has a strong reference to the `Dmabuf`.

So no corresponding change is needed for dmabufs, though perhaps its worth thinking if caching could be done differently. It could cache by `Weak<WlBuffer>` instead of `WeakDmabuf`  by implementing `ImportDmaWl`. Though using `WeakDmabuf` allows this to be used with dmabufs that aren't from Wayland. (And it could be nice to disentangle renderers from `wayland_backend`, but that would also require an `Shmbuf` type or such, instead of just a `WlBuffer` reference...)

Doing tests with dmabufs, I also noticed that `PixmanRenderer::import_dmabuf()` succeeds for non dmabuf fds (then anvil crashed later when trying to use `sync_plane`). Seems good to test this in `import_dmabuf()` and error there, and I can't think of a better way at the moment than calling `sync_plane` there.

Comparing the gles renderer, I also noticed it was pushing to `dmabuf_cache` regardless of `wayland_frontend`, but only evicting from the cache with that feature. So I removed that `#[cfg]`.