### PR TITLE
multigpu: Don't re-use textures for re-created renderers

### DIFF
--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -94,11 +94,11 @@ impl<T: Texture> ContextId<T> {
     /// Returns an [`ErasedContextId`] representing this context without the texture type.
     ///
     /// This is useful when storing or comparing contexts across different texture types.
-    pub fn erased(self) -> ErasedContextId
+    pub fn erased(&self) -> ErasedContextId
     where
         T: 'static,
     {
-        ErasedContextId(self.0, TypeId::of::<T>())
+        ErasedContextId(self.0.clone(), TypeId::of::<T>())
     }
 }
 


### PR DESCRIPTION
If a renderer gets re-created with the same api and same node, existing cached `MultiTexture`s might be used with now outdated and invalid texture ids.

This happens e.g. in cosmic-comp, which destroys `EGLContext`s, when a particular device isn't used anymore to give the driver a chance to put the device into deeper sleep modes.

The obvious solution here is to not re-invent the wheel and only use `TypeId`s + `DrmNode`s for hashing but our new `ErasedContextId`, which will change for newly created renderers, that aren't based on the same context, essentially replacing the `DrmNode`-part of our previous hashes with what used to be the `RendererId`.

This also simplifies the `MultiTextureInternal`-struct and related code quite a bit, as we don't have a double nested `HashMap` anymore.