### PR TITLE
utils: Fix `HookId` recycle logic

### DIFF
--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -211,7 +211,7 @@ impl PrivateSurfaceData {
         hook: impl Fn(&mut dyn Any, &DisplayHandle, &WlSurface) + Send + Sync + 'static,
     ) -> HookId {
         let hook: Hook<CommitHook> = Hook::new(Arc::new(hook));
-        let id = hook.id;
+        let id = hook.id.clone();
         Self::lock_user_data(surface).pre_commit_hooks.push(hook);
         id
     }
@@ -221,7 +221,7 @@ impl PrivateSurfaceData {
         hook: impl Fn(&mut dyn Any, &DisplayHandle, &WlSurface) + Send + Sync + 'static,
     ) -> HookId {
         let hook: Hook<CommitHook> = Hook::new(Arc::new(hook));
-        let id = hook.id;
+        let id = hook.id.clone();
         Self::lock_user_data(surface).post_commit_hooks.push(hook);
         id
     }
@@ -231,7 +231,7 @@ impl PrivateSurfaceData {
         hook: impl Fn(&mut dyn Any, &WlSurface) + Send + Sync + 'static,
     ) -> HookId {
         let hook: Hook<DestructionHook> = Hook::new(Arc::new(hook));
-        let id = hook.id;
+        let id = hook.id.clone();
         Self::lock_user_data(surface).destruction_hooks.push(hook);
         id
     }

--- a/src/wayland/drm_syncobj/mod.rs
+++ b/src/wayland/drm_syncobj/mod.rs
@@ -333,8 +333,8 @@ where
         match request {
             wp_linux_drm_syncobj_surface_v1::Request::Destroy => {
                 if let Ok(surface) = data.surface.upgrade() {
-                    compositor::remove_pre_commit_hook(&surface, data.commit_hook_id);
-                    compositor::remove_destruction_hook(&surface, data.destruction_hook_id);
+                    compositor::remove_pre_commit_hook(&surface, data.commit_hook_id.clone());
+                    compositor::remove_destruction_hook(&surface, data.destruction_hook_id.clone());
                     with_states(&surface, |states| {
                         *states
                             .data_map

--- a/src/wayland/shm/mod.rs
+++ b/src/wayland/shm/mod.rs
@@ -486,7 +486,7 @@ impl ShmBufferUserData {
         hook: impl Fn(&mut dyn Any, &wl_buffer::WlBuffer) + Send + Sync + 'static,
     ) -> HookId {
         let hook: Hook<DestructionHook> = Hook::new(Arc::new(hook));
-        let id = hook.id;
+        let id = hook.id.clone();
         self.destruction_hooks.lock().unwrap().push(hook);
         id
     }


### PR DESCRIPTION
Currently, the `usize` ID is recycled in `Hook`’s destructor. However, since `Hook` also implements `Clone`, the `usize` ID might be recycled more than once. And `HookId` might still be used even after the `usize` ID has already been recycled.

This PR moves the ID recycling to `HookId`’s destructor. The trade-off is that `HookId` can't be `Copy`.

Actually, I’m not sure if we even need a recyclable ID implementation, it just adds extra complexity. If we’re using a `u64` for the ID, running out of values shouldn’t really be a concern.