### PR TITLE
compositor/gbm: Don't scanout client buffers without explicit node matches

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -820,7 +820,7 @@ impl AnvilState<UdevData> {
             })
             .ok_or(DeviceAddError::PrimaryGpuMissing)?;
 
-        let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone());
+        let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone(), render_node);
 
         let color_formats = if std::env::var("ANVIL_DISABLE_10BIT").is_ok() {
             SUPPORTED_FORMATS_8BIT_ONLY

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1227,7 +1227,7 @@ where
 
                         let cursor_allocator =
                             GbmAllocator::new(gbm.clone(), GbmBufferFlags::CURSOR | GbmBufferFlags::WRITE);
-                        let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone());
+                        let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone(), None);
                         CursorState {
                             allocator: cursor_allocator,
                             framebuffer_exporter,
@@ -1409,7 +1409,7 @@ where
 
             let cursor_allocator =
                 GbmAllocator::new(gbm.clone(), GbmBufferFlags::CURSOR | GbmBufferFlags::WRITE);
-            let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone());
+            let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone(), None);
             CursorState {
                 allocator: cursor_allocator,
                 framebuffer_exporter,


### PR DESCRIPTION
See https://gitlab.freedesktop.org/drm/amd/-/issues/2075#note_2582039