### PR TITLE
xdg: Add getters for pending configures and current state serial

### DIFF
--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1993,9 +1993,7 @@ impl PopupSurface {
 
             if attributes.initial_configure_sent {
                 if let Some(state) = attributes.last_acked {
-                    if state != attributes.current {
-                        attributes.current = state;
-                    }
+                    attributes.current = state;
                 }
             }
         });

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -204,6 +204,9 @@ macro_rules! xdg_role {
                 pub last_acked: Option<$state>,
                 /// Holds the current state after a successful commit.
                 pub current: $state,
+                /// Holds the last acked configure serial at the time of the last successful
+                /// commit. This serial corresponds to the current state.
+                pub current_serial: Option<Serial>,
                 /// Does the surface have a buffer (updated on every commit)
                 has_buffer: bool,
 
@@ -294,6 +297,7 @@ macro_rules! xdg_role {
                     server_pending: None,
                     last_acked: None,
                     current: Default::default(),
+                    current_serial: None,
                     has_buffer: false,
 
                     $(
@@ -1603,6 +1607,7 @@ impl ToplevelSurface {
 
             if let Some(state) = guard.last_acked.clone() {
                 guard.current = state;
+                guard.current_serial = guard.configure_serial;
             }
         });
     }
@@ -1994,6 +1999,7 @@ impl PopupSurface {
             if attributes.initial_configure_sent {
                 if let Some(state) = attributes.last_acked {
                     attributes.current = state;
+                    attributes.current_serial = attributes.configure_serial;
                 }
             }
         });

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -285,6 +285,14 @@ macro_rules! xdg_role {
             pub fn has_pending_changes(&self) -> bool {
                 self.server_pending.as_ref().map(|s| s != self.current_server_state()).unwrap_or(false)
             }
+
+            /// Returns a list of configures sent to, but not yet acknowledged by the client.
+            ///
+            /// The list is ordered by age, so the last configure in the list is the last one sent
+            /// to the client.
+            pub fn pending_configures(&self) -> &[$configure_name] {
+                &self.pending_configures
+            }
         }
 
         impl Default for $attributes_name {


### PR DESCRIPTION
The pending configures are useful for when you need to check the state that you sent to the client, but that it hadn't acknowledged yet, along with their serials. I only expose read access so that you can't mess with the internal commit tracking.

The serials in general (like the current state serial) are useful in case you want to synchronize something to surface commits. The case I have in niri is that I want to know if the surface had already committed the state that it had last acked, or not yet. Specifically, for the surface size, I want to differentiate between when the surface acked a new size and hasn't committed in response yet, and when the surface acked a new size but committed a different size in response.