### PR TITLE
xwayland_keyboard_grab: `Clone` impl and accessor for `ZwpXwaylandKeyboardGrabV1`

### DIFF
--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -87,6 +87,15 @@ pub struct XWaylandKeyboardGrab<D: SeatHandler + 'static> {
     start_data: keyboard::GrabStartData<D>,
 }
 
+impl<D: XWaylandKeyboardGrabHandler + 'static> Clone for XWaylandKeyboardGrab<D> {
+    fn clone(&self) -> Self {
+        Self {
+            grab: self.grab.clone(),
+            start_data: self.start_data.clone(),
+        }
+    }
+}
+
 impl<D: XWaylandKeyboardGrabHandler + 'static> KeyboardGrab<D> for XWaylandKeyboardGrab<D> {
     fn input(
         &mut self,

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -87,6 +87,13 @@ pub struct XWaylandKeyboardGrab<D: SeatHandler + 'static> {
     start_data: keyboard::GrabStartData<D>,
 }
 
+impl<D: XWaylandKeyboardGrabHandler + 'static> XWaylandKeyboardGrab<D> {
+    /// Get the `zwp_xwayland_keyboard_grab_v1` object that created the grab
+    pub fn grab(&self) -> &ZwpXwaylandKeyboardGrabV1 {
+        &self.grab
+    }
+}
+
 impl<D: XWaylandKeyboardGrabHandler + 'static> Clone for XWaylandKeyboardGrab<D> {
     fn clone(&self) -> Self {
         Self {


### PR DESCRIPTION
These changes should both be helpful for custom implementations (and the default has issues: https://github.com/Smithay/smithay/issues/1714).

The default behavior should ideally be improved, but if `XWaylandKeyboardGrabHandler::grab` is an overridable method, this makes sense to have anyway.