### PR TITLE
drm/atomic: Better logging for atomic requests

### DIFF
--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -750,7 +750,6 @@ impl AtomicDrmSurface {
         let current_conns = current.connectors.clone();
         let pending_conns = pending.connectors.clone();
         let mut removed = current_conns.difference(&pending_conns);
-        let mut added = pending_conns.difference(&current_conns);
 
         for conn in removed.clone() {
             if let Ok(info) = self.fd.get_connector(*conn, false) {
@@ -760,7 +759,7 @@ impl AtomicDrmSurface {
             }
         }
 
-        for conn in added.clone() {
+        for conn in &pending_conns {
             if let Ok(info) = self.fd.get_connector(*conn, false) {
                 info!("Adding connector: {:?}", info.interface());
             } else {
@@ -782,7 +781,7 @@ impl AtomicDrmSurface {
                 self.crtc,
                 Some(pending.blob),
                 pending.vrr,
-                &mut added,
+                &mut pending_conns.iter(),
                 &mut removed,
                 &*planes,
             )?;

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -358,8 +358,8 @@ impl AtomicDrmSurface {
                 self.crtc,
                 Some(pending.blob),
                 pending.vrr,
-                &mut [conn].iter(),
-                &mut [].iter(),
+                [&conn],
+                [],
                 [&plane_state],
             )?;
             self.fd
@@ -414,8 +414,8 @@ impl AtomicDrmSurface {
             self.crtc,
             Some(pending.blob),
             pending.vrr,
-            &mut [].iter(),
-            &mut [conn].iter(),
+            [].iter(),
+            [&conn],
             [&plane_state],
         )?;
         self.fd
@@ -472,8 +472,8 @@ impl AtomicDrmSurface {
             self.crtc,
             Some(pending.blob),
             pending.vrr,
-            &mut added,
-            &mut removed,
+            added,
+            removed,
             [&plane_state],
         )?;
 
@@ -526,8 +526,8 @@ impl AtomicDrmSurface {
             self.crtc,
             Some(new_blob),
             pending.vrr,
-            &mut pending.connectors.iter(),
-            &mut [].iter(),
+            pending.connectors.iter(),
+            [],
             [&plane_state],
         )?;
         if let Err(err) = self
@@ -700,8 +700,8 @@ impl AtomicDrmSurface {
 
         let current_conns = current.connectors.clone();
         let pending_conns = pending.connectors.clone();
-        let mut removed = current_conns.difference(&pending_conns);
-        let mut added = pending_conns.difference(&current_conns);
+        let removed = current_conns.difference(&pending_conns);
+        let added = pending_conns.difference(&current_conns);
         let prop_mapping = self.prop_mapping.read().unwrap();
 
         let req = AtomicRequest::build_request(
@@ -709,8 +709,8 @@ impl AtomicDrmSurface {
             self.crtc,
             Some(pending.blob),
             pending.vrr,
-            &mut added,
-            &mut removed,
+            added,
+            removed,
             &*planes,
         )?;
 
@@ -749,7 +749,7 @@ impl AtomicDrmSurface {
         // we need the differences to know, which connectors need to change properties
         let current_conns = current.connectors.clone();
         let pending_conns = pending.connectors.clone();
-        let mut removed = current_conns.difference(&pending_conns);
+        let removed = current_conns.difference(&pending_conns);
 
         for conn in removed.clone() {
             if let Ok(info) = self.fd.get_connector(*conn, false) {
@@ -781,8 +781,8 @@ impl AtomicDrmSurface {
                 self.crtc,
                 Some(pending.blob),
                 pending.vrr,
-                &mut pending_conns.iter(),
-                &mut removed,
+                &pending_conns,
+                removed,
                 &*planes,
             )?;
 
@@ -868,8 +868,8 @@ impl AtomicDrmSurface {
             self.crtc,
             None,
             self.state.read().unwrap().vrr,
-            &mut [].iter(),
-            &mut [].iter(),
+            [],
+            [],
             &*planes,
         )?;
 
@@ -1609,8 +1609,8 @@ impl<'a> AtomicRequest<'a> {
         crtc: crtc::Handle,
         blob: Option<property::Value<'static>>,
         vrr: bool,
-        new_connectors: &mut dyn Iterator<Item = &connector::Handle>,
-        removed_connectors: &mut dyn Iterator<Item = &connector::Handle>,
+        new_connectors: impl IntoIterator<Item = &'a connector::Handle>,
+        removed_connectors: impl IntoIterator<Item = &'a connector::Handle>,
         planes: impl IntoIterator<Item = &'a PlaneState<'a>>,
     ) -> Result<AtomicRequest<'a>, Error> {
         let mut req = AtomicRequest::new(mapping);


### PR DESCRIPTION
`Invalid screen configuration` issues are rare these days, but decrypting them from logs is very cumbersome whenever they occur. This is mostly due to the property handles not having any meaning, if you don't have the property mapping.

So we do log the mapping now as well.

Additionally in debug mode we construct the whole request differently to give us actually nice output. We need a bunch of collections to do so, so this is inefficient enough to only do in debug builds, long term it might be better to find a solution how to deconstruct drm-rs's `AtomicModeReq`. But for now this should be a significant improvement.