### PR TITLE
Protocol error instead of panic if `place_above`/`_below` has no parent

### DIFF
--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -395,7 +395,7 @@ impl PrivateSurfaceData {
 
     /// Retrieve the parent surface (if any) of this surface
     pub fn get_parent(child: &WlSurface) -> Option<WlSurface> {
-        Self::lock_user_data(child).parent.as_ref().cloned()
+        Self::lock_user_data(child).parent.clone()
     }
 
     /// Retrieve the children surface (if any) of this surface
@@ -412,7 +412,7 @@ impl PrivateSurfaceData {
     ///
     /// Fails if `relative_to` is not a sibling or parent of `surface`.
     pub fn reorder(surface: &WlSurface, to: Location, relative_to: &WlSurface) -> Result<(), ()> {
-        let parent = Self::lock_user_data(surface).parent.as_ref().cloned().unwrap();
+        let parent = Self::get_parent(surface).ok_or(())?;
 
         fn index_of(surface: &WlSurface, slice: &[WlSurface]) -> Option<usize> {
             for (i, s) in slice.iter().enumerate() {


### PR DESCRIPTION
Fixes https://github.com/Smithay/smithay/issues/1693, though there may be other issues around double-buffering state, or producing protocol errors if the surface is destroy before the corresponding subsurface.

This matches Gnome. Sway doesn't seem to produce any error. So maybe wayland should clarify the correct behavior here, but a protocol error seems most reasonable.

In any case, certainly better than crashing the compositor, and it's easier to test the client when it isn't crashing the compositor.