### PR TITLE
Toplevel parent fixes, checks, and callback

### DIFF
--- a/src/wayland/shell/xdg/handlers.rs
+++ b/src/wayland/shell/xdg/handlers.rs
@@ -11,5 +11,5 @@ pub use positioner::XdgPositionerUserData;
 
 mod surface;
 pub(in crate::wayland::shell) use surface::make_popup_handle;
-pub(super) use surface::{get_parent, send_popup_configure, send_toplevel_configure, set_parent};
+pub(super) use surface::{get_parent, send_popup_configure, send_toplevel_configure};
 pub use surface::{XdgShellSurfaceUserData, XdgSurfaceUserData};

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -31,7 +31,7 @@ use super::{
 
 mod toplevel;
 use toplevel::make_toplevel_handle;
-pub use toplevel::{get_parent, send_toplevel_configure, set_parent};
+pub use toplevel::{get_parent, send_toplevel_configure};
 
 mod popup;
 pub use popup::{make_popup_handle, send_popup_configure};

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -49,9 +49,17 @@ where
                         .clone()
                 });
 
+                let old_parent = get_parent(toplevel);
+                let changed = old_parent != parent_surface;
+
                 // Parent is not double buffered, we can set it directly
                 if !set_parent(toplevel, parent_surface) {
                     toplevel.post_error(xdg_toplevel::Error::InvalidParent, "invalid parent toplevel");
+                }
+
+                if changed {
+                    let handle = make_toplevel_handle(toplevel);
+                    XdgShellHandler::parent_changed(state, handle);
                 }
             }
             xdg_toplevel::Request::SetTitle { title } => {

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1174,6 +1174,9 @@ pub trait XdgShellHandler {
 
     /// The toplevel surface set a different title.
     fn title_changed(&mut self, surface: ToplevelSurface) {}
+
+    /// The parent of a toplevel surface has changed.
+    fn parent_changed(&mut self, surface: ToplevelSurface) {}
 }
 
 /// Shell global state

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1713,15 +1713,6 @@ impl ToplevelSurface {
     pub fn parent(&self) -> Option<wl_surface::WlSurface> {
         handlers::get_parent(&self.shell_surface)
     }
-
-    /// Sets the parent of this toplevel surface and returns whether the parent was successfully set.
-    ///
-    /// The parent must be another toplevel equivalent surface.
-    ///
-    /// If the parent is `None`, the parent-child relationship is removed.
-    pub fn set_parent(&self, parent: Option<&wl_surface::WlSurface>) -> bool {
-        handlers::set_parent(&self.shell_surface, parent.cloned())
-    }
 }
 
 /// Represents the possible errors that

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -123,7 +123,6 @@ use crate::utils::{user_data::UserDataMap, Logical, Point, Rectangle, Size};
 use crate::utils::{Serial, SERIAL_COUNTER};
 use crate::wayland::compositor;
 use crate::wayland::compositor::Cacheable;
-use crate::wayland::shell::is_toplevel_equivalent;
 use std::cmp::min;
 use std::{collections::HashSet, fmt::Debug, sync::Mutex};
 
@@ -1721,16 +1720,7 @@ impl ToplevelSurface {
     ///
     /// If the parent is `None`, the parent-child relationship is removed.
     pub fn set_parent(&self, parent: Option<&wl_surface::WlSurface>) -> bool {
-        if let Some(parent) = parent {
-            if !is_toplevel_equivalent(parent) {
-                return false;
-            }
-        }
-
-        // Unset the parent
-        handlers::set_parent(&self.shell_surface, None);
-
-        true
+        handlers::set_parent(&self.shell_surface, parent.cloned())
     }
 }
 

--- a/src/wayland/xdg_foreign/mod.rs
+++ b/src/wayland/xdg_foreign/mod.rs
@@ -131,7 +131,8 @@ impl XdgForeignState {
 
 /// Macro to delegate implementation of the xdg foreign to [`XdgForeignState`].
 ///
-/// You must also implement [`XdgForeignHandler`] to use this.
+/// You must also implement [`XdgForeignHandler`] and
+/// [`XdgShellHandler`](crate::wayland::shell::xdg::XdgShellHandler) to use this.
 #[macro_export]
 macro_rules! delegate_xdg_foreign {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {

--- a/src/wayland/xdg_foreign/mod.rs
+++ b/src/wayland/xdg_foreign/mod.rs
@@ -86,7 +86,7 @@ pub struct XdgImportedUserData {
 #[derive(Debug)]
 struct ExportedState {
     exported_surface: WlSurface,
-    requested_parent: Option<(WlSurface, ZxdgImportedV2)>,
+    requested_child: Option<(WlSurface, ZxdgImportedV2)>,
     imported_by: HashSet<ZxdgImportedV2>,
 }
 


### PR DESCRIPTION
Several things here:
1. Add a self-parent and a parent loop check when setting a parent, corresponding to the protocol:

    > The parent toplevel must not be one of the child toplevel's descendants, and the parent must be different from the child toplevel, otherwise the invalid_parent protocol error is raised.
1. Fix inverted logic in xdg-foreign, tested with xdg-desktop-portal-gnome dialogs.
1. Expose an `XdgShellHandler::parent_changed()` callback so compositors can react to parent changes.

    The primary use is to restack surfaces as the protocol intends:

    > This surface should be stacked above the parent surface and all other ancestor surfaces.

    Another use is to signal parent changes to wlr-foreign-toplevel-management.

    This makes xdg-foreign depend on `XdgShellHandler`. Not sure if it's doable otherwise; realistically it's required because there's no other toplevel-equivalent yet.
1. Remove `ToplevelSurface::set_parent()`. This was used back in zxdg-shell days, not any more. Anyhow, exposing this publicly seems a bit strange because it can cause client protocol errors down the line from compositor actions.