### PR TITLE
render/multigpu: Don't use implicit modifier in `dma_shadow_copy`

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -2190,6 +2190,7 @@ where
     let modifiers = read_formats
         .intersection(&write_formats)
         .map(|f| f.modifier)
+        .filter(|m| *m != Modifier::Invalid)
         .collect::<Vec<_>>();
 
     if modifiers.is_empty() {


### PR DESCRIPTION
I've been seeing `eglCreateImageKHR` errors here copying Nvidia buffers to AMD. And worse, this somehow lead to a crash in the Nvidia driver.

It seems this was trying to use an implicit modifier, resulting in something that won't import on the other GPU. Presumably we should just filter out `Modifier::Invalid` here.