### PR TITLE
xwm: Update `override_redirect` in `MapNotify` handler

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1446,7 +1446,10 @@ where
                       x.mapped_window_id() == Some(n.window))
                 .cloned()
             {
-                if surface.is_override_redirect() {
+                // Client may have changed override-redirect flag since window creation
+                surface.state.lock().unwrap().override_redirect = n.override_redirect;
+
+                if n.override_redirect {
                     drop(_guard);
                     state.mapped_override_redirect_window(xwm_id, surface);
                 } else {


### PR DESCRIPTION
Apparently `XChangeWindowAttributes` can be used to change the `override-redirect` flag for a window, and some clients create a window without the flag, then set it this way. So we should handle the flag in `MapNotify` to detect this.

Perhaps some other things should be changed, but this seems to help. This fixes menus not showing up on cosmic-comp in REAPER and Intel Questa, and presumably various other clients.