### PR TITLE
gles/texture: Add is_unique_reference()

### DIFF
--- a/src/backend/renderer/gles/texture.rs
+++ b/src/backend/renderer/gles/texture.rs
@@ -48,6 +48,15 @@ impl GlesTexture {
     pub fn is_y_inverted(&self) -> bool {
         self.0.y_inverted
     }
+
+    /// Whether this is the only reference to this texture (strong or weak)
+    ///
+    /// Note that this tracks only references to this Smithay object (that you can get by cloning
+    /// it). If you make a reference via OpenGL directly somehow, you need to keep track of it on
+    /// your own.
+    pub fn is_unique_reference(&mut self) -> bool {
+        Arc::get_mut(&mut self.0).is_some()
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Intended for usecases like `TextureRenderBuffer` where the texture contents can change. If someone else references the same texture (for example, someone stored the texture render element for later use), the texture contents would change under the hood for them. This method lets the compositor check that nobody else has a reference to the same texture, making it safe to change its contents.

This doesn't (cannot) track extra graphics API references to the same texture object, but those are harder to make and less common; the compositor can figure out the uniqueness on its own then.

Questions for review:
1. Do I understand correctly that the TTY/winit backends don't keep other references to the textures? E.g. they don't create raw OpenGL references that go around this `Arc`.
2. Does the same function make sense for `MultiTexture` and/or `PixmanTexture`? I wasn't sure because those involve multiple texture objects across different graphics APIs.