### PR TITLE
wayland/cursor_shape: update to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ appendlist = "1.4"
 ash = { version = "0.38.0", optional = true }
 bitflags = "2.2.1"
 calloop = "0.14.0"
-cursor-icon = "1.0.0"
+cursor-icon = "1.2.0"
 cgmath = "0.18.0"
 downcast-rs = "1.2.0"
 drm-fourcc = "^2.2.0"
@@ -72,7 +72,6 @@ pixman = { version = "0.2.1", features = ["drm-fourcc", "sync"], optional = true
 aliasable = { version = "0.1.3", optional = true }
 atomic_float = "1.1.0"
 sha2 = "0.10.9"
-
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -134,7 +134,7 @@ impl CursorShapeManagerState {
         D: SeatHandler,
         D: 'static,
     {
-        let global = display.create_global::<D, CursorShapeManager, _>(1, ());
+        let global = display.create_global::<D, CursorShapeManager, _>(2, ());
         Self { global }
     }
 
@@ -351,6 +351,8 @@ fn shape_to_cursor_icon(shape: Shape) -> CursorIcon {
         Shape::AllScroll => CursorIcon::AllScroll,
         Shape::ZoomIn => CursorIcon::ZoomIn,
         Shape::ZoomOut => CursorIcon::ZoomOut,
+        Shape::DndAsk => CursorIcon::DndAsk,
+        Shape::AllResize => CursorIcon::AllResize,
         _ => CursorIcon::Default,
     }
 }


### PR DESCRIPTION
updates the cursor shape protocol to version 2. released in [wayland-protocols version 1.42](https://lists.freedesktop.org/archives/wayland-devel/2025-March/044027.html) it contains two new cursors: `dnd-ask` and `all-resize`.

needs `cursor-icon` v1.2.0, as that is the version with https://github.com/rust-windowing/cursor-icon/pull/17 included.

i tested it by patching winit and the smithay client toolkit (see https://github.com/Smithay/client-toolkit/pull/496) and using a cursor theme that has the `dnd-ask` cursor (one of the new ones, [bibata has them for example](https://github.com/ful1e5/Bibata_Cursor/blob/main/svg/groups/hand/dnd-ask.svg)) and it works when testing it with my own compositor:

![image](https://github.com/user-attachments/assets/93e83c6d-40b3-4611-9c35-c9f6d053e1f3)