### PR TITLE
selection: instantly notify clients when source dies

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -188,8 +188,8 @@ pub struct DndIcon {
 delegate_compositor!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> DataDeviceHandler for AnvilState<BackendData> {
-    fn data_device_state(&self) -> &DataDeviceState {
-        &self.data_device_state
+    fn data_device_state(&mut self) -> &mut DataDeviceState {
+        &mut self.data_device_state
     }
 }
 
@@ -255,15 +255,15 @@ impl<BackendData: Backend> SelectionHandler for AnvilState<BackendData> {
 }
 
 impl<BackendData: Backend> PrimarySelectionHandler for AnvilState<BackendData> {
-    fn primary_selection_state(&self) -> &PrimarySelectionState {
-        &self.primary_selection_state
+    fn primary_selection_state(&mut self) -> &mut PrimarySelectionState {
+        &mut self.primary_selection_state
     }
 }
 delegate_primary_selection!(@<BackendData: Backend + 'static> AnvilState<BackendData>);
 
 impl<BackendData: Backend> DataControlHandler for AnvilState<BackendData> {
-    fn data_control_state(&self) -> &DataControlState {
-        &self.data_control_state
+    fn data_control_state(&mut self) -> &mut DataControlState {
+        &mut self.data_control_state
     }
 }
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -77,8 +77,8 @@ impl SelectionHandler for App {
 }
 
 impl DataDeviceHandler for App {
-    fn data_device_state(&self) -> &DataDeviceState {
-        &self.data_device_state
+    fn data_device_state(&mut self) -> &mut DataDeviceState {
+        &mut self.data_device_state
     }
 }
 

--- a/smallvil/src/handlers/mod.rs
+++ b/smallvil/src/handlers/mod.rs
@@ -46,8 +46,8 @@ impl SelectionHandler for Smallvil {
 }
 
 impl DataDeviceHandler for Smallvil {
-    fn data_device_state(&self) -> &DataDeviceState {
-        &self.data_device_state
+    fn data_device_state(&mut self) -> &mut DataDeviceState {
+        &mut self.data_device_state
     }
 }
 

--- a/src/wayland/selection/data_device/device.rs
+++ b/src/wayland/selection/data_device/device.rs
@@ -67,6 +67,22 @@ where
                 icon,
                 serial,
             } => {
+                // Each source can only be used once.
+                if let Some(source) = source.as_ref() {
+                    if handler
+                        .data_device_state()
+                        .used_sources
+                        .insert(source.clone(), data.wl_seat.clone())
+                        .is_some()
+                    {
+                        resource.post_error(
+                            wl_data_device::Error::UsedSource,
+                            "selection source can be used only once.",
+                        );
+                        return;
+                    }
+                }
+
                 let serial = Serial::from(serial);
                 if let Some(pointer) = seat.get_pointer() {
                     if pointer.has_grab(serial) {
@@ -129,6 +145,23 @@ where
                         return;
                     }
                 };
+
+                // Each source can only be used once.
+                if let Some(source) = source.as_ref() {
+                    if handler
+                        .data_device_state()
+                        .used_sources
+                        .insert(source.clone(), data.wl_seat.clone())
+                        .is_some()
+                    {
+                        resource.post_error(
+                            wl_data_device::Error::UsedSource,
+                            "selection source can be used only once.",
+                        );
+                        return;
+                    }
+                }
+
                 let source = source.map(SelectionSourceProvider::DataDevice);
 
                 handler.new_selection(

--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -60,7 +60,7 @@
 //!     type SelectionUserData = ();
 //! }
 //! impl DataDeviceHandler for State {
-//!     fn data_device_state(&self) -> &DataDeviceState { &self.data_device_state }
+//!     fn data_device_state(&mut self) -> &mut DataDeviceState { &mut self.data_device_state }
 //!     // ... override default implementations here to customize handling ...
 //! }
 //! delegate_data_device!(State);
@@ -70,6 +70,7 @@
 
 use std::{
     cell::{Ref, RefCell},
+    collections::HashMap,
     os::unix::io::OwnedFd,
 };
 
@@ -79,6 +80,7 @@ use wayland_server::{
     protocol::{
         wl_data_device_manager::{DndAction, WlDataDeviceManager},
         wl_data_source::WlDataSource,
+        wl_seat::WlSeat,
         wl_surface::WlSurface,
     },
     Client, DisplayHandle, GlobalDispatch,
@@ -113,7 +115,7 @@ use super::{
 #[allow(unused_variables)]
 pub trait DataDeviceHandler: Sized + SelectionHandler + ClientDndGrabHandler + ServerDndGrabHandler {
     /// [DataDeviceState] getter
-    fn data_device_state(&self) -> &DataDeviceState;
+    fn data_device_state(&mut self) -> &mut DataDeviceState;
 
     /// Action chooser for DnD negociation
     fn action_choice(&mut self, available: DndAction, preferred: DndAction) -> DndAction {
@@ -195,6 +197,11 @@ pub trait ServerDndGrabHandler: SeatHandler {
 #[derive(Debug)]
 pub struct DataDeviceState {
     manager_global: GlobalId,
+    /// Used sources.
+    ///
+    /// Protocol states that each source can only be used once. We
+    /// also use it during destruction to get seat data.
+    pub(crate) used_sources: HashMap<WlDataSource, WlSeat>,
 }
 
 impl DataDeviceState {
@@ -206,7 +213,10 @@ impl DataDeviceState {
     {
         let manager_global = display.create_global::<D, WlDataDeviceManager, _>(3, ());
 
-        Self { manager_global }
+        Self {
+            manager_global,
+            used_sources: Default::default(),
+        }
     }
 
     /// [WlDataDeviceManager] GlobalId getter
@@ -467,12 +477,12 @@ mod handlers {
             _resource: &WlDataDeviceManager,
             request: wl_data_device_manager::Request,
             _data: &(),
-            _dhandle: &DisplayHandle,
+            dhandle: &DisplayHandle,
             data_init: &mut wayland_server::DataInit<'_, D>,
         ) {
             match request {
                 wl_data_device_manager::Request::CreateDataSource { id } => {
-                    data_init.init(id, DataSourceUserData::new());
+                    data_init.init(id, DataSourceUserData::new(dhandle.clone()));
                 }
                 wl_data_device_manager::Request::GetDataDevice { id, seat: wl_seat } => {
                     match Seat::<D>::from_resource(&wl_seat) {

--- a/src/wayland/selection/data_device/source.rs
+++ b/src/wayland/selection/data_device/source.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use std::{cell::RefCell, sync::Mutex};
 use tracing::error;
 
 use wayland_server::{
@@ -8,7 +8,11 @@ use wayland_server::{
     Dispatch, DisplayHandle, Resource,
 };
 
+use crate::input::Seat;
 use crate::utils::{alive_tracker::AliveTracker, IsAlive};
+use crate::wayland::selection::offer::OfferReplySource;
+use crate::wayland::selection::seat_data::SeatData;
+use crate::wayland::selection::source::SelectionSourceProvider;
 
 use super::{DataDeviceHandler, DataDeviceState};
 
@@ -35,13 +39,15 @@ impl Default for SourceMetadata {
 pub struct DataSourceUserData {
     pub(crate) inner: Mutex<SourceMetadata>,
     alive_tracker: AliveTracker,
+    display_handle: DisplayHandle,
 }
 
 impl DataSourceUserData {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(display_handle: DisplayHandle) -> Self {
         Self {
             inner: Default::default(),
             alive_tracker: Default::default(),
+            display_handle,
         }
     }
 }
@@ -80,8 +86,35 @@ where
         }
     }
 
-    fn destroyed(_state: &mut D, _client: ClientId, _resource: &WlDataSource, data: &DataSourceUserData) {
+    fn destroyed(state: &mut D, _client: ClientId, source: &WlDataSource, data: &DataSourceUserData) {
         data.alive_tracker.destroy_notify();
+
+        // Remove the source from the used ones.
+        let seat = match state
+            .data_device_state()
+            .used_sources
+            .remove(source)
+            .as_ref()
+            .and_then(Seat::<D>::from_resource)
+        {
+            Some(seat) => seat,
+            None => return,
+        };
+
+        let mut seat_data = seat
+            .user_data()
+            .get::<RefCell<SeatData<D::SelectionUserData>>>()
+            .unwrap()
+            .borrow_mut();
+
+        match seat_data.get_clipboard_selection() {
+            Some(OfferReplySource::Client(SelectionSourceProvider::DataDevice(set_source)))
+                if set_source == source =>
+            {
+                seat_data.set_clipboard_selection::<D>(&data.display_handle, None)
+            }
+            _ => (),
+        }
     }
 }
 

--- a/src/wayland/selection/ext_data_control/device.rs
+++ b/src/wayland/selection/ext_data_control/device.rs
@@ -4,6 +4,7 @@ use wayland_protocols::ext::data_control::v1::server::ext_data_control_device_v1
     self, ExtDataControlDeviceV1,
 };
 use wayland_server::protocol::wl_seat::WlSeat;
+use wayland_server::Resource;
 use wayland_server::{Client, Dispatch, DisplayHandle};
 
 use crate::input::Seat;
@@ -44,6 +45,22 @@ where
 
         match request {
             ext_data_control_device_v1::Request::SetSelection { source, .. } => {
+                // Each source can only be used once.
+                if let Some(source) = source.as_ref() {
+                    if handler
+                        .data_control_state()
+                        .used_sources
+                        .insert(source.clone(), data.wl_seat.clone())
+                        .is_some()
+                    {
+                        resource.post_error(
+                            ext_data_control_device_v1::Error::UsedSource,
+                            "selection source can be used only once.",
+                        );
+                        return;
+                    }
+                }
+
                 seat.user_data()
                     .insert_if_missing(|| RefCell::new(SeatData::<D::SelectionUserData>::new()));
 

--- a/src/wayland/selection/ext_data_control/mod.rs
+++ b/src/wayland/selection/ext_data_control/mod.rs
@@ -36,7 +36,7 @@
 //!     type SelectionUserData = ();
 //! }
 //! impl DataControlHandler for State {
-//!     fn data_control_state(&self) -> &DataControlState { &self.data_control_state }
+//!     fn data_control_state(&mut self) -> &mut DataControlState { &mut self.data_control_state }
 //!     // ... override default implementations here to customize handling ...
 //! }
 //! delegate_ext_data_control!(State);
@@ -47,8 +47,12 @@
 //! Be aware that data control clients rely on other selection providers to be implemneted, like
 //! wl_data_device or zwp_primary_selection.
 
+use std::collections::HashMap;
+
 use wayland_protocols::ext::data_control::v1::server::ext_data_control_manager_v1::ExtDataControlManagerV1;
+use wayland_protocols::ext::data_control::v1::server::ext_data_control_source_v1::ExtDataControlSourceV1;
 use wayland_server::backend::GlobalId;
+use wayland_server::protocol::wl_seat::WlSeat;
 use wayland_server::{Client, DisplayHandle, GlobalDispatch};
 
 mod device;
@@ -63,13 +67,18 @@ use super::SelectionHandler;
 /// Access the data control state.
 pub trait DataControlHandler: Sized + SelectionHandler {
     /// [`DataControlState`] getter.
-    fn data_control_state(&self) -> &DataControlState;
+    fn data_control_state(&mut self) -> &mut DataControlState;
 }
 
 /// State of the data control.
 #[derive(Debug)]
 pub struct DataControlState {
     manager_global: GlobalId,
+    /// Used sources.
+    ///
+    /// Protocol states that each source can only be used once. We
+    /// also use it during destruction to get seat data.
+    pub(crate) used_sources: HashMap<ExtDataControlSourceV1, WlSeat>,
 }
 
 impl DataControlState {
@@ -90,7 +99,10 @@ impl DataControlState {
             filter: Box::new(filter),
         };
         let manager_global = display.create_global::<D, ExtDataControlManagerV1, _>(1, data);
-        Self { manager_global }
+        Self {
+            manager_global,
+            used_sources: Default::default(),
+        }
     }
 
     /// [ExtDataControlManagerV1]  GlobalId getter.
@@ -188,7 +200,7 @@ mod handlers {
         ) {
             match request {
                 ext_data_control_manager_v1::Request::CreateDataSource { id } => {
-                    data_init.init(id, ExtDataControlSourceUserData::new());
+                    data_init.init(id, ExtDataControlSourceUserData::new(dh.clone()));
                 }
                 ext_data_control_manager_v1::Request::GetDataDevice { id, seat: wl_seat } => {
                     match Seat::<D>::from_resource(&wl_seat) {

--- a/src/wayland/selection/ext_data_control/source.rs
+++ b/src/wayland/selection/ext_data_control/source.rs
@@ -1,10 +1,14 @@
+use std::cell::RefCell;
 use std::sync::Mutex;
 
 use wayland_server::backend::ClientId;
-use wayland_server::{Dispatch, DisplayHandle, Resource};
+use wayland_server::{Dispatch, DisplayHandle};
 
-use crate::utils::alive_tracker::AliveTracker;
-use crate::utils::IsAlive;
+use crate::input::Seat;
+use crate::wayland::selection::offer::OfferReplySource;
+use crate::wayland::selection::seat_data::SeatData;
+use crate::wayland::selection::source::SelectionSourceProvider;
+use crate::wayland::selection::SelectionTarget;
 
 use wayland_protocols::ext::data_control::v1::server::ext_data_control_source_v1::{
     self, ExtDataControlSourceV1,
@@ -13,15 +17,18 @@ use wayland_protocols::ext::data_control::v1::server::ext_data_control_source_v1
 use super::{DataControlHandler, DataControlState};
 
 #[doc(hidden)]
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct ExtDataControlSourceUserData {
     pub(crate) inner: Mutex<SourceMetadata>,
-    alive_tracker: AliveTracker,
+    display_handle: DisplayHandle,
 }
 
 impl ExtDataControlSourceUserData {
-    pub(crate) fn new() -> Self {
-        Self::default()
+    pub(crate) fn new(display_handle: DisplayHandle) -> Self {
+        Self {
+            inner: Default::default(),
+            display_handle,
+        }
     }
 }
 
@@ -58,19 +65,50 @@ where
     }
 
     fn destroyed(
-        _state: &mut D,
+        state: &mut D,
         _client: ClientId,
-        _resource: &ExtDataControlSourceV1,
+        source: &ExtDataControlSourceV1,
         data: &ExtDataControlSourceUserData,
     ) {
-        data.alive_tracker.destroy_notify();
-    }
-}
+        // Remove the source from the used ones.
+        let seat = match state
+            .data_control_state()
+            .used_sources
+            .remove(source)
+            .as_ref()
+            .and_then(Seat::<D>::from_resource)
+        {
+            Some(seat) => seat,
+            None => return,
+        };
 
-impl IsAlive for ExtDataControlSourceV1 {
-    #[inline]
-    fn alive(&self) -> bool {
-        let data: &ExtDataControlSourceUserData = self.data().unwrap();
-        data.alive_tracker.alive()
+        let mut seat_data = seat
+            .user_data()
+            .get::<RefCell<SeatData<D::SelectionUserData>>>()
+            .unwrap()
+            .borrow_mut();
+
+        for target in [SelectionTarget::Primary, SelectionTarget::Clipboard] {
+            let selection = match target {
+                SelectionTarget::Primary => seat_data.get_primary_selection(),
+                SelectionTarget::Clipboard => seat_data.get_clipboard_selection(),
+            };
+
+            match selection {
+                Some(OfferReplySource::Client(SelectionSourceProvider::ExtDataControl(set_source)))
+                    if set_source == source =>
+                {
+                    match target {
+                        SelectionTarget::Primary => {
+                            seat_data.set_primary_selection::<D>(&data.display_handle, None)
+                        }
+                        SelectionTarget::Clipboard => {
+                            seat_data.set_clipboard_selection::<D>(&data.display_handle, None)
+                        }
+                    }
+                }
+                _ => (),
+            };
+        }
     }
 }

--- a/src/wayland/selection/seat_data.rs
+++ b/src/wayland/selection/seat_data.rs
@@ -2,8 +2,6 @@ use wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_device_v1
 use wayland_server::protocol::wl_data_device::WlDataDevice;
 use wayland_server::{Client, DisplayHandle, Resource};
 
-use crate::utils::IsAlive;
-
 use super::device::SelectionDevice;
 use super::offer::{OfferReplySource, SelectionOffer};
 use super::{SelectionHandler, SelectionTarget};
@@ -128,8 +126,8 @@ impl<U: Clone + Send + Sync + 'static> SeatData<U> {
         &mut self,
         dh: &DisplayHandle,
         ty: SelectionTarget,
-        mut restrict_to: Option<&SelectionDevice>,
-        mut update_data_control: bool,
+        restrict_to: Option<&SelectionDevice>,
+        update_data_control: bool,
     ) where
         D: SelectionHandler<SelectionUserData = U> + 'static,
     {
@@ -140,22 +138,6 @@ impl<U: Clone + Send + Sync + 'static> SeatData<U> {
                 &mut self.clipboard_selection,
             ),
         };
-
-        // Clear selection if it's no longer alive.
-        if selection.as_ref().is_some_and(|selection| {
-            if let OfferReplySource::Client(source) = selection {
-                !source.alive()
-            } else {
-                false
-            }
-        }) {
-            // Trigger data-control reload when selection is gone.
-            update_data_control |= true;
-            *selection = None;
-
-            // NOTE when selection provider dies, we need to refresh the state in each data device.
-            restrict_to = None;
-        }
 
         for device in self
             .known_devices

--- a/src/wayland/selection/source.rs
+++ b/src/wayland/selection/source.rs
@@ -5,7 +5,6 @@ use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection
 use wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_source_v1::ZwlrDataControlSourceV1;
 use wayland_server::{protocol::wl_data_source::WlDataSource, Resource};
 
-use crate::utils::IsAlive;
 use crate::wayland::selection::primary_selection::PrimarySourceUserData;
 
 use super::data_device::DataSourceUserData;
@@ -94,13 +93,6 @@ impl SelectionSourceProvider {
                 data.inner.lock().unwrap().mime_types.clone()
             }
         }
-    }
-}
-
-impl IsAlive for SelectionSourceProvider {
-    #[inline]
-    fn alive(&self) -> bool {
-        selection_dispatch!(self; Self(source) => source.alive())
     }
 }
 

--- a/src/wayland/selection/wlr_data_control/device.rs
+++ b/src/wayland/selection/wlr_data_control/device.rs
@@ -5,7 +5,7 @@ use wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_device_v1
     self, ZwlrDataControlDeviceV1,
 };
 use wayland_server::protocol::wl_seat::WlSeat;
-use wayland_server::{Client, Dispatch, DisplayHandle};
+use wayland_server::{Client, Dispatch, DisplayHandle, Resource};
 
 use crate::input::Seat;
 use crate::wayland::selection::device::SelectionDevice;
@@ -45,6 +45,22 @@ where
 
         match request {
             zwlr_data_control_device_v1::Request::SetSelection { source, .. } => {
+                // Each source can only be used once.
+                if let Some(source) = source.as_ref() {
+                    if handler
+                        .data_control_state()
+                        .used_sources
+                        .insert(source.clone(), data.wl_seat.clone())
+                        .is_some()
+                    {
+                        resource.post_error(
+                            zwlr_data_control_device_v1::Error::UsedSource,
+                            "selection source can be used only once.",
+                        );
+                        return;
+                    }
+                }
+
                 seat.user_data()
                     .insert_if_missing(|| RefCell::new(SeatData::<D::SelectionUserData>::new()));
 


### PR DESCRIPTION
Smithay uses lazy notify when there's actual interaction, which is unexpected and doesn't properly reflect the state of the clipboard. Instead immediately notify clients when the source was destroyed.

Links: https://github.com/YaLTeR/niri/issues/1831

--

Need to do that for all the rest of the selections protocols and drop the `alive` check, I guess.