### PR TITLE
renderer: Introduce `ContextId`

### DIFF
--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -47,7 +47,7 @@
 //!
 //! const WIDTH: i32 = 10;
 //! const HEIGHT: i32 = 10;
-//! # let mut renderer = DummyRenderer;
+//! # let mut renderer = DummyRenderer::default();
 //! # let mut framebuffer = DummyFramebuffer;
 //! # let buffer_age = 0;
 //!

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -71,7 +71,7 @@
 //!
 //! // Initialize a static damage tracker
 //! let mut damage_tracker = OutputDamageTracker::new((800, 600), 1.0, Transform::Normal);
-//! # let mut renderer = DummyRenderer;
+//! # let mut renderer = DummyRenderer::default();
 //! # let mut framebuffer = DummyFramebuffer;
 //!
 //! let mut last_update = Instant::now();

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -30,7 +30,7 @@
 //!
 //! // Initialize a static damage tracked renderer
 //! let mut damage_tracker = OutputDamageTracker::new((800, 600), 1.0, Transform::Normal);
-//! # let mut renderer = DummyRenderer;
+//! # let mut renderer = DummyRenderer::default();
 //! # let mut framebuffer = DummyFramebuffer;
 //!
 //! loop {

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -237,7 +237,7 @@ impl<R: Renderer + ImportAll> WaylandSurfaceRenderElement<R> {
         let texture = if let Ok(spb) = crate::wayland::single_pixel_buffer::get_single_pixel_buffer(&buffer) {
             WaylandSurfaceTexture::SolidColor(Color32F::from(spb.rgba32f()))
         } else {
-            WaylandSurfaceTexture::Texture(data.texture::<R>(renderer.id())?.clone())
+            WaylandSurfaceTexture::Texture(data.texture::<R>(&renderer.context_id())?.clone())
         };
 
         Some(Self {

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -46,7 +46,7 @@
 //!
 //! // Initialize a static damage tracked renderer
 //! let mut damage_tracker = OutputDamageTracker::new((800, 600), 1.0, Transform::Normal);
-//! # let mut renderer = DummyRenderer;
+//! # let mut renderer = DummyRenderer::default();
 //! # let mut framebuffer = DummyFramebuffer;
 //!
 //! loop {

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -10,7 +10,7 @@
 //! It is possible to either use a [`pre-existing texture`](TextureBuffer::from_texture) or to create the texture
 //! from [`RGBA memory`](TextureBuffer::from_memory).
 //! The [`TextureBuffer`] can be used in the smithay pipeline by using [`TextureRenderElement::from_texture_buffer`].
-//!  
+//!
 //! ## Hardware accelerated rendering
 //!
 //! [`TextureRenderBuffer`] provides a solution for hardware accelerated rending with
@@ -62,7 +62,7 @@
 //! const HEIGHT: i32 = 10;
 //!
 //! let memory = vec![0; (WIDTH * 4 * HEIGHT) as usize];
-//! # let mut renderer = DummyRenderer;
+//! # let mut renderer = DummyRenderer::default();
 //! # let mut framebuffer = DummyFramebuffer;
 //!
 //! // Create the texture buffer from a chunk of memory
@@ -120,7 +120,7 @@
 //! const HEIGHT: i32 = 10;
 //!
 //! let memory = vec![0; (WIDTH * 4 * HEIGHT) as usize];
-//! # let mut renderer = DummyRenderer;
+//! # let mut renderer = DummyRenderer::default();
 //! # let mut framebuffer = DummyFramebuffer;
 //!
 //! // Create the texture buffer from a chunk of memory

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -202,12 +202,12 @@ impl<'frame, 'buffer> BorrowMut<GlesFrame<'frame, 'buffer>> for GlowFrame<'frame
 impl RendererSuper for GlowRenderer {
     type Error = GlesError;
     type TextureId = GlesTexture;
+    type Framebuffer<'buffer> = GlesTarget<'buffer>;
     type Frame<'frame, 'buffer>
         = GlowFrame<'frame, 'buffer>
     where
         'buffer: 'frame,
         Self: 'frame;
-    type Framebuffer<'buffer> = GlesTarget<'buffer>;
 }
 
 impl Renderer for GlowRenderer {
@@ -259,8 +259,8 @@ impl Renderer for GlowRenderer {
 }
 
 impl Frame for GlowFrame<'_, '_> {
-    type TextureId = GlesTexture;
     type Error = GlesError;
+    type TextureId = GlesTexture;
 
     fn id(&self) -> usize {
         self.frame.as_ref().unwrap().id()
@@ -333,13 +333,13 @@ impl Frame for GlowFrame<'_, '_> {
     }
 
     #[profiling::function]
-    fn finish(mut self) -> Result<sync::SyncPoint, Self::Error> {
-        self.finish_internal()
+    fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
+        self.frame.as_mut().unwrap().wait(sync)
     }
 
     #[profiling::function]
-    fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
-        self.frame.as_mut().unwrap().wait(sync)
+    fn finish(mut self) -> Result<sync::SyncPoint, Self::Error> {
+        self.finish_internal()
     }
 }
 

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -32,7 +32,7 @@ use std::{
     sync::Arc,
 };
 
-use super::{element::RenderElement, Frame};
+use super::{element::RenderElement, ContextId, Frame};
 
 #[derive(Debug)]
 /// A renderer utilizing OpenGL ES 2 and [`glow`] on top for easier custom rendering.
@@ -211,8 +211,8 @@ impl RendererSuper for GlowRenderer {
 }
 
 impl Renderer for GlowRenderer {
-    fn id(&self) -> usize {
-        self.gl.id()
+    fn context_id(&self) -> ContextId {
+        self.gl.context_id()
     }
 
     fn downscale_filter(&mut self, filter: TextureFilter) -> Result<(), Self::Error> {
@@ -262,8 +262,8 @@ impl Frame for GlowFrame<'_, '_> {
     type Error = GlesError;
     type TextureId = GlesTexture;
 
-    fn id(&self) -> usize {
-        self.frame.as_ref().unwrap().id()
+    fn context_id(&self) -> ContextId {
+        self.frame.as_ref().unwrap().context_id()
     }
 
     #[profiling::function]

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1030,7 +1030,7 @@ where
     }
 }
 
-static MAX_CPU_COPIES: usize = 3; // TODO, benchmark this
+const MAX_CPU_COPIES: usize = 3; // TODO, benchmark this
 
 impl<'render, 'target, R: GraphicsApi, T: GraphicsApi> RendererSuper for MultiRenderer<'render, 'target, R, T>
 where
@@ -1810,8 +1810,8 @@ where
     <<R::Device as ApiDevice>::Renderer as RendererSuper>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as RendererSuper>::Error: 'static,
 {
-    type TextureId = MultiTexture;
     type Error = Error<R, T>;
+    type TextureId = MultiTexture;
 
     fn id(&self) -> usize {
         self.frame.as_ref().unwrap().id()
@@ -1892,13 +1892,13 @@ where
     }
 
     #[profiling::function]
-    fn finish(mut self) -> Result<sync::SyncPoint, Self::Error> {
-        self.finish_internal()
+    fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
+        self.frame.as_mut().unwrap().wait(sync).map_err(Error::Render)
     }
 
     #[profiling::function]
-    fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {
-        self.frame.as_mut().unwrap().wait(sync).map_err(Error::Render)
+    fn finish(mut self) -> Result<sync::SyncPoint, Self::Error> {
+        self.finish_internal()
     }
 }
 

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -48,8 +48,8 @@ use std::{
 };
 
 use super::{
-    sync::SyncPoint, Bind, Blit, BlitFrame, Color32F, DebugFlags, ExportMem, Frame, ImportDma, ImportMem,
-    Offscreen, Renderer, RendererSuper, Texture, TextureFilter, TextureMapping,
+    sync::SyncPoint, Bind, Blit, BlitFrame, Color32F, ContextId, DebugFlags, ExportMem, Frame, ImportDma,
+    ImportMem, Offscreen, Renderer, RendererSuper, Texture, TextureFilter, TextureMapping,
 };
 #[cfg(feature = "wayland_frontend")]
 use super::{ImportDmaWl, ImportMemWl};
@@ -1064,8 +1064,8 @@ where
     <<R::Device as ApiDevice>::Renderer as RendererSuper>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as RendererSuper>::Error: 'static,
 {
-    fn id(&self) -> usize {
-        self.render.renderer().id()
+    fn context_id(&self) -> ContextId {
+        self.render.renderer().context_id()
     }
 
     fn downscale_filter(&mut self, filter: TextureFilter) -> Result<(), Self::Error> {
@@ -1813,8 +1813,8 @@ where
     type Error = Error<R, T>;
     type TextureId = MultiTexture;
 
-    fn id(&self) -> usize {
-        self.frame.as_ref().unwrap().id()
+    fn context_id(&self) -> ContextId {
+        self.frame.as_ref().unwrap().context_id()
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -644,13 +644,13 @@ impl Frame for PixmanFrame<'_, '_> {
         self.transform
     }
 
+    fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> {
+        sync.wait().map_err(|_| PixmanError::SyncInterrupted)
+    }
+
     #[profiling::function]
     fn finish(mut self) -> Result<SyncPoint, Self::Error> {
         self.finish_internal()
-    }
-
-    fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> {
-        sync.wait().map_err(|_| PixmanError::SyncInterrupted)
     }
 }
 

--- a/src/backend/renderer/test.rs
+++ b/src/backend/renderer/test.rs
@@ -1,6 +1,4 @@
 #![allow(missing_docs)]
-#[cfg(feature = "wayland_frontend")]
-use std::cell::Cell;
 
 #[cfg(all(
     feature = "wayland_frontend",
@@ -26,7 +24,14 @@ use crate::{
     utils::{Buffer, Physical, Rectangle, Size, Transform},
 };
 
-use super::Color32F;
+#[cfg(feature = "wayland_frontend")]
+use std::cell::Cell;
+use std::sync::LazyLock;
+
+use super::{Color32F, ContextId};
+
+/// All [`DummyRenderer`] instances share the same static [`ContextId`].
+static CONTEXT_ID: LazyLock<ContextId> = LazyLock::new(ContextId::next);
 
 #[derive(Debug, Default)]
 pub struct DummyRenderer;
@@ -62,8 +67,8 @@ impl RendererSuper for DummyRenderer {
 }
 
 impl Renderer for DummyRenderer {
-    fn id(&self) -> usize {
-        0
+    fn context_id(&self) -> ContextId {
+        CONTEXT_ID.clone()
     }
 
     fn downscale_filter(&mut self, _filter: TextureFilter) -> Result<(), Self::Error> {
@@ -230,8 +235,8 @@ impl Frame for DummyFrame {
     type Error = DummyError;
     type TextureId = DummyTexture;
 
-    fn id(&self) -> usize {
-        0
+    fn context_id(&self) -> ContextId {
+        CONTEXT_ID.clone()
     }
 
     fn clear(&mut self, _color: Color32F, _damage: &[Rectangle<i32, Physical>]) -> Result<(), Self::Error> {

--- a/src/backend/renderer/test.rs
+++ b/src/backend/renderer/test.rs
@@ -53,17 +53,31 @@ impl From<DummyError> for SwapBuffersError {
 impl RendererSuper for DummyRenderer {
     type Error = DummyError;
     type TextureId = DummyTexture;
+    type Framebuffer<'buffer> = DummyFramebuffer;
     type Frame<'frame, 'buffer>
         = DummyFrame
     where
         'buffer: 'frame,
         Self: 'frame;
-    type Framebuffer<'buffer> = DummyFramebuffer;
 }
 
 impl Renderer for DummyRenderer {
     fn id(&self) -> usize {
         0
+    }
+
+    fn downscale_filter(&mut self, _filter: TextureFilter) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn upscale_filter(&mut self, _filter: TextureFilter) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn set_debug_flags(&mut self, _flags: DebugFlags) {}
+
+    fn debug_flags(&self) -> DebugFlags {
+        DebugFlags::empty()
     }
 
     fn render<'frame, 'buffer>(
@@ -75,21 +89,7 @@ impl Renderer for DummyRenderer {
     where
         'buffer: 'frame,
     {
-        Ok(DummyFrame {})
-    }
-
-    fn upscale_filter(&mut self, _filter: TextureFilter) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn downscale_filter(&mut self, _filter: TextureFilter) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn set_debug_flags(&mut self, _flags: DebugFlags) {}
-
-    fn debug_flags(&self) -> DebugFlags {
-        DebugFlags::empty()
+        Ok(DummyFrame)
     }
 
     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> {
@@ -224,7 +224,7 @@ impl Texture for DummyFramebuffer {
 }
 
 #[derive(Debug)]
-pub struct DummyFrame {}
+pub struct DummyFrame;
 
 impl Frame for DummyFrame {
     type Error = DummyError;
@@ -264,12 +264,12 @@ impl Frame for DummyFrame {
         Transform::Normal
     }
 
-    fn finish(self) -> Result<SyncPoint, Self::Error> {
-        Ok(SyncPoint::default())
-    }
-
     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> {
         sync.wait().map_err(|_| DummyError::SyncInterrupted)
+    }
+
+    fn finish(self) -> Result<SyncPoint, Self::Error> {
+        Ok(SyncPoint::default())
     }
 }
 

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -470,7 +470,7 @@ impl SurfaceView {
 ///
 /// Calls [`compositor::with_states`] internally.
 ///
-/// Returns `None`, if there never was an commit processed through `on_commit_buffer_handler`.
+/// Returns `None`, if there never was a commit processed through `on_commit_buffer_handler`.
 pub fn with_renderer_surface_state<F, T>(surface: &WlSurface, cb: F) -> Option<T>
 where
     F: FnOnce(&mut RendererSurfaceState) -> T,

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "backend_drm")]
 use crate::wayland::drm_syncobj::{DrmSyncPoint, DrmSyncobjCachedState};
 use crate::{
-    backend::renderer::{buffer_dimensions, buffer_has_alpha, element::RenderElement, ImportAll, Renderer},
+    backend::renderer::{
+        buffer_dimensions, buffer_has_alpha, element::RenderElement, ContextId, ImportAll, Renderer,
+    },
     utils::{Buffer as BufferCoord, Coordinate, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
     wayland::{
         compositor::{
@@ -12,17 +14,16 @@ use crate::{
         viewporter,
     },
 };
-use std::sync::Arc;
-use std::{
-    any::TypeId,
-    collections::{hash_map::Entry, HashMap},
-    sync::Mutex,
-};
-use tracing::{error, instrument, warn};
 
-use wayland_server::protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface};
+use std::{
+    any::Any,
+    collections::{hash_map::Entry, HashMap},
+    sync::{Arc, Mutex},
+};
 
 use super::{CommitCounter, DamageBag, DamageSet, DamageSnapshot, SurfaceView};
+use tracing::{error, instrument, warn};
+use wayland_server::protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface};
 
 /// Type stored in WlSurface states data_map
 ///
@@ -42,15 +43,15 @@ pub struct RendererSurfaceState {
     pub(crate) buffer_has_alpha: Option<bool>,
     pub(crate) buffer: Option<Buffer>,
     pub(crate) damage: DamageBag<i32, BufferCoord>,
-    pub(crate) renderer_seen: HashMap<(TypeId, usize), CommitCounter>,
-    pub(crate) textures: HashMap<(TypeId, usize), Box<dyn std::any::Any>>,
+    pub(crate) renderer_seen: HashMap<ContextId, CommitCounter>,
+    pub(crate) textures: HashMap<ContextId, Box<dyn Any>>,
     pub(crate) surface_view: Option<SurfaceView>,
     pub(crate) opaque_regions: Vec<Rectangle<i32, Logical>>,
 }
 
-// SAFETY: Only thing unsafe here is the `Box<dyn std::any::Any>`, which are the textures.
-// Those are guarded by our Renderers handling thread-safety and the TypeId+render-id.
-// Theoretically a renderer could be thread-safe, but it's texture type isn't, but that is **very** theoretical.
+/// SAFETY: Only thing unsafe here is the `Box<dyn Any>`, which are the textures.
+/// Those are guarded by our Renderers handling thread-safety and the `ContextId`.
+/// Theoretically a renderer could be thread-safe, but its texture type isn't, but that is **very** theoretical.
 unsafe impl Send for RendererSurfaceState {}
 unsafe impl Sync for RendererSurfaceState {}
 
@@ -315,14 +316,13 @@ impl RendererSurfaceState {
         self.buffer.as_ref()
     }
 
-    /// Gets a reference to the texture for the specified renderer
-    pub fn texture<R>(&self, id: usize) -> Option<&R::TextureId>
+    /// Gets a reference to the texture for the specified renderer context
+    pub fn texture<R>(&self, id: &ContextId) -> Option<&R::TextureId>
     where
         R: Renderer,
         R::TextureId: 'static,
     {
-        let texture_id = (TypeId::of::<R::TextureId>(), id);
-        self.textures.get(&texture_id).and_then(|e| e.downcast_ref())
+        self.textures.get(id).and_then(|e| e.downcast_ref())
     }
 
     /// Gets the opaque regions of this surface
@@ -496,13 +496,13 @@ where
     R::TextureId: 'static,
 {
     if let Some(data) = states.data_map.get::<RendererSurfaceStateUserData>() {
-        let texture_id = (TypeId::of::<R::TextureId>(), renderer.id());
+        let context_id = renderer.context_id();
         let mut data_ref = data.lock().unwrap();
         let data = &mut *data_ref;
 
-        let last_commit = data.renderer_seen.get(&texture_id);
+        let last_commit = data.renderer_seen.get(&context_id);
         let buffer_damage = data.damage_since(last_commit.copied());
-        if let Entry::Vacant(e) = data.textures.entry(texture_id) {
+        if let Entry::Vacant(e) = data.textures.entry(context_id.clone()) {
             if let Some(buffer) = data.buffer.as_ref() {
                 // There is no point in importing a single pixel buffer
                 if matches!(
@@ -515,7 +515,7 @@ where
                 match renderer.import_buffer(buffer, Some(states), &buffer_damage) {
                     Some(Ok(m)) => {
                         e.insert(Box::new(m));
-                        data.renderer_seen.insert(texture_id, data.current_commit());
+                        data.renderer_seen.insert(context_id, data.current_commit());
                     }
                     Some(Err(err)) => {
                         warn!("Error loading buffer: {}", err);
@@ -549,7 +549,6 @@ where
     let scale = 1.0;
     let location: Point<f64, Physical> = (0.0, 0.0).into();
 
-    let texture_id = (TypeId::of::<R::TextureId>(), renderer.id());
     let mut result = Ok(());
     with_surface_tree_downward(
         surface,
@@ -565,7 +564,7 @@ where
                 let mut data_ref = data.lock().unwrap();
                 let data = &mut *data_ref;
                 // Now, should we be drawn ?
-                if data.textures.contains_key(&texture_id) {
+                if data.textures.contains_key(&renderer.context_id()) {
                     // if yes, also process the children
                     let surface_view = data.surface_view.unwrap();
                     location += surface_view.offset.to_f64().to_physical(scale);

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -66,7 +66,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
         })
         .unwrap();
 
-    let mut renderer = DummyRenderer;
+    let mut renderer = DummyRenderer::default();
     let mut framebuffer = DummyFramebuffer;
 
     let mode = Mode {


### PR DESCRIPTION
Introduce `ContextId` to represent a renderer context, replacing the previous use of `TypeId` + `usize` ID.

This also aligns with the best practice of using the newtype pattern for IDs.