### PR TITLE
element/surface: Allow filtering of scanout candidates

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -3027,7 +3027,7 @@ where
             return None;
         };
 
-        // only try to assgin elements on a cursor plane that indicate so
+        // only try to assign elements on a cursor plane that indicate so
         if element.kind() != Kind::Cursor {
             trace!(
                 "skipping element {:?} on cursor plane(s), element kind not cursor",
@@ -3712,6 +3712,15 @@ where
         E: RenderElement<R>,
     {
         if !frame_flags.contains(FrameFlags::ALLOW_OVERLAY_PLANE_SCANOUT) {
+            return Err(None);
+        }
+
+        // only try to assign elements on an overlay plane that indicate so
+        if element.kind() != Kind::ScanoutCandidate && element.kind() != Kind::Cursor {
+            trace!(
+                "skipping element {:?} on overlay plane(s), element kind not scanout-candidate/cursor",
+                element.id(),
+            );
             return Err(None);
         }
 

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -334,6 +334,23 @@ pub enum Kind {
     /// Not marking a cursor element as `Cursor` may result in lower performance and increased power usage.
     /// In contrast, marking elements that change frequently as `Cursor` can degrade performance significantly.
     Cursor,
+    /// The element is a good candidate for scanout
+    ///
+    /// An element marked as a scanout candidate is expected to refresh frequently or with a constant rate.
+    /// As such it makes a good candidate to save resources by placing it on an overlay plane, when using the drm backend
+    /// (see [`DrmCompositor`](crate::backend::drm::compositor::DrmCompositor)).
+    ///
+    /// Examples of applications like this include video players or games. To detect good candidates compositor should
+    /// employ heuristics. For example, it might keep track of the surface commit rate and mark surfaces hitting thresholds
+    /// as scanout candidates.
+    ///
+    /// Note: You can select a different `Kind` every time you create the render element from e.g. a wayland surface.
+    /// This means it is expected that compositors dynamically choose the appropriate `Kind` at runtime instead
+    /// of relying on static configuration. E.g. it can make sense to switch back to `Unspecified` during very dynamic
+    /// scenes like animations, as moving planes can be slow on certain hardware.
+    ///
+    /// Elements not marked as scanout candidates will never be considered, when selecting potential buffers for overlay planes.
+    ScanoutCandidate,
     /// The element kind is unspecified
     #[default]
     Unspecified,


### PR DESCRIPTION
This adds an API to allow filtering, which elements should be considered for scanout and which shouldn't.

Example usage and motivation in cosmic: https://github.com/pop-os/cosmic-comp/pull/1542

Draft because I am not sure, if this is a particular good api for this feature. Ping @cmeissl on that.

Essentially since the `DrmCompositor` is the only piece of code using `underlying_storage` at the moment I opted for the lazy way of just returning `None`, if we don't want the target to be considered for scanout. This is a bit hacky, maybe another method would be more appropriate.


The bigger issue however is the change to `render_elements_from_surface_tree`.

I didn't want to modify `AsRenderElements` to pass through a closure barely used by any other element. This ends up still working in cosmic-comp, as we happen to use `render_elements_from_surface_tree` almost everywhere wayland-surfaces are involved anyway to separate popup-elements and toplevel-elements (which the default implementation for `desktop::Window` doesn't do).

However this is arguably annoying as this makes it impossible to do such filtering, while relying on `Space` or other `desktop`-abstractions for rendering.

So I am asking for ideas to make this easily controllable from compositors without trashing our current api (maybe that is a pipe-dream).

Alternatively non of this needs to be in smithay, a compositor could simply wrap the elements to do the filtering. But given the elements don't contain any references to the original surface except for their id, compositors would likely end up not using `AsRenderElements` again and we would just make everything even more annoying by forcing compositors to add another wrapper class to do this.