### PR TITLE
xwm: Add events/method for randr primary output management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ use_system_lib = ["wayland_frontend", "wayland-backend/server_system", "wayland-
 use_bindgen = ["drm-ffi/use_bindgen", "gbm/use_bindgen", "input/use_bindgen"]
 wayland_frontend = ["wayland-server", "wayland-protocols", "wayland-protocols-wlr", "wayland-protocols-misc", "tempfile"]
 x11rb_event_source = ["x11rb"]
-xwayland = ["encoding_rs", "wayland_frontend", "x11rb/composite", "x11rb/xfixes", "x11rb_event_source", "scopeguard"]
+xwayland = ["encoding_rs", "wayland_frontend", "x11rb/composite", "x11rb/xfixes", "x11rb/randr", "x11rb_event_source", "scopeguard"]
 test_all_features = ["default", "use_system_lib", "renderer_glow", "renderer_test"]
 
 [[example]]

--- a/smallvil/src/grabs/resize_grab.rs
+++ b/smallvil/src/grabs/resize_grab.rs
@@ -113,8 +113,8 @@ impl PointerGrab<Smallvil> for ResizeSurfaceGrab {
         let min_width = min_size.w.max(1);
         let min_height = min_size.h.max(1);
 
-        let max_width = (max_size.w == 0).then(i32::max_value).unwrap_or(max_size.w);
-        let max_height = (max_size.h == 0).then(i32::max_value).unwrap_or(max_size.h);
+        let max_width = if max_size.w == 0 { i32::MAX } else { max_size.w };
+        let max_height = if max_size.h == 0 { i32::MAX } else { max_size.h };
 
         self.last_window_size = Size::from((
             new_window_width.max(min_width).min(max_width),

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1285,10 +1285,10 @@ where
     /// - `output_mode_source` is used to determine the current mode, scale and transform
     /// - `surface` for the compositor to use
     /// - `planes` defines which planes the compositor is allowed to use for direct scan-out.
-    ///           `None` will result in the compositor to use all planes as specified by [`DrmSurface::planes`]
+    ///   `None` will result in the compositor to use all planes as specified by [`DrmSurface::planes`]
     /// - `allocator` used for the primary plane swapchain
     /// - `framebuffer_exporter` is used to create drm framebuffers for the swapchain buffers (and if possible
-    ///                          for element buffers) for scan-out
+    ///   for element buffers) for scan-out
     /// - `code` is the fixed format to initialize the framebuffer with
     /// - `modifiers` is the set of modifiers allowed, when allocating buffers with the specified color format
     /// - `cursor_size` as reported by the drm device, used for creating buffer for the cursor plane
@@ -3627,13 +3627,12 @@ where
                         // that to influence the test state of our elements.
                         // Adding or removing cursor can influence the other planes, but
                         // is already covered in the active planes check.
-                        let primary_plane_changed = current_plane_snapshot
-                            .primary
-                            .then(|| {
-                                frame_state.plane_properties(self.surface.plane())
-                                    != previous_frame_state.plane_properties(self.surface.plane())
-                            })
-                            .unwrap_or(false);
+                        let primary_plane_changed = if current_plane_snapshot.primary {
+                            frame_state.plane_properties(self.surface.plane())
+                                != previous_frame_state.plane_properties(self.surface.plane())
+                        } else {
+                            false
+                        };
 
                         let overlay_plane_changed =
                             self.planes.overlay.iter().enumerate().any(|(index, plane)| {

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -173,11 +173,11 @@ impl DrmDevice {
     ///
     /// - `fd` - Open drm node
     /// - `disable_connectors` - Setting this to true will initialize all connectors \
-    ///     as disabled on device creation. smithay enables connectors, when attached \
-    ///     to a surface, and disables them, when detached. Setting this to `false` \
-    ///     requires usage of `drm-rs` to disable unused connectors to prevent them \
-    ///     showing garbage, but will also prevent flickering of already turned on \
-    ///     connectors (assuming you won't change the resolution).
+    ///   as disabled on device creation. smithay enables connectors, when attached \
+    ///   to a surface, and disables them, when detached. Setting this to `false` \
+    ///   requires usage of `drm-rs` to disable unused connectors to prevent them \
+    ///   showing garbage, but will also prevent flickering of already turned on \
+    ///   connectors (assuming you won't change the resolution).
     ///
     /// # Return
     ///

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -7,23 +7,23 @@
 //! out of:
 //! - [`connectors`](drm::control::connector) represents a port on your computer, possibly with a connected monitor, TV, capture card, etc.
 //! - [`encoder`](drm::control::encoder) encodes the data of connected crtcs into a video signal for a fixed set of connectors.
-//!     E.g. you might have an analog encoder based on a DAG for VGA ports, but another one for digital ones.
-//!     Also not every encoder might be connected to every crtc.
+//!   E.g. you might have an analog encoder based on a DAG for VGA ports, but another one for digital ones.
+//!   Also not every encoder might be connected to every crtc.
 //! - [`framebuffer`] represents a buffer you may display, see `DrmSurface` below.
 //! - [`plane`] adds another layer on top of the crtcs, which allow us to layer multiple images on top of each other more efficiently
-//!     then by combining the rendered images in the rendering phase, e.g. via OpenGL. Planes have to be explicitly used by the user to be useful.
-//!     Every device has at least one primary plane used to display an image to the whole crtc. Additionally cursor and overlay planes may be present.
-//!     Cursor planes are usually very restricted in size and meant to be used for hardware cursors, while overlay planes may
-//!     be used for performance reasons to display any overlay on top of the image, e.g. the top-most windows.
-//!     Overlay planes may have a bunch of weird limitation, that you cannot query, e.g. only working on round pixel coordinates.
-//!     You code should never rely on a fixed set of overlay planes, but always have a fallback solution in place.
+//!   then by combining the rendered images in the rendering phase, e.g. via OpenGL. Planes have to be explicitly used by the user to be useful.
+//!   Every device has at least one primary plane used to display an image to the whole crtc. Additionally cursor and overlay planes may be present.
+//!   Cursor planes are usually very restricted in size and meant to be used for hardware cursors, while overlay planes may
+//!   be used for performance reasons to display any overlay on top of the image, e.g. the top-most windows.
+//!   Overlay planes may have a bunch of weird limitation, that you cannot query, e.g. only working on round pixel coordinates.
+//!   You code should never rely on a fixed set of overlay planes, but always have a fallback solution in place.
 //! - [`crtc`]s represent scanout engines of the device pointer to one framebuffer.
-//!     Their responsibility is to read the data of the framebuffer and export it into an "Encoder".
-//!     The number of crtc's represent the number of independent output devices the hardware may handle.
+//!   Their responsibility is to read the data of the framebuffer and export it into an "Encoder".
+//!   The number of crtc's represent the number of independent output devices the hardware may handle.
 //!
-//!     On modern graphic cards it is better to think about the `crtc` as some sort of rendering engine.
-//!     You can only have so many different pictures, you may display, as you have `crtc`s, but a single image
-//!     may be put onto multiple displays.
+//!  On modern graphic cards it is better to think about the `crtc` as some sort of rendering engine.
+//!  You can only have so many different pictures, you may display, as you have `crtc`s, but a single image
+//!  may be put onto multiple displays.
 //!
 //! The main functionality of a `Device` in smithay is to give access to all these properties for the user to
 //! choose an appropriate rendering configuration. What that means is defined by the requirements and constraints documented

--- a/src/backend/drm/output.rs
+++ b/src/backend/drm/output.rs
@@ -165,14 +165,14 @@ where
     /// - `device` the underlying [`DrmDevice`]
     /// - `allocator` used by created [`DrmOutput`]s for primary plane swapchains.
     /// - `exporter` used by created [`DrmOutput`]s to create drm framebuffers
-    ///              for the swapchain buffers (and if possible for element buffers)
-    ///              for scan-out.
+    ///   for the swapchain buffers (and if possible for element buffers)
+    ///   for scan-out.
     /// - `gbm` device used by created [`DrmOutput`]s for creating buffers for the
-    ///              cursor plane, `None` will disable the cursor plane.
+    ///   cursor plane, `None` will disable the cursor plane.
     /// - `color_formats` as tested in order when creating a new [`DrmOutput`]
     /// - `renderer_formats` as reported by the used renderer, used to build the
-    ///              intersection between the possible scan-out formats of the
-    ///              primary plane of created [`DrmOutput`]s and the renderer
+    ///   intersection between the possible scan-out formats of the
+    ///   primary plane of created [`DrmOutput`]s and the renderer
     pub fn new(
         device: DrmDevice,
         allocator: A,
@@ -207,7 +207,7 @@ where
     /// - `connectors` - the set of connectors the underlying surface should be initialized with
     /// - `output_mode_source`  used to to determine the size, scale and transform
     /// - `planes` defines which planes the compositor is allowed to use for direct scan-out.
-    ///           `None` will result in the compositor to use all planes as specified by [`DrmSurface::planes`][super::DrmSurface::planes]
+    ///   `None` will result in the compositor to use all planes as specified by [`DrmSurface::planes`][super::DrmSurface::planes]
     /// - `renderer` used for compositing, when commits are necessarily to realize bandwidth constraints
     /// - `render_elements` used for rendering, when commits are necessarily to realize bandwidth constraints
     #[allow(clippy::too_many_arguments)]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -40,11 +40,11 @@
 //! structured around two modules:
 //!
 //! - [`allocator`] contains generic traits representing the capability to
-//!     allocate and convert graphical buffers, as well as an implementation of this
-//!     capability using GBM (see its module-level docs for details).
+//!   allocate and convert graphical buffers, as well as an implementation of this
+//!   capability using GBM (see its module-level docs for details).
 //! - [`renderer`] provides traits representing the capability of graphics
-//!     rendering using those buffers, as well as an implementation of this
-//!     capability using GLes2 (see its module-level docs for details).
+//!   rendering using those buffers, as well as an implementation of this
+//!   capability using GLes2 (see its module-level docs for details).
 //!
 //! Alongside this backbone capability, Smithay also provides the [`drm`] module, which handles
 //! direct interaction with the graphical physical devices to setup the display pipeline and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,14 @@
 //! The provided helpers are split into two main modules:
 //!
 //! - [`backend`] contains helpers for interacting with the operating
-//!     system, such as session management, interactions with the graphic stack
-//!     and input processing.
+//!   system, such as session management, interactions with the graphic stack
+//!   and input processing.
 //! - [`wayland`] contains helpers for interacting with wayland clients
-//!     according to the wayland protocol.
+//!   according to the wayland protocol.
 //!
-//!     In addition, the [`xwayland`] module contains helpers for managing an
-//!     XWayland instance if you want to support it. See the documentation of
-//!     these respective modules for information about their usage.
+//!  In addition, the [`xwayland`] module contains helpers for managing an
+//!  XWayland instance if you want to support it. See the documentation of
+//!  these respective modules for information about their usage.
 //!
 //! ## General principles for using Smithay
 //!

--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -127,10 +127,10 @@ pub trait ClientDndGrabHandler: SeatHandler + Sized {
     /// A client started a drag'n'drop as response to a user pointer action
     ///
     /// * `source` - The data source provided by the client.
-    ///              If it is `None`, this means the DnD is restricted to surfaces of the
-    ///              same client and the client will manage data transfer by itself.
+    ///   If it is `None`, this means the DnD is restricted to surfaces of the
+    ///   same client and the client will manage data transfer by itself.
     /// * `icon` - The icon the client requested to be used to be associated with the cursor icon
-    ///            during the drag'n'drop.
+    ///   during the drag'n'drop.
     /// * `seat` - The seat on which the DnD operation was started
     fn started(&mut self, source: Option<WlDataSource>, icon: Option<WlSurface>, seat: Seat<Self>) {}
 
@@ -142,7 +142,7 @@ pub trait ClientDndGrabHandler: SeatHandler + Sized {
     ///
     /// * `target` - The target surface that the contents were dropped on.
     /// * `validated` - Whether the drop offer was negotiated and accepted. If `false`, the drop
-    ///                 was cancelled or otherwise not successful.
+    ///   was cancelled or otherwise not successful.
     /// * `seat` - The seat on which the DnD action was finished.
     fn dropped(&mut self, target: Option<WlSurface>, validated: bool, seat: Seat<Self>) {}
 }

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1103,10 +1103,10 @@ pub trait XdgShellHandler {
     /// ## Arguments
     ///
     /// - `positioner` - The state of the positioner at the timethe popup was requested.
-    ///     The positioner state can be used by the compositor
-    ///     to calculate the best placement for the popup.
-    ///     For example the compositor should prevent that a popup
-    ///     is placed outside the visible rectangle of a output.
+    ///   The positioner state can be used by the compositor
+    ///   to calculate the best placement for the popup.
+    ///   For example the compositor should prevent that a popup
+    ///   is placed outside the visible rectangle of a output.
     fn new_popup(&mut self, surface: PopupSurface, positioner: PositionerState);
 
     /// The client requested the start of an interactive move for this surface
@@ -1171,14 +1171,14 @@ pub trait XdgShellHandler {
     /// ## Arguments
     ///
     /// - `positioner` - The state of the positioner at the time the reposition request was made.
-    ///     The positioner state can be used by the compositor
-    ///     to calculate the best placement for the popup.
-    ///     For example the compositor should prevent that a popup
-    ///     is placed outside the visible rectangle of a output.
+    ///   The positioner state can be used by the compositor
+    ///   to calculate the best placement for the popup.
+    ///   For example the compositor should prevent that a popup
+    ///   is placed outside the visible rectangle of a output.
     /// - `token` - The passed token will be sent in the corresponding xdg_popup.repositioned event.
-    ///     The new popup position will not take effect until the corresponding configure event
-    ///     is acknowledged by the client. See xdg_popup.repositioned for details.
-    ///     The token itself is opaque, and has no other special meaning.
+    ///   The new popup position will not take effect until the corresponding configure event
+    ///   is acknowledged by the client. See xdg_popup.repositioned for details.
+    ///   The token itself is opaque, and has no other special meaning.
     fn reposition_request(&mut self, surface: PopupSurface, positioner: PositionerState, token: u32);
 
     /// A shell client was destroyed.

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -92,17 +92,17 @@ impl XWayland {
     /// ## Arguments
     ///
     /// - `display` - if provided, only the given display number will be tested.
-    ///     If you wish smithay to choose a display for you, pass `None`.
+    ///   If you wish smithay to choose a display for you, pass `None`.
     /// - `envs` - Allows additionally environment variables to be set when
     ///   launching XWayland.
     /// - `open_abstract_socket` - Open an abstract socket as well as filesystem
-    ///    sockets (only on available on Linux).
+    ///   sockets (only on available on Linux).
     /// - `stdout, stderr` - Allows redirecting stdout and stderr of the
     ///   XWayland process. XWayland output is rarely useful, so `Stdio::null()`
     ///   is a good choice if you're not sure.
     /// - `user_data` - Allows mutating the `XWaylandClientData::user_data`-map
-    ///    before the client is added to the wayland display. Useful for
-    ///    initializing state for global filters.
+    ///   before the client is added to the wayland display. Useful for
+    ///   initializing state for global filters.
     ///
     /// Returns a handle to the XWayland instance and the
     /// [Client](wayland_server::Client) representing the XWayland server. The


### PR DESCRIPTION
A lot of games expect to be able to query a primary output via xrandr. This adds a way for compositors to manage this state.