### PR TITLE
Fix WeakSeat Clone

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -191,8 +191,14 @@ pub struct Seat<D: SeatHandler> {
 ///
 /// Does not keep associated user data alive,
 /// and can be used to refer to a potentially already destroyed seat.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct WeakSeat<D: SeatHandler>(Weak<SeatRc<D>>);
+
+impl<D: SeatHandler> Clone for WeakSeat<D> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 impl<D: SeatHandler> WeakSeat<D> {
     /// Try to retrieve the original `Seat`, if it still exists


### PR DESCRIPTION
The derived clone is only generated if all generic types implement Clone. In this case, that's wrong because the contained type is not meant to be Clone.