### PR TITLE
compositor: Fix cursor redraw on scale change

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -508,6 +508,7 @@ struct PlaneElementState {
     id: Id,
     commit: CommitCounter,
     z_index: usize,
+    cursor_size: Option<Size<i32, Physical>>,
 }
 
 #[derive(Debug)]
@@ -3133,7 +3134,9 @@ where
                 .unwrap_or(true)
             || previous_element_state
                 .map(|element_state| {
-                    element_state.id != *element.id() || element.current_commit() != element_state.commit
+                    element_state.id != *element.id()
+                        || element.current_commit() != element_state.commit
+                        || element_state.cursor_size != Some(element_size)
                 })
                 .unwrap_or(true)
             || previous_state
@@ -3394,6 +3397,7 @@ where
                 id: element.id().clone(),
                 commit: element.current_commit(),
                 z_index: element_zindex,
+                cursor_size: Some(element_size),
             }),
             config: Some(config),
         };
@@ -4003,6 +4007,7 @@ where
                 id: element_id.clone(),
                 commit: element.current_commit(),
                 z_index: element_config.z_index,
+                cursor_size: None,
             }),
             config: Some(config),
         };


### PR DESCRIPTION
So because we are allocating a new buffer for cursor planes, the `config.dst` of the previous plane state might not actually represent the size of the cursor element, but simply the size of the cursor-plane (or the nearest size hint).

That might stay the same, if the cursor is simply rescaled, resulting in our tests failing to detect, that we need to redraw. This in particular happens with `MemoryRenderElements` + `RescaleRenderElements`, where neither the `Id` nor the `commit_counter` changes. So we have to remember the element size.

(Or we make `src`/`dst` actually use the cursor size, without re-allocating the buffer of course, but I am not sure, if compatibility for that is so great. Generally cursor planes don't seem very capable.)