### PR TITLE
feature: Renderer Framebuffer type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ encoding_rs = { version = "0.8.33", optional = true }
 profiling = "1.0.13"
 smallvec = "1.11"
 pixman = { version = "0.2.1", features = ["drm-fourcc", "sync"], optional = true }
+aliasable = { version = "0.1.3", optional = true }
 
 
 [dev-dependencies]
@@ -99,7 +100,7 @@ backend_session_libseat = ["backend_session", "libseat"]
 desktop = []
 renderer_gl = ["gl_generator", "backend_egl"]
 renderer_glow = ["renderer_gl", "glow"]
-renderer_multi = ["backend_drm"]
+renderer_multi = ["backend_drm", "aliasable"]
 renderer_pixman = ["pixman"]
 renderer_test = []
 use_system_lib = ["wayland_frontend", "wayland-backend/server_system", "wayland-sys", "gbm?/import-wayland"]

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -191,14 +191,14 @@ where
 }
 
 #[cfg(feature = "debug")]
-impl<R> RenderElement<R> for FpsElement<<R as Renderer>::TextureId>
+impl<R> RenderElement<R> for FpsElement<R::TextureId>
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
 {
     fn draw(
         &self,
-        frame: &mut <R as Renderer>::Frame<'_>,
+        frame: &mut R::Frame<'_, '_>,
         _src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -35,7 +35,7 @@ smithay::backend::renderer::element::render_elements! {
     // a feature-dependent lifetime, which introduces a lot more feature bounds
     // as the whole type changes and we can't have an unused lifetime (for when "debug" is disabled)
     // in the declaration.
-    Fps=FpsElement<<R as Renderer>::TextureId>,
+    Fps=FpsElement<R::TextureId>,
 }
 
 impl<R: Renderer> std::fmt::Debug for CustomRenderElements<R> {
@@ -195,6 +195,7 @@ pub fn render_output<'a, 'd, R>(
     space: &'a Space<WindowElement>,
     custom_elements: impl IntoIterator<Item = CustomRenderElements<R>>,
     renderer: &'a mut R,
+    framebuffer: &'a mut R::Framebuffer<'_>,
     damage_tracker: &'d mut OutputDamageTracker,
     age: usize,
     show_window_preview: bool,
@@ -205,5 +206,5 @@ where
 {
     let (elements, clear_color) =
         output_elements(output, space, custom_elements, renderer, show_window_preview);
-    damage_tracker.render_output(renderer, age, &elements, clear_color)
+    damage_tracker.render_output(renderer, framebuffer, age, &elements, clear_color)
 }

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -416,7 +416,7 @@ impl<R: Renderer> std::fmt::Debug for WindowRenderElement<R> {
 impl<R> AsRenderElements<R> for WindowElement
 where
     R: Renderer + ImportAll + ImportMem,
-    <R as Renderer>::TextureId: Clone + Texture + 'static,
+    R::TextureId: Clone + Texture + 'static,
 {
     type RenderElement = WindowRenderElement<R>;
 

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -1354,7 +1354,7 @@ impl AnvilState<UdevData> {
                 !has_rendered
             }
             Err(err) => {
-                warn!("Error during rendering: {:?}", err);
+                warn!("Error during rendering: {:#?}", err);
                 match err {
                     SwapBuffersError::AlreadySwapped => false,
                     SwapBuffersError::TemporaryFailure(err) => match err.downcast_ref::<DrmError>() {

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -68,18 +68,26 @@ pub fn init_winit(
                 let size = backend.window_size();
                 let damage = Rectangle::from_size(size);
 
-                backend.bind().unwrap();
-                smithay::desktop::space::render_output::<_, WaylandSurfaceRenderElement<GlesRenderer>, _, _>(
-                    &output,
-                    backend.renderer(),
-                    1.0,
-                    0,
-                    [&state.space],
-                    &[],
-                    &mut damage_tracker,
-                    [0.1, 0.1, 0.1, 1.0],
-                )
-                .unwrap();
+                {
+                    let (renderer, mut framebuffer) = backend.bind().unwrap();
+                    smithay::desktop::space::render_output::<
+                        _,
+                        WaylandSurfaceRenderElement<GlesRenderer>,
+                        _,
+                        _,
+                    >(
+                        &output,
+                        renderer,
+                        &mut framebuffer,
+                        1.0,
+                        0,
+                        [&state.space],
+                        &[],
+                        &mut damage_tracker,
+                        [0.1, 0.1, 0.1, 1.0],
+                    )
+                    .unwrap();
+                }
                 backend.submit(Some(&[damage])).unwrap();
 
                 state.space.elements().for_each(|window| {

--- a/src/backend/drm/compositor/elements.rs
+++ b/src/backend/drm/compositor/elements.rs
@@ -39,12 +39,12 @@ where
 {
     fn draw(
         &self,
-        frame: &mut <R as Renderer>::Frame<'_>,
+        frame: &mut R::Frame<'_, '_>,
         _src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         frame.clear(
             Color32F::TRANSPARENT,
             &damage
@@ -172,12 +172,12 @@ where
 {
     fn draw(
         &self,
-        _frame: &mut <R as Renderer>::Frame<'_>,
+        _frame: &mut R::Frame<'_, '_>,
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         // We do not actually draw anything here
         Ok(())
     }

--- a/src/backend/drm/output.rs
+++ b/src/backend/drm/output.rs
@@ -18,7 +18,7 @@ use crate::{
             gbm::GbmDevice,
             Allocator,
         },
-        renderer::{element::RenderElement, Bind, Color32F, DebugFlags, Renderer, Texture},
+        renderer::{element::RenderElement, Bind, Color32F, DebugFlags, Renderer, RendererSuper, Texture},
     },
     output::OutputModeSource,
 };
@@ -142,7 +142,7 @@ pub type DrmOutputManagerResult<U, A, F, R> = Result<
         <A as Allocator>::Error,
         <<A as Allocator>::Buffer as AsDmabuf>::Error,
         <F as ExportFramebuffer<<A as Allocator>::Buffer>>::Error,
-        <R as Renderer>::Error,
+        <R as RendererSuper>::Error,
     >,
 >;
 
@@ -224,8 +224,8 @@ where
     where
         E: RenderElement<R>,
         R: Renderer + Bind<Dmabuf>,
-        <R as Renderer>::TextureId: Texture + 'static,
-        <R as Renderer>::Error: Send + Sync + 'static,
+        R::TextureId: Texture + 'static,
+        R::Error: Send + Sync + 'static,
     {
         let output_mode_source = output_mode_source.into();
 
@@ -420,8 +420,8 @@ where
     where
         E: RenderElement<R>,
         R: Renderer + Bind<Dmabuf>,
-        <R as Renderer>::TextureId: Texture + 'static,
-        <R as Renderer>::Error: Send + Sync + 'static,
+        R::TextureId: Texture + 'static,
+        R::Error: Send + Sync + 'static,
     {
         use_mode_internal(
             &self.compositor,
@@ -449,8 +449,8 @@ where
     where
         E: RenderElement<R>,
         R: Renderer + Bind<Dmabuf>,
-        <R as Renderer>::TextureId: Texture + 'static,
-        <R as Renderer>::Error: Send + Sync + 'static,
+        R::TextureId: Texture + 'static,
+        R::Error: Send + Sync + 'static,
     {
         let mut write_guard = self.compositor.write().unwrap();
 
@@ -604,8 +604,8 @@ where
     where
         E: RenderElement<R>,
         R: Renderer + Bind<Dmabuf>,
-        <R as Renderer>::TextureId: Texture + 'static,
-        <R as Renderer>::Error: Send + Sync + 'static,
+        R::TextureId: Texture + 'static,
+        R::Error: Send + Sync + 'static,
     {
         self.with_compositor(|compositor| {
             compositor.render_frame(renderer, elements, clear_color, frame_mode)
@@ -666,8 +666,8 @@ where
     where
         E: RenderElement<R>,
         R: Renderer + Bind<Dmabuf>,
-        <R as Renderer>::TextureId: Texture + 'static,
-        <R as Renderer>::Error: Send + Sync + 'static,
+        R::TextureId: Texture + 'static,
+        R::Error: Send + Sync + 'static,
     {
         use_mode_internal(
             &self.compositor,
@@ -740,8 +740,8 @@ where
     U: 'static,
     E: RenderElement<R>,
     R: Renderer + Bind<Dmabuf>,
-    <R as Renderer>::TextureId: Texture + 'static,
-    <R as Renderer>::Error: Send + Sync + 'static,
+    R::TextureId: Texture + 'static,
+    R::Error: Send + Sync + 'static,
 {
     let mut write_guard = compositor.write().unwrap();
 
@@ -833,8 +833,8 @@ pub struct DrmOutputRenderElements<R, E>
 where
     E: RenderElement<R>,
     R: Renderer + Bind<Dmabuf>,
-    <R as Renderer>::TextureId: Texture + 'static,
-    <R as Renderer>::Error: Send + Sync + 'static,
+    R::TextureId: Texture + 'static,
+    R::Error: Send + Sync + 'static,
 {
     render_elements: HashMap<crtc::Handle, (Vec<E>, Color32F)>,
     _renderer: PhantomData<R>,
@@ -844,8 +844,8 @@ impl<R, E> DrmOutputRenderElements<R, E>
 where
     E: RenderElement<R>,
     R: Renderer + Bind<Dmabuf>,
-    <R as Renderer>::TextureId: Texture + 'static,
-    <R as Renderer>::Error: Send + Sync + 'static,
+    R::TextureId: Texture + 'static,
+    R::Error: Send + Sync + 'static,
 {
     /// Construct a new empty set of render elements
     pub fn new() -> Self {
@@ -869,8 +869,8 @@ impl<R, E> Default for DrmOutputRenderElements<R, E>
 where
     E: RenderElement<R>,
     R: Renderer + Bind<Dmabuf>,
-    <R as Renderer>::TextureId: Texture + 'static,
-    <R as Renderer>::Error: Send + Sync + 'static,
+    R::TextureId: Texture + 'static,
+    R::Error: Send + Sync + 'static,
 {
     fn default() -> Self {
         Self::new()
@@ -881,8 +881,8 @@ impl<R, E> DrmOutputRenderElements<R, E>
 where
     E: RenderElement<R>,
     R: Renderer + Bind<Dmabuf>,
-    <R as Renderer>::TextureId: Texture + 'static,
-    <R as Renderer>::Error: Send + Sync + 'static,
+    R::TextureId: Texture + 'static,
+    R::Error: Send + Sync + 'static,
 {
     /// Adds elements to be used when rendering for a given `crtc`.
     ///

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -418,6 +418,14 @@ impl EGLContext {
         unsafe { ffi::egl::GetCurrentContext() == self.context as *const _ }
     }
 
+    /// Returns true if the OpenGL context is (possibly) shared with another.
+    ///
+    /// Externally managed contexts created with `EGLContext::from_raw`
+    /// are always considered shared by this function.
+    pub fn is_shared(&self) -> bool {
+        self.externally_managed || Arc::strong_count(&self.user_data) > 1
+    }
+
     /// Returns the egl config for this context
     pub fn config_id(&self) -> ffi::egl::types::EGLConfig {
         self.config_id

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -385,7 +385,7 @@ pub trait RenderElement<R: Renderer>: Element {
     /// Draw this element
     fn draw(
         &self,
-        frame: &mut <R as Renderer>::Frame<'_>,
+        frame: &mut R::Frame<'_, '_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
@@ -474,7 +474,7 @@ where
 
     fn draw(
         &self,
-        frame: &mut <R as Renderer>::Frame<'_>,
+        frame: &mut R::Frame<'_, '_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
@@ -580,7 +580,7 @@ macro_rules! render_elements_internal {
         $vis enum $name<$lt, $renderer>
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
         {
             $(
                 $(
@@ -597,7 +597,7 @@ macro_rules! render_elements_internal {
         $vis enum $name<$lt, $renderer, $($custom),+>
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
             $(
                 $custom: $crate::backend::renderer::element::RenderElement<$renderer>,
             )+
@@ -758,18 +758,18 @@ macro_rules! render_elements_internal {
     (@draw <$renderer:ty>; $($(#[$meta:meta])* $body:ident=$field:ty $(as <$other_renderer:ty>)?),* $(,)?) => {
         fn draw(
             &self,
-            frame: &mut <$renderer as $crate::backend::renderer::Renderer>::Frame<'_>,
+            frame: &mut <$renderer as $crate::backend::renderer::RendererSuper>::Frame<'_, '_>,
             src: $crate::utils::Rectangle<f64, $crate::utils::Buffer>,
             dst: $crate::utils::Rectangle<i32, $crate::utils::Physical>,
             damage: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
             opaque_regions: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
-        ) -> Result<(), <$renderer as $crate::backend::renderer::Renderer>::Error>
+        ) -> Result<(), <$renderer as $crate::backend::renderer::RendererSuper>::Error>
         where
         $(
             $(
                 $renderer: std::convert::AsMut<$other_renderer>,
-                <$renderer as $crate::backend::renderer::Renderer>::Frame: std::convert::AsMut<<$other_renderer as $crate::backend::renderer::Renderer>::Frame>,
-                <$other_renderer as $crate::backend::renderer::Renderer>::Error: Into<<$renderer as $crate::backend::renderer::Renderer>::Error>,
+                <$renderer as $crate::backend::renderer::RendererSuper>::Frame: std::convert::AsMut<<$other_renderer as $crate::backend::renderer::RendererSuper>::Frame>,
+                <$other_renderer as $crate::backend::renderer::RendererSuper>::Error: Into<<$renderer as $crate::backend::renderer::RendererSuper>::Error>,
             )*
         )*
         {
@@ -803,12 +803,12 @@ macro_rules! render_elements_internal {
     (@draw $renderer:ty; $($(#[$meta:meta])* $body:ident=$field:ty $(as <$other_renderer:ty>)?),* $(,)?) => {
         fn draw(
             &self,
-            frame: &mut <$renderer as $crate::backend::renderer::Renderer>::Frame<'_>,
+            frame: &mut <$renderer as $crate::backend::renderer::RendererSuper>::Frame<'_, '_>,
             src: $crate::utils::Rectangle<f64, $crate::utils::Buffer>,
             dst: $crate::utils::Rectangle<i32, $crate::utils::Physical>,
             damage: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
             opaque_regions: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
-        ) -> Result<(), <$renderer as $crate::backend::renderer::Renderer>::Error>
+        ) -> Result<(), <$renderer as $crate::backend::renderer::RendererSuper>::Error>
         {
             match self {
                 $(
@@ -842,7 +842,7 @@ macro_rules! render_elements_internal {
         impl<$renderer> $crate::backend::renderer::element::Element for $name<$renderer>
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
             $($($target: $bound $(+ $additional_bound)*),+)?
         {
             $crate::render_elements_internal!(@body $($tail)*);
@@ -850,7 +850,7 @@ macro_rules! render_elements_internal {
         impl<$renderer> $crate::backend::renderer::element::RenderElement<$renderer> for $name<$renderer>
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
             $($($target: $bound $(+ $additional_bound)*),+)?
         {
             $crate::render_elements_internal!(@draw <$renderer>; $($tail)*);
@@ -860,7 +860,7 @@ macro_rules! render_elements_internal {
         impl<$lt, $renderer> $crate::backend::renderer::element::Element for $name<$lt, $renderer>
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
             $($($target: $bound $(+ $additional_bound)*),+)?
         {
             $crate::render_elements_internal!(@body $($tail)*);
@@ -868,7 +868,7 @@ macro_rules! render_elements_internal {
         impl<$lt, $renderer> $crate::backend::renderer::element::RenderElement<$renderer> for $name<$lt, $renderer>
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
             $($($target: $bound $(+ $additional_bound)*),+)?
         {
             $crate::render_elements_internal!(@draw <$renderer>; $($tail)*);
@@ -878,7 +878,7 @@ macro_rules! render_elements_internal {
         impl<$renderer, $($custom),+> $crate::backend::renderer::element::Element for $name<$renderer, $($custom),+>
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
             $(
                 $custom: $crate::backend::renderer::element::RenderElement<$renderer> + $crate::backend::renderer::element::Element,
             )+
@@ -889,7 +889,7 @@ macro_rules! render_elements_internal {
         impl<$renderer, $($custom),+> $crate::backend::renderer::element::RenderElement<$renderer> for $name<$renderer, $($custom),+>
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
             $(
                 $custom: $crate::backend::renderer::element::RenderElement<$renderer> + $crate::backend::renderer::element::Element,
             )+
@@ -902,7 +902,7 @@ macro_rules! render_elements_internal {
         impl<$lt, $renderer, $($custom),+> $crate::backend::renderer::element::Element for $name<$lt, $renderer, $($custom),+>
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
             $(
                 $custom: $crate::backend::renderer::element::RenderElement<$renderer> + $crate::backend::renderer::element::Element,
             )+
@@ -913,7 +913,7 @@ macro_rules! render_elements_internal {
         impl<$lt, $renderer, $($custom),+> $crate::backend::renderer::element::RenderElement<$renderer> for $name<$lt, $renderer, $($custom),+>
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
             $(
                 $custom: $crate::backend::renderer::element::RenderElement<$renderer> + $crate::backend::renderer::element::Element,
             )+
@@ -930,7 +930,7 @@ macro_rules! render_elements_internal {
         impl<$renderer> $crate::backend::renderer::element::RenderElement<$renderer> for $name
         where
             $renderer: $crate::backend::renderer::Renderer,
-            <$renderer as $crate::backend::renderer::Renderer>::TextureId: 'static,
+            <$renderer as $crate::backend::renderer::RendererSuper>::TextureId: 'static,
         {
             $crate::render_elements_internal!(@draw <$renderer>; $($tail)*);
         }
@@ -1146,12 +1146,12 @@ macro_rules! render_elements_internal {
 /// # impl<R: Renderer> RenderElement<R> for MyRenderElement1 {
 /// #     fn draw(
 /// #         &self,
-/// #         _frame: &mut <R as Renderer>::Frame<'_>,
+/// #         _frame: &mut R::Frame<'_, '_>,
 /// #         _src: Rectangle<f64, Buffer>,
 /// #         _dst: Rectangle<i32, Physical>,
 /// #         _damage: &[Rectangle<i32, Physical>],
 /// #         _opaque_regions: &[Rectangle<i32, Physical>],
-/// #     ) -> Result<(), <R as Renderer>::Error> {
+/// #     ) -> Result<(), R::Error> {
 /// #         unimplemented!()
 /// #     }
 /// # }
@@ -1175,14 +1175,14 @@ macro_rules! render_elements_internal {
 /// # }
 /// #
 /// # impl<R: Renderer> RenderElement<R> for MyRenderElement2 {
-/// #     fn draw<'a>(
+/// #     fn draw(
 /// #         &self,
-/// #         _frame: &mut <R as Renderer>::Frame<'a>,
+/// #         _frame: &mut R::Frame<'_, '_>,
 /// #         _src: Rectangle<f64, Buffer>,
 /// #         _dst: Rectangle<i32, Physical>,
 /// #         _damage: &[Rectangle<i32, Physical>],
 /// #         _opaque_regions: &[Rectangle<i32, Physical>],
-/// #     ) -> Result<(), <R as Renderer>::Error> {
+/// #     ) -> Result<(), R::Error> {
 /// #         unimplemented!()
 /// #     }
 /// # }
@@ -1251,97 +1251,15 @@ macro_rules! render_elements_internal {
 /// # use smithay::{
 /// #     backend::{
 /// #         allocator::Fourcc,
-/// #         renderer::{Color32F, DebugFlags, Frame, Renderer, Texture, TextureFilter, sync::SyncPoint},
+/// #         renderer::{Color32F, DebugFlags, Frame, Renderer, Texture, TextureFilter, sync::SyncPoint, gles::{GlesRenderer, GlesTexture}},
 /// #     },
 /// #     utils::{Buffer, Physical, Rectangle, Size, Transform},
 /// # };
-/// #
-/// # #[derive(Clone, Debug)]
-/// # struct MyRendererTextureId;
-/// #
-/// # impl Texture for MyRendererTextureId {
-/// #     fn width(&self) -> u32 {
-/// #         unimplemented!()
-/// #     }
-/// #     fn height(&self) -> u32 {
-/// #         unimplemented!()
-/// #     }
-/// #     fn format(&self) -> Option<Fourcc> {
-/// #         unimplemented!()
-/// #     }
-/// # }
-/// #
-/// # struct MyRendererFrame;
-/// #
-/// # impl Frame for MyRendererFrame {
-/// #     type Error = std::convert::Infallible;
-/// #     type TextureId = MyRendererTextureId;
-/// #
-/// #     fn id(&self) -> usize { unimplemented!() }
-/// #     fn clear(&mut self, _: Color32F, _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
-/// #         unimplemented!()
-/// #     }
-/// #     fn draw_solid(
-/// #         &mut self,
-/// #         _dst: Rectangle<i32, Physical>,
-/// #         _damage: &[Rectangle<i32, Physical>],
-/// #         _color: Color32F,
-/// #     ) -> Result<(), Self::Error> {
-/// #         unimplemented!()
-/// #     }
-/// #     fn render_texture_from_to(
-/// #         &mut self,
-/// #         _: &Self::TextureId,
-/// #         _: Rectangle<f64, Buffer>,
-/// #         _: Rectangle<i32, Physical>,
-/// #         _: &[Rectangle<i32, Physical>],
-/// #         _: &[Rectangle<i32, Physical>],
-/// #         _: Transform,
-/// #         _: f32,
-/// #     ) -> Result<(), Self::Error> {
-/// #         unimplemented!()
-/// #     }
-/// #     fn transformation(&self) -> Transform {
-/// #         unimplemented!()
-/// #     }
-/// #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
-/// #     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> { unimplemented!() }
-/// # }
-/// #
-/// # #[derive(Debug)]
-/// # struct MyRenderer;
-/// #
-/// # impl Renderer for MyRenderer {
-/// #     type Error = std::convert::Infallible;
-/// #     type TextureId = MyRendererTextureId;
-/// #     type Frame<'a> = MyRendererFrame;
-/// #
-/// #     fn id(&self) -> usize {
-/// #         unimplemented!()
-/// #     }
-/// #     fn downscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
-/// #         unimplemented!()
-/// #     }
-/// #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
-/// #         unimplemented!()
-/// #     }
-/// #     fn set_debug_flags(&mut self, flags: DebugFlags) {
-/// #         unimplemented!()
-/// #     }
-/// #     fn debug_flags(&self) -> DebugFlags {
-/// #         unimplemented!()
-/// #     }
-/// #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>
-/// #     {
-/// #         unimplemented!()
-/// #     }
-/// #     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> { unimplemented!() }
-/// # }
 /// use smithay::backend::renderer::element::{render_elements, texture::TextureRenderElement};
 ///
 /// render_elements! {
-///     MyRenderElements<=MyRenderer>;
-///     Texture=TextureRenderElement<MyRendererTextureId>,
+///     MyRenderElements<=GlesRenderer>;
+///     Texture=TextureRenderElement<GlesTexture>,
 /// }
 /// ```
 #[macro_export]
@@ -1475,12 +1393,12 @@ where
 {
     fn draw(
         &self,
-        frame: &mut <R as Renderer>::Frame<'_>,
+        frame: &mut R::Frame<'_, '_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         self.0.draw(frame, src, dst, damage, opaque_regions)
     }
 

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -24,169 +24,11 @@
 //! #     backend::allocator::{Fourcc, dmabuf::Dmabuf},
 //! #     backend::renderer::{
 //! #         Color32F, DebugFlags, Frame, ImportDma, ImportDmaWl, ImportMem, ImportMemWl, Renderer, Texture,
-//! #         TextureFilter, sync::SyncPoint,
+//! #         TextureFilter, sync::SyncPoint, test::{DummyRenderer, DummyFramebuffer},
 //! #     },
 //! #     utils::{Buffer, Physical},
 //! #     wayland::compositor::SurfaceData,
 //! # };
-//! #
-//! # #[derive(Clone, Debug)]
-//! # struct FakeTexture;
-//! #
-//! # impl Texture for FakeTexture {
-//! #     fn width(&self) -> u32 {
-//! #         unimplemented!()
-//! #     }
-//! #     fn height(&self) -> u32 {
-//! #         unimplemented!()
-//! #     }
-//! #     fn format(&self) -> Option<Fourcc> {
-//! #         unimplemented!()
-//! #     }
-//! # }
-//! #
-//! # struct FakeFrame;
-//! #
-//! # impl Frame for FakeFrame {
-//! #     type Error = std::convert::Infallible;
-//! #     type TextureId = FakeTexture;
-//! #
-//! #     fn id(&self) -> usize { unimplemented!() }
-//! #     fn clear(&mut self, _: Color32F, _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn draw_solid(
-//! #         &mut self,
-//! #         _dst: Rectangle<i32, Physical>,
-//! #         _damage: &[Rectangle<i32, Physical>],
-//! #         _color: Color32F,
-//! #     ) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn render_texture_from_to(
-//! #         &mut self,
-//! #         _: &Self::TextureId,
-//! #         _: Rectangle<f64, Buffer>,
-//! #         _: Rectangle<i32, Physical>,
-//! #         _: &[Rectangle<i32, Physical>],
-//! #         _: &[Rectangle<i32, Physical>],
-//! #         _: Transform,
-//! #         _: f32,
-//! #     ) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn transformation(&self) -> Transform {
-//! #         unimplemented!()
-//! #     }
-//! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
-//! #     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> { unimplemented!() }
-//! # }
-//! #
-//! # #[derive(Debug)]
-//! # struct FakeRenderer;
-//! #
-//! # impl Renderer for FakeRenderer {
-//! #     type Error = std::convert::Infallible;
-//! #     type TextureId = FakeTexture;
-//! #     type Frame<'a> = FakeFrame;
-//! #
-//! #     fn id(&self) -> usize {
-//! #         unimplemented!()
-//! #     }
-//! #     fn downscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn set_debug_flags(&mut self, _: DebugFlags) {
-//! #         unimplemented!()
-//! #     }
-//! #     fn debug_flags(&self) -> DebugFlags {
-//! #         unimplemented!()
-//! #     }
-//! #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>
-//! #     {
-//! #         unimplemented!()
-//! #     }
-//! #     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> { unimplemented!() }
-//! # }
-//! #
-//! # impl ImportMem for FakeRenderer {
-//! #     fn import_memory(
-//! #         &mut self,
-//! #         _: &[u8],
-//! #         _: Fourcc,
-//! #         _: Size<i32, Buffer>,
-//! #         _: bool,
-//! #     ) -> Result<Self::TextureId, Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn update_memory(
-//! #         &mut self,
-//! #         _: &Self::TextureId,
-//! #         _: &[u8],
-//! #         _: Rectangle<i32, Buffer>,
-//! #     ) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn mem_formats(&self) -> Box<dyn Iterator<Item=Fourcc>> {
-//! #         unimplemented!()
-//! #     }
-//! # }
-//! #
-//! # impl ImportMemWl for FakeRenderer {
-//! #     fn import_shm_buffer(
-//! #         &mut self,
-//! #         _buffer: &wayland_server::protocol::wl_buffer::WlBuffer,
-//! #         _surface: Option<&SurfaceData>,
-//! #         _damage: &[Rectangle<i32, Buffer>],
-//! #     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error> {
-//! #         unimplemented!()
-//! #     }
-//! # }
-//! # #[cfg(all(
-//! #     feature = "wayland_frontend",
-//! #     feature = "backend_egl",
-//! #     feature = "use_system_lib"
-//! # ))]
-//! # impl ImportEgl for FakeRenderer {
-//! #     fn bind_wl_display(
-//! #         &mut self,
-//! #         _display: &wayland_server::DisplayHandle,
-//! #     ) -> Result<(), egl::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #
-//! #     fn unbind_wl_display(&mut self) {
-//! #         unimplemented!()
-//! #     }
-//! #
-//! #     fn egl_reader(&self) -> Option<&EGLBufferReader> {
-//! #         unimplemented!()
-//! #     }
-//! #
-//! #     fn import_egl_buffer(
-//! #         &mut self,
-//! #         _buffer: &wayland_server::protocol::wl_buffer::WlBuffer,
-//! #         _surface: Option<&SurfaceData>,
-//! #         _damage: &[Rectangle<i32, Buffer>],
-//! #     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error> {
-//! #         unimplemented!()
-//! #     }
-//! # }
-//! #
-//! # impl ImportDma for FakeRenderer {
-//! #     fn import_dmabuf(
-//! #         &mut self,
-//! #         _dmabuf: &Dmabuf,
-//! #         _damage: Option<&[Rectangle<i32, Buffer>]>,
-//! #     ) -> Result<<Self as Renderer>::TextureId, <Self as Renderer>::Error> {
-//! #         unimplemented!()
-//! #     }
-//! # }
-//! #
-//! # impl ImportDmaWl for FakeRenderer {}
 //! use smithay::{
 //!     backend::renderer::{
 //!         damage::OutputDamageTracker,
@@ -204,17 +46,18 @@
 //!
 //! // Initialize a static damage tracked renderer
 //! let mut damage_tracker = OutputDamageTracker::new((800, 600), 1.0, Transform::Normal);
-//! # let mut renderer = FakeRenderer;
+//! # let mut renderer = DummyRenderer;
+//! # let mut framebuffer = DummyFramebuffer;
 //!
 //! loop {
 //!     // Create the render elements from the surface
 //!     let location = Point::from((100, 100));
-//!     let render_elements: Vec<WaylandSurfaceRenderElement<FakeRenderer>> =
+//!     let render_elements: Vec<WaylandSurfaceRenderElement<DummyRenderer>> =
 //!         render_elements_from_surface_tree(&mut renderer, &surface, location, 1.0, 1.0, Kind::Unspecified);
 //!
 //!     // Render the element(s)
 //!     damage_tracker
-//!         .render_output(&mut renderer, 0, &*render_elements, [0.8, 0.8, 0.9, 1.0])
+//!         .render_output(&mut renderer, &mut framebuffer, 0, &*render_elements, [0.8, 0.8, 0.9, 1.0])
 //!         .expect("failed to render output");
 //! }
 //! ```
@@ -254,7 +97,7 @@ pub fn render_elements_from_surface_tree<R, E>(
 ) -> Vec<E>
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: Clone + 'static,
+    R::TextureId: Clone + 'static,
     E: From<WaylandSurfaceRenderElement<R>>,
 {
     let location = location.into().to_f64();
@@ -314,7 +157,7 @@ where
 #[derive(Debug)]
 pub enum WaylandSurfaceTexture<R: Renderer> {
     /// A renderer texture
-    Texture(<R as Renderer>::TextureId),
+    Texture(R::TextureId),
     /// A solid color
     SolidColor(Color32F),
 }
@@ -355,9 +198,9 @@ impl<R: Renderer + ImportAll> WaylandSurfaceRenderElement<R> {
         location: Point<f64, Physical>,
         alpha: f32,
         kind: Kind,
-    ) -> Result<Option<Self>, <R as Renderer>::Error>
+    ) -> Result<Option<Self>, R::Error>
     where
-        <R as Renderer>::TextureId: Clone + 'static,
+        R::TextureId: Clone + 'static,
     {
         let id = Id::from_wayland_resource(surface);
         crate::backend::renderer::utils::import_surface(renderer, states)?;
@@ -387,7 +230,7 @@ impl<R: Renderer + ImportAll> WaylandSurfaceRenderElement<R> {
         data: &RendererSurfaceState,
     ) -> Option<Self>
     where
-        <R as Renderer>::TextureId: Clone + 'static,
+        R::TextureId: Clone + 'static,
     {
         let buffer = data.buffer()?.clone();
 
@@ -528,7 +371,7 @@ impl<R: Renderer + ImportAll> Element for WaylandSurfaceRenderElement<R> {
 impl<R> RenderElement<R> for WaylandSurfaceRenderElement<R>
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: Texture + 'static,
+    R::TextureId: Texture + 'static,
 {
     #[inline]
     fn underlying_storage(&self, _renderer: &mut R) -> Option<UnderlyingStorage<'_>> {
@@ -537,9 +380,9 @@ where
 
     #[instrument(level = "trace", skip(frame))]
     #[profiling::function]
-    fn draw<'a>(
+    fn draw(
         &self,
-        frame: &mut <R as Renderer>::Frame<'a>,
+        frame: &mut R::Frame<'_, '_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],

--- a/src/backend/renderer/element/tests.rs
+++ b/src/backend/renderer/element/tests.rs
@@ -35,23 +35,23 @@ render_elements! {
 }
 
 render_elements! {
-    TextureIdTest<R> where R: ImportMem, <R as Renderer>::TextureId: Clone;
+    TextureIdTest<R> where R: ImportMem, R::TextureId: Clone;
     Memory=ImportMemRenderElement,
 }
 
 render_elements! {
-    TextureIdTest1<R> where R: ImportMem, <R as Renderer>::TextureId: 'static;
+    TextureIdTest1<R> where R: ImportMem, R::TextureId: 'static;
     Memory=ImportMemRenderElement,
 }
 
 render_elements! {
-    TextureIdTest2<'a, R, C> where R: ImportMem, <R as Renderer>::TextureId: 'a;
+    TextureIdTest2<'a, R, C> where R: ImportMem, R::TextureId: 'a;
     Memory=ImportMemRenderElement,
     Custom=&'a C,
 }
 
 render_elements! {
-    TextureIdTest3<'a, R, C> where R: ImportMem, <R as Renderer>::TextureId: Clone + 'a;
+    TextureIdTest3<'a, R, C> where R: ImportMem, R::TextureId: Clone + 'a;
     Memory=ImportMemRenderElement,
     Custom=&'a C,
 }
@@ -145,12 +145,12 @@ where
 {
     fn draw(
         &self,
-        _frame: &mut <R as Renderer>::Frame<'_>,
+        _frame: &mut R::Frame<'_, '_>,
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         todo!()
     }
 }
@@ -183,12 +183,12 @@ where
 {
     fn draw(
         &self,
-        _frame: &mut <R as Renderer>::Frame<'_>,
+        _frame: &mut R::Frame<'_, '_>,
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         todo!()
     }
 }
@@ -230,12 +230,12 @@ where
 {
     fn draw(
         &self,
-        _frame: &mut <R as Renderer>::Frame<'_>,
+        _frame: &mut R::Frame<'_, '_>,
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         todo!()
     }
 }
@@ -276,12 +276,12 @@ where
 {
     fn draw(
         &self,
-        _frame: &mut <R as Renderer>::Frame<'_>,
+        _frame: &mut R::Frame<'_, '_>,
         _src: Rectangle<f64, Buffer>,
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         todo!()
     }
 }

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -385,9 +385,9 @@ impl<T> RenderContext<'_, T> {
     /// Draw to the buffer
     pub fn draw<F, E>(&mut self, f: F) -> Result<(), E>
     where
-        F: FnOnce(&T) -> Result<Vec<Rectangle<i32, Buffer>>, E>,
+        F: FnOnce(&mut T) -> Result<Vec<Rectangle<i32, Buffer>>, E>,
     {
-        let draw_damage = f(&self.buffer.texture)?;
+        let draw_damage = f(&mut self.buffer.texture)?;
         self.damage.extend(draw_damage);
         Ok(())
     }

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -41,114 +41,9 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{Color32F, DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
+//! #     backend::renderer::{Color32F, DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint, test::{DummyRenderer, DummyFramebuffer}},
 //! #     utils::{Buffer, Physical, Rectangle, Size},
 //! # };
-//! #
-//! # #[derive(Clone, Debug)]
-//! # struct FakeTexture;
-//! #
-//! # impl Texture for FakeTexture {
-//! #     fn width(&self) -> u32 {
-//! #         unimplemented!()
-//! #     }
-//! #     fn height(&self) -> u32 {
-//! #         unimplemented!()
-//! #     }
-//! #     fn format(&self) -> Option<Fourcc> {
-//! #         unimplemented!()
-//! #     }
-//! # }
-//! #
-//! # struct FakeFrame;
-//! #
-//! # impl Frame for FakeFrame {
-//! #     type Error = std::convert::Infallible;
-//! #     type TextureId = FakeTexture;
-//! #
-//! #     fn id(&self) -> usize { unimplemented!() }
-//! #     fn clear(&mut self, _: Color32F, _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn draw_solid(
-//! #         &mut self,
-//! #         _dst: Rectangle<i32, Physical>,
-//! #         _damage: &[Rectangle<i32, Physical>],
-//! #         _color: Color32F,
-//! #     ) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn render_texture_from_to(
-//! #         &mut self,
-//! #         _: &Self::TextureId,
-//! #         _: Rectangle<f64, Buffer>,
-//! #         _: Rectangle<i32, Physical>,
-//! #         _: &[Rectangle<i32, Physical>],
-//! #         _: &[Rectangle<i32, Physical>],
-//! #         _: Transform,
-//! #         _: f32,
-//! #     ) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn transformation(&self) -> Transform {
-//! #         unimplemented!()
-//! #     }
-//! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
-//! #     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> { unimplemented!() }
-//! # }
-//! #
-//! # #[derive(Debug)]
-//! # struct FakeRenderer;
-//! #
-//! # impl Renderer for FakeRenderer {
-//! #     type Error = std::convert::Infallible;
-//! #     type TextureId = FakeTexture;
-//! #     type Frame<'a> = FakeFrame;
-//! #
-//! #     fn id(&self) -> usize {
-//! #         unimplemented!()
-//! #     }
-//! #     fn downscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn set_debug_flags(&mut self, _: DebugFlags) {
-//! #         unimplemented!()
-//! #     }
-//! #     fn debug_flags(&self) -> DebugFlags {
-//! #         unimplemented!()
-//! #     }
-//! #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>
-//! #     {
-//! #         unimplemented!()
-//! #     }
-//! #     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> { unimplemented!() }
-//! # }
-//! #
-//! # impl ImportMem for FakeRenderer {
-//! #     fn import_memory(
-//! #         &mut self,
-//! #         _: &[u8],
-//! #         _: Fourcc,
-//! #         _: Size<i32, Buffer>,
-//! #         _: bool,
-//! #     ) -> Result<Self::TextureId, Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn update_memory(
-//! #         &mut self,
-//! #         _: &Self::TextureId,
-//! #         _: &[u8],
-//! #         _: Rectangle<i32, Buffer>,
-//! #     ) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn mem_formats(&self) -> Box<dyn Iterator<Item=Fourcc>> {
-//! #         unimplemented!()
-//! #     }
-//! # }
 //! use smithay::{
 //!     backend::{
 //!         allocator::Fourcc,
@@ -167,7 +62,8 @@
 //! const HEIGHT: i32 = 10;
 //!
 //! let memory = vec![0; (WIDTH * 4 * HEIGHT) as usize];
-//! # let mut renderer = FakeRenderer;
+//! # let mut renderer = DummyRenderer;
+//! # let mut framebuffer = DummyFramebuffer;
 //!
 //! // Create the texture buffer from a chunk of memory
 //! let texture_buffer = TextureBuffer::from_memory(
@@ -192,7 +88,7 @@
 //!
 //!     // Render the element(s)
 //!     damage_tracker
-//!         .render_output(&mut renderer, 0, &[&render_element], [0.8, 0.8, 0.9, 1.0])
+//!         .render_output(&mut renderer, &mut framebuffer, 0, &[&render_element], [0.8, 0.8, 0.9, 1.0])
 //!         .expect("failed to render output");
 //! }
 //! ```
@@ -201,114 +97,9 @@
 //!
 //! ```no_run
 //! # use smithay::{
-//! #     backend::renderer::{Color32F, DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint},
+//! #     backend::renderer::{Color32F, DebugFlags, Frame, ImportMem, Renderer, Texture, TextureFilter, sync::SyncPoint, test::{DummyRenderer, DummyFramebuffer}},
 //! #     utils::{Buffer, Physical},
 //! # };
-//! #
-//! # #[derive(Clone, Debug)]
-//! # struct FakeTexture;
-//! #
-//! # impl Texture for FakeTexture {
-//! #     fn width(&self) -> u32 {
-//! #         unimplemented!()
-//! #     }
-//! #     fn height(&self) -> u32 {
-//! #         unimplemented!()
-//! #     }
-//! #     fn format(&self) -> Option<Fourcc> {
-//! #         unimplemented!()
-//! #     }
-//! # }
-//! #
-//! # struct FakeFrame;
-//! #
-//! # impl Frame for FakeFrame {
-//! #     type Error = std::convert::Infallible;
-//! #     type TextureId = FakeTexture;
-//! #
-//! #     fn id(&self) -> usize { unimplemented!() }
-//! #     fn clear(&mut self, _: Color32F, _: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn draw_solid(
-//! #         &mut self,
-//! #         _dst: Rectangle<i32, Physical>,
-//! #         _damage: &[Rectangle<i32, Physical>],
-//! #         _color: Color32F,
-//! #     ) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn render_texture_from_to(
-//! #         &mut self,
-//! #         _: &Self::TextureId,
-//! #         _: Rectangle<f64, Buffer>,
-//! #         _: Rectangle<i32, Physical>,
-//! #         _: &[Rectangle<i32, Physical>],
-//! #         _: &[Rectangle<i32, Physical>],
-//! #         _: Transform,
-//! #         _: f32,
-//! #     ) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn transformation(&self) -> Transform {
-//! #         unimplemented!()
-//! #     }
-//! #     fn finish(self) -> Result<SyncPoint, Self::Error> { unimplemented!() }
-//! #     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> { unimplemented!() }
-//! # }
-//! #
-//! # #[derive(Debug)]
-//! # struct FakeRenderer;
-//! #
-//! # impl Renderer for FakeRenderer {
-//! #     type Error = std::convert::Infallible;
-//! #     type TextureId = FakeTexture;
-//! #     type Frame<'a> = FakeFrame;
-//! #
-//! #     fn id(&self) -> usize {
-//! #         unimplemented!()
-//! #     }
-//! #     fn downscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn upscale_filter(&mut self, _: TextureFilter) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn set_debug_flags(&mut self, _: DebugFlags) {
-//! #         unimplemented!()
-//! #     }
-//! #     fn debug_flags(&self) -> DebugFlags {
-//! #         unimplemented!()
-//! #     }
-//! #     fn render(&mut self, _: Size<i32, Physical>, _: Transform) -> Result<Self::Frame<'_>, Self::Error>
-//! #     {
-//! #         unimplemented!()
-//! #     }
-//! #     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> { unimplemented!() }
-//! # }
-//! #
-//! # impl ImportMem for FakeRenderer {
-//! #     fn import_memory(
-//! #         &mut self,
-//! #         _: &[u8],
-//! #         _: Fourcc,
-//! #         _: Size<i32, Buffer>,
-//! #         _: bool,
-//! #     ) -> Result<Self::TextureId, Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn update_memory(
-//! #         &mut self,
-//! #         _: &Self::TextureId,
-//! #         _: &[u8],
-//! #         _: Rectangle<i32, Buffer>,
-//! #     ) -> Result<(), Self::Error> {
-//! #         unimplemented!()
-//! #     }
-//! #     fn mem_formats(&self) -> Box<dyn Iterator<Item=Fourcc>> {
-//! #         unimplemented!()
-//! #     }
-//! # }
 //! use std::time::{Duration, Instant};
 //!
 //! use smithay::{
@@ -329,7 +120,8 @@
 //! const HEIGHT: i32 = 10;
 //!
 //! let memory = vec![0; (WIDTH * 4 * HEIGHT) as usize];
-//! # let mut renderer = FakeRenderer;
+//! # let mut renderer = DummyRenderer;
+//! # let mut framebuffer = DummyFramebuffer;
 //!
 //! // Create the texture buffer from a chunk of memory
 //! let mut texture_render_buffer = TextureRenderBuffer::from_memory(
@@ -397,7 +189,7 @@
 //!
 //!     // Render the element(s)
 //!     damage_tracker
-//!         .render_output(&mut renderer, 0, &[&render_element], [0.8, 0.8, 0.9, 1.0])
+//!         .render_output(&mut renderer, &mut framebuffer, 0, &[&render_element], [0.8, 0.8, 0.9, 1.0])
 //!         .expect("failed to render output");
 //! }
 //! ```
@@ -460,7 +252,7 @@ impl<T> TextureBuffer<T> {
         scale: i32,
         transform: Transform,
         opaque_regions: Option<Vec<Rectangle<i32, Buffer>>>,
-    ) -> Result<Self, <R as Renderer>::Error> {
+    ) -> Result<Self, R::Error> {
         let texture = renderer.import_memory(data, format, size.into(), flipped)?;
         Ok(TextureBuffer::from_texture(
             renderer,
@@ -523,7 +315,7 @@ impl<T: Texture> TextureRenderBuffer<T> {
         scale: i32,
         transform: Transform,
         opaque_regions: Option<Vec<Rectangle<i32, Buffer>>>,
-    ) -> Result<Self, <R as Renderer>::Error> {
+    ) -> Result<Self, R::Error> {
         let texture = renderer.import_memory(data, format, size.into(), flipped)?;
         Ok(TextureRenderBuffer::from_texture(
             renderer,
@@ -558,7 +350,7 @@ impl<T: Texture> TextureRenderBuffer<T> {
         data: &[u8],
         region: Rectangle<i32, Buffer>,
         opaque_regions: Option<Vec<Rectangle<i32, Buffer>>>,
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         assert_eq!(self.renderer_id, renderer.id());
         renderer.update_memory(&self.texture, data, region)?;
         self.damage_tracker.lock().unwrap().add([region]);
@@ -894,14 +686,14 @@ where
 {
     #[instrument(level = "trace", skip(self, frame))]
     #[profiling::function]
-    fn draw<'a>(
+    fn draw(
         &self,
-        frame: &mut <R as Renderer>::Frame<'a>,
+        frame: &mut R::Frame<'_, '_>,
         src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         if frame.id() != self.renderer_id {
             warn!("trying to render texture from different renderer");
             return Ok(());

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -95,12 +95,12 @@ impl<E: Element> Element for RescaleRenderElement<E> {
 impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RescaleRenderElement<E> {
     fn draw(
         &self,
-        frame: &mut <R as Renderer>::Frame<'_>,
+        frame: &mut R::Frame<'_, '_>,
         src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
         dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
         damage: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
         opaque_regions: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         self.element.draw(frame, src, dst, damage, opaque_regions)
     }
 
@@ -279,12 +279,12 @@ impl<E: Element> Element for CropRenderElement<E> {
 impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for CropRenderElement<E> {
     fn draw(
         &self,
-        frame: &mut <R as Renderer>::Frame<'_>,
+        frame: &mut R::Frame<'_, '_>,
         src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
         dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
         damage: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
         opaque_regions: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         self.element.draw(frame, src, dst, damage, opaque_regions)
     }
 
@@ -381,12 +381,12 @@ impl<E: Element> Element for RelocateRenderElement<E> {
 impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RelocateRenderElement<E> {
     fn draw(
         &self,
-        frame: &mut <R as Renderer>::Frame<'_>,
+        frame: &mut R::Frame<'_, '_>,
         src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
         dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
         damage: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
         opaque_regions: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
-    ) -> Result<(), <R as Renderer>::Error> {
+    ) -> Result<(), R::Error> {
         self.element.draw(frame, src, dst, damage, opaque_regions)
     }
 

--- a/src/backend/renderer/gles/element.rs
+++ b/src/backend/renderer/gles/element.rs
@@ -107,7 +107,7 @@ impl RenderElement<GlesRenderer> for PixelShaderElement {
     #[profiling::function]
     fn draw(
         &self,
-        frame: &mut GlesFrame<'_>,
+        frame: &mut GlesFrame<'_, '_>,
         src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
@@ -204,7 +204,7 @@ impl RenderElement<GlesRenderer> for TextureShaderElement {
     #[profiling::function]
     fn draw(
         &self,
-        frame: &mut GlesFrame<'_>,
+        frame: &mut GlesFrame<'_, '_>,
         src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -12,13 +12,10 @@ use std::{
     sync::{
         atomic::{AtomicBool, AtomicPtr, Ordering},
         mpsc::{channel, Receiver, Sender},
-        Arc,
+        Arc, Mutex, RwLock,
     },
 };
 use tracing::{debug, error, info, info_span, instrument, span, span::EnteredSpan, trace, warn, Level};
-
-#[cfg(feature = "wayland_frontend")]
-use std::sync::Mutex;
 
 pub mod element;
 mod error;
@@ -85,6 +82,7 @@ enum CleanupResource {
     EGLImage(EGLImage),
     Mapping(ffi::types::GLuint, *const std::ffi::c_void),
     Program(ffi::types::GLuint),
+    Sync(ffi::types::GLsync),
 }
 unsafe impl Send for CleanupResource {}
 
@@ -237,8 +235,10 @@ pub enum Capability {
     _10Bit,
     /// GlesRenderer supports creating of Renderbuffers with usable formats
     Renderbuffer,
-    /// GlesRenderer supports fencing,
+    /// GlesRenderer supports fencing
     Fencing,
+    /// GlesRenderer supports fencing and exporting it to EGL
+    ExportFence,
     /// GlesRenderer supports GL debug
     Debug,
 }
@@ -406,11 +406,13 @@ impl GlesRenderer {
             debug!("Blitting is supported");
             capabilities.push(Capability::_10Bit);
             debug!("10-bit formats are supported");
+            capabilities.push(Capability::Fencing);
+            debug!("Fencing is supported");
         }
 
         if exts.iter().any(|ext| ext == "GL_OES_EGL_sync") {
-            debug!("Fencing is supported");
-            capabilities.push(Capability::Fencing);
+            debug!("EGL Fencing is supported");
+            capabilities.push(Capability::ExportFence);
         }
 
         if exts.iter().any(|ext| ext == "GL_KHR_debug") {
@@ -477,9 +479,11 @@ impl GlesRenderer {
                 Capability::Instancing => {
                     GlesError::GLExtensionNotSupported(&["GL_EXT_instanced_arrays", "GL_EXT_draw_instanced"])
                 }
-                Capability::Blit | Capability::_10Bit => GlesError::GLVersionNotSupported(version::GLES_3_0),
+                Capability::Blit | Capability::_10Bit | Capability::Fencing => {
+                    GlesError::GLVersionNotSupported(version::GLES_3_0)
+                }
                 Capability::Renderbuffer => GlesError::GLExtensionNotSupported(&["GL_OES_rgb8_rgba8"]),
-                Capability::Fencing => GlesError::GLExtensionNotSupported(&["GL_OES_EGL_sync"]),
+                Capability::ExportFence => GlesError::GLExtensionNotSupported(&["GL_OES_EGL_sync"]),
                 Capability::Debug => GlesError::GLExtensionNotSupported(&["GL_KHR_debug"]),
             };
             return Err(err);
@@ -665,6 +669,9 @@ impl GlesRenderer {
                 CleanupResource::Program(program) => unsafe {
                     self.gl.DeleteProgram(program);
                 },
+                CleanupResource::Sync(sync) => unsafe {
+                    self.gl.DeleteSync(sync);
+                },
             }
         }
     }
@@ -675,6 +682,13 @@ impl GlesRenderer {
     }
 }
 
+/// Warning: If your context only supports OpenGL ES 2.0 and
+/// you are sharing EGLContexts, using [`import_shm_buffer`]
+/// will insert a `glFinish()` call for every buffer import
+/// to synchronize texture access.
+///
+/// As a compositor developer consider not sharing
+/// contexts, if OpenGL ES 3.0 is unavailable.
 #[cfg(feature = "wayland_frontend")]
 impl ImportMemWl for GlesRenderer {
     #[instrument(level = "trace", parent = &self.span, skip(self))]
@@ -690,6 +704,14 @@ impl ImportMemWl for GlesRenderer {
         // why not store a `GlesTexture`? because the user might do so.
         // this is guaranteed a non-public internal type, so we are good.
         type CacheMap = HashMap<usize, Arc<GlesTextureInternal>>;
+
+        let mut surface_lock = surface.as_ref().map(|surface_data| {
+            surface_data
+                .data_map
+                .get_or_insert_threadsafe(|| Arc::new(Mutex::new(CacheMap::new())))
+                .lock()
+                .unwrap()
+        });
 
         with_buffer_contents(buffer, |ptr, len, data| {
             self.make_current()?;
@@ -731,20 +753,9 @@ impl ImportMemWl for GlesRenderer {
 
             let id = self.id();
             let texture = GlesTexture(
-                surface
-                    .and_then(|surface| {
-                        surface
-                            .data_map
-                            .insert_if_missing_threadsafe(|| Arc::new(Mutex::new(CacheMap::new())));
-                        surface
-                            .data_map
-                            .get::<Arc<Mutex<CacheMap>>>()
-                            .unwrap()
-                            .lock()
-                            .unwrap()
-                            .get(&id)
-                            .cloned()
-                    })
+                surface_lock
+                    .as_ref()
+                    .and_then(|cache| cache.get(&id).cloned())
                     .filter(|texture| texture.size == (width, height).into())
                     .unwrap_or_else(|| {
                         let mut tex = 0;
@@ -753,6 +764,7 @@ impl ImportMemWl for GlesRenderer {
                         upload_full = true;
                         let new = Arc::new(GlesTextureInternal {
                             texture: tex,
+                            sync: RwLock::default(),
                             format: Some(internal_format),
                             has_alpha,
                             is_external: false,
@@ -761,21 +773,16 @@ impl ImportMemWl for GlesRenderer {
                             egl_images: None,
                             destruction_callback_sender: self.destruction_callback_sender.clone(),
                         });
-                        if let Some(surface) = surface {
-                            let copy = new.clone();
-                            surface
-                                .data_map
-                                .get::<Arc<Mutex<CacheMap>>>()
-                                .unwrap()
-                                .lock()
-                                .unwrap()
-                                .insert(id, copy);
+                        if let Some(cache) = surface_lock.as_mut() {
+                            cache.insert(id, new.clone());
                         }
                         new
                     }),
             );
 
+            let mut sync_lock = texture.0.sync.write().unwrap();
             unsafe {
+                sync_lock.wait_for_all(&self.gl);
                 self.gl.BindTexture(ffi::TEXTURE_2D, texture.0.texture);
                 self.gl
                     .TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_WRAP_S, ffi::CLAMP_TO_EDGE as i32);
@@ -820,7 +827,14 @@ impl ImportMemWl for GlesRenderer {
 
                 self.gl.PixelStorei(ffi::UNPACK_ROW_LENGTH, 0);
                 self.gl.BindTexture(ffi::TEXTURE_2D, 0);
+
+                if self.capabilities.contains(&Capability::Fencing) {
+                    sync_lock.update_write(&self.gl);
+                } else if self.egl.is_shared() {
+                    self.gl.Finish();
+                }
             }
+            std::mem::drop(sync_lock);
 
             Ok(texture)
         })
@@ -907,9 +921,20 @@ impl ImportMem for GlesRenderer {
                 );
                 self.gl.BindTexture(ffi::TEXTURE_2D, 0);
             }
+
+            let mut sync = RwLock::<TextureSync>::default();
+            if self.capabilities.contains(&Capability::Fencing) {
+                sync.get_mut().unwrap().update_write(&self.gl);
+            } else if self.egl.is_shared() {
+                unsafe {
+                    self.gl.Finish();
+                }
+            };
+
             // new texture, upload in full
             GlesTextureInternal {
                 texture: tex,
+                sync,
                 format: Some(internal),
                 has_alpha,
                 is_external: false,
@@ -949,7 +974,9 @@ impl ImportMem for GlesRenderer {
             return Err(GlesError::UnexpectedSize);
         }
 
+        let mut sync_lock = texture.0.sync.write().unwrap();
         unsafe {
+            sync_lock.wait_for_all(&self.gl);
             self.gl.BindTexture(ffi::TEXTURE_2D, texture.0.texture);
             self.gl
                 .TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_WRAP_S, ffi::CLAMP_TO_EDGE as i32);
@@ -973,6 +1000,12 @@ impl ImportMem for GlesRenderer {
             self.gl.PixelStorei(ffi::UNPACK_SKIP_PIXELS, 0);
             self.gl.PixelStorei(ffi::UNPACK_SKIP_ROWS, 0);
             self.gl.BindTexture(ffi::TEXTURE_2D, 0);
+
+            if self.capabilities.contains(&Capability::Fencing) {
+                sync_lock.update_write(&self.gl);
+            } else if self.egl.is_shared() {
+                self.gl.Finish();
+            }
         }
 
         Ok(())
@@ -1045,6 +1078,7 @@ impl ImportEgl for GlesRenderer {
 
         let texture = GlesTexture(Arc::new(GlesTextureInternal {
             texture: tex,
+            sync: RwLock::default(),
             format: match egl.format {
                 EGLFormat::RGB | EGLFormat::RGBA => Some(ffi::RGBA8),
                 EGLFormat::External => None,
@@ -1091,6 +1125,7 @@ impl ImportDma for GlesRenderer {
             let has_alpha = has_alpha(buffer.format().code);
             let texture = GlesTexture(Arc::new(GlesTextureInternal {
                 texture: tex,
+                sync: RwLock::default(),
                 format: Some(format),
                 has_alpha,
                 is_external,
@@ -1448,6 +1483,8 @@ impl Bind<GlesTexture> for GlesRenderer {
         let bind = || {
             let mut fbo = 0;
             unsafe {
+                // TODO: we should keep the lock, while the Target is active
+                texture.0.sync.read().unwrap().wait_for_upload(&self.gl);
                 self.gl.GenFramebuffers(1, &mut fbo as *mut _);
                 self.gl.BindFramebuffer(ffi::FRAMEBUFFER, fbo);
                 self.gl.FramebufferTexture2D(
@@ -2294,7 +2331,7 @@ impl GlesFrame<'_> {
         self.renderer.cleanup();
 
         // if we support egl fences we should use it
-        if self.renderer.capabilities.contains(&Capability::Fencing) {
+        if self.renderer.capabilities.contains(&Capability::ExportFence) {
             if let Ok(fence) = EGLFence::create(self.renderer.egl.display()) {
                 unsafe {
                     self.renderer.gl.Flush();
@@ -2666,7 +2703,9 @@ impl GlesFrame<'_> {
 
         // render
         let gl = &self.renderer.gl;
+        let sync_lock = tex.0.sync.read().unwrap();
         unsafe {
+            sync_lock.wait_for_upload(gl);
             gl.ActiveTexture(ffi::TEXTURE0);
             gl.BindTexture(target, tex.0.texture);
             gl.TexParameteri(
@@ -2746,6 +2785,12 @@ impl GlesFrame<'_> {
             gl.BindTexture(target, 0);
             gl.DisableVertexAttribArray(program.attrib_vert as u32);
             gl.DisableVertexAttribArray(program.attrib_vert_position as u32);
+
+            if self.renderer.capabilities.contains(&Capability::Fencing) {
+                sync_lock.update_read(gl);
+            } else if self.renderer.egl.is_shared() {
+                gl.Finish();
+            };
         }
 
         Ok(())

--- a/src/backend/renderer/gles/texture.rs
+++ b/src/backend/renderer/gles/texture.rs
@@ -93,8 +93,8 @@ impl TextureSync {
 
     pub(super) fn wait_for_all(&mut self, gl: &Gles2) {
         unsafe {
-            wait_for_syncpoint(&mut self.read_sync.get_mut().unwrap(), gl);
-            wait_for_syncpoint(&mut self.write_sync.get_mut().unwrap(), gl);
+            wait_for_syncpoint(self.read_sync.get_mut().unwrap(), gl);
+            wait_for_syncpoint(self.write_sync.get_mut().unwrap(), gl);
         }
     }
 

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -16,8 +16,8 @@ use crate::{
         renderer::{
             element::UnderlyingStorage,
             gles::{element::*, *},
-            sync, Bind, Blit, Color32F, DebugFlags, ExportMem, ImportDma, ImportMem, Offscreen, Renderer,
-            RendererSuper, TextureFilter,
+            sync, Bind, Blit, BlitFrame, Color32F, DebugFlags, ExportMem, ImportDma, ImportMem, Offscreen,
+            Renderer, RendererSuper, TextureFilter,
         },
     },
     utils::{Buffer as BufferCoord, Physical, Rectangle, Size, Transform},
@@ -514,6 +514,28 @@ where
     #[profiling::function]
     fn create_buffer(&mut self, format: Fourcc, size: Size<i32, BufferCoord>) -> Result<T, GlesError> {
         self.gl.create_buffer(format, size)
+    }
+}
+
+impl<'buffer> BlitFrame<GlesTarget<'buffer>> for GlowFrame<'_, 'buffer> {
+    fn blit_to(
+        &mut self,
+        to: &mut GlesTarget<'buffer>,
+        src: Rectangle<i32, Physical>,
+        dst: Rectangle<i32, Physical>,
+        filter: TextureFilter,
+    ) -> Result<(), Self::Error> {
+        self.frame.as_mut().unwrap().blit_to(to, src, dst, filter)
+    }
+
+    fn blit_from(
+        &mut self,
+        from: &GlesTarget<'buffer>,
+        src: Rectangle<i32, Physical>,
+        dst: Rectangle<i32, Physical>,
+        filter: TextureFilter,
+    ) -> Result<(), Self::Error> {
+        self.frame.as_mut().unwrap().blit_from(from, src, dst, filter)
     }
 }
 

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -319,9 +319,9 @@ impl RendererSurfaceState {
     pub fn texture<R>(&self, id: usize) -> Option<&R::TextureId>
     where
         R: Renderer,
-        <R as Renderer>::TextureId: 'static,
+        R::TextureId: 'static,
     {
-        let texture_id = (TypeId::of::<<R as Renderer>::TextureId>(), id);
+        let texture_id = (TypeId::of::<R::TextureId>(), id);
         self.textures.get(&texture_id).and_then(|e| e.downcast_ref())
     }
 
@@ -486,13 +486,13 @@ where
 /// to let smithay handle buffer management.
 #[instrument(level = "trace", skip_all)]
 #[profiling::function]
-pub fn import_surface<R>(renderer: &mut R, states: &SurfaceData) -> Result<(), <R as Renderer>::Error>
+pub fn import_surface<R>(renderer: &mut R, states: &SurfaceData) -> Result<(), R::Error>
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
 {
     if let Some(data) = states.data_map.get::<RendererSurfaceStateUserData>() {
-        let texture_id = (TypeId::of::<<R as Renderer>::TextureId>(), renderer.id());
+        let texture_id = (TypeId::of::<R::TextureId>(), renderer.id());
         let mut data_ref = data.lock().unwrap();
         let data = &mut *data_ref;
 
@@ -537,15 +537,15 @@ where
 /// to let smithay handle buffer management.
 #[instrument(level = "trace", skip_all)]
 #[profiling::function]
-pub fn import_surface_tree<R>(renderer: &mut R, surface: &WlSurface) -> Result<(), <R as Renderer>::Error>
+pub fn import_surface_tree<R>(renderer: &mut R, surface: &WlSurface) -> Result<(), R::Error>
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
 {
     let scale = 1.0;
     let location: Point<f64, Physical> = (0.0, 0.0).into();
 
-    let texture_id = (TypeId::of::<<R as Renderer>::TextureId>(), renderer.id());
+    let texture_id = (TypeId::of::<R::TextureId>(), renderer.id());
     let mut result = Ok(());
     with_surface_tree_downward(
         surface,
@@ -592,15 +592,15 @@ where
 /// to let smithay handle buffer management.
 #[instrument(level = "trace", skip(frame, scale, elements))]
 #[profiling::function]
-pub fn draw_render_elements<'a, R, S, E>(
-    frame: &mut <R as Renderer>::Frame<'a>,
+pub fn draw_render_elements<R, S, E>(
+    frame: &mut R::Frame<'_, '_>,
     scale: S,
     elements: &[E],
     damage: &[Rectangle<i32, Physical>],
-) -> Result<Option<Vec<Rectangle<i32, Physical>>>, <R as Renderer>::Error>
+) -> Result<Option<Vec<Rectangle<i32, Physical>>>, R::Error>
 where
     R: Renderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     S: Into<Scale<f64>>,
     E: RenderElement<R>,
 {

--- a/src/desktop/space/element/mod.rs
+++ b/src/desktop/space/element/mod.rs
@@ -169,7 +169,7 @@ impl<
         E: AsRenderElements<R>,
     > AsRenderElements<R> for SpaceElements<'a, E>
 where
-    <R as Renderer>::TextureId: Clone + Texture + 'static,
+    R::TextureId: Clone + Texture + 'static,
     <E as AsRenderElements<R>>::RenderElement: 'a,
     SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>:
         From<Wrap<<E as AsRenderElements<R>>::RenderElement>>,

--- a/src/desktop/space/element/wayland.rs
+++ b/src/desktop/space/element/wayland.rs
@@ -32,7 +32,7 @@ impl IsAlive for SurfaceTree {
 impl<R> AsRenderElements<R> for SurfaceTree
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: Clone + 'static,
+    R::TextureId: Clone + 'static,
 {
     type RenderElement = WaylandSurfaceRenderElement<R>;
 

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -386,7 +386,7 @@ impl<E: SpaceElement + PartialEq> Space<E> {
         alpha: f32,
     ) -> Vec<<E as AsRenderElements<R>>::RenderElement>
     where
-        <R as Renderer>::TextureId: Texture + 'static,
+        R::TextureId: Texture + 'static,
         E: AsRenderElements<R>,
         <E as AsRenderElements<R>>::RenderElement: 'a,
     {
@@ -426,7 +426,7 @@ impl<E: SpaceElement + PartialEq> Space<E> {
         alpha: f32,
     ) -> Result<Vec<SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>>, OutputError>
     where
-        <R as Renderer>::TextureId: Clone + Texture + 'static,
+        R::TextureId: Clone + Texture + 'static,
         E: AsRenderElements<R>,
         <E as AsRenderElements<R>>::RenderElement: 'a,
         SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>:
@@ -588,7 +588,7 @@ pub fn space_render_elements<
     alpha: f32,
 ) -> Result<Vec<SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>>, OutputNoMode>
 where
-    <R as Renderer>::TextureId: Clone + Texture + 'static,
+    R::TextureId: Clone + Texture + 'static,
     <E as AsRenderElements<R>>::RenderElement: 'a,
     SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>:
         From<Wrap<<E as AsRenderElements<R>>::RenderElement>>,
@@ -675,6 +675,7 @@ pub fn render_output<
 >(
     output: &Output,
     renderer: &mut R,
+    framebuffer: &mut R::Framebuffer<'_>,
     alpha: f32,
     age: usize,
     spaces: S,
@@ -683,7 +684,7 @@ pub fn render_output<
     clear_color: impl Into<Color32F>,
 ) -> Result<RenderOutputResult<'d>, OutputDamageTrackerError<R::Error>>
 where
-    <R as Renderer>::TextureId: Clone + Texture + 'static,
+    R::TextureId: Clone + Texture + 'static,
     <E as AsRenderElements<R>>::RenderElement: 'a,
     SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>:
         From<Wrap<<E as AsRenderElements<R>>::RenderElement>>,
@@ -700,5 +701,5 @@ where
     render_elements.extend(custom_elements.iter().map(OutputRenderElements::Custom));
     render_elements.extend(space_render_elements.into_iter().map(OutputRenderElements::Space));
 
-    damage_tracker.render_output(renderer, age, &render_elements, clear_color)
+    damage_tracker.render_output(renderer, framebuffer, age, &render_elements, clear_color)
 }

--- a/src/desktop/space/wayland/layer.rs
+++ b/src/desktop/space/wayland/layer.rs
@@ -13,7 +13,7 @@ use crate::{
 impl<R> AsRenderElements<R> for LayerSurface
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: Clone + 'static,
+    R::TextureId: Clone + 'static,
 {
     type RenderElement = WaylandSurfaceRenderElement<R>;
 

--- a/src/desktop/space/wayland/window.rs
+++ b/src/desktop/space/wayland/window.rs
@@ -87,7 +87,7 @@ impl SpaceElement for Window {
 impl<R> AsRenderElements<R> for Window
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: Clone + 'static,
+    R::TextureId: Clone + 'static,
 {
     type RenderElement = WaylandSurfaceRenderElement<R>;
 

--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -97,7 +97,7 @@ impl SpaceElement for X11Surface {
 impl<R> crate::backend::renderer::element::AsRenderElements<R> for X11Surface
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: Clone + 'static,
+    R::TextureId: Clone + 'static,
 {
     type RenderElement = WaylandSurfaceRenderElement<R>;
 

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -7,7 +7,11 @@ use std::{
 use smithay::{
     backend::{
         input::ButtonState,
-        renderer::{damage::OutputDamageTracker, element::AsRenderElements, test::DummyRenderer},
+        renderer::{
+            damage::OutputDamageTracker,
+            element::AsRenderElements,
+            test::{DummyFramebuffer, DummyRenderer},
+        },
     },
     input::pointer::{
         ButtonEvent, CursorImageAttributes, CursorImageStatus, MotionEvent, RelativeMotionEvent,
@@ -62,7 +66,8 @@ pub fn run(channel: Channel<WlcsEvent>) {
         })
         .unwrap();
 
-    let mut renderer = DummyRenderer::new();
+    let mut renderer = DummyRenderer;
+    let mut framebuffer = DummyFramebuffer;
 
     let mode = Mode {
         size: (800, 600).into(),
@@ -150,6 +155,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
                 &state.space,
                 elements,
                 &mut renderer,
+                &mut framebuffer,
                 &mut damage_tracker,
                 0,
                 false,


### PR DESCRIPTION
Superseeds https://github.com/Smithay/smithay/pull/1616.

Original description:
> Attempt to solve https://github.com/Smithay/smithay/issues/1615.
>
> This solution isn't perfect, most notably it doesn't synchronize across the access of `Bind<GlesTexture>`. To do that we would need to be able to store the lock, which means moving the `GlesTarget` into the `GlesFrame` and making `Bind` return a `Frame`. I think we talked about this, so we should fix this at some point, but I didn't want to do that refactor now.
>
> Fixing `Bind` would automatically solve this for exporting and other things as well, as all of these rely to binding a framebuffer container object to our texture.
>
> (Also binding a texture to write to it and sampling from it in a separate thread is probably a operation not as common.)

I lied, I did the refactor. The changes to `Renderer` and `Bind` are fairly small, however the fallout was huge, but since none of this compiles without all the other changes, I wasn't sure how to split this apart further. Please excuse the giant PR/commit everybody.