### PR TITLE
fix: the point containment to an `input_region`

### DIFF
--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -47,7 +47,7 @@ impl RendererSurfaceState {
             .input_region
             .as_ref()
             .unwrap()
-            .contains(point.to_i32_round())
+            .contains(point.to_i32_floor())
     }
 }
 


### PR DESCRIPTION
This fixes a bug where defining an input region on the bottom or right edges of a surface causes pointer input to be skipped when moving the pointer to those edges. Especially noticeable and annoying when the surface is fullscreen or positioned so the region aligns with the screen edges.