### PR TITLE
text-input: fix active instance tracking

### DIFF
--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -211,7 +211,7 @@ where
     ) {
         match request {
             zwp_input_method_v2::Request::CommitString { text } => {
-                data.text_input_handle.with_focused_text_input(|ti, _surface| {
+                data.text_input_handle.with_active_text_input(|ti, _surface| {
                     ti.commit_string(Some(text.clone()));
                 });
             }
@@ -220,7 +220,7 @@ where
                 cursor_begin,
                 cursor_end,
             } => {
-                data.text_input_handle.with_focused_text_input(|ti, _surface| {
+                data.text_input_handle.with_active_text_input(|ti, _surface| {
                     ti.preedit_string(Some(text.clone()), cursor_begin, cursor_end);
                 });
             }
@@ -228,7 +228,7 @@ where
                 before_length,
                 after_length,
             } => {
-                data.text_input_handle.with_focused_text_input(|ti, _surface| {
+                data.text_input_handle.with_active_text_input(|ti, _surface| {
                     ti.delete_surrounding_text(before_length, after_length);
                 });
             }
@@ -332,8 +332,6 @@ where
         data: &InputMethodUserData<D>,
     ) {
         data.handle.inner.lock().unwrap().instance = None;
-        data.text_input_handle.with_focused_text_input(|ti, surface| {
-            ti.leave(surface);
-        });
+        data.text_input_handle.leave();
     }
 }

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -54,7 +54,7 @@ where
         let keyboard = inner.grab.as_ref().unwrap();
         inner
             .text_input_handle
-            .focused_text_input_serial_or_default(serial.0, |serial| {
+            .active_text_input_serial_or_default(serial.0, |serial| {
                 keyboard.key(serial, time, keycode.raw() - 8, key_state.into());
                 if let Some(serialized) = modifiers.map(|m| m.serialized) {
                     keyboard.modifiers(


### PR DESCRIPTION
Only one text-input must be enabled at a time, by checking the text-input id when issuing a request and comparing to the active one, however the regular `Enabled` events must be send for all of them, and as for the leave, we also send it for all the events to make it symmetrical with the `enter.

Fixes: 475072d410df (text-input: Ensure only one enabled...)
Fixes #1604.

--

Should be backported to patch release, otherwise text-input doesn't work at all.
