### PR TITLE
vulkan: fix validation error VUID-vkBindImageMemory-image-01445

### DIFF
--- a/src/backend/allocator/vulkan/mod.rs
+++ b/src/backend/allocator/vulkan/mod.rs
@@ -750,9 +750,13 @@ impl VulkanAllocator {
         // TODO: Memory type index
         let mut export_memory_allocate_info = vk::ExportMemoryAllocateInfo::default()
             .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
+        // VUID-vkBindImageMemory-image-01445
+        let mut memory_dedicated_allocate_info = vk::MemoryDedicatedAllocateInfo::default()
+            .image(guard.image);
         let alloc_create_info = vk::MemoryAllocateInfo::default()
             .allocation_size(memory_reqs.size)
-            .push_next(&mut export_memory_allocate_info);
+            .push_next(&mut export_memory_allocate_info)
+            .push_next(&mut memory_dedicated_allocate_info);
 
         unsafe {
             // Allocate memory for the image.


### PR DESCRIPTION
fixed vulkan validation error when creating an image and using vkBindImageMemory, detailed here: https://vulkan.lunarg.com/doc/view/1.4.321.1/linux/antora/spec/latest/chapters/resources.html#VUID-vkBindImageMemory-image-01445
