### PR TITLE
Add a `GpuManager::device_mut()` method

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -239,6 +239,14 @@ impl<A: GraphicsApi> GpuManager<A> {
         Ok(&self.devices)
     }
 
+    /// Get all devices enumerated by the API.
+    pub fn devices_mut(&mut self) -> Result<&mut [A::Device], A::Error> {
+        if self.api.needs_enumeration() {
+            self.api.enumerate(&mut self.devices)?;
+        }
+        Ok(&mut self.devices)
+    }
+
     /// Create a [`MultiRenderer`] from a single device.
     ///
     /// This a convenience function to deal with the same types even, if you only need one device.

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -232,19 +232,19 @@ impl<A: GraphicsApi> GpuManager<A> {
     }
 
     /// Get all devices enumerated by the API.
-    pub fn devices(&mut self) -> Result<&[A::Device], A::Error> {
+    pub fn devices(&mut self) -> Result<impl Iterator<Item = &A::Device>, A::Error> {
         if self.api.needs_enumeration() {
             self.api.enumerate(&mut self.devices)?;
         }
-        Ok(&self.devices)
+        Ok(self.devices.iter())
     }
 
     /// Get all devices enumerated by the API.
-    pub fn devices_mut(&mut self) -> Result<&mut [A::Device], A::Error> {
+    pub fn devices_mut(&mut self) -> Result<impl Iterator<Item = &mut A::Device>, A::Error> {
         if self.api.needs_enumeration() {
             self.api.enumerate(&mut self.devices)?;
         }
-        Ok(&mut self.devices)
+        Ok(self.devices.iter_mut())
     }
 
     /// Create a [`MultiRenderer`] from a single device.


### PR DESCRIPTION
Renderers require mut references for most things. Allocators also need an `&mut` to allocate. The `node` isn't mutable, though `mem::swap` could replace the whole `GbmGlesDevice` (already possible elsewhere with the just renderer).