### PR TITLE
Make `GlesPixelProgram` / `GlesTexProgram` `Send + Sync`

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1856,7 +1856,7 @@ impl GlesRenderer {
         let tint = CStr::from_bytes_with_nul(b"tint\0").expect("NULL terminated");
 
         unsafe {
-            Ok(GlesPixelProgram(Rc::new(GlesPixelProgramInner {
+            Ok(GlesPixelProgram(Arc::new(GlesPixelProgramInner {
                 normal: GlesPixelProgramInternal {
                     program,
                     uniform_matrix: self

--- a/src/backend/renderer/gles/shaders/implicit/mod.rs
+++ b/src/backend/renderer/gles/shaders/implicit/mod.rs
@@ -29,6 +29,9 @@ pub(in super::super) struct GlesTexProgramVariant {
 }
 
 /// Gles texture shader
+///
+/// The program can be used with the same [`GlesRenderer`] it was created with, or one using a
+/// shared [`EGLContext`].
 #[derive(Debug, Clone)]
 pub struct GlesTexProgram(pub(in super::super) Arc<GlesTexProgramInner>);
 
@@ -82,6 +85,9 @@ pub(in super::super) struct GlesSolidProgram {
 }
 
 /// Gles pixel shader
+///
+/// The program can be used with the same [`GlesRenderer`] it was created with, or one using a
+/// shared [`EGLContext`].
 #[derive(Debug, Clone)]
 pub struct GlesPixelProgram(pub(in super::super) Arc<GlesPixelProgramInner>);
 

--- a/src/backend/renderer/gles/shaders/implicit/mod.rs
+++ b/src/backend/renderer/gles/shaders/implicit/mod.rs
@@ -30,7 +30,7 @@ pub(in super::super) struct GlesTexProgramVariant {
 
 /// Gles texture shader
 #[derive(Debug, Clone)]
-pub struct GlesTexProgram(pub(in super::super) Rc<GlesTexProgramInner>);
+pub struct GlesTexProgram(pub(in super::super) Arc<GlesTexProgramInner>);
 
 #[derive(Debug)]
 pub(in super::super) struct GlesTexProgramInner {
@@ -83,7 +83,7 @@ pub(in super::super) struct GlesSolidProgram {
 
 /// Gles pixel shader
 #[derive(Debug, Clone)]
-pub struct GlesPixelProgram(pub(in super::super) Rc<GlesPixelProgramInner>);
+pub struct GlesPixelProgram(pub(in super::super) Arc<GlesPixelProgramInner>);
 
 #[derive(Debug)]
 pub(in super::super) struct GlesPixelProgramInner {

--- a/src/backend/renderer/gles/shaders/mod.rs
+++ b/src/backend/renderer/gles/shaders/mod.rs
@@ -210,7 +210,7 @@ pub(super) unsafe fn texture_program(
         })
     };
 
-    Ok(GlesTexProgram(Rc::new(GlesTexProgramInner {
+    Ok(GlesTexProgram(Arc::new(GlesTexProgramInner {
         variants: [
             create_variant(&[])?,
             create_variant(&[shaders::NO_ALPHA])?,

--- a/src/backend/renderer/gles/texture.rs
+++ b/src/backend/renderer/gles/texture.rs
@@ -2,6 +2,9 @@ use super::*;
 use std::sync::Arc;
 
 /// A handle to a GLES texture
+///
+/// The texture can be used with the same [`GlesRenderer`] it was created with, or one using a
+/// shared [`EGLContext`].
 #[derive(Debug, Clone)]
 pub struct GlesTexture(pub(super) Arc<GlesTextureInternal>);
 


### PR DESCRIPTION
https://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf appendix C states that programs, like textures, can be shared between contexts. So I believe this has the same considerations for use in different renderers/contexts/threads as `GlesTexture`.