### PR TITLE
gles: Sync texture uploads for shared contexts

### DIFF
--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -418,6 +418,14 @@ impl EGLContext {
         unsafe { ffi::egl::GetCurrentContext() == self.context as *const _ }
     }
 
+    /// Returns true if the OpenGL context is (possibly) shared with another.
+    ///
+    /// Externally managed contexts created with `EGLContext::from_raw`
+    /// are always considered shared by this function.
+    pub fn is_shared(&self) -> bool {
+        self.externally_managed || Arc::strong_count(&self.user_data) > 1
+    }
+
     /// Returns the egl config for this context
     pub fn config_id(&self) -> ffi::egl::types::EGLConfig {
         self.config_id


### PR DESCRIPTION
Attempt to solve https://github.com/Smithay/smithay/issues/1615.

This solution isn't perfect, most notably it doesn't synchronize across the access of `Bind<GlesTexture>`. To do that we would need to be able to store the lock, which means moving the `GlesTarget` into the `GlesFrame` and making `Bind` return a `Frame`. I think we talked about this, so we should fix this at some point, but I didn't want to do that refactor now.

Fixing `Bind` would automatically solve this for exporting and other things as well, as all of these rely to binding a framebuffer container object to our texture.

(Also binding a texture to write to it and sampling from it in a separate thread is probably a operation not as common.)

Additionally we keep a lock to the surface-data, so threads should not be able to race imports to the same texture any more.

In an attempt to not punish GL ES 2.0 contexts too much (which don't support fencing at all), we do try to track whether a context is shared or not in the first place, before we fall back to `glFinish`. This means writes to a texture while a shared context is constructed *could* potentially be still racy, but I doubt this is a real problem.

