### PR TITLE
xwm: Handle `_NET_WM_WINDOW_OPACITY` window property

### DIFF
--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -107,12 +107,15 @@ where
         renderer: &mut R,
         location: Point<i32, Physical>,
         scale: Scale<f64>,
-        alpha: f32,
+        mut alpha: f32,
     ) -> Vec<C> {
         let state = self.state.lock().unwrap();
         let Some(surface) = state.wl_surface.as_ref() else {
             return Vec::new();
         };
+        if let Some(opacity) = state.opacity {
+            alpha *= (opacity as f32) / (u32::MAX as f32);
+        }
         render_elements_from_surface_tree(renderer, surface, location, scale, alpha, Kind::Unspecified)
     }
 }

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -173,6 +173,7 @@ mod atoms {
             _NET_WM_NAME,
             _NET_WM_MOVERESIZE,
             _NET_WM_PID,
+            _NET_WM_WINDOW_OPACITY,
             _NET_WM_WINDOW_TYPE,
             _NET_WM_WINDOW_TYPE_DROPDOWN_MENU,
             _NET_WM_WINDOW_TYPE_DIALOG,


### PR DESCRIPTION
As defined by https://specifications.freedesktop.org/wm-spec/latest/ar01s05.html.

Not sure how often this is used, but `xwaylandvideobridge` uses it (among other properties to try to hide its window from view).