### PR TITLE
Make `has_modifier()` return `true` for linear modifiers

### DIFF
--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -246,9 +246,9 @@ impl Dmabuf {
         self.0.planes.iter().map(|p| p.stride)
     }
 
-    /// Returns if this buffer format has any vendor-specific modifiers set or is implicit/linear
+    /// Returns if this buffer format has any vendor-specific modifiers set or is implicit
     pub fn has_modifier(&self) -> bool {
-        self.0.modifier != Modifier::Invalid && self.0.modifier != Modifier::Linear
+        self.0.modifier != Modifier::Invalid
     }
 
     /// Returns if the buffer is stored inverted on the y-axis

--- a/src/backend/allocator/gbm.rs
+++ b/src/backend/allocator/gbm.rs
@@ -364,7 +364,10 @@ impl Dmabuf {
             offsets[i] = offset as i32;
         }
 
-        if self.has_modifier() || self.num_planes() > 1 || self.offsets().next().unwrap() != 0 {
+        if (self.has_modifier() && self.format().modifier != Modifier::Linear)
+            || self.num_planes() > 1
+            || self.offsets().next().unwrap() != 0
+        {
             gbm.import_buffer_object_from_dma_buf_with_modifiers(
                 self.num_planes() as u32,
                 handles,


### PR DESCRIPTION
`has_modifier()` is used in two places. One has a special case for linear modifiers (which could handled specially regardless of what `has_modifier()` returns. The other use doesn't handle linear in any special way, and is probably incorrect, though drivers may tend to work with it anyway.

Implicit modifiers are not in general linear, so semantically this didn't make much sense.

Leaving as a draft, since I'm not actually sure what this breaks or fixes in practice. There may be a reason it was done this way.