### PR TITLE
Fixup docs-rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["gui"]
 rust-version = "1.80.1"
 
 [package.metadata.docs.rs]
-features = ["test_all_features"]
+features = ["test_all_features", "libseat/docs_rs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]
@@ -42,7 +42,7 @@ glow = { version = "0.16", optional = true }
 input = { version = "0.9.0", default-features = false, features=["libinput_1_19"], optional = true }
 indexmap = "2.0"
 libc = "0.2.103"
-libseat = { version = "0.2.1", optional = true, default-features = false }
+libseat = { version = "0.2.3", optional = true, default-features = false }
 libloading = { version="0.8.0", optional = true }
 rustix = { version = "0.38.18", features = ["event", "fs", "mm", "net", "shm", "time"] }
 rand = "0.8.4"


### PR DESCRIPTION
Just disables linking of libseat in docs-rs environment