### PR TITLE
wl_seat v10 with compositor key repeat

### DIFF
--- a/anvil/src/focus.rs
+++ b/anvil/src/focus.rs
@@ -5,7 +5,7 @@ use smithay::xwayland::xwm::XwmOfferData;
 #[cfg(feature = "xwayland")]
 use smithay::xwayland::X11Surface;
 pub use smithay::{
-    backend::input::KeyState,
+    backend::input::KeyEvent,
     desktop::{LayerSurface, PopupKind},
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
@@ -261,12 +261,12 @@ impl<BackendData: Backend> KeyboardTarget<AnvilState<BackendData>> for KeyboardF
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
         key: KeysymHandle<'_>,
-        state: KeyState,
+        event: KeyEvent,
         serial: Serial,
         time: u32,
     ) {
         self.inner_keyboard_target()
-            .key(seat, data, key, state, serial, time)
+            .key(seat, data, key, event, serial, time)
     }
     fn modifiers(
         &self,

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -14,8 +14,8 @@ use smithay::utils::SERIAL_COUNTER;
 use smithay::wayland::virtual_keyboard::VirtualKeyboardHandler;
 use smithay::{
     backend::input::{
-        self, Axis, AxisSource, Event, InputBackend, InputEvent, KeyState, KeyboardKeyEvent,
-        PointerAxisEvent, PointerButtonEvent,
+        self, Axis, AxisSource, Event, InputBackend, InputEvent, KeyEvent, KeyState, PointerAxisEvent,
+        PointerButtonEvent,
     },
     desktop::{layer_map_for_output, WindowSurfaceType},
     input::{
@@ -65,6 +65,13 @@ use smithay::{
         tablet_manager::{TabletDescriptor, TabletSeatTrait},
     },
 };
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct KeyboardEvent {
+    kind: KeyEvent,
+    code: Keycode,
+    time_msec: u32,
+}
 
 impl<BackendData: Backend> AnvilState<BackendData> {
     // Allow in this method because of existing usage
@@ -137,12 +144,12 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         }
     }
 
-    fn keyboard_key_to_action<B: InputBackend>(&mut self, evt: B::KeyboardKeyEvent) -> KeyAction {
-        let keycode = evt.key_code();
-        let state = evt.state();
-        debug!(?keycode, ?state, "key");
+    fn keyboard_event_to_action(&mut self, evt: KeyboardEvent) -> KeyAction {
+        let keycode = evt.code;
+        let event = evt.kind;
+        debug!(?keycode, ?event, "key");
         let serial = SCOUNTER.next_serial();
-        let time = Event::time_msec(&evt);
+        let time = evt.time_msec;
         let mut suppressed_keys = self.suppressed_keys.clone();
         let keyboard = self.seat.get_keyboard().unwrap();
 
@@ -159,7 +166,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 });
                 if let Some(surface) = surface {
                     keyboard.set_focus(self, Some(surface.into()), serial);
-                    keyboard.input::<(), _>(self, keycode, state, serial, time, |_, _, _| {
+                    keyboard.input::<(), _>(self, keycode, event, serial, time, |_, _, _| {
                         FilterResult::Forward
                     });
                     return KeyAction::None;
@@ -178,11 +185,11 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             .unwrap_or(false);
 
         let action = keyboard
-            .input(self, keycode, state, serial, time, |_, modifiers, handle| {
+            .input(self, keycode, event, serial, time, |_, modifiers, handle| {
                 let keysym = handle.modified_sym();
 
                 debug!(
-                    ?state,
+                    ?event,
                     mods = ?modifiers,
                     keysym = ::xkbcommon::xkb::keysym_get_name(keysym),
                     "keysym"
@@ -193,27 +200,36 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 // Additionally add the key to the suppressed keys
                 // so that we can decide on a release if the key
                 // should be forwarded to the client or not.
-                if let KeyState::Pressed = state {
-                    if !inhibited {
-                        let action = process_keyboard_shortcut(*modifiers, keysym);
+                match event {
+                    KeyEvent::Pressed | KeyEvent::Repeated => {
+                        let filter = if !inhibited {
+                            let action = process_keyboard_shortcut(*modifiers, keysym);
 
-                        if action.is_some() {
-                            suppressed_keys.push(keysym);
+                            if action.is_some() {
+                                suppressed_keys.push(keysym);
+                            }
+
+                            action
+                                .map(FilterResult::Intercept)
+                                .unwrap_or(FilterResult::Forward)
+                        } else {
+                            FilterResult::Forward
+                        };
+
+                        // If the user keeps holding the key long enough to trigger a repeat that gets forwarded to the client, then the client needs to receive the release event too.
+                        if let (&FilterResult::Forward, KeyEvent::Repeated) = (&filter, state) {
+                            suppressed_keys.retain(|k| *k != keysym);
                         }
-
-                        action
-                            .map(FilterResult::Intercept)
-                            .unwrap_or(FilterResult::Forward)
-                    } else {
-                        FilterResult::Forward
+                        filter
                     }
-                } else {
-                    let suppressed = suppressed_keys.contains(&keysym);
-                    if suppressed {
-                        suppressed_keys.retain(|k| *k != keysym);
-                        FilterResult::Intercept(KeyAction::None)
-                    } else {
-                        FilterResult::Forward
+                    KeyEvent::Released => {
+                        let suppressed = suppressed_keys.contains(&keysym);
+                        if suppressed {
+                            suppressed_keys.retain(|k| *k != keysym);
+                            FilterResult::Intercept(KeyAction::None)
+                        } else {
+                            FilterResult::Forward
+                        }
                     }
                 }
             })
@@ -221,6 +237,19 @@ impl<BackendData: Backend> AnvilState<BackendData> {
 
         self.suppressed_keys = suppressed_keys;
         action
+    }
+
+    fn on_keyboard_event<B: InputBackend>(
+        &mut self,
+        evt: B::KeyboardKeyEvent,
+        on_event: impl Fn(&mut Self, KeyEvent, u32, Keycode) + Clone + 'static,
+    ) {
+        self.seat.get_keyboard().unwrap().key_register_repeat::<B>(
+            self,
+            |data: &Self| &data.handle,
+            evt,
+            on_event,
+        )
     }
 
     fn on_pointer_button<B: InputBackend>(&mut self, evt: B::PointerButtonEvent) {
@@ -445,78 +474,12 @@ impl<BackendData: Backend> AnvilState<BackendData> {
 impl<BackendData: Backend> AnvilState<BackendData> {
     pub fn process_input_event_windowed<B: InputBackend>(&mut self, event: InputEvent<B>, output_name: &str) {
         match event {
-            InputEvent::Keyboard { event } => match self.keyboard_key_to_action::<B>(event) {
-                KeyAction::ScaleUp => {
-                    let output = self
-                        .space
-                        .outputs()
-                        .find(|o| o.name() == output_name)
-                        .unwrap()
-                        .clone();
-
-                    let current_scale = output.current_scale().fractional_scale();
-                    let new_scale = current_scale + 0.25;
-                    output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
-
-                    crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
-                    self.backend_data.reset_buffers(&output);
-                }
-
-                KeyAction::ScaleDown => {
-                    let output = self
-                        .space
-                        .outputs()
-                        .find(|o| o.name() == output_name)
-                        .unwrap()
-                        .clone();
-
-                    let current_scale = output.current_scale().fractional_scale();
-                    let new_scale = f64::max(1.0, current_scale - 0.25);
-                    output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
-
-                    crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
-                    self.backend_data.reset_buffers(&output);
-                }
-
-                KeyAction::RotateOutput => {
-                    let output = self
-                        .space
-                        .outputs()
-                        .find(|o| o.name() == output_name)
-                        .unwrap()
-                        .clone();
-
-                    let current_transform = output.current_transform();
-                    let new_transform = match current_transform {
-                        Transform::Normal => Transform::_90,
-                        Transform::_90 => Transform::_180,
-                        Transform::_180 => Transform::_270,
-                        Transform::_270 => Transform::Flipped,
-                        Transform::Flipped => Transform::Flipped90,
-                        Transform::Flipped90 => Transform::Flipped180,
-                        Transform::Flipped180 => Transform::Flipped270,
-                        Transform::Flipped270 => Transform::Normal,
-                    };
-                    tracing::info!(?current_transform, ?new_transform, output = ?output.name(), "changing output transform");
-                    output.change_current_state(None, Some(new_transform), None, None);
-                    crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
-                    self.backend_data.reset_buffers(&output);
-                }
-
-                action => match action {
-                    KeyAction::None
-                    | KeyAction::Quit
-                    | KeyAction::Run(_)
-                    | KeyAction::TogglePreview
-                    | KeyAction::ToggleDecorations => self.process_common_key_action(action),
-
-                    _ => tracing::warn!(
-                        ?action,
-                        output_name,
-                        "Key action unsupported on on output backend.",
-                    ),
-                },
-            },
+            InputEvent::Keyboard { event } => {
+                let output_name = output_name.to_owned();
+                self.on_keyboard_event::<B>(event, move |state: &mut Self, event, time_ms, keycode| {
+                    state.process_key_event_windowed(event, time_ms, keycode, &output_name)
+                })
+            }
 
             InputEvent::PointerMotionAbsolute { event } => {
                 let output = self
@@ -530,6 +493,92 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             InputEvent::PointerButton { event } => self.on_pointer_button::<B>(event),
             InputEvent::PointerAxis { event } => self.on_pointer_axis::<B>(event),
             _ => (), // other events are not handled in anvil (yet)
+        }
+    }
+
+    fn process_key_event_windowed(
+        &mut self,
+        event: KeyEvent,
+        time_ms: u32,
+        keycode: Keycode,
+        output_name: &str,
+    ) {
+        let event = KeyboardEvent {
+            kind: event,
+            code: keycode,
+            time_msec: time_ms,
+        };
+        match self.keyboard_event_to_action(event) {
+            KeyAction::ScaleUp => {
+                let output = self
+                    .space
+                    .outputs()
+                    .find(|o| o.name() == output_name)
+                    .unwrap()
+                    .clone();
+
+                let current_scale = output.current_scale().fractional_scale();
+                let new_scale = current_scale + 0.25;
+                output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
+
+                crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
+                self.backend_data.reset_buffers(&output);
+            }
+
+            KeyAction::ScaleDown => {
+                let output = self
+                    .space
+                    .outputs()
+                    .find(|o| o.name() == output_name)
+                    .unwrap()
+                    .clone();
+
+                let current_scale = output.current_scale().fractional_scale();
+                let new_scale = f64::max(1.0, current_scale - 0.25);
+                output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
+
+                crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
+                self.backend_data.reset_buffers(&output);
+            }
+
+            KeyAction::RotateOutput => {
+                let output = self
+                    .space
+                    .outputs()
+                    .find(|o| o.name() == output_name)
+                    .unwrap()
+                    .clone();
+
+                let current_transform = output.current_transform();
+                let new_transform = match current_transform {
+                    Transform::Normal => Transform::_90,
+                    Transform::_90 => Transform::_180,
+                    Transform::_180 => Transform::_270,
+                    Transform::_270 => Transform::Flipped,
+                    Transform::Flipped => Transform::Flipped90,
+                    Transform::Flipped90 => Transform::Flipped180,
+                    Transform::Flipped180 => Transform::Flipped270,
+                    Transform::Flipped270 => Transform::Normal,
+                };
+                tracing::info!(?current_transform, ?new_transform, output = ?output.name(), "changing output transform");
+                output.change_current_state(None, Some(new_transform), None, None);
+                crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
+                self.backend_data.reset_buffers(&output);
+            }
+
+            action => match action {
+                KeyAction::None
+                | KeyAction::Quit
+                | KeyAction::Run(_)
+                | KeyAction::TogglePreview
+                | KeyAction::ToggleDecorations => self.process_common_key_action(action),
+
+                _ => tracing::warn!(
+                    ?action,
+                    output_name,
+                    "Key action unsupported on on output backend.",
+                ),
+            },
         }
     }
 
@@ -559,11 +608,12 @@ impl<BackendData: Backend> AnvilState<BackendData> {
 
     pub fn release_all_keys(&mut self) {
         let keyboard = self.seat.get_keyboard().unwrap();
+        keyboard.key_stop_repeat(self, |data| &data.handle);
         for keycode in keyboard.pressed_keys() {
             keyboard.input(
                 self,
                 keycode,
-                KeyState::Released,
+                KeyEvent::Released,
                 SCOUNTER.next_serial(),
                 0,
                 |_, _, _| FilterResult::Forward::<bool>,
@@ -576,158 +626,11 @@ impl<BackendData: Backend> AnvilState<BackendData> {
 impl AnvilState<UdevData> {
     pub fn process_input_event<B: InputBackend>(&mut self, dh: &DisplayHandle, event: InputEvent<B>) {
         match event {
-            InputEvent::Keyboard { event, .. } => match self.keyboard_key_to_action::<B>(event) {
-                #[cfg(feature = "udev")]
-                KeyAction::VtSwitch(vt) => {
-                    info!(to = vt, "Trying to switch vt");
-                    if let Err(err) = self.backend_data.session.change_vt(vt) {
-                        error!(vt, "Error switching vt: {}", err);
-                    }
-                }
-                KeyAction::Screen(num) => {
-                    let geometry = self
-                        .space
-                        .outputs()
-                        .nth(num)
-                        .map(|o| self.space.output_geometry(o).unwrap());
-
-                    if let Some(geometry) = geometry {
-                        let x = geometry.loc.x as f64 + geometry.size.w as f64 / 2.0;
-                        let y = geometry.size.h as f64 / 2.0;
-                        let location = (x, y).into();
-                        let pointer = self.pointer.clone();
-                        let under = self.surface_under(location);
-                        pointer.motion(
-                            self,
-                            under,
-                            &MotionEvent {
-                                location,
-                                serial: SCOUNTER.next_serial(),
-                                time: self.clock.now().as_millis(),
-                            },
-                        );
-                        pointer.frame(self);
-                    }
-                }
-                KeyAction::ScaleUp => {
-                    let pos = self.pointer.current_location().to_i32_round();
-                    let output = self
-                        .space
-                        .outputs()
-                        .find(|o| self.space.output_geometry(o).unwrap().contains(pos))
-                        .cloned();
-
-                    if let Some(output) = output {
-                        let (output_location, scale) = (
-                            self.space.output_geometry(&output).unwrap().loc,
-                            output.current_scale().fractional_scale(),
-                        );
-                        let new_scale = scale + 0.25;
-                        output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
-
-                        let rescale = scale / new_scale;
-                        let output_location = output_location.to_f64();
-                        let mut pointer_output_location = self.pointer.current_location() - output_location;
-                        pointer_output_location.x *= rescale;
-                        pointer_output_location.y *= rescale;
-                        let pointer_location = output_location + pointer_output_location;
-
-                        crate::shell::fixup_positions(&mut self.space, pointer_location);
-                        let pointer = self.pointer.clone();
-                        let under = self.surface_under(pointer_location);
-                        pointer.motion(
-                            self,
-                            under,
-                            &MotionEvent {
-                                location: pointer_location,
-                                serial: SCOUNTER.next_serial(),
-                                time: self.clock.now().as_millis(),
-                            },
-                        );
-                        pointer.frame(self);
-                        self.backend_data.reset_buffers(&output);
-                    }
-                }
-                KeyAction::ScaleDown => {
-                    let pos = self.pointer.current_location().to_i32_round();
-                    let output = self
-                        .space
-                        .outputs()
-                        .find(|o| self.space.output_geometry(o).unwrap().contains(pos))
-                        .cloned();
-
-                    if let Some(output) = output {
-                        let (output_location, scale) = (
-                            self.space.output_geometry(&output).unwrap().loc,
-                            output.current_scale().fractional_scale(),
-                        );
-                        let new_scale = f64::max(1.0, scale - 0.25);
-                        output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
-
-                        let rescale = scale / new_scale;
-                        let output_location = output_location.to_f64();
-                        let mut pointer_output_location = self.pointer.current_location() - output_location;
-                        pointer_output_location.x *= rescale;
-                        pointer_output_location.y *= rescale;
-                        let pointer_location = output_location + pointer_output_location;
-
-                        crate::shell::fixup_positions(&mut self.space, pointer_location);
-                        let pointer = self.pointer.clone();
-                        let under = self.surface_under(pointer_location);
-                        pointer.motion(
-                            self,
-                            under,
-                            &MotionEvent {
-                                location: pointer_location,
-                                serial: SCOUNTER.next_serial(),
-                                time: self.clock.now().as_millis(),
-                            },
-                        );
-                        pointer.frame(self);
-                        self.backend_data.reset_buffers(&output);
-                    }
-                }
-                KeyAction::RotateOutput => {
-                    let pos = self.pointer.current_location().to_i32_round();
-                    let output = self
-                        .space
-                        .outputs()
-                        .find(|o| self.space.output_geometry(o).unwrap().contains(pos))
-                        .cloned();
-
-                    if let Some(output) = output {
-                        let current_transform = output.current_transform();
-                        let new_transform = match current_transform {
-                            Transform::Normal => Transform::_90,
-                            Transform::_90 => Transform::_180,
-                            Transform::_180 => Transform::_270,
-                            Transform::_270 => Transform::Flipped,
-                            Transform::Flipped => Transform::Flipped90,
-                            Transform::Flipped90 => Transform::Flipped180,
-                            Transform::Flipped180 => Transform::Flipped270,
-                            Transform::Flipped270 => Transform::Normal,
-                        };
-                        output.change_current_state(None, Some(new_transform), None, None);
-                        crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
-                        self.backend_data.reset_buffers(&output);
-                    }
-                }
-                KeyAction::ToggleTint => {
-                    let mut debug_flags = self.backend_data.debug_flags();
-                    debug_flags.toggle(DebugFlags::TINT);
-                    self.backend_data.set_debug_flags(debug_flags);
-                }
-
-                action => match action {
-                    KeyAction::None
-                    | KeyAction::Quit
-                    | KeyAction::Run(_)
-                    | KeyAction::TogglePreview
-                    | KeyAction::ToggleDecorations => self.process_common_key_action(action),
-
-                    _ => unreachable!(),
-                },
-            },
+            InputEvent::Keyboard { event, .. } => {
+                self.on_keyboard_event::<B>(event, move |state: &mut Self, event, time_ms, keycode| {
+                    state.process_key_event(event, time_ms, keycode)
+                })
+            }
             InputEvent::PointerMotion { event, .. } => self.on_pointer_move::<B>(dh, event),
             InputEvent::PointerMotionAbsolute { event, .. } => self.on_pointer_move_absolute::<B>(dh, event),
             InputEvent::PointerButton { event, .. } => self.on_pointer_button::<B>(event),
@@ -776,6 +679,166 @@ impl AnvilState<UdevData> {
             _ => {
                 // other events are not handled in anvil (yet)
             }
+        }
+    }
+
+    fn process_key_event(&mut self, event: KeyEvent, time_ms: u32, keycode: Keycode) {
+        let event = KeyboardEvent {
+            kind: event,
+            code: keycode,
+            time_msec: time_ms,
+        };
+        match self.keyboard_event_to_action(event) {
+            #[cfg(feature = "udev")]
+            KeyAction::VtSwitch(vt) => {
+                info!(to = vt, "Trying to switch vt");
+                if let Err(err) = self.backend_data.session.change_vt(vt) {
+                    error!(vt, "Error switching vt: {}", err);
+                }
+            }
+            KeyAction::Screen(num) => {
+                let geometry = self
+                    .space
+                    .outputs()
+                    .nth(num)
+                    .map(|o| self.space.output_geometry(o).unwrap());
+
+                if let Some(geometry) = geometry {
+                    let x = geometry.loc.x as f64 + geometry.size.w as f64 / 2.0;
+                    let y = geometry.size.h as f64 / 2.0;
+                    let location = (x, y).into();
+                    let pointer = self.pointer.clone();
+                    let under = self.surface_under(location);
+                    pointer.motion(
+                        self,
+                        under,
+                        &MotionEvent {
+                            location,
+                            serial: SCOUNTER.next_serial(),
+                            time: self.clock.now().as_millis(),
+                        },
+                    );
+                    pointer.frame(self);
+                }
+            }
+            KeyAction::ScaleUp => {
+                let pos = self.pointer.current_location().to_i32_round();
+                let output = self
+                    .space
+                    .outputs()
+                    .find(|o| self.space.output_geometry(o).unwrap().contains(pos))
+                    .cloned();
+
+                if let Some(output) = output {
+                    let (output_location, scale) = (
+                        self.space.output_geometry(&output).unwrap().loc,
+                        output.current_scale().fractional_scale(),
+                    );
+                    let new_scale = scale + 0.25;
+                    output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
+
+                    let rescale = scale / new_scale;
+                    let output_location = output_location.to_f64();
+                    let mut pointer_output_location = self.pointer.current_location() - output_location;
+                    pointer_output_location.x *= rescale;
+                    pointer_output_location.y *= rescale;
+                    let pointer_location = output_location + pointer_output_location;
+
+                    crate::shell::fixup_positions(&mut self.space, pointer_location);
+                    let pointer = self.pointer.clone();
+                    let under = self.surface_under(pointer_location);
+                    pointer.motion(
+                        self,
+                        under,
+                        &MotionEvent {
+                            location: pointer_location,
+                            serial: SCOUNTER.next_serial(),
+                            time: self.clock.now().as_millis(),
+                        },
+                    );
+                    pointer.frame(self);
+                    self.backend_data.reset_buffers(&output);
+                }
+            }
+            KeyAction::ScaleDown => {
+                let pos = self.pointer.current_location().to_i32_round();
+                let output = self
+                    .space
+                    .outputs()
+                    .find(|o| self.space.output_geometry(o).unwrap().contains(pos))
+                    .cloned();
+
+                if let Some(output) = output {
+                    let (output_location, scale) = (
+                        self.space.output_geometry(&output).unwrap().loc,
+                        output.current_scale().fractional_scale(),
+                    );
+                    let new_scale = f64::max(1.0, scale - 0.25);
+                    output.change_current_state(None, None, Some(Scale::Fractional(new_scale)), None);
+
+                    let rescale = scale / new_scale;
+                    let output_location = output_location.to_f64();
+                    let mut pointer_output_location = self.pointer.current_location() - output_location;
+                    pointer_output_location.x *= rescale;
+                    pointer_output_location.y *= rescale;
+                    let pointer_location = output_location + pointer_output_location;
+
+                    crate::shell::fixup_positions(&mut self.space, pointer_location);
+                    let pointer = self.pointer.clone();
+                    let under = self.surface_under(pointer_location);
+                    pointer.motion(
+                        self,
+                        under,
+                        &MotionEvent {
+                            location: pointer_location,
+                            serial: SCOUNTER.next_serial(),
+                            time: self.clock.now().as_millis(),
+                        },
+                    );
+                    pointer.frame(self);
+                    self.backend_data.reset_buffers(&output);
+                }
+            }
+            KeyAction::RotateOutput => {
+                let pos = self.pointer.current_location().to_i32_round();
+                let output = self
+                    .space
+                    .outputs()
+                    .find(|o| self.space.output_geometry(o).unwrap().contains(pos))
+                    .cloned();
+
+                if let Some(output) = output {
+                    let current_transform = output.current_transform();
+                    let new_transform = match current_transform {
+                        Transform::Normal => Transform::_90,
+                        Transform::_90 => Transform::_180,
+                        Transform::_180 => Transform::_270,
+                        Transform::_270 => Transform::Flipped,
+                        Transform::Flipped => Transform::Flipped90,
+                        Transform::Flipped90 => Transform::Flipped180,
+                        Transform::Flipped180 => Transform::Flipped270,
+                        Transform::Flipped270 => Transform::Normal,
+                    };
+                    output.change_current_state(None, Some(new_transform), None, None);
+                    crate::shell::fixup_positions(&mut self.space, self.pointer.current_location());
+                    self.backend_data.reset_buffers(&output);
+                }
+            }
+            KeyAction::ToggleTint => {
+                let mut debug_flags = self.backend_data.debug_flags();
+                debug_flags.toggle(DebugFlags::TINT);
+                self.backend_data.set_debug_flags(debug_flags);
+            }
+
+            action => match action {
+                KeyAction::None
+                | KeyAction::Quit
+                | KeyAction::Run(_)
+                | KeyAction::TogglePreview
+                | KeyAction::ToggleDecorations => self.process_common_key_action(action),
+
+                _ => unreachable!(),
+            },
         }
     }
 
@@ -1340,7 +1403,7 @@ impl<BackendData: Backend> VirtualKeyboardHandler for AnvilState<BackendData> {
         keyboard: KeyboardHandle<Self>,
     ) {
         let serial = SERIAL_COUNTER.next_serial();
-        keyboard.input(self, keycode, state, serial, time, |_, _, _| {
+        keyboard.input(self, keycode, state.into(), serial, time, |_, _, _| {
             FilterResult::Forward::<bool>
         });
     }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -177,7 +177,7 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
                     keyboard.input::<(), _>(
                         &mut state,
                         event.key_code(),
-                        event.state(),
+                        event.state().into(),
                         0.into(),
                         0,
                         |_, _, _| {

--- a/examples/seat.rs
+++ b/examples/seat.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         keyboard.input(
             &mut state,
             smithay::backend::input::Keycode::from(9u32),
-            smithay::backend::input::KeyState::Pressed,
+            smithay::backend::input::KeyEvent::Pressed,
             0.into(),
             0,
             |_, _, _| {

--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -23,7 +23,7 @@ impl Smallvil {
                 self.seat.get_keyboard().unwrap().input::<(), _>(
                     self,
                     event.key_code(),
-                    event.state(),
+                    event.state().into(),
                     serial,
                     time,
                     |_, _, _| FilterResult::Forward,

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -96,6 +96,26 @@ pub enum KeyState {
     Pressed,
 }
 
+/// Keyboard key event. Modelled on the wl_keyboard KeyState.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum KeyEvent {
+    /// Key was released
+    Released,
+    /// Key was pressed
+    Pressed,
+    /// Key is being held and repetition was triggered.
+    Repeated,
+}
+
+impl From<KeyState> for KeyEvent {
+    fn from(k: KeyState) -> Self {
+        match k {
+            KeyState::Released => Self::Released,
+            KeyState::Pressed => Self::Pressed,
+        }
+    }
+}
+
 /// Trait for keyboard event
 pub trait KeyboardKeyEvent<B: InputBackend>: Event<B> {
     /// Returns the numerical button code of the keyboard button.

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -6,7 +6,7 @@ use std::{
 use wayland_server::{protocol::wl_surface::WlSurface, Resource};
 
 use crate::{
-    backend::input::{ButtonState, KeyState, Keycode},
+    backend::input::{ButtonState, KeyEvent, Keycode},
     input::{
         keyboard::{
             GrabStartData as KeyboardGrabStartData, KeyboardGrab, KeyboardHandle, KeyboardInnerHandle,
@@ -443,7 +443,7 @@ where
         data: &mut D,
         handle: &mut KeyboardInnerHandle<'_, D>,
         keycode: Keycode,
-        state: KeyState,
+        event: KeyEvent,
         modifiers: Option<ModifiersState>,
         serial: Serial,
         time: u32,
@@ -459,7 +459,7 @@ where
             handle.unset_grab(self, data, serial, false);
         }
 
-        handle.input(data, keycode, state, modifiers, serial, time)
+        handle.input(data, keycode, event, modifiers, serial, time)
     }
 
     fn set_focus(

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -1,18 +1,23 @@
 //! Keyboard-related types for smithay's input abstraction
 
-use crate::backend::input::KeyState;
+use crate::backend::input::{Event, InputBackend, KeyEvent, KeyState, KeyboardKeyEvent};
+use crate::reexports::calloop::LoopHandle;
 use crate::utils::{IsAlive, Serial, SERIAL_COUNTER};
+use calloop::RegistrationToken;
 use downcast_rs::{impl_downcast, Downcast};
 use std::collections::HashSet;
 #[cfg(feature = "wayland_frontend")]
 use std::sync::RwLock;
+use std::time::Duration;
 use std::{
     default::Default,
     fmt, io,
     sync::{Arc, Mutex},
 };
 use thiserror::Error;
-use tracing::{debug, info, info_span, instrument, trace};
+#[cfg(feature = "wayland_frontend")]
+use tracing::error;
+use tracing::{debug, info, info_span, instrument, trace, warn};
 
 use xkbcommon::xkb::ffi::XKB_STATE_LAYOUT_EFFECTIVE;
 pub use xkbcommon::xkb::{self, keysyms, Keycode, Keysym};
@@ -47,7 +52,7 @@ where
         seat: &Seat<D>,
         data: &mut D,
         key: KeysymHandle<'_>,
-        state: KeyState,
+        event: KeyEvent,
         serial: Serial,
         time: u32,
     );
@@ -215,6 +220,19 @@ pub(crate) struct KbdInternal<D: SeatHandler> {
     led_mapping: LedMapping,
     pub(crate) led_state: LedState,
     grab: GrabStatus<dyn KeyboardGrab<D>>,
+    /// Holds the token to cancel key repeat.
+    /// The token gets cleared when the keyboard is dropped, to neutralize the repeat callback.
+    pub(crate) key_repeat_timer: Arc<Mutex<Option<RegistrationToken>>>,
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl<D: SeatHandler> Drop for KbdInternal<D> {
+    fn drop(&mut self) {
+        let timer = self.key_repeat_timer.lock().unwrap().take();
+        if timer.is_some() {
+            error!("A keyboard was dropped without unregistering a repeat handler. This is a bug in smithay or in the compositor.");
+        }
+    }
 }
 
 // focus_hook does not implement debug, so we have to impl Debug manually
@@ -229,6 +247,7 @@ impl<D: SeatHandler> fmt::Debug for KbdInternal<D> {
             .field("xkb", &self.xkb)
             .field("repeat_rate", &self.repeat_rate)
             .field("repeat_delay", &self.repeat_delay)
+            .field("key_repeat_timer", &self.key_repeat_timer)
             .finish()
     }
 }
@@ -266,20 +285,24 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
             led_mapping,
             led_state,
             grab: GrabStatus::None,
+            key_repeat_timer: Arc::new(Mutex::new(None)),
         })
     }
 
     // returns whether the modifiers or led state has changed
-    fn key_input(&mut self, keycode: Keycode, state: KeyState) -> (bool, bool) {
+    fn key_input(&mut self, keycode: Keycode, event: KeyEvent) -> (bool, bool) {
         // track pressed keys as xkbcommon does not seem to expose it :(
-        let direction = match state {
-            KeyState::Pressed => {
+        let direction = match event {
+            KeyEvent::Pressed => {
                 self.pressed_keys.insert(keycode);
                 xkb::KeyDirection::Down
             }
-            KeyState::Released => {
+            KeyEvent::Released => {
                 self.pressed_keys.remove(&keycode);
                 xkb::KeyDirection::Up
+            }
+            KeyEvent::Repeated => {
+                return (false, false);
             }
         };
 
@@ -602,10 +625,10 @@ pub trait KeyboardGrab<D: SeatHandler>: Downcast {
         data: &mut D,
         handle: &mut KeyboardInnerHandle<'_, D>,
         keycode: Keycode,
-        state: KeyState,
+        event: KeyEvent,
         modifiers: Option<ModifiersState>,
         serial: Serial,
-        time: u32,
+        time_ms: u32,
     );
 
     /// A focus change was requested.
@@ -931,6 +954,106 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         }
     }
 
+    /// Processes the keyboard event, starting or stopping key repeat.
+    /// If this method is used, it must receive all keyboard events.
+    /// The `on_event` argument will be called with all events: the ones received directly and the generated repeats.
+    pub fn key_register_repeat<B: InputBackend>(
+        &self,
+        data: &mut D,
+        get_handle: impl Fn(&D) -> &LoopHandle<'static, D> + 'static,
+        event: B::KeyboardKeyEvent,
+        // event, timeout, code.
+        // This is Clone because there are two closures in here...
+        on_event: impl Fn(&mut D, KeyEvent, u32, Keycode) + Clone + 'static,
+    ) {
+        let time_ms = event.time_msec();
+        let keycode = event.key_code();
+        let state = event.state();
+
+        // Forward initial hardware event as logical event
+        on_event(data, state.into(), time_ms, keycode);
+
+        // Unregister preexisting repeating
+        // Releasing a key press obviously stops the repeat.
+        // But also, pressing another key stops the repeat of the previous key and starts it for the newly pressed key.
+        // TODO: this may had odd consequences when a modifier is pressed as the second key. But is that worth worrying about?
+        self.key_stop_repeat(data, &get_handle);
+
+        // Register repeating
+        match event.state() {
+            KeyState::Pressed => {
+                let mut guard = self.arc.internal.lock().unwrap();
+                let delay = guard.repeat_delay;
+                let rate = guard.repeat_rate;
+                let mut time_ms = time_ms;
+
+                // This closure-in-closure business is somewhat ugly.
+                // The reason is that there are two timers needed: first, the delay timer, and after the delay, the repeat timer. Both of them receive different tokens for cancelling, so we have to swap the token after the delay.
+                // The only comparable alternative I can think of is to wrap the key_repeat_timer in an Mutex<Arc<>> and change the token when delay turns into repeat. But locks are worse than nesting.
+                let kbd = self.arc.clone();
+                let duration = Duration::from_millis(delay as _);
+                let handle = get_handle(data);
+                let token = handle.insert_source(
+                    calloop::timer::Timer::from_duration(duration),
+                    move |_, _, data| {
+                        time_ms += delay as u32;
+                        on_event(data, KeyEvent::Repeated, time_ms, keycode);
+                        let mut guard = kbd.internal.lock().unwrap();
+
+                        let handle = get_handle(data);
+                        {
+                            let timer = guard.key_repeat_timer.lock().unwrap();
+                            match *timer {
+                                Some(token) => handle.remove(token),
+                                None => debug!("Key starts repeating but there is no delay timer. Was repeat already cancelled?"),
+                            };
+                        }
+
+                        // This implementation doesn't take into account changes to the repeat rate after repeating begins.
+                        let kbd = kbd.clone();
+                        let on_event = on_event.clone();
+                        let duration = Duration::from_millis(rate as _);
+                        let token = handle.insert_source(
+                            calloop::timer::Timer::from_duration(duration),
+                            move |_, _, data| {
+                                time_ms += rate as u32;
+                                let guard = kbd.internal.lock().unwrap();
+                                let timer = guard.key_repeat_timer.lock().unwrap();
+
+                                // If the timer has been orphaned by dropping the keyboard, don't actually send the event, don't register a repeat.
+                                if timer.is_some() {
+                                    drop(timer);
+                                    drop(guard);
+                                    on_event(data, KeyEvent::Repeated, time_ms, keycode);
+                                    calloop::timer::TimeoutAction::ToDuration(duration)
+                                } else {
+                                    debug!("Cancelling an orphaned keyboard repeat.");
+                                    calloop::timer::TimeoutAction::Drop
+                                }
+                            },
+                        ).unwrap();
+                        guard.key_repeat_timer = Arc::new(Mutex::new(Some(token)));
+                        calloop::timer::TimeoutAction::Drop
+                    }
+                ).unwrap();
+                guard.key_repeat_timer = Arc::new(Mutex::new(Some(token)));
+            }
+            KeyState::Released => {
+                // Nothing to do; timer is released for both in the common path.
+            }
+        }
+    }
+
+    /// Cancels any ongoing key repeat
+    pub fn key_stop_repeat(&self, data: &mut D, get_handle: impl Fn(&D) -> &LoopHandle<'static, D>) {
+        let guard = self.arc.internal.lock().unwrap();
+        let mut timer = guard.key_repeat_timer.lock().unwrap();
+        if let Some(token) = timer.take() {
+            let handle = get_handle(data);
+            handle.remove(token);
+        };
+    }
+
     /// Handle a keystroke
     ///
     /// All keystrokes from the input backend should be fed _in order_ to this method of the
@@ -949,7 +1072,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         &self,
         data: &mut D,
         keycode: Keycode,
-        state: KeyState,
+        event: KeyEvent,
         serial: Serial,
         time: u32,
         filter: F,
@@ -957,14 +1080,14 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     where
         F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> FilterResult<T>,
     {
-        let (filter_result, mods_changed) = self.input_intercept(data, keycode, state, filter);
+        let (filter_result, mods_changed) = self.input_intercept(data, keycode, event, filter);
         if let FilterResult::Intercept(val) = filter_result {
             // the filter returned `FilterResult::Intercept(T)`, we do not forward to client
             trace!("Input was intercepted by filter");
             return Some(val);
         }
 
-        self.input_forward(data, keycode, state, serial, time, mods_changed);
+        self.input_forward(data, keycode, event, serial, time, mods_changed);
         None
     }
 
@@ -979,16 +1102,16 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         &self,
         data: &mut D,
         keycode: Keycode,
-        state: KeyState,
+        event: KeyEvent,
         filter: F,
     ) -> (T, bool)
     where
         F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> T,
     {
-        trace!("Handling keystroke");
+        trace!("Handling key event");
 
         let mut guard = self.arc.internal.lock().unwrap();
-        let (mods_changed, leds_changed) = guard.key_input(keycode, state);
+        let (mods_changed, leds_changed) = guard.key_input(keycode, event);
         let led_state = guard.led_state;
         let mods_state = guard.mods_state;
         let xkb = guard.xkb.clone();
@@ -1014,26 +1137,18 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         &self,
         data: &mut D,
         keycode: Keycode,
-        state: KeyState,
+        event: KeyEvent,
         serial: Serial,
-        time: u32,
+        time_ms: u32,
         mods_changed: bool,
     ) {
         let mut guard = self.arc.internal.lock().unwrap();
-        match state {
-            KeyState::Pressed => {
-                guard.forwarded_pressed_keys.insert(keycode);
-            }
-            KeyState::Released => {
-                guard.forwarded_pressed_keys.remove(&keycode);
-            }
-        };
 
         // forward to client if no keybinding is triggered
         let seat = self.get_seat(data);
         let modifiers = mods_changed.then_some(guard.mods_state);
         guard.with_grab(data, &seat, |data, handle, grab| {
-            grab.input(data, handle, keycode, state, modifiers, serial, time);
+            grab.input(data, handle, keycode, event, modifiers, serial, time_ms);
         });
         if guard.focus.is_some() {
             trace!("Input forwarded to client");
@@ -1166,6 +1281,11 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
                 continue;
             };
             if kbd.version() >= 4 {
+                let rate = if kbd.version() >= 10 {
+                    0 // Enables compositor-side key repeat. See wl_keyboard key event
+                } else {
+                    rate
+                };
                 kbd.repeat_info(rate, delay);
             }
         }
@@ -1281,7 +1401,7 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
         &mut self,
         data: &mut D,
         keycode: Keycode,
-        key_state: KeyState,
+        key_event: KeyEvent,
         modifiers: Option<ModifiersState>,
         serial: Serial,
         time: u32,
@@ -1306,7 +1426,7 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
             keycode,
         };
 
-        focus.key(self.seat, data, key, key_state, serial, time);
+        focus.key(self.seat, data, key, key_event, serial, time);
         if let Some(mods) = modifiers {
             focus.modifiers(self.seat, data, mods, serial);
         }
@@ -1392,12 +1512,12 @@ impl<D: SeatHandler + 'static> KeyboardGrab<D> for DefaultGrab {
         data: &mut D,
         handle: &mut KeyboardInnerHandle<'_, D>,
         keycode: Keycode,
-        state: KeyState,
+        event: KeyEvent,
         modifiers: Option<ModifiersState>,
         serial: Serial,
         time: u32,
     ) {
-        handle.input(data, keycode, state, modifiers, serial, time)
+        handle.input(data, keycode, event, modifiers, serial, time)
     }
 
     fn set_focus(

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! ```
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::KeyEvent;
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -70,7 +70,7 @@
 //! #       seat: &Seat<State>,
 //! #       data: &mut State,
 //! #       key: KeysymHandle<'_>,
-//! #       state: KeyState,
+//! #       event: KeyEvent,
 //! #       serial: Serial,
 //! #       time: u32,
 //! #   ) {}
@@ -363,7 +363,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     ///
     /// ```no_run
     /// # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
-    /// # use smithay::backend::input::KeyState;
+    /// # use smithay::backend::input::KeyEvent;
     /// # use smithay::input::{
     /// #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
     /// #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -404,7 +404,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #       seat: &Seat<State>,
     /// #       data: &mut State,
     /// #       key: KeysymHandle<'_>,
-    /// #       state: KeyState,
+    /// #       event: KeyEvent,
     /// #       serial: Serial,
     /// #       time: u32,
     /// #   ) {}
@@ -484,7 +484,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     ///
     /// ```no_run
     /// # use smithay::input::{Seat, SeatState, SeatHandler, keyboard::XkbConfig, pointer::CursorImageStatus};
-    /// # use smithay::backend::input::KeyState;
+    /// # use smithay::backend::input::KeyEvent;
     /// # use smithay::input::{
     /// #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
     /// #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -525,7 +525,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #       seat: &Seat<State>,
     /// #       data: &mut State,
     /// #       key: KeysymHandle<'_>,
-    /// #       state: KeyState,
+    /// #       event: KeyEvent,
     /// #       serial: Serial,
     /// #       time: u32,
     /// #   ) {}

--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -12,7 +12,7 @@
 //! use smithay::wayland::cursor_shape::CursorShapeManagerState;
 //! use smithay::delegate_cursor_shape;
 //!
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::KeyEvent;
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -63,7 +63,7 @@
 //! #       seat: &Seat<State>,
 //! #       data: &mut State,
 //! #       key: KeysymHandle<'_>,
-//! #       state: KeyState,
+//! #       event: KeyEvent,
 //! #       serial: Serial,
 //! #       time: u32,
 //! #   ) {}

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -18,7 +18,7 @@ use crate::input::{
 };
 use crate::wayland::text_input::TextInputHandle;
 use crate::{
-    backend::input::{KeyState, Keycode},
+    backend::input::{KeyEvent, Keycode},
     utils::Serial,
 };
 
@@ -45,7 +45,7 @@ where
         _data: &mut D,
         _handle: &mut KeyboardInnerHandle<'_, D>,
         keycode: Keycode,
-        key_state: KeyState,
+        key_event: KeyEvent,
         modifiers: Option<ModifiersState>,
         serial: Serial,
         time: u32,
@@ -55,7 +55,7 @@ where
         inner
             .text_input_handle
             .active_text_input_serial_or_default(serial.0, |serial| {
-                keyboard.key(serial, time, keycode.raw() - 8, key_state.into());
+                keyboard.key(serial, time, keycode.raw() - 8, key_event.into());
                 if let Some(serialized) = modifiers.map(|m| m.serialized) {
                     keyboard.modifiers(
                         serial,

--- a/src/wayland/pointer_gestures.rs
+++ b/src/wayland/pointer_gestures.rs
@@ -21,7 +21,7 @@
 //!
 //! use smithay::wayland::pointer_gestures::PointerGesturesState;
 //! use smithay::delegate_pointer_gestures;
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::KeyEvent;
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -63,7 +63,7 @@
 //! #       seat: &Seat<State>,
 //! #       data: &mut State,
 //! #       key: KeysymHandle<'_>,
-//! #       state: KeyState,
+//! #       event: KeyEvent,
 //! #       serial: Serial,
 //! #       time: u32,
 //! #   ) {}

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -9,7 +9,7 @@
 //!
 //! use smithay::wayland::relative_pointer::RelativePointerManagerState;
 //! use smithay::delegate_relative_pointer;
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::KeyEvent;
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -51,7 +51,7 @@
 //! #       seat: &Seat<State>,
 //! #       data: &mut State,
 //! #       key: KeysymHandle<'_>,
-//! #       state: KeyState,
+//! #       event: KeyEvent,
 //! #       serial: Serial,
 //! #       time: u32,
 //! #   ) {}

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -173,7 +173,7 @@ impl<D: SeatHandler + 'static> SeatState<D> {
     {
         let Seat { arc } = self.new_seat(name);
 
-        let global_id = display.create_global::<D, _, _>(9, SeatGlobalData { arc: arc.clone() });
+        let global_id = display.create_global::<D, _, _>(10, SeatGlobalData { arc: arc.clone() });
         arc.inner.lock().unwrap().global = Some(global_id);
 
         Seat { arc }

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -47,7 +47,7 @@ use wayland_server::{
 };
 
 use crate::{
-    backend::input::{KeyState, Keycode},
+    backend::input::{KeyEvent, Keycode},
     input::{
         keyboard::{self, KeyboardGrab, KeyboardInnerHandle},
         Seat, SeatHandler,
@@ -109,7 +109,7 @@ impl<D: XWaylandKeyboardGrabHandler + 'static> KeyboardGrab<D> for XWaylandKeybo
         data: &mut D,
         handle: &mut KeyboardInnerHandle<'_, D>,
         keycode: Keycode,
-        state: KeyState,
+        event: KeyEvent,
         modifiers: Option<keyboard::ModifiersState>,
         serial: Serial,
         time: u32,
@@ -120,7 +120,7 @@ impl<D: XWaylandKeyboardGrabHandler + 'static> KeyboardGrab<D> for XWaylandKeybo
             handle.unset_grab(self, data, serial, false);
         }
 
-        handle.input(data, keycode, state, modifiers, serial, time)
+        handle.input(data, keycode, event, modifiers, serial, time)
     }
 
     fn set_focus(

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -19,7 +19,7 @@
 //! #
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 //! # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::KeyEvent;
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -60,7 +60,7 @@
 //! #       seat: &Seat<State>,
 //! #       data: &mut State,
 //! #       key: KeysymHandle<'_>,
-//! #       state: KeyState,
+//! #       event: KeyEvent,
 //! #       serial: Serial,
 //! #       time: u32,
 //! #   ) {}

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -42,7 +42,7 @@
 //! # }
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 //! # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus, dnd::DndGrabHandler};
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::KeyEvent;
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::input::KeyState,
+    backend::input::KeyEvent,
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
         pointer::{
@@ -1168,7 +1168,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for X11Surface {
         seat: &Seat<D>,
         data: &mut D,
         key: KeysymHandle<'_>,
-        state: KeyState,
+        event: KeyEvent,
         serial: Serial,
         time: u32,
     ) {
@@ -1178,10 +1178,10 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for X11Surface {
 
         let mut xstate = self.state.lock().unwrap();
         if let Some(surface) = xstate.wl_surface.as_ref() {
-            KeyboardTarget::key(surface, seat, data, key, state, serial, time)
+            KeyboardTarget::key(surface, seat, data, key, event, serial, time)
         } else if let Some((_, keys, _, pending_serial)) = xstate.pending_enter.as_mut() {
             let raw = key.raw_code();
-            if state == KeyState::Released {
+            if event == KeyEvent::Released {
                 keys.retain(|c| *c != raw);
             } else {
                 keys.push(raw);


### PR DESCRIPTION
This adds compositor-side key repeat from the just released wl_keyboard v10.

There are some problems:
1. ~~Repeat events have the same serial~~
2. Filtering may be broken
3. Arming the repeat timeout is ugly

With the above in mind, I'm not sure if I plugged it in the correct place, so I'm marking this as a draft.