### PR TITLE
impl Div<N> for Size<N, Kind>

### DIFF
--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -992,6 +992,19 @@ impl<N: Coordinate + Div<Output = N>, KindLhs, KindRhs> Div<Size<N, KindRhs>> fo
     }
 }
 
+impl<N: Coordinate + Div, Kind> Div<N> for Size<N, Kind> {
+    type Output = Size<<N as Div>::Output, Kind>;
+
+    #[inline]
+    fn div(self, rhs: N) -> Self::Output {
+        Size {
+            w: self.w / rhs,
+            h: self.h / rhs,
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
 impl<N: Coordinate + Mul, Kind> Mul<N> for Size<N, Kind> {
     type Output = Size<<N as Mul>::Output, Kind>;
 


### PR DESCRIPTION
there already is an `impl Mul<N> for Size<N, Kind>`, so i think it just makes sense to also have a function that does the opposite. also saves me one `Size::from((size.w * 3 / 4, size.h * 3 / 4))` where i can now do a `size * 3 / 4`. you could also do this with `.downscale` (and `.upscale` respectively), but those are a little less convenient to use and (in my opinion) less clear.