### PR TITLE
support delayed blocker

### DIFF
--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -118,7 +118,7 @@ use std::{any::Any, sync::Mutex};
 pub use self::cache::{Cacheable, CachedState, MultiCache};
 pub use self::handlers::{RegionUserData, SubsurfaceCachedState, SubsurfaceUserData, SurfaceUserData};
 use self::transaction::TransactionQueue;
-pub use self::transaction::{Barrier, Blocker, BlockerState, BlockerKind};
+pub use self::transaction::{Barrier, Blocker, BlockerKind, BlockerState, SurfaceBarrier};
 pub use self::tree::{AlreadyHasRole, TraversalAction};
 use self::tree::{PrivateSurfaceData, SuggestedSurfaceState};
 pub use crate::utils::hook::HookId;

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -118,7 +118,7 @@ use std::{any::Any, sync::Mutex};
 pub use self::cache::{Cacheable, CachedState, MultiCache};
 pub use self::handlers::{RegionUserData, SubsurfaceCachedState, SubsurfaceUserData, SurfaceUserData};
 use self::transaction::TransactionQueue;
-pub use self::transaction::{Barrier, Blocker, BlockerState};
+pub use self::transaction::{Barrier, Blocker, BlockerState, BlockerKind};
 pub use self::tree::{AlreadyHasRole, TraversalAction};
 use self::tree::{PrivateSurfaceData, SuggestedSurfaceState};
 pub use crate::utils::hook::HookId;


### PR DESCRIPTION
This PR extends the existing `Blocker` API with a `BlockerKind`. Allowing to put blockers into two groups, `Immediate` and `Delayed`. `Blocker`s with `BlockerKind::Delayed` will only be evaluated once all  `Immediate` have been cleared.
After all  `Immediate` blockers have been cleared all `Blocker`s will be notified, allowing delayed blockers to make a decision based on that.
All blockers still need to be cleared for the transaction to be unblocked.

Additionally the PR adds a reference implementation of a delayed blocker, `SurfaceBarrier`.

One example for this is implementing animation transactions spanning multiple otherwise unrelated surfaces.
While this can be implemented without the `SurfaceBarrier`, it might help to enhance synchronization when some other blockers further delay the buffer.

A compositor could place a `Immediate` blocker, like for example a simple `Barrier`, on each surface participating in the animation transaction and also register it in a `SurfaceBarrier` with the same scope as the animation transaction.
Once the `Immediate` blocker representing the transaction is cleared, the blocker in the `SurfaceBarrier` will try to resolve and ping the compositor once it completed.

cc @YaLTeR