### PR TITLE
renderer: Require `Texture` for framebuffer types

### DIFF
--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -268,7 +268,7 @@ pub trait RendererSuper: fmt::Debug {
     /// Texture Handle type used by this renderer.
     type TextureId: Texture;
     /// Framebuffer to draw onto
-    type Framebuffer<'buffer>;
+    type Framebuffer<'buffer>: Texture;
     /// Type representing a currently in-progress frame during the [`Renderer::render`]-call
     type Frame<'frame, 'buffer>: Frame<Error = Self::Error, TextureId = Self::TextureId>
     where

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -775,6 +775,36 @@ where
     }
 }
 
+impl<R: GraphicsApi, T: GraphicsApi> Texture for MultiFramebuffer<'_, R, T> {
+    fn size(&self) -> Size<i32, BufferCoords> {
+        match &self.0 {
+            MultiFramebufferInternal::Render(framebuffer) => framebuffer.size(),
+            MultiFramebufferInternal::Target(framebuffer) => framebuffer.size(),
+        }
+    }
+
+    fn width(&self) -> u32 {
+        match &self.0 {
+            MultiFramebufferInternal::Render(framebuffer) => framebuffer.width(),
+            MultiFramebufferInternal::Target(framebuffer) => framebuffer.width(),
+        }
+    }
+
+    fn height(&self) -> u32 {
+        match &self.0 {
+            MultiFramebufferInternal::Render(framebuffer) => framebuffer.height(),
+            MultiFramebufferInternal::Target(framebuffer) => framebuffer.height(),
+        }
+    }
+
+    fn format(&self) -> Option<Fourcc> {
+        match &self.0 {
+            MultiFramebufferInternal::Render(framebuffer) => framebuffer.format(),
+            MultiFramebufferInternal::Target(framebuffer) => framebuffer.format(),
+        }
+    }
+}
+
 /// [`Frame`] implementation of a [`MultiRenderer`].
 ///
 /// Leaking the frame will potentially keep it from doing necessary copies

--- a/src/backend/renderer/test.rs
+++ b/src/backend/renderer/test.rs
@@ -209,6 +209,20 @@ impl ImportDmaWl for DummyRenderer {}
 #[derive(Debug)]
 pub struct DummyFramebuffer;
 
+impl Texture for DummyFramebuffer {
+    fn width(&self) -> u32 {
+        0
+    }
+
+    fn height(&self) -> u32 {
+        0
+    }
+
+    fn format(&self) -> Option<Fourcc> {
+        None
+    }
+}
+
 #[derive(Debug)]
 pub struct DummyFrame {}
 


### PR DESCRIPTION
I think it is pretty reasonable to be able to query the format and size of a bound framebuffer.

This is particularly useful in code that might now get passed in an opaque framebuffer handle, but needs to know the format/size to allocate an offscreen texture for post-processing. Sending this data out of band seems entirely unnecessary.

Bike-shedding: Should we rename the `Texture` trait at this point?