### PR TITLE
anvil: Avoid panicing on cursor themes with a total delay of 0

### DIFF
--- a/anvil/src/cursor.rs
+++ b/anvil/src/cursor.rs
@@ -62,6 +62,9 @@ fn nearest_images(size: u32, images: &[Image]) -> impl Iterator<Item = &Image> {
 
 fn frame(mut millis: u32, size: u32, images: &[Image]) -> Image {
     let total = nearest_images(size, images).fold(0, |acc, image| acc + image.delay);
+    if total == 0 {
+        return nearest_images(size, images).next().unwrap().clone();
+    }
     millis %= total;
 
     for img in nearest_images(size, images) {


### PR DESCRIPTION
This fixes an immediate crash when using [phinger-cursors-dark](https://github.com/phisch/phinger-cursors) as the cursor theme.
I'm not entirely sure if a delays of 0 are valid and if this is how they should be handled (this still skips all such frames, except if it's the first and all frames have a delay of 0), it's undocumented beyond "delay: CARD32 Delay between animation frames in milliseconds" in XCURSOR(3).