### PR TITLE
xwm: Update override-redirect flag on map request

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1422,6 +1422,14 @@ where
                     }
 
                     surface.state.lock().unwrap().mapped_onto = Some(frame_win);
+
+                    // A MapRequest can only happen when an X11 window does not have the
+                    // override-redirect flag set. It's possible for a window to be created as
+                    // override-redirect and later set the flag to false before mapping.
+                    // In that case, we set the X11Surface's override-redirect state to false here
+                    // to prevent `set_mapped` and `configure` from failing.
+                    surface.state.lock().unwrap().override_redirect = false;
+
                     drop(_guard);
                     state.map_window_request(xwm_id, surface);
                 }


### PR DESCRIPTION
This PR sets the `override_redirect` field on `X11Surface` to false inside of `Event::MapRequest`. According to [these here docs](https://x.org/releases/X11R7.7/doc/man/man3/XMapWindow.3.xhtml), `MapRequest` only happens when override-redirect is false. However, if an X11 window was created with override_redirect set to true then later set it false before mapping, we reached `MapRequest` with an `X11Surface` whose `override_redirect` was still true, never updating it. This led to weird side-effects like configures and maps failing.

As it turns out, if you update the flag to false then windows actually start showing up! After testing with cosmic-comp, this should fix pop-os/cosmic-comp#1089 and pop-os/cosmic-comp#979. Haven't tested with the following but it may also fix pop-os/cosmic-comp#850 and a few games from pop-os/cosmic-epoch#311. And maybe a few other similar issues that I haven't looked hard enough for.

NB: wlroots updates the flag in `map_window_notify` and `configure_notify`, but due to the way we're reparenting everything to a new window, we
1. Need the update directly in `MapRequest` to get `set_mapped` to work, and
2. I don't know if allowing `override_redirect` to change within `configure_notify` will mess anything up with `mapped_onto` and whatnot,

so I decided on a simple "set it to false only on map".