### PR TITLE
wayland/drm_syncobj: Don't leak syncobj on export

### DIFF
--- a/src/wayland/drm_syncobj/sync_point.rs
+++ b/src/wayland/drm_syncobj/sync_point.rs
@@ -162,10 +162,9 @@ impl DrmSyncPoint {
             let _ = device.destroy_syncobj(syncobj);
             return Err(err);
         };
+
         let res = device.syncobj_to_fd(syncobj, true);
-        if res.is_err() {
-            let _ = device.destroy_syncobj(syncobj);
-        }
+        let _ = device.destroy_syncobj(syncobj);
         res
     }
 


### PR DESCRIPTION
Fixes https://github.com/Smithay/smithay/issues/1780

Yeah, we were leaking this before unintentionally.