### PR TITLE
Add option to accept any node for direct scanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Breaking changes
+
+`GbmFramebufferExporter::new` now accepts a `NodeFilter` as import node, which
+enables accepting dmabufs originating from any node.
+
+```diff
+-GbmFramebufferExporter::new(gbm, node);
++GbmFramebufferExporter::new(gbm, node.into());
+
+-GbmFramebufferExporter::new(gbm, None);
++GbmFramebufferExporter::new(gbm, NodeFilter::None);
+
+-GbmFramebufferExporter::new(gbm, Some(node));
++GbmFramebufferExporter::new(gbm, node.into());
+
++GbmFramebufferExporter::new(gbm, NodeFilter::All);
+```
+
 ## 0.7.0
 
 ### Breaking changes

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -88,7 +88,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                             .into_iter()
                             .chain(
                                 #[cfg(feature = "xwayland")]
-                                self.xdisplay.map(|v| ("DISPLAY", format!(":{}", v))),
+                                self.xdisplay.map(|v| ("DISPLAY", format!(":{v}"))),
                                 #[cfg(not(feature = "xwayland"))]
                                 None,
                             ),

--- a/anvil/src/main.rs
+++ b/anvil/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
                 println!();
                 println!("Possible backends are:");
                 for b in POSSIBLE_BACKENDS {
-                    println!("\t{}", b);
+                    println!("\t{b}");
                 }
             }
         }

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -928,7 +928,7 @@ impl AnvilState<UdevData> {
                 lease_state.add_connector::<AnvilState<UdevData>>(
                     connector.handle(),
                     output_name,
-                    format!("{} {}", make, model),
+                    format!("{make} {model}"),
                 );
             }
         } else {
@@ -1289,7 +1289,7 @@ impl AnvilState<UdevData> {
                             ..
                         })) if source.kind() == io::ErrorKind::PermissionDenied
                     ),
-                    SwapBuffersError::ContextLost(err) => panic!("Rendering loop lost: {}", err),
+                    SwapBuffersError::ContextLost(err) => panic!("Rendering loop lost: {err}"),
                 }
             }
         };
@@ -1489,7 +1489,7 @@ impl AnvilState<UdevData> {
                                 .expect("failed to reset drm device");
                             true
                         }
-                        _ => panic!("Rendering loop lost: {}", err),
+                        _ => panic!("Rendering loop lost: {err}"),
                     },
                 }
             }

--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -824,7 +824,7 @@ impl AnvilState<UdevData> {
             })
             .ok_or(DeviceAddError::PrimaryGpuMissing)?;
 
-        let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone(), render_node);
+        let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone(), render_node.into());
 
         let color_formats = if std::env::var("ANVIL_DISABLE_10BIT").is_ok() {
             SUPPORTED_FORMATS_8BIT_ONLY

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -176,7 +176,7 @@ use crate::{
 
 use super::{
     error::AccessError,
-    exporter::{gbm::GbmFramebufferExporter, ExportBuffer, ExportFramebuffer},
+    exporter::{gbm::GbmFramebufferExporter, gbm::NodeFilter, ExportBuffer, ExportFramebuffer},
     surface::VrrSupport,
     DrmSurface, Framebuffer, PlaneClaim, PlaneInfo, Planes,
 };
@@ -1227,7 +1227,7 @@ where
 
                         let cursor_allocator =
                             GbmAllocator::new(gbm.clone(), GbmBufferFlags::CURSOR | GbmBufferFlags::WRITE);
-                        let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone(), None);
+                        let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone(), NodeFilter::None);
                         CursorState {
                             allocator: cursor_allocator,
                             framebuffer_exporter,
@@ -1409,7 +1409,7 @@ where
 
             let cursor_allocator =
                 GbmAllocator::new(gbm.clone(), GbmBufferFlags::CURSOR | GbmBufferFlags::WRITE);
-            let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone(), None);
+            let framebuffer_exporter = GbmFramebufferExporter::new(gbm.clone(), NodeFilter::None);
             CursorState {
                 allocator: cursor_allocator,
                 framebuffer_exporter,

--- a/src/backend/drm/exporter/gbm.rs
+++ b/src/backend/drm/exporter/gbm.rs
@@ -35,7 +35,7 @@ pub struct GbmFramebufferExporter<A: AsFd + 'static> {
     gbm: gbm::Device<A>,
     drm_node: Option<DrmNode>,
     #[cfg_attr(not(feature = "wayland_frontend"), allow(unused))]
-    import_node: Option<DrmNode>,
+    import_node: NodeFilter,
 }
 
 impl<A: AsFd + 'static> GbmFramebufferExporter<A> {
@@ -43,8 +43,10 @@ impl<A: AsFd + 'static> GbmFramebufferExporter<A> {
     ///
     /// `import_node` will be used to filter dmabufs to originate from a particular
     /// device before considering them for direct scanout.
-    /// If `import_node` is `None` direct-scanout of client-buffers won't be used.
-    pub fn new(gbm: gbm::Device<A>, import_node: Option<DrmNode>) -> Self {
+    ///
+    /// If `import_node` is [`NodeFilter::None`], direct-scanout of client-buffers
+    /// won't be used.
+    pub fn new(gbm: gbm::Device<A>, import_node: NodeFilter) -> Self {
         let drm_node = DrmNode::from_file(gbm.as_fd()).ok();
         Self {
             gbm,
@@ -95,13 +97,13 @@ impl<A: AsFd + 'static> ExportFramebuffer<GbmBuffer> for GbmFramebufferExporter<
             #[cfg(not(all(feature = "backend_egl", feature = "use_system_lib")))]
             ExportBuffer::Wayland(buffer) => crate::wayland::dmabuf::get_dmabuf(buffer)
                 .ok()
-                .is_some_and(|buf| buf.node().is_some_and(|node| Some(node) == self.import_node)),
+                .is_some_and(|buf| buf.node().is_some_and(|node| self.import_node == node)),
             #[cfg(all(feature = "backend_egl", feature = "use_system_lib"))]
             ExportBuffer::Wayland(buffer) => match crate::backend::renderer::buffer_type(buffer) {
                 Some(crate::backend::renderer::BufferType::Dma) => crate::wayland::dmabuf::get_dmabuf(buffer)
                     .unwrap()
                     .node()
-                    .is_some_and(|node| Some(node) == self.import_node),
+                    .is_some_and(|node| self.import_node == node),
                 // Argubly we need specialization here. If the renderer (which we have in `element_config`, which calls this function)
                 // has `ImportEGL`, we can verify that `EGLBufferRender` is some, which means we have the renderer advertised via wl_drm,
                 // which means this is probably fine.
@@ -121,6 +123,42 @@ impl<A: AsFd + 'static> ExportFramebuffer<GbmBuffer> for GbmFramebufferExporter<
     fn can_add_framebuffer(&self, buffer: &ExportBuffer<'_, GbmBuffer>) -> bool {
         match buffer {
             ExportBuffer::Allocator(_) => true,
+        }
+    }
+}
+
+/// Filter to matching nodes against.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NodeFilter {
+    /// Consider no nodes a match.
+    None,
+    /// Consider all nodes a match.
+    All,
+    /// Consider only the specified node a match.
+    Node(DrmNode),
+}
+
+impl PartialEq<DrmNode> for NodeFilter {
+    fn eq(&self, other: &DrmNode) -> bool {
+        match self {
+            Self::None => false,
+            Self::All => true,
+            Self::Node(node) => node == other,
+        }
+    }
+}
+
+impl From<DrmNode> for NodeFilter {
+    fn from(node: DrmNode) -> Self {
+        Self::Node(node)
+    }
+}
+
+impl From<Option<DrmNode>> for NodeFilter {
+    fn from(node: Option<DrmNode>) -> Self {
+        match node {
+            Some(node) => Self::Node(node),
+            None => Self::None,
         }
     }
 }

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -1079,7 +1079,7 @@ impl EGLBufferReader {
             ffi::egl::TEXTURE_Y_XUXV_WL => {
                 return Err(BufferAccessError::UnsupportedMultiPlanarFormat(Format::Y_XUXV))
             }
-            x => panic!("EGL returned invalid texture type: {}", x),
+            x => panic!("EGL returned invalid texture type: {x}"),
         };
 
         let mut width: i32 = 0;

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -120,11 +120,10 @@ impl fmt::Debug for BufferAccessError {
             BufferAccessError::EGLImageCreationFailed(_) => {
                 write!(formatter, "BufferAccessError::EGLImageCreationFailed")
             }
-            BufferAccessError::EglExtensionNotSupported(ref err) => write!(formatter, "{:?}", err),
+            BufferAccessError::EglExtensionNotSupported(ref err) => write!(formatter, "{err:?}"),
             BufferAccessError::UnsupportedMultiPlanarFormat(ref fmt) => write!(
                 formatter,
-                "BufferAccessError::UnsupportedMultiPlanerFormat({:?})",
-                fmt
+                "BufferAccessError::UnsupportedMultiPlanerFormat({fmt:?})",
             ),
             BufferAccessError::Destroyed => write!(formatter, "BufferAccessError::Destroyed"),
         }

--- a/src/backend/renderer/gles/shaders/mod.rs
+++ b/src/backend/renderer/gles/shaders/mod.rs
@@ -124,7 +124,7 @@ pub(super) unsafe fn texture_program(
         let shader = src.replace(
             "//_DEFINES_",
             &defines.iter().fold(String::new(), |mut shader, define| {
-                let _ = writeln!(&mut shader, "#define {}", define);
+                let _ = writeln!(&mut shader, "#define {define}");
                 shader
             }),
         );
@@ -134,7 +134,7 @@ pub(super) unsafe fn texture_program(
                 .iter()
                 .chain(&[shaders::DEBUG_FLAGS])
                 .fold(String::new(), |mut shader, define| {
-                    let _ = writeln!(shader, "#define {}", define);
+                    let _ = writeln!(shader, "#define {define}");
                     shader
                 }),
         );

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -167,15 +167,15 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::RenderApiError(err) => write!(f, "Error::RenderApiError({:?})", err),
-            Error::TargetApiError(err) => write!(f, "Error::TargetApiError({:?})", err),
-            Error::NoDevice(dev) => write!(f, "Error::NoDevice({:?})", dev),
-            Error::MismatchedDevice(dev) => write!(f, "Error::MismatchedDevice({:?})", dev),
+            Error::RenderApiError(err) => write!(f, "Error::RenderApiError({err:?})"),
+            Error::TargetApiError(err) => write!(f, "Error::TargetApiError({err:?})"),
+            Error::NoDevice(dev) => write!(f, "Error::NoDevice({dev:?})"),
+            Error::MismatchedDevice(dev) => write!(f, "Error::MismatchedDevice({dev:?})"),
             Error::DeviceMissing => write!(f, "Error::DeviceMissing"),
-            Error::Render(err) => write!(f, "Error::Render({:?})", err),
-            Error::Target(err) => write!(f, "Error::Target({:?})", err),
+            Error::Render(err) => write!(f, "Error::Render({err:?})"),
+            Error::Target(err) => write!(f, "Error::Target({err:?})"),
             Error::ImportFailed => write!(f, "Error::ImportFailed"),
-            Error::AllocatorError(err) => write!(f, "Error::AllocationError({})", err),
+            Error::AllocatorError(err) => write!(f, "Error::AllocationError({err})"),
         }
     }
 }

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -715,15 +715,15 @@ unsafe extern "system" fn vulkan_debug_utils_callback(
         // terminator.
         let message = unsafe { CStr::from_ptr((*p_callback_data).p_message) }.to_string_lossy();
         // Message type is in full uppercase since we print the bitflag debug representation.
-        let ty = format!("{:?}", message_type).to_lowercase();
+        let ty = format!("{message_type:?}").to_lowercase();
 
         match message_severity {
             vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE => {
-                trace!(ty, "{}", message)
+                trace!(ty, "{message}")
             }
-            vk::DebugUtilsMessageSeverityFlagsEXT::INFO => info!(ty, "{}", message),
-            vk::DebugUtilsMessageSeverityFlagsEXT::WARNING => warn!(ty, "{}", message),
-            vk::DebugUtilsMessageSeverityFlagsEXT::ERROR => error!(ty, "{}", message),
+            vk::DebugUtilsMessageSeverityFlagsEXT::INFO => info!(ty, "{message}"),
+            vk::DebugUtilsMessageSeverityFlagsEXT::WARNING => warn!(ty, "{message}"),
+            vk::DebugUtilsMessageSeverityFlagsEXT::ERROR => error!(ty, "{message}"),
             _ => (),
         }
     });

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -942,8 +942,8 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     /// [`FilterResult::Intercept`] a value can be passed to be returned by the whole function.
     /// This mechanism can be used to implement compositor-level key bindings for example.
     ///
-    /// The module [`keysyms`] exposes definitions of all possible keysyms
-    /// to be compared against. This includes non-character keysyms, such as XF86 special keys.
+    /// The module [`keysyms`] exposes definitions of all possible keysyms to be compared against.
+    /// This includes non-character keysyms, such as XF86 special keys.
     #[instrument(level = "trace", parent = &self.arc.span, skip(self, data, filter))]
     pub fn input<T, F>(
         &self,

--- a/src/wayland/dmabuf/dispatch.rs
+++ b/src/wayland/dmabuf/dispatch.rs
@@ -254,7 +254,7 @@ where
                 if plane_idx as usize >= MAX_PLANES {
                     params.post_error(
                         zwp_linux_buffer_params_v1::Error::PlaneIdx,
-                        format!("Plane index {} is out of bounds", plane_idx),
+                        format!("Plane index {plane_idx} is out of bounds"),
                     );
                     return;
                 }
@@ -265,7 +265,7 @@ where
                 if planes.iter().any(|plane| plane.plane_idx == plane_idx) {
                     params.post_error(
                         zwp_linux_buffer_params_v1::Error::PlaneSet,
-                        format!("Plane index {} is already set.", plane_idx),
+                        format!("Plane index {plane_idx} is already set."),
                     );
                     return;
                 }
@@ -283,10 +283,7 @@ where
                     if params.version() >= 5 && modifier != data_modifier {
                         params.post_error(
                             zwp_linux_buffer_params_v1::Error::InvalidFormat,
-                            format!(
-                                "Planes have non-matching modifiers: {:?} != {:?}",
-                                modifier, data_modifier
-                            ),
+                            format!("Planes have non-matching modifiers: {modifier:?} != {data_modifier:?}",),
                         );
                     }
                 } else {

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -1107,7 +1107,7 @@ impl DmabufParamsData {
             Err(_) => {
                 params.post_error(
                     zwp_linux_buffer_params_v1::Error::InvalidFormat,
-                    format!("Format {:x} is not supported", format),
+                    format!("Format {format:x} is not supported"),
                 );
 
                 return None;
@@ -1119,7 +1119,7 @@ impl DmabufParamsData {
         if !self.formats.contains_key(&format) {
             params.post_error(
                 zwp_linux_buffer_params_v1::Error::InvalidFormat,
-                format!("Format {:?}/{:x} is not supported.", format, format as u32),
+                format!("Format {format:?}/{:x} is not supported.", format as u32),
             );
             return None;
         }

--- a/src/wayland/drm_syncobj/mod.rs
+++ b/src/wayland/drm_syncobj/mod.rs
@@ -335,7 +335,7 @@ where
                         Err(err) => {
                             resource.post_error(
                                 wp_linux_drm_syncobj_manager_v1::Error::InvalidTimeline as u32,
-                                format!("failed to import syncobj timeline: {}", err),
+                                format!("failed to import syncobj timeline: {err}"),
                             );
                         }
                     }

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -77,7 +77,7 @@ where
                     Err(layer) => {
                         shell.post_error(
                             zwlr_layer_shell_v1::Error::InvalidLayer,
-                            format!("invalid layer: {:?}", layer),
+                            format!("invalid layer: {layer:?}"),
                         );
                         return;
                     }

--- a/src/wayland/shell/wlr_layer/types.rs
+++ b/src/wayland/shell/wlr_layer/types.rs
@@ -36,7 +36,7 @@ impl TryFrom<WEnum<zwlr_layer_shell_v1::Layer>> for Layer {
             WEnum::Value(Layer::Overlay) => Ok(Self::Overlay),
             layer => Err((
                 zwlr_layer_shell_v1::Error::InvalidLayer,
-                format!("invalid layer: {:?}", layer),
+                format!("invalid layer: {layer:?}"),
             )),
         }
     }
@@ -113,7 +113,7 @@ impl TryFrom<WEnum<zwlr_layer_surface_v1::KeyboardInteractivity>> for KeyboardIn
             WEnum::Value(KeyboardInteractivity::OnDemand) => Ok(Self::OnDemand),
             ki => Err((
                 zwlr_layer_surface_v1::Error::InvalidKeyboardInteractivity,
-                format!("wrong keyboard interactivity value: {:?}", ki),
+                format!("wrong keyboard interactivity value: {ki:?}"),
             )),
         }
     }
@@ -171,7 +171,7 @@ impl TryFrom<WEnum<zwlr_layer_surface_v1::Anchor>> for Anchor {
 
         a.ok_or((
             zwlr_layer_surface_v1::Error::InvalidAnchor,
-            format!("invalid anchor {:?}", anchor),
+            format!("invalid anchor {anchor:?}"),
         ))
     }
 }

--- a/src/wayland/shm/handlers.rs
+++ b/src/wayland/shm/handlers.rs
@@ -128,12 +128,11 @@ where
                 let message = if offset < 0 {
                     Some("offset must not be negative".to_string())
                 } else if width <= 0 || height <= 0 {
-                    Some(format!("invalid width or height ({}x{})", width, height))
+                    Some(format!("invalid width or height ({width}x{height})"))
                 } else if stride.checked_div(wl_bytes_per_pixel(format)).unwrap_or(0) < width {
                     // stride is in bytes...
                     Some(format!(
-                        "width must not be larger than stride (width {}, stride {})",
-                        width,
+                        "width must not be larger than stride (width {width}, stride {})",
                         stride.checked_div(wl_bytes_per_pixel(format)).unwrap_or(0)
                     ))
                 } else if (i32::MAX / stride) < height {
@@ -157,7 +156,7 @@ where
                         if !state.shm_state().formats.contains(&format) {
                             pool.post_error(
                                 wl_shm::Error::InvalidFormat,
-                                format!("format {:?} not supported", format),
+                                format!("format {format:?} not supported"),
                             );
 
                             return;
@@ -181,7 +180,7 @@ where
                     WEnum::Unknown(unknown) => {
                         pool.post_error(
                             wl_shm::Error::InvalidFormat,
-                            format!("unknown format 0x{:x}", unknown),
+                            format!("unknown format 0x{unknown:x}"),
                         );
                     }
                 }

--- a/src/wayland/shm/pool.rs
+++ b/src/wayland/shm/pool.rs
@@ -306,7 +306,7 @@ unsafe fn place_sigbus_handler() {
             let mut old_action = mem::zeroed();
             if libc::sigaction(libc::SIGBUS, &action, &mut old_action) == -1 {
                 let e = rustix::io::Errno::from_raw_os_error(errno::errno().0);
-                panic!("sigaction failed for SIGBUS handler: {:?}", e);
+                panic!("sigaction failed for SIGBUS handler: {e:?}");
             }
 
             old_action

--- a/src/xwayland/x11_sockets.rs
+++ b/src/xwayland/x11_sockets.rs
@@ -29,7 +29,7 @@ pub(crate) fn prepare_x11_sockets(
                     // we got a lockfile, try and create the socket
                     match open_x11_sockets_for_display(d, open_abstract_socket) {
                         Ok(sockets) => return Ok((lock, sockets)),
-                        Err(err) => warn!(display = d, "Failed to create sockets: {}", err),
+                        Err(err) => warn!(display = d, "Failed to create sockets: {err}"),
                     }
                 }
             }
@@ -53,7 +53,7 @@ impl X11Lock {
     /// Try to grab a lockfile for given X display number
     fn grab(number: u32) -> Result<X11Lock, ()> {
         debug!(display = number, "Attempting to aquire an X11 display lock");
-        let filename = format!("/tmp/.X{}-lock", number);
+        let filename = format!("/tmp/.X{number}-lock");
         let lockfile = ::std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -141,7 +141,7 @@ fn open_x11_sockets_for_display(
     display: u32,
     open_abstract_socket: bool,
 ) -> rustix::io::Result<Vec<UnixStream>> {
-    let path = format!("/tmp/.X11-unix/X{}", display);
+    let path = format!("/tmp/.X11-unix/X{display}");
     let _ = ::std::fs::remove_file(&path);
     // We know this path is not too long, these unwrap cannot fail
     let fs_addr = SocketAddrUnix::new(path.as_bytes()).unwrap();

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -139,7 +139,7 @@ impl XWayland {
         command
             .stdout(stdout)
             .stderr(stderr)
-            .arg(format!(":{}", display_number))
+            .arg(format!(":{display_number}"))
             .arg("-verbose")
             .arg("-rootless")
             .arg("-terminate")


### PR DESCRIPTION
This patch introduces a breaking change which allows restoring the pre-0.7.0 functionality of acccepting any node for direct scanout for the `GbmFramebufferExporter` constructor.

While it would be possible to do the same in a non-breaking manner by introducing a separate constructor, this should be more elegant long-term while requiring minimal breaking changes.