### PR TITLE
feat: implement KeyboardHandle::set_modifier_state

### DIFF
--- a/src/input/keyboard/modifiers_state.rs
+++ b/src/input/keyboard/modifiers_state.rs
@@ -48,6 +48,72 @@ impl ModifiersState {
         self.iso_level5_shift = state.mod_name_is_active(&xkb::MOD_NAME_MOD3, xkb::STATE_MODS_EFFECTIVE);
         self.serialized = serialize_modifiers(state);
     }
+
+    /// Serialize modifier state back to be sent to xkb.
+    pub fn serialize_back(&self, state: &xkb::State) -> SerializedMods {
+        let keymap = state.get_keymap();
+
+        let mut locked: u32 = 0;
+        let mut depressed: u32 = 0;
+
+        if self.caps_lock {
+            let index = keymap.mod_get_index(&xkb::MOD_NAME_CAPS);
+            if index != xkb::MOD_INVALID {
+                locked |= 1 << index;
+            }
+        }
+        if self.num_lock {
+            let index = keymap.mod_get_index(&xkb::MOD_NAME_NUM);
+            if index != xkb::MOD_INVALID {
+                locked |= 1 << index;
+            }
+        }
+        if self.ctrl {
+            let index = keymap.mod_get_index(&xkb::MOD_NAME_CTRL);
+            if index != xkb::MOD_INVALID {
+                depressed |= 1 << index;
+            }
+        }
+        if self.alt {
+            let index = keymap.mod_get_index(&xkb::MOD_NAME_ALT);
+            if index != xkb::MOD_INVALID {
+                depressed |= 1 << index;
+            }
+        }
+        if self.shift {
+            let index = keymap.mod_get_index(&xkb::MOD_NAME_SHIFT);
+            if index != xkb::MOD_INVALID {
+                depressed |= 1 << index;
+            }
+        }
+        if self.logo {
+            let index = keymap.mod_get_index(&xkb::MOD_NAME_LOGO);
+            if index != xkb::MOD_INVALID {
+                depressed |= 1 << index;
+            }
+        }
+        if self.iso_level3_shift {
+            let index = keymap.mod_get_index(&xkb::MOD_NAME_ISO_LEVEL3_SHIFT);
+            if index != xkb::MOD_INVALID {
+                depressed |= 1 << index;
+            }
+        }
+        if self.iso_level5_shift {
+            let index = keymap.mod_get_index(&xkb::MOD_NAME_MOD3);
+            if index != xkb::MOD_INVALID {
+                depressed |= 1 << index;
+            }
+        }
+
+        let layout_effective = state.serialize_layout(xkb::STATE_LAYOUT_EFFECTIVE);
+
+        SerializedMods {
+            depressed,
+            latched: 0,
+            locked,
+            layout_effective,
+        }
+    }
 }
 
 /// Serialized modifier state


### PR DESCRIPTION
to enable compositor side control of modifiers such as num lock.

This PR is an implementation of a [recommendation](https://github.com/YaLTeR/niri/issues/291#issuecomment-2657328970) made by @kylewillmon in a Niri issue requesting support to enable num lock at startup: https://github.com/YaLTeR/niri/issues/291

Disclaimer: I'm new to rust so I'm extra happy for all feedback that points out code smells.