### PR TITLE
Improve geometry APIs, to be closer to `euclid`

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -211,7 +211,7 @@ where
         for digit in value_str.chars().map(|d| d.to_digit(10).unwrap()) {
             let digit_location = dst.loc.to_f64() + offset;
             let digit_size = Size::<i32, Logical>::from((22, 35)).to_f64().to_physical(scale);
-            let dst = Rectangle::from_loc_and_size(
+            let dst = Rectangle::new(
                 digit_location.to_i32_round(),
                 ((digit_size.to_point() + digit_location).to_i32_round() - digit_location.to_i32_round())
                     .to_size(),
@@ -227,15 +227,15 @@ where
                 .collect::<Vec<_>>();
             let texture_src: Rectangle<i32, Buffer> = match digit {
                 9 => Rectangle::from_size((22, 35).into()),
-                6 => Rectangle::from_loc_and_size((22, 0), (22, 35)),
-                3 => Rectangle::from_loc_and_size((44, 0), (22, 35)),
-                1 => Rectangle::from_loc_and_size((66, 0), (22, 35)),
-                8 => Rectangle::from_loc_and_size((0, 35), (22, 35)),
-                0 => Rectangle::from_loc_and_size((22, 35), (22, 35)),
-                2 => Rectangle::from_loc_and_size((44, 35), (22, 35)),
-                7 => Rectangle::from_loc_and_size((0, 70), (22, 35)),
-                4 => Rectangle::from_loc_and_size((22, 70), (22, 35)),
-                5 => Rectangle::from_loc_and_size((44, 70), (22, 35)),
+                6 => Rectangle::new((22, 0).into(), (22, 35).into()),
+                3 => Rectangle::new((44, 0).into(), (22, 35).into()),
+                1 => Rectangle::new((66, 0).into(), (22, 35).into()),
+                8 => Rectangle::new((0, 35).into(), (22, 35).into()),
+                0 => Rectangle::new((22, 35).into(), (22, 35).into()),
+                2 => Rectangle::new((44, 35).into(), (22, 35).into()),
+                7 => Rectangle::new((0, 70).into(), (22, 35).into()),
+                4 => Rectangle::new((22, 70).into(), (22, 35).into()),
+                5 => Rectangle::new((44, 70).into(), (22, 35).into()),
                 _ => unreachable!(),
             };
 

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -171,7 +171,7 @@ where
         } else {
             3
         };
-        Rectangle::from_loc_and_size((0, 0), (24 * digits, 35)).to_f64()
+        Rectangle::from_size((24 * digits, 35).into()).to_f64()
     }
 
     fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
@@ -182,7 +182,7 @@ where
         } else {
             3
         };
-        Rectangle::from_loc_and_size((0, 0), (24 * digits, 35)).to_physical_precise_round(scale)
+        Rectangle::from_size((24 * digits, 35).into()).to_physical_precise_round(scale)
     }
 
     fn current_commit(&self) -> CommitCounter {
@@ -226,7 +226,7 @@ where
                 })
                 .collect::<Vec<_>>();
             let texture_src: Rectangle<i32, Buffer> = match digit {
-                9 => Rectangle::from_loc_and_size((0, 0), (22, 35)),
+                9 => Rectangle::from_size((22, 35).into()),
                 6 => Rectangle::from_loc_and_size((22, 0), (22, 35)),
                 3 => Rectangle::from_loc_and_size((44, 0), (22, 35)),
                 1 => Rectangle::from_loc_and_size((66, 0), (22, 35)),

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -122,7 +122,7 @@ where
                 preview_padding + (preview_padding + preview_size.w) * column as i32,
                 preview_padding + (preview_padding + preview_size.h) * row as i32,
             ));
-            let constrain = Rectangle::from_loc_and_size(preview_location, preview_size);
+            let constrain = Rectangle::new(preview_location, preview_size);
             constrain_space_element(
                 renderer,
                 window,

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -420,7 +420,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerResiz
             #[cfg(feature = "xwayland")]
             WindowSurface::X11(x11) => {
                 let location = data.space.element_location(&self.window).unwrap();
-                x11.configure(Rectangle::from_loc_and_size(location, self.last_window_size))
+                x11.configure(Rectangle::new(location, self.last_window_size))
                     .unwrap();
             }
         }
@@ -505,7 +505,7 @@ impl<BackendData: Backend> PointerGrab<AnvilState<BackendData>> for PointerResiz
 
                         data.space.map_element(self.window.clone(), location, true);
                     }
-                    x11.configure(Rectangle::from_loc_and_size(location, self.last_window_size))
+                    x11.configure(Rectangle::new(location, self.last_window_size))
                         .unwrap();
 
                     let Some(surface) = self.window.wl_surface() else {
@@ -718,7 +718,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
 
                     data.space.map_element(self.window.clone(), location, true);
                 }
-                x11.configure(Rectangle::from_loc_and_size(location, self.last_window_size))
+                x11.configure(Rectangle::new(location, self.last_window_size))
                     .unwrap();
 
                 let Some(surface) = self.window.wl_surface() else {
@@ -817,7 +817,7 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
             #[cfg(feature = "xwayland")]
             WindowSurface::X11(x11) => {
                 let location = data.space.element_location(&self.window).unwrap();
-                x11.configure(Rectangle::from_loc_and_size(location, self.last_window_size))
+                x11.configure(Rectangle::new(location, self.last_window_size))
                     .unwrap();
             }
         }

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -411,7 +411,7 @@ fn place_new_window(
             let geo = space.output_geometry(&o)?;
             let map = layer_map_for_output(&o);
             let zone = map.non_exclusive_zone();
-            Some(Rectangle::from_loc_and_size(geo.loc + zone.loc, zone.size))
+            Some(Rectangle::new(geo.loc + zone.loc, zone.size))
         })
         .unwrap_or_else(|| Rectangle::from_size((800, 800).into()));
 
@@ -455,7 +455,7 @@ pub fn fixup_positions(space: &mut Space<WindowElement>, pointer_location: Point
             let geo = space.output_geometry(o)?;
             let map = layer_map_for_output(o);
             let zone = map.non_exclusive_zone();
-            Some(Rectangle::from_loc_and_size(geo.loc + zone.loc, zone.size))
+            Some(Rectangle::new(geo.loc + zone.loc, zone.size))
         })
         .collect::<Vec<_>>();
     for window in space.elements() {

--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -413,7 +413,7 @@ fn place_new_window(
             let zone = map.non_exclusive_zone();
             Some(Rectangle::from_loc_and_size(geo.loc + zone.loc, zone.size))
         })
-        .unwrap_or_else(|| Rectangle::from_loc_and_size((0, 0), (800, 800)));
+        .unwrap_or_else(|| Rectangle::from_size((800, 800).into()));
 
     // set the initial toplevel bounds
     #[allow(irrefutable_let_patterns)]

--- a/anvil/src/shell/x11.rs
+++ b/anvil/src/shell/x11.rs
@@ -367,10 +367,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                             .and_then(|data| data.restore())
                         {
                             window
-                                .configure(Rectangle::from_loc_and_size(
-                                    initial_window_location,
-                                    old_geo.size,
-                                ))
+                                .configure(Rectangle::new(initial_window_location, old_geo.size))
                                 .unwrap();
                         }
                     }
@@ -413,10 +410,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 .and_then(|data| data.restore())
             {
                 window
-                    .configure(Rectangle::from_loc_and_size(
-                        initial_window_location,
-                        old_geo.size,
-                    ))
+                    .configure(Rectangle::new(initial_window_location, old_geo.size))
                     .unwrap();
             }
         }

--- a/benches/geometry.rs
+++ b/benches/geometry.rs
@@ -20,7 +20,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut rand = rand::thread_rng();
     let x = rand.gen_range(0..max_x);
     let y = rand.gen_range(0..max_y);
-    let test_element = Rectangle::from_loc_and_size((x, y), element_size);
+    let test_element = Rectangle::new((x, y).into(), element_size);
 
     let x_min = (test_element.loc.x - element_size.w) + 1;
     let x_max = (test_element.loc.x + element_size.w) - 1;
@@ -35,7 +35,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         .map(|_| {
             let x = rand.gen_range(x_min..=x_max);
             let y = rand.gen_range(y_min..=y_max);
-            Rectangle::from_loc_and_size((x, y), element_size)
+            Rectangle::new((x, y).into(), element_size)
         })
         .collect::<Vec<_>>();
 

--- a/examples/buffer_test.rs
+++ b/examples/buffer_test.rs
@@ -287,7 +287,7 @@ where
     frame
         .clear(
             Color32F::new(1.0, 0.0, 0.0, 1.0),
-            &[Rectangle::from_loc_and_size((0, 0), (w / 2, h / 2))],
+            &[Rectangle::from_size((w / 2, h / 2).into())],
         )
         .expect("Render error");
     frame
@@ -335,7 +335,7 @@ where
             1,
             1.,
             Transform::Normal,
-            &[Rectangle::from_loc_and_size((0, 0), (w, h))],
+            &[Rectangle::from_size((w, h).into())],
             &[],
             1.0,
         )
@@ -348,7 +348,7 @@ where
 
     if let Some(path) = dump {
         let mapping = renderer
-            .copy_framebuffer(Rectangle::from_loc_and_size((0, 0), (w, h)), Fourcc::Abgr8888)
+            .copy_framebuffer(Rectangle::from_size((w, h).into()), Fourcc::Abgr8888)
             .expect("Failed to map framebuffer");
         let copy = renderer.map_texture(&mapping).expect("Failed to read mapping");
         image::save_buffer(path, copy, w as u32, h as u32, image::ColorType::Rgba8)

--- a/examples/buffer_test.rs
+++ b/examples/buffer_test.rs
@@ -293,19 +293,19 @@ where
     frame
         .clear(
             Color32F::new(0.0, 1.0, 0.0, 1.0),
-            &[Rectangle::from_loc_and_size((w / 2, 0), (w / 2, h / 2))],
+            &[Rectangle::new((w / 2, 0).into(), (w / 2, h / 2).into())],
         )
         .expect("Render error");
     frame
         .clear(
             Color32F::new(0.0, 0.0, 1.0, 1.0),
-            &[Rectangle::from_loc_and_size((0, h / 2), (w / 2, h / 2))],
+            &[Rectangle::new((0, h / 2).into(), (w / 2, h / 2).into())],
         )
         .expect("Render error");
     frame
         .clear(
             Color32F::new(1.0, 1.0, 0.0, 1.0),
-            &[Rectangle::from_loc_and_size((w / 2, h / 2), (w / 2, h / 2))],
+            &[Rectangle::new((w / 2, h / 2).into(), (w / 2, h / 2).into())],
         )
         .expect("Render error");
     frame

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -208,7 +208,7 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
         backend.bind().unwrap();
 
         let size = backend.window_size();
-        let damage = Rectangle::from_loc_and_size((0, 0), size);
+        let damage = Rectangle::from_size(size);
 
         let elements = state
             .xdg_shell_state

--- a/smallvil/src/handlers/xdg_shell.rs
+++ b/smallvil/src/handlers/xdg_shell.rs
@@ -111,7 +111,7 @@ impl XdgShellHandler for Smallvil {
                 start_data,
                 window,
                 edges.into(),
-                Rectangle::from_loc_and_size(initial_window_location, initial_window_size),
+                Rectangle::new(initial_window_location, initial_window_size),
             );
 
             pointer.set_grab(self, grab, serial, Focus::Clear);

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -66,7 +66,7 @@ pub fn init_winit(
             WinitEvent::Input(event) => state.process_input_event(event),
             WinitEvent::Redraw => {
                 let size = backend.window_size();
-                let damage = Rectangle::from_loc_and_size((0, 0), size);
+                let damage = Rectangle::from_size(size);
 
                 backend.bind().unwrap();
                 smithay::desktop::space::render_output::<_, WaylandSurfaceRenderElement<GlesRenderer>, _, _>(

--- a/src/backend/drm/compositor/elements.rs
+++ b/src/backend/drm/compositor/elements.rs
@@ -5,7 +5,7 @@ use crate::{
         Color32F, Frame, Renderer,
     },
     render_elements,
-    utils::{Buffer, Physical, Point, Rectangle, Scale, Transform},
+    utils::{Buffer, Physical, Rectangle, Scale, Transform},
 };
 
 render_elements! {
@@ -81,7 +81,7 @@ impl Element for HolepunchRenderElement {
     }
 
     fn opaque_regions(&self, _scale: Scale<f64>) -> OpaqueRegions<i32, Physical> {
-        OpaqueRegions::from_slice(&[Rectangle::from_loc_and_size(Point::default(), self.geometry.size)])
+        OpaqueRegions::from_slice(&[Rectangle::from_size(self.geometry.size)])
     }
 }
 

--- a/src/backend/drm/compositor/frame_result.rs
+++ b/src/backend/drm/compositor/frame_result.rs
@@ -83,14 +83,11 @@ impl<B: Buffer> Element for SwapchainElement<'_, '_, B> {
     }
 
     fn src(&self) -> Rectangle<f64, BufferCoords> {
-        Rectangle::from_loc_and_size((0, 0), self.slot.size()).to_f64()
+        Rectangle::from_size(self.slot.size()).to_f64()
     }
 
     fn geometry(&self, _scale: Scale<f64>) -> Rectangle<i32, Physical> {
-        Rectangle::from_loc_and_size(
-            (0, 0),
-            self.slot.size().to_logical(1, self.transform).to_physical(1),
-        )
+        Rectangle::from_size(self.slot.size().to_logical(1, self.transform).to_physical(1))
     }
 
     fn transform(&self) -> Transform {
@@ -319,10 +316,7 @@ where
                     _ => unreachable!(),
                 };
                 let size = dmabuf.size();
-                let geometry = Rectangle::from_loc_and_size(
-                    (0, 0),
-                    size.to_logical(1, Transform::Normal).to_physical(1),
-                );
+                let geometry = Rectangle::from_size(size.to_logical(1, Transform::Normal).to_physical(1));
                 opaque_regions.push(geometry);
                 Some((sync.clone(), dmabuf, geometry))
             }

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -3345,7 +3345,7 @@ where
         };
 
         let src = Rectangle::from_size(cursor_buffer_size).to_f64();
-        let dst = Rectangle::from_loc_and_size(cursor_plane_location, cursor_plane_size);
+        let dst = Rectangle::new(cursor_plane_location, cursor_plane_size);
 
         let config = PlaneConfig {
             properties: PlaneProperties {

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1547,8 +1547,8 @@ where
             element_state: None,
             config: Some(PlaneConfig {
                 properties: PlaneProperties {
-                    src: Rectangle::from_loc_and_size(Point::default(), dmabuf.size()).to_f64(),
-                    dst: Rectangle::from_loc_and_size(Point::default(), mode_size),
+                    src: Rectangle::from_size(dmabuf.size()).to_f64(),
+                    dst: Rectangle::from_size(mode_size),
                     transform: Transform::Normal,
                     alpha: 1.0,
                     format: buffer.format(),
@@ -1717,7 +1717,7 @@ where
         // The renderer (and also the logic for direct scan-out) will take care of the
         // actual transform during rendering
         let output_geometry: Rectangle<_, Physical> =
-            Rectangle::from_loc_and_size((0, 0), output_transform.transform_size(current_size));
+            Rectangle::from_size(output_transform.transform_size(current_size));
 
         // We always acquire a buffer from the swapchain even
         // if we could end up doing direct scan-out on the primary plane.
@@ -1813,8 +1813,8 @@ where
             element_state: None,
             config: Some(PlaneConfig {
                 properties: PlaneProperties {
-                    src: Rectangle::from_loc_and_size(Point::default(), dmabuf.size()).to_f64(),
-                    dst: Rectangle::from_loc_and_size(Point::default(), current_size),
+                    src: Rectangle::from_size(dmabuf.size()).to_f64(),
+                    dst: Rectangle::from_size(current_size),
                     // NOTE: We do not apply the transform to the primary plane as this is handled by the dtr/renderer
                     transform: Transform::Normal,
                     alpha: 1.0,
@@ -3318,12 +3318,9 @@ where
                         pixman_renderer.bind(PixmanRenderBuffer::from(cursor_dst))?;
 
                         let mut frame = pixman_renderer.render(cursor_plane_size, output_transform)?;
-                        frame.clear(
-                            Color32F::TRANSPARENT,
-                            &[Rectangle::from_loc_and_size((0, 0), cursor_plane_size)],
-                        )?;
+                        frame.clear(Color32F::TRANSPARENT, &[Rectangle::from_size(cursor_plane_size)])?;
                         let src = element.src();
-                        let dst = Rectangle::from_loc_and_size((0, 0), element_geometry.size);
+                        let dst = Rectangle::from_size(element_geometry.size);
                         frame.render_texture_from_to(
                             &cursor_texture,
                             src,
@@ -3347,7 +3344,7 @@ where
             }
         };
 
-        let src = Rectangle::from_loc_and_size(Point::default(), cursor_buffer_size).to_f64();
+        let src = Rectangle::from_size(cursor_buffer_size).to_f64();
         let dst = Rectangle::from_loc_and_size(cursor_plane_location, cursor_plane_size);
 
         let config = PlaneConfig {

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -14,7 +14,7 @@ use std::sync::{
 };
 
 use crate::backend::drm::error::AccessError;
-use crate::utils::{Coordinate, Point, Rectangle, Transform};
+use crate::utils::{Coordinate, Rectangle, Transform};
 use crate::{
     backend::{
         allocator::format::{get_bpp, get_depth},
@@ -340,10 +340,9 @@ impl AtomicDrmSurface {
                 [&PlaneState {
                     handle: self.plane,
                     config: Some(PlaneConfig {
-                        src: Rectangle::from_loc_and_size(Point::default(), pending.mode.size()).to_f64(),
-                        dst: Rectangle::from_loc_and_size(
-                            Point::default(),
-                            (pending.mode.size().0 as i32, pending.mode.size().1 as i32),
+                        src: Rectangle::from_size(pending.mode.size().into()).to_f64(),
+                        dst: Rectangle::from_size(
+                            (pending.mode.size().0 as i32, pending.mode.size().1 as i32).into(),
                         ),
                         transform: Transform::Normal,
                         alpha: 1.0,
@@ -393,10 +392,9 @@ impl AtomicDrmSurface {
             [&PlaneState {
                 handle: self.plane,
                 config: Some(PlaneConfig {
-                    src: Rectangle::from_loc_and_size(Point::default(), pending.mode.size()).to_f64(),
-                    dst: Rectangle::from_loc_and_size(
-                        Point::default(),
-                        (pending.mode.size().0 as i32, pending.mode.size().1 as i32),
+                    src: Rectangle::from_size(pending.mode.size().into()).to_f64(),
+                    dst: Rectangle::from_size(
+                        (pending.mode.size().0 as i32, pending.mode.size().1 as i32).into(),
                     ),
                     transform: Transform::Normal,
                     alpha: 1.0,
@@ -448,10 +446,9 @@ impl AtomicDrmSurface {
             [&PlaneState {
                 handle: self.plane,
                 config: Some(PlaneConfig {
-                    src: Rectangle::from_loc_and_size(Point::default(), pending.mode.size()).to_f64(),
-                    dst: Rectangle::from_loc_and_size(
-                        Point::default(),
-                        (pending.mode.size().0 as i32, pending.mode.size().1 as i32),
+                    src: Rectangle::from_size(pending.mode.size().into()).to_f64(),
+                    dst: Rectangle::from_size(
+                        (pending.mode.size().0 as i32, pending.mode.size().1 as i32).into(),
                     ),
                     transform: Transform::Normal,
                     alpha: 1.0,
@@ -501,11 +498,8 @@ impl AtomicDrmSurface {
             [&PlaneState {
                 handle: self.plane,
                 config: Some(PlaneConfig {
-                    src: Rectangle::from_loc_and_size(Point::default(), mode.size()).to_f64(),
-                    dst: Rectangle::from_loc_and_size(
-                        Point::default(),
-                        (mode.size().0 as i32, mode.size().1 as i32),
-                    ),
+                    src: Rectangle::from_size(mode.size().into()).to_f64(),
+                    dst: Rectangle::from_size((mode.size().0 as i32, mode.size().1 as i32).into()),
                     transform: Transform::Normal,
                     alpha: 1.0,
                     damage_clips: None,
@@ -624,10 +618,9 @@ impl AtomicDrmSurface {
         let plane_config = PlaneState {
             handle: self.plane,
             config: Some(PlaneConfig {
-                src: Rectangle::from_loc_and_size(Point::default(), pending.mode.size()).to_f64(),
-                dst: Rectangle::from_loc_and_size(
-                    Point::default(),
-                    (pending.mode.size().0 as i32, pending.mode.size().1 as i32),
+                src: Rectangle::from_size(pending.mode.size().into()).to_f64(),
+                dst: Rectangle::from_size(
+                    (pending.mode.size().0 as i32, pending.mode.size().1 as i32).into(),
                 ),
                 transform: Transform::Normal,
                 alpha: 1.0,
@@ -1351,14 +1344,14 @@ mod test {
 
     #[test]
     fn test_fixed_point() {
-        let geometry: Rectangle<f64, Physical> = Rectangle::from_loc_and_size((0.0, 0.0), (1920.0, 1080.0));
+        let geometry: Rectangle<f64, Physical> = Rectangle::from_size((1920.0, 1080.0).into());
         let fixed = to_fixed(geometry.size.w) as u64;
         assert_eq!(125829120, fixed);
     }
 
     #[test]
     fn test_fractional_fixed_point() {
-        let geometry: Rectangle<f64, Physical> = Rectangle::from_loc_and_size((0.0, 0.0), (1920.1, 1080.0));
+        let geometry: Rectangle<f64, Physical> = Rectangle::from_size((1920.1, 1080.0).into());
         let fixed = to_fixed(geometry.size.w) as u64;
         assert_eq!(125835674, fixed);
     }

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -14,7 +14,7 @@ use crate::backend::drm::gbm::{framebuffer_from_bo, GbmFramebuffer};
 use crate::backend::drm::{plane_has_property, DrmError, DrmSurface};
 use crate::backend::renderer::sync::SyncPoint;
 use crate::backend::SwapBuffersError;
-use crate::utils::{DevPath, Physical, Point, Rectangle, Transform};
+use crate::utils::{DevPath, Physical, Rectangle, Transform};
 
 use tracing::{debug, error, info_span, instrument, trace, warn};
 
@@ -219,15 +219,8 @@ where
         let plane_state = PlaneState {
             handle: drm.plane(),
             config: Some(PlaneConfig {
-                src: Rectangle::from_loc_and_size(
-                    Point::default(),
-                    (mode.size().0 as i32, mode.size().1 as i32),
-                )
-                .to_f64(),
-                dst: Rectangle::from_loc_and_size(
-                    Point::default(),
-                    (mode.size().0 as i32, mode.size().1 as i32),
-                ),
+                src: Rectangle::from_size((mode.size().0 as i32, mode.size().1 as i32).into()).to_f64(),
+                dst: Rectangle::from_size((mode.size().0 as i32, mode.size().1 as i32).into()),
                 alpha: 1.0,
                 transform: Transform::Normal,
                 damage_clips: None,
@@ -352,11 +345,8 @@ where
         } = self.queued_fb.take().unwrap();
         let handle = slot.userdata().get::<GbmFramebuffer>().unwrap();
         let mode = self.drm.pending_mode();
-        let src =
-            Rectangle::from_loc_and_size(Point::default(), (mode.size().0 as i32, mode.size().1 as i32))
-                .to_f64();
-        let dst =
-            Rectangle::from_loc_and_size(Point::default(), (mode.size().0 as i32, mode.size().1 as i32));
+        let src = Rectangle::from_size((mode.size().0 as i32, mode.size().1 as i32).into()).to_f64();
+        let dst = Rectangle::from_size((mode.size().0 as i32, mode.size().1 as i32).into());
 
         let damage_clips = damage.and_then(|damage| {
             PlaneDamageClips::from_damage(self.drm.device_fd(), src, dst, damage)

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -172,7 +172,7 @@
 //!             // Update the changed parts of the buffer
 //!
 //!             // Return the updated parts
-//!             Result::<_, ()>::Ok(vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))])
+//!             Result::<_, ()>::Ok(vec![Rectangle::from_size((WIDTH, HEIGHT).into())])
 //!         });
 //!
 //!         last_update = now;
@@ -474,7 +474,7 @@ impl OutputDamageTracker {
         // We have to apply to output transform to the output size so that the intersection
         // tests in damage_output_internal produces the correct results and do not crop
         // damage with the wrong size
-        let output_geo = Rectangle::from_loc_and_size((0, 0), output_transform.transform_size(output_size));
+        let output_geo = Rectangle::from_size(output_transform.transform_size(output_size));
 
         let mut render_elements: Vec<&E> = Vec::with_capacity(elements.len());
         let states = self.damage_output_internal(
@@ -807,7 +807,7 @@ impl OutputDamageTracker {
         // We have to apply to output transform to the output size so that the intersection
         // tests in damage_output_internal produces the correct results and do not crop
         // damage with the wrong size
-        let output_geo = Rectangle::from_loc_and_size((0, 0), output_transform.transform_size(output_size));
+        let output_geo = Rectangle::from_size(output_transform.transform_size(output_size));
 
         // This will hold all the damage we need for this rendering step
         let mut render_elements: Vec<&E> = Vec::with_capacity(elements.len());

--- a/src/backend/renderer/damage/shaper.rs
+++ b/src/backend/renderer/damage/shaper.rs
@@ -78,7 +78,7 @@ impl<const MIN_TILE_SIDE: i32> DamageShaper<MIN_TILE_SIDE> {
         let bbox_w = x_max - x_min;
         let bbox_h = y_max - y_min;
 
-        let damage_bbox = Rectangle::<i32, Physical>::from_loc_and_size((x_min, y_min), (bbox_w, bbox_h));
+        let damage_bbox = Rectangle::<i32, Physical>::new((x_min, y_min).into(), (bbox_w, bbox_h).into());
 
         // Damage the current bounding box when there's a damage rect covering near all the area.
         if max_damage_area as f32 / (damage_bbox.size.w * damage_bbox.size.h) as f32
@@ -200,7 +200,7 @@ impl<const MIN_TILE_SIDE: i32> DamageShaper<MIN_TILE_SIDE> {
             for y in (bbox.loc.y..bbox.loc.y + bbox.size.h).step_by(tile_size.h as usize) {
                 // NOTE the in_damage is constrained to the `bbox`, so it can't go outside
                 // the tile, even though some tiles could go outside the `bbox`.
-                let bbox = Rectangle::<i32, Physical>::from_loc_and_size((x, y), tile_size);
+                let bbox = Rectangle::<i32, Physical>::new((x, y).into(), tile_size);
                 let mut tile = Tile {
                     bbox,
                     damage: None,
@@ -327,12 +327,12 @@ mod tests {
     #[test]
     fn tile_shaping() {
         let mut damage = vec![
-            Rectangle::<i32, Physical>::from_loc_and_size((98, 406), (36, 48)),
-            Rectangle::<i32, Physical>::from_loc_and_size((158, 502), (828, 168)),
-            Rectangle::<i32, Physical>::from_loc_and_size((122, 694), (744, 528)),
-            Rectangle::<i32, Physical>::from_loc_and_size((194, 1318), (420, 72)),
-            Rectangle::<i32, Physical>::from_loc_and_size((146, 1414), (312, 48)),
-            Rectangle::<i32, Physical>::from_loc_and_size((32, 406), (108, 1152)),
+            Rectangle::<i32, Physical>::new((98, 406).into(), (36, 48).into()),
+            Rectangle::<i32, Physical>::new((158, 502).into(), (828, 168).into()),
+            Rectangle::<i32, Physical>::new((122, 694).into(), (744, 528).into()),
+            Rectangle::<i32, Physical>::new((194, 1318).into(), (420, 72).into()),
+            Rectangle::<i32, Physical>::new((146, 1414).into(), (312, 48).into()),
+            Rectangle::<i32, Physical>::new((32, 406).into(), (108, 1152).into()),
         ];
 
         let mut shaper = shaper();
@@ -383,7 +383,7 @@ mod tests {
 
         for x in 0..w {
             for y in 0..h {
-                let rect = Rectangle::<i32, Physical>::from_loc_and_size((x, y), (1, 1));
+                let rect = Rectangle::<i32, Physical>::new((x, y).into(), (1, 1).into());
                 damage.push(rect);
             }
         }
@@ -398,7 +398,7 @@ mod tests {
         let w1 = 216;
         let h1 = 144;
         let overlap1 = Rectangle::<i32, Physical>::from_size((w1, h1).into());
-        let overlap2 = Rectangle::<i32, Physical>::from_loc_and_size((w1, h1), (w - w1, h - h1));
+        let overlap2 = Rectangle::<i32, Physical>::new((w1, h1).into(), (w - w1, h - h1).into());
         damage.push(overlap1);
         damage.push(overlap2);
 

--- a/src/backend/renderer/damage/shaper.rs
+++ b/src/backend/renderer/damage/shaper.rs
@@ -350,7 +350,7 @@ mod tests {
         assert!(shaper.tiles_cache.is_empty());
 
         // Having big chunk of damage shouldn't trigger tiling.
-        let bbox = Rectangle::<i32, Physical>::from_loc_and_size((0, 0), (3840, 2160));
+        let bbox = Rectangle::<i32, Physical>::from_size((3840, 2160).into());
         damage.push(bbox);
         shaper.shape_damage(&mut damage);
         assert_eq!(damage[0], bbox);
@@ -364,7 +364,7 @@ mod tests {
         shaper.shape_damage(&mut damage);
         assert!(damage.is_empty());
 
-        let rect = Rectangle::<i32, Physical>::from_loc_and_size((0, 0), (5, 5));
+        let rect = Rectangle::<i32, Physical>::from_size((5, 5).into());
         damage.push(rect);
         shaper.shape_damage(&mut damage);
         assert!(damage.len() == 1);
@@ -397,7 +397,7 @@ mod tests {
 
         let w1 = 216;
         let h1 = 144;
-        let overlap1 = Rectangle::<i32, Physical>::from_loc_and_size((0, 0), (w1, h1));
+        let overlap1 = Rectangle::<i32, Physical>::from_size((w1, h1).into());
         let overlap2 = Rectangle::<i32, Physical>::from_loc_and_size((w1, h1), (w - w1, h - h1));
         damage.push(overlap1);
         damage.push(overlap2);

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -163,12 +163,11 @@
 //!     });
 //!
 //!     // Return the whole buffer as damage
-//!     Result::<_, ()>::Ok(vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))])
+//!     Result::<_, ()>::Ok(vec![Rectangle::from_size((WIDTH, HEIGHT).into())])
 //! });
 //!
 //! // Optionally update the opaque regions
-//! render_context.update_opaque_regions(Some(vec![Rectangle::from_loc_and_size(
-//!     Point::default(),
+//! render_context.update_opaque_regions(Some(vec![Rectangle::from_size(
 //!     Size::from((WIDTH, HEIGHT)),
 //! )]));
 //!
@@ -190,7 +189,7 @@
 //!             // Update the changed parts of the buffer
 //!
 //!             // Return the updated parts
-//!             Result::<_, ()>::Ok(vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))])
+//!             Result::<_, ()>::Ok(vec![Rectangle::from_size((WIDTH, HEIGHT).into())])
 //!         });
 //!
 //!         last_update = now;
@@ -423,7 +422,7 @@ impl MemoryRenderBufferInner {
             .damage_bag
             .damage_since(last_commit)
             .map(|d| d.into_iter().reduce(|a, b| a.merge(b)).unwrap_or_default())
-            .unwrap_or_else(|| Rectangle::from_loc_and_size(Point::default(), self.mem.size()));
+            .unwrap_or_else(|| Rectangle::from_size(self.mem.size()));
 
         let tex = match self.textures.entry(texture_id) {
             Entry::Occupied(entry) => {
@@ -605,7 +604,7 @@ impl<R: Renderer> MemoryRenderBufferRenderElement<R> {
             .or_else(|| src.map(|src| Size::from((src.size.w as i32, src.size.h as i32))))
             .unwrap_or_else(|| inner.mem.size().to_logical(inner.scale, inner.transform));
 
-        let src = src.unwrap_or_else(|| Rectangle::from_loc_and_size(Point::default(), size.to_f64()));
+        let src = src.unwrap_or_else(|| Rectangle::from_size(size.to_f64()));
 
         Ok(MemoryRenderBufferRenderElement {
             id: buffer.id.clone(),
@@ -693,9 +692,7 @@ impl<R: Renderer> Element for MemoryRenderBufferRenderElement<R> {
                     })
                     .collect::<DamageSet<_, _>>()
             })
-            .unwrap_or_else(|| {
-                DamageSet::from_slice(&[Rectangle::from_loc_and_size(Point::default(), physical_size)])
-            })
+            .unwrap_or_else(|| DamageSet::from_slice(&[Rectangle::from_size(physical_size)]))
     }
 
     fn opaque_regions(&self, scale: Scale<f64>) -> OpaqueRegions<i32, Physical> {

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -660,7 +660,7 @@ impl<R: Renderer> Element for MemoryRenderBufferRenderElement<R> {
     }
 
     fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
-        Rectangle::from_loc_and_size(self.location.to_i32_round(), self.physical_size(scale))
+        Rectangle::new(self.location.to_i32_round(), self.physical_size(scale))
     }
 
     fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -360,7 +360,7 @@ pub trait Element {
     /// Get the damage since the provided commit relative to the element
     fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
         if commit != Some(self.current_commit()) {
-            DamageSet::from_slice(&[Rectangle::from_loc_and_size((0, 0), self.geometry(scale).size)])
+            DamageSet::from_slice(&[Rectangle::from_size(self.geometry(scale).size)])
         } else {
             DamageSet::default()
         }

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -265,12 +265,12 @@ impl SolidColorRenderElement {
         kind: Kind,
     ) -> Self {
         let color = color.into();
-        let src = Rectangle::from_loc_and_size((0, 0), geometry.size)
+        let src = Rectangle::from_size(geometry.size)
             .to_f64()
             .to_logical(1f64)
             .to_buffer(1f64, Transform::Normal, &geometry.size.to_f64().to_logical(1f64));
         let opaque_regions = if color.is_opaque() {
-            vec![Rectangle::from_loc_and_size((0, 0), geometry.size)]
+            vec![Rectangle::from_size(geometry.size)]
         } else {
             vec![]
         };

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -251,7 +251,7 @@ impl SolidColorRenderElement {
         alpha: f32,
         kind: Kind,
     ) -> Self {
-        let geo = Rectangle::from_loc_and_size(location, buffer.size.to_physical_precise_round(scale));
+        let geo = Rectangle::new(location.into(), buffer.size.to_physical_precise_round(scale));
         let color = buffer.color * alpha;
         Self::new(buffer.id.clone(), geo, buffer.commit, color, kind)
     }

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -468,9 +468,7 @@ impl<R: Renderer + ImportAll> Element for WaylandSurfaceRenderElement<R> {
         let dst_size = self.size(scale);
         self.damage
             .damage_since(commit)
-            .unwrap_or_else(|| {
-                DamageSet::from_slice(&[Rectangle::from_loc_and_size((0, 0), self.buffer_dimensions)])
-            })
+            .unwrap_or_else(|| DamageSet::from_slice(&[Rectangle::from_size(self.buffer_dimensions)]))
             .iter()
             .filter_map(|rect| {
                 rect.to_f64()

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -449,7 +449,7 @@ impl<R: Renderer + ImportAll> Element for WaylandSurfaceRenderElement<R> {
     }
 
     fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
-        Rectangle::from_loc_and_size(self.location.to_i32_round(), self.size(scale))
+        Rectangle::new(self.location.to_i32_round(), self.size(scale))
     }
 
     fn src(&self) -> Rectangle<f64, BufferCoords> {
@@ -511,7 +511,7 @@ impl<R: Renderer + ImportAll> Element for WaylandSurfaceRenderElement<R> {
                 let size = ((r.size.to_f64().to_physical(scale).to_point() + self.location).to_i32_round()
                     - self.location.to_i32_round())
                 .to_size();
-                Rectangle::from_loc_and_size(loc, size)
+                Rectangle::new(loc, size)
             })
             .collect::<OpaqueRegions<_, _>>()
     }

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -352,15 +352,13 @@
 //!     // Your draw code here...
 //!
 //!     // Return the damage areas
-//!     Result::<_, ()>::Ok(vec![Rectangle::from_loc_and_size(
-//!         Point::default(),
+//!     Result::<_, ()>::Ok(vec![Rectangle::from_size(
 //!         Size::from((WIDTH, HEIGHT)),
 //!     )])
 //! });
 //!
 //! // Optionally update the opaque regions
-//! render_context.update_opaque_regions(Some(vec![Rectangle::from_loc_and_size(
-//!     Point::default(),
+//! render_context.update_opaque_regions(Some(vec![Rectangle::from_size(
 //!     Size::from((WIDTH, HEIGHT)),
 //! )]));
 //!
@@ -380,7 +378,7 @@
 //!             // Update the changed parts of the buffer
 //!
 //!             // Return the updated parts
-//!             Result::<_, ()>::Ok(vec![Rectangle::from_loc_and_size(Point::default(), (WIDTH, HEIGHT))])
+//!             Result::<_, ()>::Ok(vec![Rectangle::from_size((WIDTH, HEIGHT).into())])
 //!         });
 //!
 //!         last_update = now;
@@ -640,12 +638,9 @@ pub struct TextureRenderElement<T> {
 
 impl<T: Texture> TextureRenderElement<T> {
     fn damage_since(&self, commit: Option<CommitCounter>) -> DamageSet<i32, Buffer> {
-        self.snapshot.damage_since(commit).unwrap_or_else(|| {
-            DamageSet::from_slice(&[Rectangle::from_loc_and_size(
-                Point::default(),
-                self.texture.size(),
-            )])
-        })
+        self.snapshot
+            .damage_since(commit)
+            .unwrap_or_else(|| DamageSet::from_slice(&[Rectangle::from_size(self.texture.size())]))
     }
 }
 
@@ -790,7 +785,7 @@ impl<T: Texture> TextureRenderElement<T> {
 
     fn src(&self) -> Rectangle<f64, Logical> {
         self.src
-            .unwrap_or_else(|| Rectangle::from_loc_and_size(Point::default(), self.logical_size().to_f64()))
+            .unwrap_or_else(|| Rectangle::from_size(self.logical_size().to_f64()))
     }
 
     fn scale(&self) -> Scale<f64> {

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -818,7 +818,7 @@ where
     }
 
     fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
-        Rectangle::from_loc_and_size(self.location.to_i32_round(), self.physical_size(scale))
+        Rectangle::new(self.location.to_i32_round(), self.physical_size(scale))
     }
 
     fn transform(&self) -> Transform {

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -2356,7 +2356,7 @@ impl GlesFrame<'_> {
                     .size
                     .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
 
-                let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+                let rect = Rectangle::new(rect_constrained_loc, rect_clamped_size);
                 [
                     (dest.loc.x + rect.loc.x) as f32,
                     (dest.loc.y + rect.loc.y) as f32,
@@ -2373,7 +2373,7 @@ impl GlesFrame<'_> {
                     .size
                     .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
 
-                let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+                let rect = Rectangle::new(rect_constrained_loc, rect_clamped_size);
                 // Add the 4 f32s per damage rectangle for each of the 6 vertices.
                 (0..6).flat_map(move |_| {
                     [
@@ -2492,7 +2492,7 @@ impl GlesFrame<'_> {
                     .size
                     .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
 
-                let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+                let rect = Rectangle::new(rect_constrained_loc, rect_clamped_size);
                 [
                     rect.loc.x as f32,
                     rect.loc.y as f32,
@@ -2775,7 +2775,7 @@ impl GlesFrame<'_> {
                     .size
                     .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
 
-                let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+                let rect = Rectangle::new(rect_constrained_loc, rect_clamped_size);
                 [
                     rect.loc.x as f32,
                     rect.loc.y as f32,
@@ -2792,7 +2792,7 @@ impl GlesFrame<'_> {
                     .size
                     .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
 
-                let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+                let rect = Rectangle::new(rect_constrained_loc, rect_clamped_size);
                 // Add the 4 f32s per damage rectangle for each of the 6 vertices.
                 (0..6).flat_map(move |_| {
                     [
@@ -2992,7 +2992,7 @@ mod tests {
     #[test]
     fn texture_normal_double_size() {
         let src: Rectangle<f64, Buffer> = Rectangle::from_size((1000f64, 500f64).into());
-        let dest: Rectangle<i32, Physical> = Rectangle::from_loc_and_size((442, 144), (500, 250));
+        let dest: Rectangle<i32, Physical> = Rectangle::new((442, 144).into(), (500, 250).into());
         let texture_size: Size<i32, Buffer> = Size::from((1000, 500));
         let transform = Transform::Normal;
 
@@ -3011,8 +3011,8 @@ mod tests {
 
     #[test]
     fn texture_scaler_crop() {
-        let src: Rectangle<f64, Buffer> = Rectangle::from_loc_and_size((42.5f64, 50.5f64), (110f64, 154f64));
-        let dest: Rectangle<i32, Physical> = Rectangle::from_loc_and_size((813, 214), (55, 77));
+        let src: Rectangle<f64, Buffer> = Rectangle::new((42.5f64, 50.5f64).into(), (110f64, 154f64).into());
+        let dest: Rectangle<i32, Physical> = Rectangle::new((813, 214).into(), (55, 77).into());
         let texture_size: Size<i32, Buffer> = Size::from((842, 674));
         let transform = Transform::Normal;
 
@@ -3044,7 +3044,7 @@ mod tests {
     #[test]
     fn texture_normal() {
         let src: Rectangle<f64, Buffer> = Rectangle::from_size((500f64, 250f64).into());
-        let dest: Rectangle<i32, Physical> = Rectangle::from_loc_and_size((442, 144), (500, 250));
+        let dest: Rectangle<i32, Physical> = Rectangle::new((442, 144).into(), (500, 250).into());
         let texture_size: Size<i32, Buffer> = Size::from((500, 250));
         let transform = Transform::Normal;
 
@@ -3064,7 +3064,7 @@ mod tests {
     #[test]
     fn texture_flipped() {
         let src: Rectangle<f64, Buffer> = Rectangle::from_size((500f64, 250f64).into());
-        let dest: Rectangle<i32, Physical> = Rectangle::from_loc_and_size((442, 144), (500, 250));
+        let dest: Rectangle<i32, Physical> = Rectangle::new((442, 144).into(), (500, 250).into());
         let texture_size: Size<i32, Buffer> = Size::from((500, 250));
         let transform = Transform::Flipped;
 
@@ -3084,7 +3084,7 @@ mod tests {
     #[test]
     fn texture_90() {
         let src: Rectangle<f64, Buffer> = Rectangle::from_size((250f64, 500f64).into());
-        let dest: Rectangle<i32, Physical> = Rectangle::from_loc_and_size((442, 144), (500, 250));
+        let dest: Rectangle<i32, Physical> = Rectangle::new((442, 144).into(), (500, 250).into());
         let texture_size: Size<i32, Buffer> = Size::from((250, 500));
         let transform = Transform::_90;
 
@@ -3104,7 +3104,7 @@ mod tests {
     #[test]
     fn texture_180() {
         let src: Rectangle<f64, Buffer> = Rectangle::from_size((500f64, 250f64).into());
-        let dest: Rectangle<i32, Physical> = Rectangle::from_loc_and_size((442, 144), (500, 250));
+        let dest: Rectangle<i32, Physical> = Rectangle::new((442, 144).into(), (500, 250).into());
         let texture_size: Size<i32, Buffer> = Size::from((500, 250));
         let transform = Transform::_180;
 
@@ -3124,7 +3124,7 @@ mod tests {
     #[test]
     fn texture_270() {
         let src: Rectangle<f64, Buffer> = Rectangle::from_size((250f64, 500f64).into());
-        let dest: Rectangle<i32, Physical> = Rectangle::from_loc_and_size((442, 144), (500, 250));
+        let dest: Rectangle<i32, Physical> = Rectangle::new((442, 144).into(), (500, 250).into());
         let texture_size: Size<i32, Buffer> = Size::from((250, 500));
         let transform = Transform::_270;
 
@@ -3144,7 +3144,7 @@ mod tests {
     #[test]
     fn texture_flipped_90() {
         let src: Rectangle<f64, Buffer> = Rectangle::from_size((250f64, 500f64).into());
-        let dest: Rectangle<i32, Physical> = Rectangle::from_loc_and_size((442, 144), (500, 250));
+        let dest: Rectangle<i32, Physical> = Rectangle::new((442, 144).into(), (500, 250).into());
         let texture_size: Size<i32, Buffer> = Size::from((250, 500));
         let transform = Transform::Flipped90;
 
@@ -3164,7 +3164,7 @@ mod tests {
     #[test]
     fn texture_flipped_180() {
         let src: Rectangle<f64, Buffer> = Rectangle::from_size((500f64, 250f64).into());
-        let dest: Rectangle<i32, Physical> = Rectangle::from_loc_and_size((442, 144), (500, 250));
+        let dest: Rectangle<i32, Physical> = Rectangle::new((442, 144).into(), (500, 250).into());
         let texture_size: Size<i32, Buffer> = Size::from((500, 250));
         let transform = Transform::Flipped180;
 
@@ -3184,7 +3184,7 @@ mod tests {
     #[test]
     fn texture_flipped_270() {
         let src: Rectangle<f64, Buffer> = Rectangle::from_size((250f64, 500f64).into());
-        let dest: Rectangle<i32, Physical> = Rectangle::from_loc_and_size((442, 144), (500, 250));
+        let dest: Rectangle<i32, Physical> = Rectangle::new((442, 144).into(), (500, 250).into());
         let texture_size: Size<i32, Buffer> = Size::from((250, 500));
         let transform = Transform::Flipped270;
 

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -206,7 +206,7 @@ pub trait Frame {
     ) -> Result<(), Self::Error> {
         self.render_texture_from_to(
             texture,
-            Rectangle::from_loc_and_size(Point::<i32, BufferCoord>::from((0, 0)), texture.size()).to_f64(),
+            Rectangle::from_size(texture.size()).to_f64(),
             Rectangle::from_loc_and_size(
                 pos,
                 texture

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -207,7 +207,7 @@ pub trait Frame {
         self.render_texture_from_to(
             texture,
             Rectangle::from_size(texture.size()).to_f64(),
-            Rectangle::from_loc_and_size(
+            Rectangle::new(
                 pos,
                 texture
                     .size()

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1339,8 +1339,7 @@ where
                         let dst = damage_rect
                             .to_logical(1, Transform::Normal, &buffer_size)
                             .to_physical(1);
-                        let src = Rectangle::from_loc_and_size(damage_rect.loc - rect.loc, damage_rect.size)
-                            .to_f64();
+                        let src = Rectangle::new(damage_rect.loc - rect.loc, damage_rect.size).to_f64();
                         let damage = &[Rectangle::from_size(dst.size)];
                         frame
                             .clear(Color32F::TRANSPARENT, &[dst])

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -335,7 +335,7 @@ impl Frame for PixmanFrame<'_> {
     #[profiling::function]
     fn clear(&mut self, color: Color32F, at: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
         self.draw_solid_color(
-            Rectangle::from_loc_and_size((0, 0), self.size),
+            Rectangle::from_size(self.size),
             at,
             color,
             Operation::Src,

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -226,7 +226,7 @@ impl RendererSurfaceState {
                             .size
                             .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
 
-                        let rect = Rectangle::from_loc_and_size(rect_constrained_loc, rect_clamped_size);
+                        let rect = Rectangle::new(rect_constrained_loc, rect_clamped_size);
 
                         (kind, rect)
                     })

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -204,7 +204,7 @@ impl RendererSurfaceState {
                         &surface_size,
                     ),
                 }
-                .intersection(Rectangle::from_loc_and_size((0, 0), buffer_dimensions))
+                .intersection(Rectangle::from_size(buffer_dimensions))
             });
             self.damage.add(buffer_damage);
         }
@@ -213,8 +213,7 @@ impl RendererSurfaceState {
         if new_buffer || surface_view_changed {
             self.opaque_regions.clear();
             if !self.buffer_has_alpha.unwrap_or(true) {
-                self.opaque_regions
-                    .push(Rectangle::from_loc_and_size((0, 0), surface_view.dst))
+                self.opaque_regions.push(Rectangle::from_size(surface_view.dst))
             } else if let Some(region_attributes) = &attrs.opaque_region {
                 let opaque_regions = region_attributes
                     .rects
@@ -222,9 +221,7 @@ impl RendererSurfaceState {
                     .map(|(kind, rect)| {
                         let dest_size = surface_view.dst;
 
-                        let rect_constrained_loc = rect
-                            .loc
-                            .constrain(Rectangle::from_extemities((0, 0), dest_size.to_point()));
+                        let rect_constrained_loc = rect.loc.constrain(Rectangle::from_size(dest_size));
                         let rect_clamped_size = rect
                             .size
                             .clamp((0, 0), (dest_size.to_point() - rect_constrained_loc).to_size());
@@ -277,7 +274,7 @@ impl RendererSurfaceState {
         self.damage.damage_since(commit).unwrap_or_else(|| {
             self.buffer_dimensions
                 .as_ref()
-                .map(|size| DamageSet::from_slice(&[Rectangle::from_loc_and_size((0, 0), *size)]))
+                .map(|size| DamageSet::from_slice(&[Rectangle::from_size(*size)]))
                 .unwrap_or_default()
         })
     }
@@ -421,7 +418,7 @@ impl SurfaceView {
 
         let src = viewport
             .src
-            .unwrap_or_else(|| Rectangle::from_loc_and_size((0.0, 0.0), surface_size.to_f64()));
+            .unwrap_or_else(|| Rectangle::from_size(surface_size.to_f64()));
         let dst = viewport
             .size()
             .unwrap_or(surface_size.to_client(1).to_logical(client_scale as i32));

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -339,8 +339,8 @@ where
                 let damage = damage
                     .iter()
                     .map(|rect| {
-                        Rectangle::from_loc_and_size(
-                            (rect.loc.x, bind_size.h - rect.loc.y - rect.size.h),
+                        Rectangle::new(
+                            (rect.loc.x, bind_size.h - rect.loc.y - rect.size.h).into(),
                             rect.size,
                         )
                     })

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -293,7 +293,7 @@ impl<E: SpaceElement + PartialEq> Space<E> {
         let transform: Transform = o.current_transform();
         let location = output_location(self.id, o);
         o.current_mode().map(|mode| {
-            Rectangle::from_loc_and_size(
+            Rectangle::new(
                 location,
                 transform
                     .transform_size(mode.size)

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -335,9 +335,7 @@ impl<E: SpaceElement + PartialEq> Space<E> {
             .iter()
             .cloned()
             .map(|o| {
-                let geo = self
-                    .output_geometry(&o)
-                    .unwrap_or_else(|| Rectangle::from_loc_and_size((0, 0), (0, 0)));
+                let geo = self.output_geometry(&o).unwrap_or_else(Rectangle::zero);
                 (o, geo)
             })
             .collect::<Vec<_>>();

--- a/src/desktop/space/wayland/mod.rs
+++ b/src/desktop/space/wayland/mod.rs
@@ -62,7 +62,7 @@ pub fn output_update(output: &Output, output_overlap: Option<Rectangle<i32, Logi
 
             if let Some(surface_view) = data.and_then(|d| d.lock().unwrap().surface_view) {
                 location += surface_view.offset;
-                let surface_rectangle = Rectangle::from_loc_and_size(location, surface_view.dst);
+                let surface_rectangle = Rectangle::new(location, surface_view.dst);
                 if output_overlap.overlaps(surface_rectangle) {
                     // We found a matching output, check if we already sent enter
                     output.enter(wl_surface);

--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -28,7 +28,7 @@ impl WaylandFocus for X11Surface {
 impl SpaceElement for X11Surface {
     fn bbox(&self) -> Rectangle<i32, Logical> {
         let geo = X11Surface::geometry(self);
-        Rectangle::from_loc_and_size((0, 0), geo.size)
+        Rectangle::from_size(geo.size)
     }
 
     fn is_in_input_region(&self, point: &Point<f64, Logical>) -> bool {

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -51,8 +51,7 @@ pub fn layer_map_for_output(o: &Output) -> MutexGuard<'_, LayerMap> {
         Mutex::new(LayerMap {
             layers: IndexSet::new(),
             output: o.downgrade(),
-            zone: Rectangle::from_loc_and_size(
-                (0, 0),
+            zone: Rectangle::from_size(
                 o.current_mode()
                     .map(|mode| {
                         let logical_size = mode
@@ -252,8 +251,7 @@ impl LayerMap {
             let span = debug_span!("layer_map", output = output.name());
             let _guard = span.enter();
 
-            let output_rect = Rectangle::from_loc_and_size(
-                (0, 0),
+            let output_rect = Rectangle::from_size(
                 output
                     .current_mode()
                     .map(|mode| {

--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -63,7 +63,7 @@ where
     P: Into<Point<i32, Logical>>,
 {
     let location = location.into();
-    let mut bounding_box = Rectangle::from_loc_and_size(location, (0, 0));
+    let mut bounding_box = Rectangle::new(location, (0, 0).into());
     with_surface_tree_downward(
         surface,
         location,
@@ -74,7 +74,7 @@ where
             if let Some(surface_view) = data.and_then(|d| d.lock().unwrap().surface_view) {
                 loc += surface_view.offset;
                 // Update the bounding box.
-                bounding_box = bounding_box.merge(Rectangle::from_loc_and_size(loc, surface_view.dst));
+                bounding_box = bounding_box.merge(Rectangle::new(loc, surface_view.dst));
 
                 TraversalAction::DoChildren(loc)
             } else {

--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -30,11 +30,7 @@ impl RendererSurfaceState {
             Some(size) => size,
         };
 
-        let rect = Rectangle {
-            loc: (0, 0).into(),
-            size,
-        }
-        .to_f64();
+        let rect = Rectangle::from_size(size).to_f64();
 
         // The input region is always within the surface itself, so if the surface itself doesn't contain the
         // point we can return false.

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -117,7 +117,7 @@ impl Window {
         Window(Arc::new(WindowInner {
             id,
             surface: WindowSurface::Wayland(toplevel),
-            bbox: Mutex::new(Rectangle::from_loc_and_size((0, 0), (0, 0))),
+            bbox: Mutex::new(Rectangle::zero()),
             z_index: AtomicU8::new(RenderZindex::Shell as u8),
             user_data: UserDataMap::new(),
         }))
@@ -131,7 +131,7 @@ impl Window {
         Window(Arc::new(WindowInner {
             id,
             surface: WindowSurface::X11(surface),
-            bbox: Mutex::new(Rectangle::from_loc_and_size((0, 0), (0, 0))),
+            bbox: Mutex::new(Rectangle::zero()),
             z_index: AtomicU8::new(RenderZindex::Shell as u8),
             user_data: UserDataMap::new(),
         }))

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -1114,6 +1114,7 @@ impl<Kind> Rectangle<f64, Kind> {
 
 impl<N: Coordinate, Kind> Rectangle<N, Kind> {
     /// Create a new [`Rectangle`] from the coordinates of its top-left corner and its dimensions
+    #[deprecated(note = "use new or from_size")]
     #[inline]
     pub fn from_loc_and_size(loc: impl Into<Point<N, Kind>>, size: impl Into<Size<N, Kind>>) -> Self {
         Rectangle {
@@ -1312,32 +1313,35 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
                     continue;
                 }
 
-                let top_rect = Rectangle::from_loc_and_size(
+                let top_rect = Rectangle::new(
                     item.loc,
-                    (item.size.w, intersection.loc.y.saturating_sub(item.loc.y)),
+                    (item.size.w, intersection.loc.y.saturating_sub(item.loc.y)).into(),
                 );
-                let left_rect: Rectangle<N, Kind> = Rectangle::from_loc_and_size(
-                    (item.loc.x, intersection.loc.y),
-                    (intersection.loc.x.saturating_sub(item.loc.x), intersection.size.h),
+                let left_rect: Rectangle<N, Kind> = Rectangle::new(
+                    (item.loc.x, intersection.loc.y).into(),
+                    (intersection.loc.x.saturating_sub(item.loc.x), intersection.size.h).into(),
                 );
-                let right_rect: Rectangle<N, Kind> = Rectangle::from_loc_and_size(
+                let right_rect: Rectangle<N, Kind> = Rectangle::new(
                     (
                         intersection.loc.x.saturating_add(intersection.size.w),
                         intersection.loc.y,
-                    ),
+                    )
+                        .into(),
                     (
                         (item.loc.x.saturating_add(item.size.w))
                             .saturating_sub(intersection.loc.x.saturating_add(intersection.size.w)),
                         intersection.size.h,
-                    ),
+                    )
+                        .into(),
                 );
-                let bottom_rect: Rectangle<N, Kind> = Rectangle::from_loc_and_size(
-                    (item.loc.x, intersection.loc.y.saturating_add(intersection.size.h)),
+                let bottom_rect: Rectangle<N, Kind> = Rectangle::new(
+                    (item.loc.x, intersection.loc.y.saturating_add(intersection.size.h)).into(),
                     (
                         item.size.w,
                         (item.loc.y.saturating_add(item.size.h))
                             .saturating_sub(intersection.loc.y.saturating_add(intersection.size.h)),
-                    ),
+                    )
+                        .into(),
                 );
 
                 if !top_rect.is_empty() {
@@ -1634,7 +1638,7 @@ impl Transform {
             Transform::Flipped270 => (rect.loc.y, rect.loc.x).into(),
         };
 
-        Rectangle::from_loc_and_size(loc, size)
+        Rectangle::new(loc, size)
     }
 
     /// Returns true if the transformation would flip contents
@@ -1701,7 +1705,7 @@ mod tests {
 
     #[test]
     fn transform_rect_ident() {
-        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let rect = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
         let size = Size::from((70, 90));
         let transform = Transform::Normal;
 
@@ -1710,112 +1714,112 @@ mod tests {
 
     #[test]
     fn transform_rect_90() {
-        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let rect = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
         let size = Size::from((70, 90));
         let transform = Transform::_90;
 
         assert_eq!(
-            Rectangle::from_loc_and_size((30, 10), (40, 30)),
+            Rectangle::new((30, 10).into(), (40, 30).into()),
             transform.transform_rect_in(rect, &size)
         )
     }
 
     #[test]
     fn transform_rect_180() {
-        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let rect = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
         let size = Size::from((70, 90));
         let transform = Transform::_180;
 
         assert_eq!(
-            Rectangle::from_loc_and_size((30, 30), (30, 40)),
+            Rectangle::new((30, 30).into(), (30, 40).into()),
             transform.transform_rect_in(rect, &size)
         )
     }
 
     #[test]
     fn transform_rect_270() {
-        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let rect = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
         let size = Size::from((70, 90));
         let transform = Transform::_270;
 
         assert_eq!(
-            Rectangle::from_loc_and_size((20, 30), (40, 30)),
+            Rectangle::new((20, 30).into(), (40, 30).into()),
             transform.transform_rect_in(rect, &size)
         )
     }
 
     #[test]
     fn transform_rect_f() {
-        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let rect = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
         let size = Size::from((70, 90));
         let transform = Transform::Flipped;
 
         assert_eq!(
-            Rectangle::from_loc_and_size((30, 20), (30, 40)),
+            Rectangle::new((30, 20).into(), (30, 40).into()),
             transform.transform_rect_in(rect, &size)
         )
     }
 
     #[test]
     fn transform_rect_f90() {
-        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let rect = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
         let size = Size::from((70, 80));
         let transform = Transform::Flipped90;
 
         assert_eq!(
-            Rectangle::from_loc_and_size((20, 30), (40, 30)),
+            Rectangle::new((20, 30).into(), (40, 30).into()),
             transform.transform_rect_in(rect, &size)
         )
     }
 
     #[test]
     fn transform_rect_f180() {
-        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let rect = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
         let size = Size::from((70, 90));
         let transform = Transform::Flipped180;
 
         assert_eq!(
-            Rectangle::from_loc_and_size((10, 30), (30, 40)),
+            Rectangle::new((10, 30).into(), (30, 40).into()),
             transform.transform_rect_in(rect, &size)
         )
     }
 
     #[test]
     fn transform_rect_f270() {
-        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let rect = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
         let size = Size::from((70, 90));
         let transform = Transform::Flipped270;
 
         assert_eq!(
-            Rectangle::from_loc_and_size((20, 10), (40, 30)),
+            Rectangle::new((20, 10).into(), (40, 30).into()),
             transform.transform_rect_in(rect, &size)
         )
     }
 
     #[test]
     fn rectangle_contains_rect_itself() {
-        let rect = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
+        let rect = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
         assert!(rect.contains_rect(rect));
     }
 
     #[test]
     fn rectangle_contains_rect_outside() {
-        let first = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
-        let second = Rectangle::<i32, Logical>::from_loc_and_size((41, 61), (30, 40));
+        let first = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
+        let second = Rectangle::<i32, Logical>::new((41, 61).into(), (30, 40).into());
         assert!(!first.contains_rect(second));
     }
 
     #[test]
     fn rectangle_contains_rect_extends() {
-        let first = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 40));
-        let second = Rectangle::<i32, Logical>::from_loc_and_size((10, 20), (30, 45));
+        let first = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 40).into());
+        let second = Rectangle::<i32, Logical>::new((10, 20).into(), (30, 45).into());
         assert!(!first.contains_rect(second));
     }
 
     #[test]
     fn rectangle_subtract_full() {
         let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
-        let inner = Rectangle::<i32, Logical>::from_loc_and_size((-10, -10), (1000, 1000));
+        let inner = Rectangle::<i32, Logical>::new((-10, -10).into(), (1000, 1000).into());
 
         let rects = outer.subtract_rect(inner);
         assert_eq!(rects, vec![])
@@ -1824,7 +1828,7 @@ mod tests {
     #[test]
     fn rectangle_subtract_center_hole() {
         let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
-        let inner = Rectangle::<i32, Logical>::from_loc_and_size((10, 10), (80, 80));
+        let inner = Rectangle::<i32, Logical>::new((10, 10).into(), (80, 80).into());
 
         let rects = outer.subtract_rect(inner);
         assert_eq!(
@@ -1833,11 +1837,11 @@ mod tests {
                 // Top rect
                 Rectangle::<i32, Logical>::from_size((100, 10).into()),
                 // Left rect
-                Rectangle::<i32, Logical>::from_loc_and_size((0, 10), (10, 80)),
+                Rectangle::<i32, Logical>::new((0, 10).into(), (10, 80).into()),
                 // Right rect
-                Rectangle::<i32, Logical>::from_loc_and_size((90, 10), (10, 80)),
+                Rectangle::<i32, Logical>::new((90, 10).into(), (10, 80).into()),
                 // Bottom rect
-                Rectangle::<i32, Logical>::from_loc_and_size((0, 90), (100, 10)),
+                Rectangle::<i32, Logical>::new((0, 90).into(), (100, 10).into()),
             ]
         )
     }
@@ -1845,14 +1849,14 @@ mod tests {
     #[test]
     fn rectangle_subtract_full_top() {
         let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
-        let inner = Rectangle::<i32, Logical>::from_loc_and_size((0, -20), (100, 100));
+        let inner = Rectangle::<i32, Logical>::new((0, -20).into(), (100, 100).into());
 
         let rects = outer.subtract_rect(inner);
         assert_eq!(
             rects,
             vec![
                 // Bottom rect
-                Rectangle::<i32, Logical>::from_loc_and_size((0, 80), (100, 20)),
+                Rectangle::<i32, Logical>::new((0, 80).into(), (100, 20).into()),
             ]
         )
     }
@@ -1860,7 +1864,7 @@ mod tests {
     #[test]
     fn rectangle_subtract_full_bottom() {
         let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
-        let inner = Rectangle::<i32, Logical>::from_loc_and_size((0, 20), (100, 100));
+        let inner = Rectangle::<i32, Logical>::new((0, 20).into(), (100, 100).into());
 
         let rects = outer.subtract_rect(inner);
         assert_eq!(
@@ -1875,14 +1879,14 @@ mod tests {
     #[test]
     fn rectangle_subtract_full_left() {
         let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
-        let inner = Rectangle::<i32, Logical>::from_loc_and_size((-20, 0), (100, 100));
+        let inner = Rectangle::<i32, Logical>::new((-20, 0).into(), (100, 100).into());
 
         let rects = outer.subtract_rect(inner);
         assert_eq!(
             rects,
             vec![
                 // Right rect
-                Rectangle::<i32, Logical>::from_loc_and_size((80, 0), (20, 100)),
+                Rectangle::<i32, Logical>::new((80, 0).into(), (20, 100).into()),
             ]
         )
     }
@@ -1890,7 +1894,7 @@ mod tests {
     #[test]
     fn rectangle_subtract_full_right() {
         let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
-        let inner = Rectangle::<i32, Logical>::from_loc_and_size((20, 0), (100, 100));
+        let inner = Rectangle::<i32, Logical>::new((20, 0).into(), (100, 100).into());
 
         let rects = outer.subtract_rect(inner);
         assert_eq!(
@@ -1904,42 +1908,42 @@ mod tests {
 
     #[test]
     fn rectangle_overlaps_or_touches_top() {
-        let top = Rectangle::<i32, Logical>::from_loc_and_size((0, -24), (800, 24));
+        let top = Rectangle::<i32, Logical>::new((0, -24).into(), (800, 24).into());
         let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(main.overlaps_or_touches(top));
     }
 
     #[test]
     fn rectangle_overlaps_or_touches_left() {
-        let left = Rectangle::<i32, Logical>::from_loc_and_size((-4, -24), (4, 624));
+        let left = Rectangle::<i32, Logical>::new((-4, -24).into(), (4, 624).into());
         let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(main.overlaps_or_touches(left));
     }
 
     #[test]
     fn rectangle_overlaps_or_touches_right() {
-        let right = Rectangle::<i32, Logical>::from_loc_and_size((800, -24), (4, 624));
+        let right = Rectangle::<i32, Logical>::new((800, -24).into(), (4, 624).into());
         let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(main.overlaps_or_touches(right));
     }
 
     #[test]
     fn rectangle_no_overlap_top() {
-        let top = Rectangle::<i32, Logical>::from_loc_and_size((0, -24), (800, 24));
+        let top = Rectangle::<i32, Logical>::new((0, -24).into(), (800, 24).into());
         let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(!main.overlaps(top));
     }
 
     #[test]
     fn rectangle_no_overlap_left() {
-        let left = Rectangle::<i32, Logical>::from_loc_and_size((-4, -24), (4, 624));
+        let left = Rectangle::<i32, Logical>::new((-4, -24).into(), (4, 624).into());
         let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(!main.overlaps(left));
     }
 
     #[test]
     fn rectangle_no_overlap_right() {
-        let right = Rectangle::<i32, Logical>::from_loc_and_size((800, -24), (4, 624));
+        let right = Rectangle::<i32, Logical>::new((800, -24).into(), (4, 624).into());
         let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(!main.overlaps(right));
     }

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -1122,6 +1122,30 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
         }
     }
 
+    /// Create a new [`Rectangle`] from the coordinates of its top-left corner and its dimensions
+    #[inline]
+    pub fn new(loc: Point<N, Kind>, size: Size<N, Kind>) -> Self {
+        Rectangle { loc, size }
+    }
+
+    /// Create a new [`Rectangle`] from its dimensions, with location zero
+    #[inline]
+    pub fn from_size(size: Size<N, Kind>) -> Self {
+        Rectangle {
+            loc: (N::ZERO, N::ZERO).into(),
+            size,
+        }
+    }
+
+    /// Create a new [`Rectangle`] with location and size zero
+    #[inline]
+    pub fn zero() -> Self {
+        Rectangle {
+            loc: (N::ZERO, N::ZERO).into(),
+            size: (N::ZERO, N::ZERO).into(),
+        }
+    }
+
     /// Create a new [`Rectangle`] from the coordinates of its top-left corner and its bottom-right corner
     #[inline]
     pub fn from_extemities(

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -1814,7 +1814,7 @@ mod tests {
 
     #[test]
     fn rectangle_subtract_full() {
-        let outer = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (100, 100));
+        let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
         let inner = Rectangle::<i32, Logical>::from_loc_and_size((-10, -10), (1000, 1000));
 
         let rects = outer.subtract_rect(inner);
@@ -1823,7 +1823,7 @@ mod tests {
 
     #[test]
     fn rectangle_subtract_center_hole() {
-        let outer = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (100, 100));
+        let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
         let inner = Rectangle::<i32, Logical>::from_loc_and_size((10, 10), (80, 80));
 
         let rects = outer.subtract_rect(inner);
@@ -1831,7 +1831,7 @@ mod tests {
             rects,
             vec![
                 // Top rect
-                Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (100, 10)),
+                Rectangle::<i32, Logical>::from_size((100, 10).into()),
                 // Left rect
                 Rectangle::<i32, Logical>::from_loc_and_size((0, 10), (10, 80)),
                 // Right rect
@@ -1844,7 +1844,7 @@ mod tests {
 
     #[test]
     fn rectangle_subtract_full_top() {
-        let outer = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (100, 100));
+        let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
         let inner = Rectangle::<i32, Logical>::from_loc_and_size((0, -20), (100, 100));
 
         let rects = outer.subtract_rect(inner);
@@ -1859,7 +1859,7 @@ mod tests {
 
     #[test]
     fn rectangle_subtract_full_bottom() {
-        let outer = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (100, 100));
+        let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
         let inner = Rectangle::<i32, Logical>::from_loc_and_size((0, 20), (100, 100));
 
         let rects = outer.subtract_rect(inner);
@@ -1867,14 +1867,14 @@ mod tests {
             rects,
             vec![
                 // Top rect
-                Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (100, 20)),
+                Rectangle::<i32, Logical>::from_size((100, 20).into()),
             ]
         )
     }
 
     #[test]
     fn rectangle_subtract_full_left() {
-        let outer = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (100, 100));
+        let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
         let inner = Rectangle::<i32, Logical>::from_loc_and_size((-20, 0), (100, 100));
 
         let rects = outer.subtract_rect(inner);
@@ -1889,7 +1889,7 @@ mod tests {
 
     #[test]
     fn rectangle_subtract_full_right() {
-        let outer = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (100, 100));
+        let outer = Rectangle::<i32, Logical>::from_size((100, 100).into());
         let inner = Rectangle::<i32, Logical>::from_loc_and_size((20, 0), (100, 100));
 
         let rects = outer.subtract_rect(inner);
@@ -1897,7 +1897,7 @@ mod tests {
             rects,
             vec![
                 // Left rect
-                Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (20, 100)),
+                Rectangle::<i32, Logical>::from_size((20, 100).into()),
             ]
         )
     }
@@ -1905,42 +1905,42 @@ mod tests {
     #[test]
     fn rectangle_overlaps_or_touches_top() {
         let top = Rectangle::<i32, Logical>::from_loc_and_size((0, -24), (800, 24));
-        let main = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (800, 600));
+        let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(main.overlaps_or_touches(top));
     }
 
     #[test]
     fn rectangle_overlaps_or_touches_left() {
         let left = Rectangle::<i32, Logical>::from_loc_and_size((-4, -24), (4, 624));
-        let main = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (800, 600));
+        let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(main.overlaps_or_touches(left));
     }
 
     #[test]
     fn rectangle_overlaps_or_touches_right() {
         let right = Rectangle::<i32, Logical>::from_loc_and_size((800, -24), (4, 624));
-        let main = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (800, 600));
+        let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(main.overlaps_or_touches(right));
     }
 
     #[test]
     fn rectangle_no_overlap_top() {
         let top = Rectangle::<i32, Logical>::from_loc_and_size((0, -24), (800, 24));
-        let main = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (800, 600));
+        let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(!main.overlaps(top));
     }
 
     #[test]
     fn rectangle_no_overlap_left() {
         let left = Rectangle::<i32, Logical>::from_loc_and_size((-4, -24), (4, 624));
-        let main = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (800, 600));
+        let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(!main.overlaps(left));
     }
 
     #[test]
     fn rectangle_no_overlap_right() {
         let right = Rectangle::<i32, Logical>::from_loc_and_size((800, -24), (4, 624));
-        let main = Rectangle::<i32, Logical>::from_loc_and_size((0, 0), (800, 600));
+        let main = Rectangle::<i32, Logical>::from_size((800, 600).into());
         assert!(!main.overlaps(right));
     }
 

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -983,6 +983,19 @@ impl<N: Coordinate + Div<Output = N>, KindLhs, KindRhs> Div<Size<N, KindRhs>> fo
     }
 }
 
+impl<N: Coordinate + Mul, Kind> Mul<N> for Size<N, Kind> {
+    type Output = Size<<N as Mul>::Output, Kind>;
+
+    #[inline]
+    fn mul(self, rhs: N) -> Self::Output {
+        Size {
+            w: self.w * rhs,
+            h: self.h * rhs,
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
 impl<N: Clone, Kind> Clone for Size<N, Kind> {
     #[inline]
     fn clone(&self) -> Self {

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -219,7 +219,7 @@ where
                         .pending()
                         .damage
                         .push(Damage::Surface(
-                            Rectangle::<i32, Client>::from_loc_and_size((x, y), (width, height))
+                            Rectangle::<i32, Client>::new((x, y).into(), (width, height).into())
                                 .to_logical(client_scale),
                         ));
                 });
@@ -307,9 +307,9 @@ where
                         .get::<SurfaceAttributes>()
                         .pending()
                         .damage
-                        .push(Damage::Buffer(Rectangle::from_loc_and_size(
-                            (x, y),
-                            (width, height),
+                        .push(Damage::Buffer(Rectangle::new(
+                            (x, y).into(),
+                            (width, height).into(),
                         )))
                 });
             }
@@ -388,11 +388,11 @@ where
         match request {
             wl_region::Request::Add { x, y, width, height } => guard.rects.push((
                 RectangleKind::Add,
-                Rectangle::<i32, Client>::from_loc_and_size((x, y), (width, height)).to_logical(client_scale),
+                Rectangle::<i32, Client>::new((x, y).into(), (width, height).into()).to_logical(client_scale),
             )),
             wl_region::Request::Subtract { x, y, width, height } => guard.rects.push((
                 RectangleKind::Subtract,
-                Rectangle::<i32, Client>::from_loc_and_size((x, y), (width, height)).to_logical(client_scale),
+                Rectangle::<i32, Client>::new((x, y).into(), (width, height).into()).to_logical(client_scale),
             )),
             wl_region::Request::Destroy => {
                 // all is handled by our destructor

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -793,7 +793,7 @@ mod tests {
             rects: vec![
                 (RectangleKind::Add, Rectangle::from_size((10, 10).into())),
                 (RectangleKind::Subtract, Rectangle::from_size((5, 5).into())),
-                (RectangleKind::Add, Rectangle::from_loc_and_size((2, 2), (2, 2))),
+                (RectangleKind::Add, Rectangle::new((2, 2).into(), (2, 2).into())),
             ],
         };
 

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -768,7 +768,7 @@ mod tests {
     #[test]
     fn region_attributes_add() {
         let region = RegionAttributes {
-            rects: vec![(RectangleKind::Add, Rectangle::from_loc_and_size((0, 0), (10, 10)))],
+            rects: vec![(RectangleKind::Add, Rectangle::from_size((10, 10).into()))],
         };
 
         assert!(region.contains((0, 0)));
@@ -778,11 +778,8 @@ mod tests {
     fn region_attributes_add_subtract() {
         let region = RegionAttributes {
             rects: vec![
-                (RectangleKind::Add, Rectangle::from_loc_and_size((0, 0), (10, 10))),
-                (
-                    RectangleKind::Subtract,
-                    Rectangle::from_loc_and_size((0, 0), (5, 5)),
-                ),
+                (RectangleKind::Add, Rectangle::from_size((10, 10).into())),
+                (RectangleKind::Subtract, Rectangle::from_size((5, 5).into())),
             ],
         };
 
@@ -794,11 +791,8 @@ mod tests {
     fn region_attributes_add_subtract_add() {
         let region = RegionAttributes {
             rects: vec![
-                (RectangleKind::Add, Rectangle::from_loc_and_size((0, 0), (10, 10))),
-                (
-                    RectangleKind::Subtract,
-                    Rectangle::from_loc_and_size((0, 0), (5, 5)),
-                ),
+                (RectangleKind::Add, Rectangle::from_size((10, 10).into())),
+                (RectangleKind::Subtract, Rectangle::from_size((5, 5).into())),
                 (RectangleKind::Add, Rectangle::from_loc_and_size((2, 2), (2, 2))),
             ],
         };

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -109,7 +109,7 @@ impl InputMethodHandle {
         height: i32,
     ) {
         let mut inner = self.inner.lock().unwrap();
-        inner.popup_handle.rectangle = Rectangle::from_loc_and_size((x, y), (width, height));
+        inner.popup_handle.rectangle = Rectangle::new((x, y).into(), (width, height).into());
 
         let mut popup_surface = match inner.popup_handle.surface.clone() {
             Some(popup_surface) => popup_surface,

--- a/src/wayland/input_method/input_method_popup_surface.rs
+++ b/src/wayland/input_method/input_method_popup_surface.rs
@@ -101,7 +101,7 @@ impl PopupSurface {
     ///
     /// [`location`]: Self::location
     pub fn set_text_input_rectangle(&mut self, x: i32, y: i32, width: i32, height: i32) {
-        *self.rectangle.lock().unwrap() = Rectangle::from_loc_and_size((x, y), (width, height));
+        *self.rectangle.lock().unwrap() = Rectangle::new((x, y).into(), (width, height).into());
         *self.location.lock().unwrap() = (x, y).into();
         self.surface_role.text_input_rectangle(x, y, width, height);
     }

--- a/src/wayland/shell/xdg/handlers/positioner.rs
+++ b/src/wayland/shell/xdg/handlers/positioner.rs
@@ -52,7 +52,7 @@ where
                         "Invalid size for positioner's anchor rectangle.",
                     );
                 } else {
-                    state.anchor_rect = Rectangle::from_loc_and_size((x, y), (width, height));
+                    state.anchor_rect = Rectangle::new((x, y).into(), (width, height).into());
                 }
             }
             xdg_positioner::Request::SetAnchor { anchor } => {

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -255,7 +255,7 @@ where
 
                 compositor::with_states(surface, |states| {
                     states.cached_state.get::<SurfaceCachedState>().pending().geometry =
-                        Some(Rectangle::from_loc_and_size((x, y), (width, height)));
+                        Some(Rectangle::new((x, y).into(), (width, height).into()));
                 });
             }
             xdg_surface::Request::AckConfigure { serial } => {

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -619,10 +619,7 @@ impl PositionerState {
         //  example if the anchor of the anchor rectangle is at (x, y), the surface
         //  has the gravity bottom|right, and the offset is (ox, oy), the calculated
         //  surface position will be (x + ox, y + oy)
-        let mut geometry = Rectangle {
-            loc: self.offset,
-            size: self.rect_size,
-        };
+        let mut geometry = Rectangle::new(self.offset, self.rect_size);
 
         // Defines the anchor point for the anchor rectangle. The specified anchor
         // is used derive an anchor point that the child surface will be

--- a/src/wayland/viewporter/mod.rs
+++ b/src/wayland/viewporter/mod.rs
@@ -251,7 +251,7 @@ where
                     let src = if is_unset {
                         None
                     } else {
-                        let src = Rectangle::from_loc_and_size((x, y), (width, height));
+                        let src = Rectangle::new((x, y).into(), (width, height).into());
                         trace!(surface = ?surface, src = ?src, "setting surface viewport src");
                         Some(src)
                     };

--- a/src/wayland/viewporter/mod.rs
+++ b/src/wayland/viewporter/mod.rs
@@ -365,7 +365,7 @@ pub fn ensure_viewport_valid(states: &SurfaceData, buffer_size: Size<i32, Logica
         let mut guard = states.cached_state.get::<ViewportCachedState>();
         let state = guard.current();
 
-        let buffer_rect = Rectangle::from_loc_and_size((0.0, 0.0), buffer_size.to_f64());
+        let buffer_rect = Rectangle::from_size(buffer_size.to_f64());
         let src = state.src.unwrap_or(buffer_rect);
         let valid = buffer_rect.contains_rect(src);
         if !valid {

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1352,9 +1352,9 @@ where
             }
 
             let geo = conn.get_geometry(n.window)?.reply()?;
-            let geometry = Rectangle::<i32, Client>::from_loc_and_size(
-                (geo.x as i32, geo.y as i32),
-                (geo.width as i32, geo.height as i32),
+            let geometry = Rectangle::<i32, Client>::new(
+                (geo.x as i32, geo.y as i32).into(),
+                (geo.width as i32, geo.height as i32).into(),
             )
             .to_logical(xwm.client_scale.load(Ordering::Acquire) as i32);
 
@@ -1526,9 +1526,9 @@ where
             trace!(window = ?n, "configured X11 Window");
 
             let client_scale = xwm.client_scale.load(Ordering::Acquire);
-            let geometry = Rectangle::<i32, Client>::from_loc_and_size(
-                (n.x as i32, n.y as i32),
-                (n.width as i32, n.height as i32),
+            let geometry = Rectangle::<i32, Client>::new(
+                (n.x as i32, n.y as i32).into(),
+                (n.width as i32, n.height as i32).into(),
             )
             .to_logical(client_scale as i32);
 


### PR DESCRIPTION
I want to update https://github.com/Smithay/smithay/pull/1136, make any needed improvements upstream to `euclid`, and get that merged. But it requires a lot of changes both in Smithay and compositors using it. Perhaps adding some APIs and uses of the `#[deprecated]` attribute first could make that a little less painful to deal with.

Even if Smithay didn't move to `euclid`, it would be worth borrowing some ideas to make geometry handling more strongly typed, as well as a couple API conveniences.