### PR TITLE
update to rustix 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ indexmap = "2.0"
 libc = "0.2.103"
 libseat = { version = "0.2.3", optional = true, default-features = false }
 libloading = { version="0.8.0", optional = true }
-rustix = { version = "0.38.18", features = ["event", "fs", "mm", "net", "shm", "time"] }
+rustix = { version = "1.0.7", features = ["event", "fs", "mm", "net", "pipe", "process", "shm", "time"] }
 rand = "0.9.0"
 scopeguard = { version = "1.1.0", optional = true }
 tracing = "0.1.37"

--- a/src/xwayland/x11_sockets.rs
+++ b/src/xwayland/x11_sockets.rs
@@ -178,7 +178,7 @@ fn open_socket(addr: SocketAddrUnix) -> rustix::io::Result<UnixStream> {
         None,
     )?;
     // bind it to requested address
-    rustix::net::bind_unix(&fd, &addr)?;
+    rustix::net::bind(&fd, &addr)?;
     rustix::net::listen(&fd, 1)?;
     Ok(UnixStream::from(fd))
 }


### PR DESCRIPTION
i had to do 4 changes for the update:

1. i had to enable the "pipe" and "process" features. i think those were enabled by a transitive dependency on rustix, that had already enabled them, but since those were enabling them for rustix 0.38, i had to enable them explicitly for rustix 1.0.
2. similar to https://github.com/Smithay/drm-rs/pull/223, i had to change the generic for `rustix::ioctl` from a `type` to a `const`.
3. `rustix::event::poll` changed the type from a `c_int` to an `Option<&Timespec>`. since the timeout was 0, i don't have to convert anything and only construct a 0-ed `Timespec`. i opted against using `Timespec::default` as i thought that doing it this way was more clear.
4. rustix merged all of the `rustix::net::bind_*` fns into a single `rustix::net::bind` that takes an `&impl SocketAddrArg`

as far as i can tell, none of the "silent behavior changes" mentioned in [rustix's `CHANGES.md`](https://github.com/bytecodealliance/rustix/blob/92466d9860d95aa15b8ad0a5ea4cb88b39ccc63f/CHANGES.md) apply here.

i tested this locally with my own compositor and everything worked just fine (though i don't use all of smithay there).

i realised that i forgot some functions that were not compiled on linux. in the second commit in [a2171c8e002ba28bc31be2547d1695c45389b1c5], i (attempt to) fix the rustix errors for non-linux, non-android and non-freebsd targets, but i cannot actually check if they are working, as i do not have access to an openbsd machine or similar. additionally, i believe that function already doesn't compile, as it was forgotten to be updated when rand got bumped in #1703.