### PR TITLE
Drop `once_cell` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ libc = "0.2.103"
 libseat = { version = "0.2.1", optional = true, default-features = false }
 libloading = { version="0.8.0", optional = true }
 rustix = { version = "0.38.18", features = ["event", "fs", "mm", "net", "shm", "time"] }
-once_cell = "1.8.0"
 rand = "0.8.4"
 scopeguard = { version = "1.1.0", optional = true }
 tracing = "0.1.37"

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -1,19 +1,17 @@
 //! Type safe native types for safe egl initialisation
 
-use std::ffi::{c_int, CStr};
-use std::hash::{Hash, Hasher};
-use std::mem::MaybeUninit;
-use std::ops::Deref;
-use std::sync::Arc;
-use std::sync::{Mutex, Weak};
 use std::{
     collections::HashSet,
+    ffi::{c_int, CStr},
+    hash::{Hash, Hasher},
+    mem::MaybeUninit,
+    ops::Deref,
     os::unix::io::{AsRawFd, FromRawFd, OwnedFd},
+    sync::{Arc, LazyLock, Mutex, Weak},
 };
 
 use indexmap::IndexSet;
 use libc::c_void;
-use once_cell::sync::Lazy;
 #[cfg(all(feature = "use_system_lib", feature = "wayland_frontend"))]
 use wayland_server::{protocol::wl_buffer::WlBuffer, DisplayHandle, Resource};
 #[cfg(all(feature = "use_system_lib", feature = "wayland_frontend"))]
@@ -42,7 +40,8 @@ use tracing::{debug, error, info, info_span, instrument, trace, warn};
 
 #[cfg(all(feature = "wayland_frontend", feature = "use_system_lib"))]
 pub(crate) static BUFFER_READER: Mutex<Option<WeakBufferReader>> = Mutex::new(None);
-static DISPLAYS: Lazy<Mutex<HashSet<WeakEGLDisplayHandle>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+static DISPLAYS: LazyLock<Mutex<HashSet<WeakEGLDisplayHandle>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
 
 /// Wrapper around [`ffi::EGLDisplay`](ffi::egl::types::EGLDisplay) to ensure display is only destroyed
 /// once all resources bound to it have been dropped.

--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -142,11 +142,10 @@ pub fn make_sure_egl_is_loaded() -> Result<Vec<String>, Error> {
 pub mod egl {
     use super::*;
     use libloading::Library;
-    use once_cell::sync::Lazy;
-    use std::sync::Once;
+    use std::sync::{LazyLock, Once};
 
-    pub static LIB: Lazy<Library> =
-        Lazy::new(|| unsafe { Library::new("libEGL.so.1") }.expect("Failed to load LibEGL"));
+    pub static LIB: LazyLock<Library> =
+        LazyLock::new(|| unsafe { Library::new("libEGL.so.1") }.expect("Failed to load LibEGL"));
 
     pub static LOAD: Once = Once::new();
     pub static DEBUG: Once = Once::new();

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -1,11 +1,11 @@
 //! Implementation of the rendering traits using pixman
+
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
+    Arc, LazyLock, Mutex,
 };
 
 use drm_fourcc::{DrmFormat, DrmFourcc, DrmModifier};
-use once_cell::sync::Lazy;
 use pixman::{Filter, FormatCode, Image, Operation, Repeat};
 use tracing::warn;
 
@@ -1145,7 +1145,7 @@ impl ImportDma for PixmanRenderer {
     }
 
     fn dmabuf_formats(&self) -> FormatSet {
-        static DMABUF_FORMATS: Lazy<FormatSet> = Lazy::new(|| {
+        static DMABUF_FORMATS: LazyLock<FormatSet> = LazyLock::new(|| {
             SUPPORTED_FORMATS
                 .iter()
                 .map(|code| DrmFormat {
@@ -1202,7 +1202,7 @@ impl Bind<Dmabuf> for PixmanRenderer {
     }
 
     fn supported_formats(&self) -> Option<FormatSet> {
-        static DMABUF_FORMATS: Lazy<FormatSet> = Lazy::new(|| {
+        static DMABUF_FORMATS: LazyLock<FormatSet> = LazyLock::new(|| {
             SUPPORTED_FORMATS
                 .iter()
                 .map(|code| DrmFormat {
@@ -1239,7 +1239,7 @@ impl Bind<PixmanRenderBuffer> for PixmanRenderer {
     }
 
     fn supported_formats(&self) -> Option<FormatSet> {
-        static RENDER_BUFFER_FORMATS: Lazy<FormatSet> = Lazy::new(|| {
+        static RENDER_BUFFER_FORMATS: LazyLock<FormatSet> = LazyLock::new(|| {
             SUPPORTED_FORMATS
                 .iter()
                 .map(|code| DrmFormat {

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -68,7 +68,7 @@
 use std::{
     env::{self, VarError},
     ffi::{CStr, CString},
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 
 use ash::{
@@ -78,7 +78,6 @@ use ash::{
     Entry,
 };
 use libc::c_void;
-use once_cell::sync::Lazy;
 use scopeguard::ScopeGuard;
 use tracing::{error, info, info_span, instrument, trace, warn};
 
@@ -94,8 +93,8 @@ mod phd;
 
 pub mod version;
 
-static LIBRARY: Lazy<Result<Entry, LoadError>> =
-    Lazy::new(|| unsafe { Entry::load().map_err(|_| LoadError) });
+static LIBRARY: LazyLock<Result<Entry, LoadError>> =
+    LazyLock::new(|| unsafe { Entry::load().map_err(|_| LoadError) });
 
 /// Error loading the Vulkan library
 #[derive(Debug, thiserror::Error)]

--- a/src/utils/ids.rs
+++ b/src/utils/ids.rs
@@ -1,11 +1,13 @@
 macro_rules! id_gen {
     ($mod_name:ident) => {
         mod $mod_name {
-            use once_cell::sync::Lazy;
-            use std::{collections::HashSet, sync::Mutex};
+            use std::{
+                collections::HashSet,
+                sync::{LazyLock, Mutex},
+            };
 
-            static ID_DATA: Lazy<Mutex<(HashSet<usize>, usize)>> =
-                Lazy::new(|| Mutex::new((HashSet::new(), 0)));
+            static ID_DATA: LazyLock<Mutex<(HashSet<usize>, usize)>> =
+                LazyLock::new(|| Mutex::new((HashSet::new(), 0)));
 
             pub(crate) fn next() -> usize {
                 let (id_set, counter) = &mut *ID_DATA.lock().unwrap();

--- a/src/wayland/shm/pool.rs
+++ b/src/wayland/shm/pool.rs
@@ -8,12 +8,11 @@ use std::{
     ptr,
     sync::{
         mpsc::{channel, Sender},
-        OnceLock, RwLock,
+        LazyLock, OnceLock, RwLock,
     },
     thread,
 };
 
-use once_cell::sync::Lazy;
 use rustix::mm;
 use tracing::{debug, instrument, trace};
 
@@ -28,7 +27,7 @@ use tracing::{debug, instrument, trace};
 //
 // To work around this problem, we spawn a separate thread whose sole purpose is dropping stuff we
 // send it through a channel. Conveniently, Pool is already Send, so there's no problem doing this.
-static DROP_THIS: Lazy<Sender<InnerPool>> = Lazy::new(|| {
+static DROP_THIS: LazyLock<Sender<InnerPool>> = LazyLock::new(|| {
     let (tx, rx) = channel();
     thread::Builder::new()
         .name("Shm dropping thread".to_owned())

--- a/src/wayland/xdg_toplevel_icon.rs
+++ b/src/wayland/xdg_toplevel_icon.rs
@@ -8,7 +8,7 @@
 
 use std::{
     collections::HashSet,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use wayland_protocols::xdg::{
@@ -18,6 +18,7 @@ use wayland_protocols::xdg::{
         xdg_toplevel_icon_v1::{self, XdgToplevelIconV1},
     },
 };
+
 use wayland_server::{
     backend::{ClientId, GlobalId},
     protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface},
@@ -112,7 +113,7 @@ struct IconData {
 #[derive(Debug, Default)]
 pub struct XdgToplevelIconUserData {
     builder: Mutex<IconData>,
-    constructed: once_cell::sync::OnceCell<IconData>,
+    constructed: OnceLock<IconData>,
     buffer_destruction_hooks: Mutex<Vec<(WlBuffer, HookId)>>,
 }
 


### PR DESCRIPTION
`once_cell` can now be fully replaced by `std`.