### PR TITLE
anvil: Remove documentation for `ANVIL_DISABLE_DRM_COMPOSITOR`

### DIFF
--- a/anvil/README.md
+++ b/anvil/README.md
@@ -48,7 +48,6 @@ The currently available backends are:
 | ANVIL_DRM_DEVICE              | /dev/dri/card0  | tty-udev  |
 | ANVIL_DISABLE_10BIT           | any             | tty-udev  |
 | ANVIL_DISABLE_DIRECT_SCANOUT  | any             | tty-udev  |
-| ANVIL_DISABLE_DRM_COMPOSITOR  | any             | tty-udev  |
 | ANVIL_NO_VULKAN               | 1,true,yes,y    | x11       |
 | SMITHAY_USE_LEGACY            | 1,true,yes,y    | tty-udev  |
 | SMITHAY_VK_VERSION            | 1.3             |           |


### PR DESCRIPTION
4deb3d5c seems to have removed this.