### PR TITLE
gles: Share CleanupResource receiver as EGLContext user data 

### DIFF
--- a/src/backend/renderer/gles/texture.rs
+++ b/src/backend/renderer/gles/texture.rs
@@ -36,7 +36,7 @@ impl GlesTexture {
             y_inverted: false,
             size,
             egl_images: None,
-            destruction_callback_sender: renderer.destruction_callback_sender.clone(),
+            destruction_callback_sender: renderer.gles_cleanup().sender.clone(),
         }))
     }
 


### PR DESCRIPTION
With shared contexts, certain resources created by one renderer may not be freed until after that renderer is destroyed (for instance, on output hotplug), potentially leaking resources.

Instead, track the resources to be freed centrally. As long as one renderer exists, and periodically calls `cleanup`, resources will be cleaned up. Meanwhile, if all of the contexts are destroyed, EGL will implicitly free all the resources.

This should fix https://github.com/Smithay/smithay/issues/1752.