### PR TITLE
implement a Point::new and a Size::new constructor

### DIFF
--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -341,6 +341,17 @@ pub struct Point<N, Kind> {
     _kind: std::marker::PhantomData<Kind>,
 }
 
+impl<N, Kind> Point<N, Kind> {
+    /// Create a new Point
+    pub const fn new(x: N, y: N) -> Point<N, Kind> {
+        Point {
+            x,
+            y,
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
 impl<N: Coordinate, Kind> Point<N, Kind> {
     /// Convert this [`Point`] to a [`Size`] with the same coordinates
     ///
@@ -593,11 +604,7 @@ impl<N: Coordinate> Point<N, Buffer> {
 impl<N, Kind> From<(N, N)> for Point<N, Kind> {
     #[inline]
     fn from((x, y): (N, N)) -> Point<N, Kind> {
-        Point {
-            x,
-            y,
-            _kind: std::marker::PhantomData,
-        }
+        Point::new(x, y)
     }
 }
 
@@ -699,6 +706,22 @@ pub struct Size<N, Kind> {
     /// vertical coordinate
     pub h: N,
     _kind: std::marker::PhantomData<Kind>,
+}
+
+impl<N: Coordinate, Kind> Size<N, Kind> {
+    /// Create a new Size
+    pub fn new(w: N, h: N) -> Size<N, Kind> {
+        debug_assert!(
+            w.non_negative() && h.non_negative(),
+            "Attempting to create a `Size` of negative size: {:?}",
+            (w, h)
+        );
+        Size {
+            w,
+            h,
+            _kind: std::marker::PhantomData,
+        }
+    }
 }
 
 impl<N: Coordinate, Kind> Size<N, Kind> {
@@ -920,16 +943,7 @@ impl<N: Coordinate> Size<N, Buffer> {
 impl<N: Coordinate, Kind> From<(N, N)> for Size<N, Kind> {
     #[inline]
     fn from((w, h): (N, N)) -> Size<N, Kind> {
-        debug_assert!(
-            w.non_negative() && h.non_negative(),
-            "Attempting to create a `Size` of negative size: {:?}",
-            (w, h)
-        );
-        Size {
-            w,
-            h,
-            _kind: std::marker::PhantomData,
-        }
+        Size::new(w, h)
     }
 }
 


### PR DESCRIPTION
the main reason is that i was very annoyed at having to unnecessary double parenthesis when calling `Size::from((w, h))`, which i don't have to do with `Size::new(w, h)`.

another benefit is, that `Point::new` is const so you can create a `Point` in const (though i haven't ever needed that). since `Size::new` has a `debug_assert!` that calls a trait method, i cannot make that `const` without removing the assertion.