### PR TITLE
input/keyboard: Use hash for ID of `KeymapFile`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ smallvec = "1.11"
 pixman = { version = "0.2.1", features = ["drm-fourcc", "sync"], optional = true }
 aliasable = { version = "0.1.3", optional = true }
 atomic_float = "1.1.0"
+sha2 = "0.10.9"
 
 
 [dev-dependencies]

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -24,7 +24,7 @@ use wayland_server::{Resource, Weak};
 #[cfg(feature = "wayland_frontend")]
 mod keymap_file;
 #[cfg(feature = "wayland_frontend")]
-pub use keymap_file::KeymapFile;
+pub use keymap_file::{KeymapFile, KeymapFileId};
 
 mod modifiers_state;
 pub use modifiers_state::{ModifiersState, SerializedMods};
@@ -360,7 +360,7 @@ pub(crate) struct KbdRc<D: SeatHandler> {
     pub(crate) last_enter: Mutex<Option<Serial>>,
     pub(crate) span: tracing::Span,
     #[cfg(feature = "wayland_frontend")]
-    pub(crate) active_keymap: RwLock<usize>,
+    pub(crate) active_keymap: RwLock<KeymapFileId>,
 }
 
 #[cfg(not(feature = "wayland_frontend"))]


### PR DESCRIPTION
This fixes excessive keymap events with `virtual-keyboard-unstable-v1` clients like fcitx5.

This depends on `sha2`. Adding a new dependency for this is annoying, but this is a fairly widely used crate. `blake3` could also work but is less widely used. Perhaps a dependency couple be avoided if `SipHasher` is good enough, but as I understand it's not really meant to guarantee an absence of collisions (but may be good enough in practice here?).

I expect computing a hash won't impact performance much, compared to clients having to process excessive `keymap` events