### PR TITLE
Fix broken CI due to redundant-explicit-link errors

### DIFF
--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -1042,7 +1042,7 @@ impl EGLBufferReader {
     /// Try to receive [`EGLBuffer`] from a given [`WlBuffer`].
     ///
     /// In case the buffer is not managed by EGL (but e.g. the [`wayland::shm` module](crate::wayland::shm))
-    /// a [`BufferAccessError::NotManaged`](crate::backend::egl::BufferAccessError::NotManaged) is returned.
+    /// a [`BufferAccessError::NotManaged`] is returned.
     #[profiling::function]
     pub fn egl_buffer_contents(
         &self,

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -942,7 +942,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     /// [`FilterResult::Intercept`] a value can be passed to be returned by the whole function.
     /// This mechanism can be used to implement compositor-level key bindings for example.
     ///
-    /// The module [`keysyms`](crate::input::keyboard::keysyms) exposes definitions of all possible keysyms
+    /// The module [`keysyms`] exposes definitions of all possible keysyms
     /// to be compared against. This includes non-character keysyms, such as XF86 special keys.
     #[instrument(level = "trace", parent = &self.arc.span, skip(self, data, filter))]
     pub fn input<T, F>(

--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -259,7 +259,7 @@ where
 /// You need to provide the available mime types for this selection.
 ///
 /// Whenever a client requests to read the selection, your callback will
-/// receive a [`SelectionHandler::send_selection`](crate::wayland::selection::SelectionHandler::send_selection) event.
+/// receive a [`SelectionHandler::send_selection`] event.
 #[instrument(name = "wayland_data_device", level = "debug", skip(dh, seat, user_data), fields(seat = seat.name()))]
 pub fn set_data_device_selection<D>(
     dh: &DisplayHandle,


### PR DESCRIPTION
rustdoc::redundant-explicit-link matches more cases in the nightly rust version. Remove the redundant links that trigger the warning, which is processed as an error in CI due to `-D warnings` in the rustdoc flags.

The three redundant links all refer to items that are imported into the current file and therefore do not require explicit, absolute links to resolve.