### PR TITLE
xsettings: Fix string values

### DIFF
--- a/src/xwayland/xwm/settings.rs
+++ b/src/xwayland/xwm/settings.rs
@@ -227,7 +227,8 @@ impl Value {
             Value::String(val) => {
                 let val = val.as_bytes();
                 data.extend(&(val.len() as u32).to_ne_bytes());
-                data.extend(val)
+                data.extend(val);
+                data.extend(std::iter::repeat(0u8).take(pad(val.len())));
             }
             Value::Color(val) => {
                 for component in val {


### PR DESCRIPTION
Forgot the pad when implementing this and only noticed this now trying to set `Gtk/CursorThemeName`.