### PR TITLE
xwayland: Fix potentially missed keyboard-events

### DIFF
--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -18,6 +18,71 @@
 //! );
 //! #
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+//! # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
+//! # use smithay::backend::input::KeyState;
+//! # use smithay::input::{
+//! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
+//! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
+//! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
+//! #             GestureHoldBeginEvent, GestureHoldEndEvent},
+//! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
+//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
+//! # };
+//! # use smithay::utils::{IsAlive, Serial};
+//! #
+//! # #[derive(Debug, Clone, PartialEq)]
+//! # struct Target;
+//! # impl IsAlive for Target {
+//! #   fn alive(&self) -> bool { true }
+//! # }
+//! # impl PointerTarget<State> for Target {
+//! #   fn enter(&self, seat: &Seat<State>, data: &mut State, event: &MotionEvent) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &MotionEvent) {}
+//! #   fn relative_motion(&self, seat: &Seat<State>, data: &mut State, event: &RelativeMotionEvent) {}
+//! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
+//! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
+//! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
+//! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
+//! #   fn gesture_pinch_begin(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchBeginEvent) {}
+//! #   fn gesture_pinch_update(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchUpdateEvent) {}
+//! #   fn gesture_pinch_end(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchEndEvent) {}
+//! #   fn gesture_hold_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldBeginEvent) {}
+//! #   fn gesture_hold_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldEndEvent) {}
+//! # }
+//! # impl KeyboardTarget<State> for Target {
+//! #   fn enter(&self, seat: &Seat<State>, data: &mut State, keys: Vec<KeysymHandle<'_>>, serial: Serial) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial) {}
+//! #   fn key(
+//! #       &self,
+//! #       seat: &Seat<State>,
+//! #       data: &mut State,
+//! #       key: KeysymHandle<'_>,
+//! #       state: KeyState,
+//! #       serial: Serial,
+//! #       time: u32,
+//! #   ) {}
+//! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
+//! # }
+//! # impl TouchTarget<State> for Target {
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
+//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
+//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
+//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+//! # }
+//! # impl SeatHandler for State {
+//! #     type KeyboardFocus = Target;
+//! #     type PointerFocus = Target;
+//! #     type TouchFocus = Target;
+//! #     fn seat_state(&mut self) -> &mut SeatState<Self> { unreachable!() }
+//! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&Target>) {}
+//! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) {}
+//! # }
 //!
 //! impl XWaylandShellHandler for State {
 //!     fn xwayland_shell_state(&mut self) -> &mut XWaylandShellState {
@@ -73,6 +138,7 @@ use wayland_server::{
 };
 
 use crate::{
+    input::SeatHandler,
     wayland::compositor,
     xwayland::{xwm::XwmId, X11Surface, XWaylandClientData, XwmHandler},
 };
@@ -179,7 +245,7 @@ impl<D> Dispatch<XwaylandShellV1, (), D> for XWaylandShellState
 where
     D: Dispatch<XwaylandShellV1, ()>,
     D: Dispatch<XwaylandSurfaceV1, XWaylandSurfaceUserData>,
-    D: XWaylandShellHandler + XwmHandler,
+    D: XWaylandShellHandler + XwmHandler + SeatHandler,
     D: 'static,
 {
     fn request(
@@ -250,7 +316,7 @@ where
     }
 }
 
-fn serial_commit_hook<D: XWaylandShellHandler + XwmHandler + 'static>(
+fn serial_commit_hook<D: XWaylandShellHandler + XwmHandler + SeatHandler + 'static>(
     state: &mut D,
     _dh: &DisplayHandle,
     surface: &WlSurface,
@@ -286,7 +352,7 @@ fn serial_commit_hook<D: XWaylandShellHandler + XwmHandler + 'static>(
                             "associated X11 window to wl_surface in commit hook",
                         );
 
-                        xsurface.state.lock().unwrap().wl_surface = Some(surface.clone());
+                        xsurface.set_wl_surface(state, Some(surface.clone()));
 
                         XWaylandShellHandler::surface_associated(state, *xwm_id, surface.clone(), xsurface);
                     } else {


### PR DESCRIPTION
This PR tries to address multiple short-comings of our current focus tracking code specifically around Xwayland (but not necessarily requiring Xwayland for reproduction, just weird usage of our public api).


1. We want to send `wl_keyboard::leave` events for focused surfaces, which are about to be destroyed. On the client-side these show up as targeting a `nil`-surface, as the client-side drops the surface immediately after sending the destruction request. However longer-lived clients might still rely on these events and omitting them isn't valid from the protocol perspective. E.g. Xwayland uses these to clear any still "pressed" keys.

However if we remove the focus after processing the `unmap_notify`, the `X11Surface` already has no `wl_surface` any more to forward the leave-event to. Keeping a weak-variant doesn't help - as the surface would already be destroyed - and keeping a `WlSurface` alive sounds like a good opportunity for leaks.

So lets fix this with an destruction_hook, which means wrapping types like `X11Surface` have one less event to worry about.


2. `X11Surface` currently might completely ignore any keyboard events, if the surface in question isn't mapped and we don't have a `wl_surface` to target. This is simply a bad API, as downstream needs to verify it targets a mapped surface before treating it like any other `KeyboardTarget`. We also need to intercept these events to send additional messages to the X11 socket...

cosmic-comp is doing this wrong currently, mapping x11 windows on `XwaylandHandler::map_notify`, which is intuitive, but frequently misses the `wl_keyboard::enter`-event of all things.

This is theoretically an issue with pointer/touch events as well, but we don't have anything to render without a surface and no valid input-regions anyway, so this doesn't manifest in any serious errors, while keyboard related shenanigans cause a variety of fun issues like surfaces never getting focus or "stuck" keys.

To combat this we could split the `X11Surface` type into a `MappedX11Surface`-variant or .... simply keep track of any keyboard events we should have delivered already. That is what the second commit tries to do (not so elegantly, but it works just fine in testing).

Anyway... feedback is very welcome.