### PR TITLE
Fix leaks of `SeatRc` and `KbdRc`, but using `Weak` in user data

### DIFF
--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::Weak};
 
 use tracing::{error, instrument, trace, warn};
 use wayland_server::{
@@ -14,7 +14,7 @@ use super::WaylandFocus;
 use crate::{
     backend::input::{KeyState, Keycode},
     input::{
-        keyboard::{KeyboardHandle, KeyboardTarget, KeysymHandle, ModifiersState},
+        keyboard::{KbdRc, KeyboardHandle, KeyboardTarget, KeysymHandle, ModifiersState},
         Seat, SeatHandler, SeatState,
     },
     utils::Serial,
@@ -88,13 +88,15 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     /// May return `None` for a valid `WlKeyboard` that was created without
     /// the keyboard capability.
     pub fn from_resource(seat: &WlKeyboard) -> Option<Self> {
-        seat.data::<KeyboardUserData<D>>()?.handle.clone()
+        Some(Self {
+            arc: seat.data::<KeyboardUserData<D>>()?.handle.as_ref()?.upgrade()?,
+        })
     }
 }
 
 /// User data for keyboard
 pub struct KeyboardUserData<D: SeatHandler> {
-    pub(crate) handle: Option<KeyboardHandle<D>>,
+    pub(crate) handle: Option<Weak<KbdRc<D>>>,
 }
 
 impl<D: SeatHandler> fmt::Debug for KeyboardUserData<D> {
@@ -122,13 +124,8 @@ where
     }
 
     fn destroyed(_state: &mut D, _client_id: ClientId, keyboard: &WlKeyboard, data: &KeyboardUserData<D>) {
-        if let Some(ref handle) = data.handle {
-            handle
-                .arc
-                .known_kbds
-                .lock()
-                .unwrap()
-                .retain(|k| k.id() != keyboard.id())
+        if let Some(ref arc) = data.handle.as_ref().and_then(|h| h.upgrade()) {
+            arc.known_kbds.lock().unwrap().retain(|k| k.id() != keyboard.id())
         }
     }
 }


### PR DESCRIPTION
This fixes https://github.com/Smithay/smithay/issues/1422.

This can be tested by adding `Drop` impls that print to those two types, or using tools that detect leaks.

It's probably worth examining more to see why this created a cycle or otherwise didn't get freed, but if we don't anticipate issues, maybe it's best to use `Weak` in every possible place. I also need to look into some other reported leaks.