### PR TITLE
gles: Don't call `GenTextures` before `make_current()`

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -818,6 +818,10 @@ impl ImportMemWl for GlesRenderer {
 
             let mut upload_full = false;
 
+            unsafe {
+                self.egl.make_current()?;
+            }
+
             let id = self.context_id();
             let texture = GlesTexture(
                 surface_lock
@@ -849,7 +853,6 @@ impl ImportMemWl for GlesRenderer {
 
             let mut sync_lock = texture.0.sync.write().unwrap();
             unsafe {
-                self.egl.make_current()?;
                 sync_lock.wait_for_all(&self.gl);
                 self.gl.BindTexture(ffi::TEXTURE_2D, texture.0.texture);
                 self.gl


### PR DESCRIPTION
The `unwrap_or_else()` call here in `import_shm_buffer()` has a call to `self.gl.GenTextures()`, but `self.egl.make_current()` was only being called in the next block.

It appears this was the cause of some issues I saw on a multi-GPU system, where `GenTextures` ended up being called on the last current context, which if it was on the other GPU, caused this `GlesTexture` to be using the same texture ID as whatever other texture was assigned the same ID.