### PR TITLE
Omit type conversion in `AsRenderElements::render_elements()` #1626

### DIFF
--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -71,16 +71,13 @@ where
     R: Renderer<TextureId = T> + ImportAll + ImportMem,
 {
     type RenderElement = PointerRenderElement<R>;
-    fn render_elements<E>(
+    fn render_elements(
         &self,
         renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         alpha: f32,
-    ) -> Vec<E>
-    where
-        E: From<PointerRenderElement<R>>,
-    {
+    ) -> Vec<Self::RenderElement> {
         match &self.status {
             CursorImageStatus::Hidden => vec![],
             // Always render `Default` for a named shape.
@@ -104,16 +101,17 @@ where
                 }
             }
             CursorImageStatus::Surface(surface) => {
-                let elements: Vec<PointerRenderElement<R>> =
-                    smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
-                        renderer,
-                        surface,
-                        location,
-                        scale,
-                        alpha,
-                        Kind::Cursor,
-                    );
-                elements.into_iter().map(E::from).collect()
+                smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
+                    renderer,
+                    surface,
+                    location,
+                    scale,
+                    alpha,
+                    Kind::Cursor,
+                )
+                .into_iter()
+                .map(PointerRenderElement::Surface)
+                .collect()
             }
         }
     }

--- a/anvil/src/render.rs
+++ b/anvil/src/render.rs
@@ -72,15 +72,15 @@ impl<R: Renderer + ImportAll + ImportMem, E: RenderElement<R> + std::fmt::Debug>
     }
 }
 
-pub fn space_preview_elements<'a, R, C>(
+pub fn space_preview_elements<'a, R>(
     renderer: &'a mut R,
     space: &'a Space<WindowElement>,
     output: &'a Output,
-) -> impl Iterator<Item = C> + 'a
+) -> impl Iterator<Item = CropRenderElement<RelocateRenderElement<RescaleRenderElement<WindowRenderElement<R>>>>>
+       + 'a
 where
     R: Renderer + ImportAll + ImportMem,
     R::TextureId: Clone + 'static,
-    C: From<CropRenderElement<RelocateRenderElement<RescaleRenderElement<WindowRenderElement<R>>>>> + 'a,
 {
     let constrain_behavior = ConstrainBehavior {
         reference: ConstrainReference::BoundingBox,
@@ -173,7 +173,11 @@ where
             .collect::<Vec<_>>();
 
         if show_window_preview && space.elements_for_output(output).count() > 0 {
-            output_render_elements.extend(space_preview_elements(renderer, space, output));
+            output_render_elements.extend(
+                space_preview_elements(renderer, space, output)
+                    .into_iter()
+                    .map(OutputRenderElements::Preview),
+            );
         }
 
         let space_elements = smithay::desktop::space::space_render_elements::<_, WindowElement, _>(

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -420,13 +420,13 @@ where
 {
     type RenderElement = WindowRenderElement<R>;
 
-    fn render_elements<C: From<Self::RenderElement>>(
+    fn render_elements(
         &self,
         renderer: &mut R,
         mut location: Point<i32, Physical>,
         scale: Scale<f64>,
         alpha: f32,
-    ) -> Vec<C> {
+    ) -> Vec<Self::RenderElement> {
         let window_bbox = SpaceElement::bbox(&self.0);
 
         if self.decoration_state().is_ssd && !window_bbox.is_empty() {
@@ -435,24 +435,24 @@ where
             let mut state = self.decoration_state();
             let width = window_geo.size.w;
             state.header_bar.redraw(width as u32);
-            let mut vec = AsRenderElements::<R>::render_elements::<WindowRenderElement<R>>(
-                &state.header_bar,
-                renderer,
-                location,
-                scale,
-                alpha,
-            );
+            let mut vec: Vec<WindowRenderElement<R>> =
+                AsRenderElements::<R>::render_elements(&state.header_bar, renderer, location, scale, alpha)
+                    .into_iter()
+                    .map(WindowRenderElement::Decoration)
+                    .collect();
 
             location.y += (scale.y * HEADER_BAR_HEIGHT as f64) as i32;
 
             let window_elements =
-                AsRenderElements::render_elements(&self.0, renderer, location, scale, alpha);
+                AsRenderElements::render_elements(&self.0, renderer, location, scale, alpha)
+                    .into_iter()
+                    .map(WindowRenderElement::Window);
             vec.extend(window_elements);
-            vec.into_iter().map(C::from).collect()
+            vec
         } else {
             AsRenderElements::render_elements(&self.0, renderer, location, scale, alpha)
                 .into_iter()
-                .map(C::from)
+                .map(WindowRenderElement::Window)
                 .collect()
         }
     }

--- a/anvil/src/shell/ssd.rs
+++ b/anvil/src/shell/ssd.rs
@@ -233,13 +233,13 @@ impl HeaderBar {
 impl<R: Renderer> AsRenderElements<R> for HeaderBar {
     type RenderElement = SolidColorRenderElement;
 
-    fn render_elements<C: From<Self::RenderElement>>(
+    fn render_elements(
         &self,
         _renderer: &mut R,
         location: Point<i32, smithay::utils::Physical>,
         scale: smithay::utils::Scale<f64>,
         alpha: f32,
-    ) -> Vec<C> {
+    ) -> Vec<Self::RenderElement> {
         let header_end_offset: Point<i32, Logical> = Point::from((self.width as i32, 0));
         let button_offset: Point<i32, Logical> = Point::from((BUTTON_WIDTH as i32, 0));
 

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -1468,14 +1468,17 @@ fn render_surface<'a>(
         }
 
         custom_elements.extend(
-            pointer_element.render_elements(
-                renderer,
-                (cursor_pos - cursor_hotspot.to_f64())
-                    .to_physical(scale)
-                    .to_i32_round(),
-                scale,
-                1.0,
-            ),
+            pointer_element
+                .render_elements(
+                    renderer,
+                    (cursor_pos - cursor_hotspot.to_f64())
+                        .to_physical(scale)
+                        .to_i32_round(),
+                    scale,
+                    1.0,
+                )
+                .into_iter()
+                .map(CustomRenderElements::Pointer),
         );
 
         // draw the dnd icon if applicable
@@ -1485,13 +1488,17 @@ fn render_surface<'a>(
                     .to_physical(scale)
                     .to_i32_round();
                 if icon.surface.alive() {
-                    custom_elements.extend(AsRenderElements::<UdevRenderer<'a>>::render_elements(
-                        &SurfaceTree::from_surface(&icon.surface),
-                        renderer,
-                        dnd_icon_pos,
-                        scale,
-                        1.0,
-                    ));
+                    custom_elements.extend(
+                        AsRenderElements::<UdevRenderer<'a>>::render_elements(
+                            &SurfaceTree::from_surface(&icon.surface),
+                            renderer,
+                            dnd_icon_pos,
+                            scale,
+                            1.0,
+                        )
+                        .into_iter()
+                        .map(CustomRenderElements::Surface),
+                    );
                 }
             }
         }

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -318,14 +318,17 @@ pub fn run_winit() {
                 let mut elements = Vec::<CustomRenderElements<GlesRenderer>>::new();
 
                 elements.extend(
-                    pointer_element.render_elements(
-                        renderer,
-                        (cursor_pos - cursor_hotspot.to_f64())
-                            .to_physical(scale)
-                            .to_i32_round(),
-                        scale,
-                        1.0,
-                    ),
+                    pointer_element
+                        .render_elements(
+                            renderer,
+                            (cursor_pos - cursor_hotspot.to_f64())
+                                .to_physical(scale)
+                                .to_i32_round(),
+                            scale,
+                            1.0,
+                        )
+                        .into_iter()
+                        .map(CustomRenderElements::Pointer),
                 );
 
                 // draw the dnd icon if any
@@ -334,13 +337,17 @@ pub fn run_winit() {
                         .to_physical(scale)
                         .to_i32_round();
                     if icon.surface.alive() {
-                        elements.extend(AsRenderElements::<GlesRenderer>::render_elements(
-                            &smithay::desktop::space::SurfaceTree::from_surface(&icon.surface),
-                            renderer,
-                            dnd_icon_pos,
-                            scale,
-                            1.0,
-                        ));
+                        elements.extend(
+                            AsRenderElements::<GlesRenderer>::render_elements(
+                                &smithay::desktop::space::SurfaceTree::from_surface(&icon.surface),
+                                renderer,
+                                dnd_icon_pos,
+                                scale,
+                                1.0,
+                            )
+                            .into_iter()
+                            .map(CustomRenderElements::Surface),
+                        );
                     }
                 }
 

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -363,14 +363,17 @@ pub fn run_x11() {
 
             pointer_element.set_status(state.cursor_status.clone());
             elements.extend(
-                pointer_element.render_elements(
-                    &mut backend_data.renderer,
-                    (cursor_pos - cursor_hotspot.to_f64())
-                        .to_physical(scale)
-                        .to_i32_round(),
-                    scale,
-                    1.0,
-                ),
+                pointer_element
+                    .render_elements(
+                        &mut backend_data.renderer,
+                        (cursor_pos - cursor_hotspot.to_f64())
+                            .to_physical(scale)
+                            .to_i32_round(),
+                        scale,
+                        1.0,
+                    )
+                    .into_iter()
+                    .map(CustomRenderElements::Pointer),
             );
 
             // draw the dnd icon if any
@@ -379,13 +382,17 @@ pub fn run_x11() {
                     .to_physical(scale)
                     .to_i32_round();
                 if icon.surface.alive() {
-                    elements.extend(AsRenderElements::<GlesRenderer>::render_elements(
-                        &smithay::desktop::space::SurfaceTree::from_surface(&icon.surface),
-                        &mut backend_data.renderer,
-                        dnd_icon_pos,
-                        scale,
-                        1.0,
-                    ));
+                    elements.extend(
+                        AsRenderElements::<GlesRenderer>::render_elements(
+                            &smithay::desktop::space::SurfaceTree::from_surface(&icon.surface),
+                            &mut backend_data.renderer,
+                            dnd_icon_pos,
+                            scale,
+                            1.0,
+                        )
+                        .into_iter()
+                        .map(CustomRenderElements::Surface),
+                    );
                 }
             }
 

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -408,13 +408,13 @@ where
     /// Type of the render element
     type RenderElement: RenderElement<R>;
     /// Returns render elements for a given position and scale
-    fn render_elements<C: From<Self::RenderElement>>(
+    fn render_elements(
         &self,
         renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         alpha: f32,
-    ) -> Vec<C>;
+    ) -> Vec<Self::RenderElement>;
 }
 
 impl<E> Element for &E

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -242,13 +242,19 @@ where
 {
     type RenderElement = SolidColorRenderElement;
 
-    fn render_elements<C: From<Self::RenderElement>>(
+    fn render_elements(
         &self,
         _renderer: &mut R,
-        location: crate::utils::Point<i32, crate::utils::Physical>,
-        scale: crate::utils::Scale<f64>,
+        location: Point<i32, Physical>,
+        scale: Scale<f64>,
         alpha: f32,
-    ) -> Vec<C> {
-        vec![SolidColorRenderElement::from_buffer(self, location, scale, alpha, Kind::Unspecified).into()]
+    ) -> Vec<Self::RenderElement> {
+        vec![SolidColorRenderElement::from_buffer(
+            self,
+            location,
+            scale,
+            alpha,
+            Kind::Unspecified,
+        )]
     }
 }

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -87,22 +87,21 @@ use super::{CommitCounter, Element, Id, Kind, RenderElement, UnderlyingStorage};
 /// Retrieve the [`WaylandSurfaceRenderElement`]s for a surface tree
 #[instrument(level = "trace", skip(renderer, location, scale))]
 #[profiling::function]
-pub fn render_elements_from_surface_tree<R, E>(
+pub fn render_elements_from_surface_tree<R>(
     renderer: &mut R,
     surface: &wl_surface::WlSurface,
     location: impl Into<Point<i32, Physical>>,
     scale: impl Into<Scale<f64>>,
     alpha: f32,
     kind: Kind,
-) -> Vec<E>
+) -> Vec<WaylandSurfaceRenderElement<R>>
 where
     R: Renderer + ImportAll,
     R::TextureId: Clone + 'static,
-    E: From<WaylandSurfaceRenderElement<R>>,
 {
     let location = location.into().to_f64();
     let scale = scale.into();
-    let mut surfaces: Vec<E> = Vec::new();
+    let mut surfaces = Vec::new();
 
     compositor::with_surface_tree_downward(
         surface,
@@ -138,7 +137,7 @@ where
                     match WaylandSurfaceRenderElement::from_surface(
                         renderer, surface, states, location, alpha, kind,
                     ) {
-                        Ok(Some(surface)) => surfaces.push(surface.into()),
+                        Ok(Some(surface)) => surfaces.push(surface),
                         Ok(None) => {} // surface is not mapped
                         Err(err) => {
                             warn!("Failed to import surface: {}", err);

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -451,7 +451,7 @@ bitflags::bitflags! {
 /// See [`constrain_render_elements`] for more information
 #[profiling::function]
 #[allow(clippy::too_many_arguments)]
-pub fn constrain_as_render_elements<R, E, C>(
+pub fn constrain_as_render_elements<R, E>(
     element: &E,
     renderer: &mut R,
     location: impl Into<Point<i32, Physical>>,
@@ -461,20 +461,18 @@ pub fn constrain_as_render_elements<R, E, C>(
     behavior: ConstrainScaleBehavior,
     align: ConstrainAlign,
     output_scale: impl Into<Scale<f64>>,
-) -> impl Iterator<Item = C>
+) -> impl Iterator<
+    Item = CropRenderElement<
+        RelocateRenderElement<RescaleRenderElement<<E as AsRenderElements<R>>::RenderElement>>,
+    >,
+>
 where
     R: Renderer,
     E: AsRenderElements<R>,
-    C: From<
-        CropRenderElement<
-            RelocateRenderElement<RescaleRenderElement<<E as AsRenderElements<R>>::RenderElement>>,
-        >,
-    >,
 {
     let location = location.into();
     let output_scale = output_scale.into();
-    let elements: Vec<<E as AsRenderElements<R>>::RenderElement> =
-        AsRenderElements::<R>::render_elements(element, renderer, location, output_scale, alpha);
+    let elements = element.render_elements(renderer, location, output_scale, alpha);
     constrain_render_elements(
         elements,
         location,
@@ -484,7 +482,6 @@ where
         align,
         output_scale,
     )
-    .map(C::from)
 }
 
 /// Constrain render elements on a specific location with a specific size

--- a/src/desktop/space/element/mod.rs
+++ b/src/desktop/space/element/mod.rs
@@ -1,11 +1,7 @@
 use std::hash::Hash;
 
 #[cfg(feature = "wayland_frontend")]
-use crate::{
-    backend::renderer::{element::surface::WaylandSurfaceRenderElement, ImportAll},
-    desktop::LayerSurface,
-    wayland::shell::wlr_layer::Layer,
-};
+use crate::{backend::renderer::ImportAll, desktop::LayerSurface, wayland::shell::wlr_layer::Layer};
 use crate::{
     backend::renderer::{
         element::{AsRenderElements, Wrap},
@@ -171,36 +167,29 @@ impl<
 where
     R::TextureId: Clone + Texture + 'static,
     <E as AsRenderElements<R>>::RenderElement: 'a,
-    SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>:
-        From<Wrap<<E as AsRenderElements<R>>::RenderElement>>,
 {
     type RenderElement = SpaceRenderElements<R, <E as AsRenderElements<R>>::RenderElement>;
 
     #[profiling::function]
-    fn render_elements<C: From<Self::RenderElement>>(
+    fn render_elements(
         &self,
         renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         alpha: f32,
-    ) -> Vec<C> {
+    ) -> Vec<Self::RenderElement> {
         match &self {
             #[cfg(feature = "wayland_frontend")]
-            SpaceElements::Layer { surface, .. } => AsRenderElements::<R>::render_elements::<
-                WaylandSurfaceRenderElement<R>,
-            >(surface, renderer, location, scale, alpha)
-            .into_iter()
-            .map(SpaceRenderElements::Surface)
-            .map(C::from)
-            .collect(),
+            SpaceElements::Layer { surface, .. } => surface
+                .render_elements(renderer, location, scale, alpha)
+                .into_iter()
+                .map(SpaceRenderElements::Surface)
+                .collect(),
             SpaceElements::Element(element) => element
                 .element
-                .render_elements::<Wrap<<E as AsRenderElements<R>>::RenderElement>>(
-                    renderer, location, scale, alpha,
-                )
+                .render_elements(renderer, location, scale, alpha)
                 .into_iter()
-                .map(SpaceRenderElements::Element)
-                .map(C::from)
+                .map(|x| SpaceRenderElements::Element(Wrap::from(x)))
                 .collect(),
         }
     }

--- a/src/desktop/space/element/wayland.rs
+++ b/src/desktop/space/element/wayland.rs
@@ -37,13 +37,13 @@ where
     type RenderElement = WaylandSurfaceRenderElement<R>;
 
     #[profiling::function]
-    fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
+    fn render_elements(
         &self,
         renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         alpha: f32,
-    ) -> Vec<C> {
+    ) -> Vec<Self::RenderElement> {
         crate::backend::renderer::element::surface::render_elements_from_surface_tree(
             renderer,
             &self.surface,

--- a/src/desktop/space/utils.rs
+++ b/src/desktop/space/utils.rs
@@ -38,7 +38,7 @@ pub struct ConstrainBehavior {
 ///
 /// see [`constrain_as_render_elements`]
 #[profiling::function]
-pub fn constrain_space_element<R, E, C>(
+pub fn constrain_space_element<R, E>(
     renderer: &mut R,
     element: &E,
     location: impl Into<Point<i32, Logical>>,
@@ -46,15 +46,14 @@ pub fn constrain_space_element<R, E, C>(
     scale: impl Into<Scale<f64>>,
     constrain: Rectangle<i32, Logical>,
     behavior: ConstrainBehavior,
-) -> impl Iterator<Item = C>
+) -> impl Iterator<
+    Item = CropRenderElement<
+        RelocateRenderElement<RescaleRenderElement<<E as AsRenderElements<R>>::RenderElement>>,
+    >,
+>
 where
     R: Renderer,
     E: SpaceElement + AsRenderElements<R>,
-    C: From<
-        CropRenderElement<
-            RelocateRenderElement<RescaleRenderElement<<E as AsRenderElements<R>>::RenderElement>>,
-        >,
-    >,
 {
     let location = location.into();
     let scale = scale.into();

--- a/src/desktop/space/wayland/layer.rs
+++ b/src/desktop/space/wayland/layer.rs
@@ -18,16 +18,17 @@ where
     type RenderElement = WaylandSurfaceRenderElement<R>;
 
     #[profiling::function]
-    fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
+    fn render_elements(
         &self,
         renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         alpha: f32,
-    ) -> Vec<C> {
+    ) -> Vec<Self::RenderElement> {
         let surface = self.wl_surface();
 
-        let mut render_elements: Vec<C> = Vec::new();
+        let mut render_elements = Vec::new();
+
         let popup_render_elements =
             PopupManager::popups_for_surface(surface).flat_map(|(popup, popup_offset)| {
                 let offset = (popup_offset - popup.geometry().loc)
@@ -44,7 +45,6 @@ where
                     Kind::Unspecified,
                 )
             });
-
         render_elements.extend(popup_render_elements);
 
         render_elements.extend(render_elements_from_surface_tree(

--- a/src/desktop/space/wayland/window.rs
+++ b/src/desktop/space/wayland/window.rs
@@ -91,17 +91,16 @@ where
 {
     type RenderElement = WaylandSurfaceRenderElement<R>;
 
-    #[profiling::function]
-    fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
+    fn render_elements(
         &self,
         renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         alpha: f32,
-    ) -> Vec<C> {
+    ) -> Vec<Self::RenderElement> {
         match self.underlying_surface() {
             WindowSurface::Wayland(s) => {
-                let mut render_elements: Vec<C> = Vec::new();
+                let mut render_elements = Vec::new();
                 let surface = s.wl_surface();
                 let popup_render_elements =
                     PopupManager::popups_for_surface(surface).flat_map(|(popup, popup_offset)| {

--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -102,13 +102,13 @@ where
     type RenderElement = WaylandSurfaceRenderElement<R>;
 
     #[profiling::function]
-    fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
+    fn render_elements(
         &self,
         renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         alpha: f32,
-    ) -> Vec<C> {
+    ) -> Vec<Self::RenderElement> {
         let state = self.state.lock().unwrap();
         let Some(surface) = state.wl_surface.as_ref() else {
             return Vec::new();


### PR DESCRIPTION
This patch omits type conversion in
`AsRenderElements::render_elements()` and simplifies it.

Closes: #1626