### PR TITLE
xdg_activation: Allow passing all data in `XdgActivationState::create_external_token`

### DIFF
--- a/src/wayland/xdg_activation/mod.rs
+++ b/src/wayland/xdg_activation/mod.rs
@@ -153,6 +153,19 @@ impl XdgActivationTokenData {
     }
 }
 
+impl Default for XdgActivationTokenData {
+    fn default() -> Self {
+        Self {
+            client_id: None,
+            serial: None,
+            app_id: None,
+            surface: None,
+            timestamp: Instant::now(),
+            user_data: Arc::new(UserDataMap::new()),
+        }
+    }
+}
+
 /// Tracks the list of pending and current activation requests
 #[derive(Debug)]
 pub struct XdgActivationState {
@@ -185,9 +198,10 @@ impl XdgActivationState {
     /// instead use the return arguments to handle any initialization of the data you might need and to copy the token.
     pub fn create_external_token(
         &mut self,
-        app_id: impl Into<Option<String>>,
+        data: impl Into<Option<XdgActivationTokenData>>,
     ) -> (&XdgActivationToken, &XdgActivationTokenData) {
-        let (token, data) = XdgActivationTokenData::new(None, None, app_id.into(), None);
+        let token = XdgActivationToken::new();
+        let data = data.into().unwrap_or_default();
         self.known_tokens.insert(token.clone(), data);
         self.known_tokens.get_key_value(&token).unwrap()
     }


### PR DESCRIPTION
I'm not sure about the api style, alternatively this could return a `&mut XdgActivationTokenData` instead and drop the argument. This is breaking, but not for the common case of `activation_state.create_external_token(None)`.

Example usage in niri ipc (not upstreamed), creating an activation token as if it was created by the focused/requested window:
```rs
        Request::DebugCreateActivationToken { id } => {
            let (tx, rx) = async_channel::bounded(1);

            ctx.event_loop.insert_idle(move |state| {
                let window = id
                    .and_then(|id| {
                        state
                            .niri
                            .layout
                            .windows()
                            .find(|(_, m)| m.id().get() == id)
                            .map(|(_, w)| w)
                    })
                    .or_else(|| state.niri.layout.focus());
                let toplevel = window.map(|window| window.toplevel());
                let app_id = toplevel
                    .and_then(|toplevel| with_toplevel_role(toplevel, |role| role.app_id.clone()));
                let surface = toplevel.map(|toplevel| toplevel.wl_surface().clone());
                let (token, data) =
                    state
                        .niri
                        .activation_state
                        .create_external_token(XdgActivationTokenData {
                            app_id,
                            surface,
                            ..Default::default()
                        });
                let _ = tx.send_blocking(token.to_string());
            });

            let result = rx.recv().await;
            let token = result.map_err(|_| String::from("error creating activation token"))?;
            Response::DebugCreateActivationToken(token)
        }

```