### PR TITLE
Add serial number from libdisplay-info to output::PhysicalProperties

### DIFF
--- a/anvil/src/udev.rs
+++ b/anvil/src/udev.rs
@@ -930,6 +930,11 @@ impl AnvilState<UdevData> {
             .and_then(|info| info.model())
             .unwrap_or_else(|| "Unknown".into());
 
+        let serial_number = display_info
+            .as_ref()
+            .and_then(|info| info.serial())
+            .unwrap_or_else(|| "Unknown".into());
+
         if non_desktop {
             info!("Connector {} is non-desktop, setting up for leasing", output_name);
             device.non_desktop_connectors.push((connector.handle(), crtc));
@@ -958,6 +963,7 @@ impl AnvilState<UdevData> {
                     subpixel: connector.subpixel().into(),
                     make,
                     model,
+                    serial_number,
                 },
             );
             let global = output.create_global::<AnvilState<UdevData>>(&self.display_handle);

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -119,6 +119,7 @@ pub fn run_winit() {
             subpixel: Subpixel::Unknown,
             make: "Smithay".into(),
             model: "Winit".into(),
+            serial_number: "Unknown".into(),
         },
     );
     let _global = output.create_global::<AnvilState<WinitData>>(&display.handle());

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -228,6 +228,7 @@ pub fn run_x11() {
             subpixel: Subpixel::Unknown,
             make: "Smithay".into(),
             model: "X11".into(),
+            serial_number: "Unknown".into(),
         },
     );
     let _global = output.create_global::<AnvilState<X11Data>>(&display.handle());

--- a/smallvil/src/winit.rs
+++ b/smallvil/src/winit.rs
@@ -35,6 +35,7 @@ pub fn init_winit(
             subpixel: Subpixel::Unknown,
             make: "Smithay".into(),
             model: "Winit".into(),
+            serial_number: "Unknown".into(),
         },
     );
     let _global = output.create_global::<Smallvil>(display_handle);

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -78,6 +78,7 @@
 //!         make: "N/A".into(),
 //!         model: "N/A".into(),
 //!         subpixel: Subpixel::Unknown,
+//!         serial_number: "N/A".into(),
 //!     },
 //! );
 //!

--- a/src/output.rs
+++ b/src/output.rs
@@ -33,6 +33,7 @@
 //!         subpixel: Subpixel::HorizontalRgb,  // subpixel information
 //!         make: "Screens Inc".into(),     // make of the monitor
 //!         model: "Monitor Ultra".into(),  // model of the monitor
+//!         serial_number: "KL11C28J04XJ".into(), // serial number of the monitor
 //!     },
 //! );
 //! // Now you can configure it
@@ -167,6 +168,8 @@ pub struct PhysicalProperties {
     pub make: String,
     /// Textual representation of the model
     pub model: String,
+    /// Textual representation of the serial number
+    pub serial_number: String,
 }
 
 /// Describes the scale advertised to clients.

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -40,6 +40,7 @@
 //!         subpixel: Subpixel::HorizontalRgb,  // subpixel information
 //!         make: "Screens Inc".into(),     // make of the monitor
 //!         model: "Monitor Ultra".into(),  // model of the monitor
+//!         serial_number: "KL11C28J04XJ".into(), // serial number of the monitor
 //!     },
 //! );
 //! // create a global, if you want to advertise it to clients

--- a/src/wayland/presentation/mod.rs
+++ b/src/wayland/presentation/mod.rs
@@ -52,6 +52,7 @@
 //! #         subpixel: Subpixel::HorizontalRgb,  // subpixel information
 //! #         make: "Screens Inc".into(),     // make of the monitor
 //! #         model: "Monitor Ultra".into(),  // model of the monitor
+//! #         serial_number: "KL11C28J04XJ".into(), // serial number of the monitor
 //! #     },
 //! # );
 //! // ... render frame ...

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -81,6 +81,7 @@ pub fn run(channel: Channel<WlcsEvent>) {
             subpixel: Subpixel::Unknown,
             make: "Smithay".into(),
             model: "WLCS".into(),
+            serial_number: "Unknown".into(),
         },
     );
     let _global = output.create_global::<AnvilState<TestState>>(&state.display_handle);


### PR DESCRIPTION
Serial number, together with make and model, is a common way to identify an output. 

My reason for adding this is ultimately to implement [wlr_output_head_v1::serial_number](https://wayland.app/protocols/wlr-output-management-unstable-v1#zwlr_output_head_v1:event:serial_number) in Cosmic. I have two monitors with the same model and make, so output configuration tools like Kanshi and Shikane can't differentiate them.