### PR TITLE
Add #[must_use] annotations to geometry module

### DIFF
--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -33,14 +33,18 @@ pub trait Coordinate:
     /// A Coordinate that is 0
     const ZERO: Self;
     /// Downscale the coordinate
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     fn downscale(self, scale: Self) -> Self;
     /// Upscale the coordinate
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     fn upscale(self, scale: Self) -> Self;
     /// Convert the coordinate to a f64
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     fn to_f64(self) -> f64;
     /// Convert to this coordinate from a f64
     fn from_f64(v: f64) -> Self;
     /// Compare and return the smaller one
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     fn min(self, other: Self) -> Self {
         if self < other {
             self
@@ -49,6 +53,7 @@ pub trait Coordinate:
         }
     }
     /// Compare and return the larger one
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     fn max(self, other: Self) -> Self {
         if self > other {
             self
@@ -59,13 +64,17 @@ pub trait Coordinate:
     /// Test if the coordinate is not negative
     fn non_negative(self) -> bool;
     /// Returns the absolute value of this coordinate
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     fn abs(self) -> Self;
 
     /// Saturating integer addition. Computes self + other, saturating at the numeric bounds instead of overflowing.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     fn saturating_add(self, other: Self) -> Self;
     /// Saturating integer subtraction. Computes self - other, saturating at the numeric bounds instead of overflowing.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     fn saturating_sub(self, other: Self) -> Self;
     /// Saturating integer multiplication. Computes self * other, saturating at the numeric bounds instead of overflowing.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     fn saturating_mul(self, other: Self) -> Self;
 }
 
@@ -405,6 +414,7 @@ impl<N: Coordinate, Kind> Point<N, Kind> {
     ///
     /// Checks that the coordinates are positive with a `debug_assert!()`.
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_size(self) -> Size<N, Kind> {
         debug_assert!(
             self.x.non_negative() && self.y.non_negative(),
@@ -422,6 +432,7 @@ impl<N: Coordinate, Kind> Point<N, Kind> {
     ///
     /// Ensures that the coordinates are positive by taking their absolute value
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_size_abs(self) -> Size<N, Kind> {
         Size {
             w: self.x.abs(),
@@ -432,6 +443,7 @@ impl<N: Coordinate, Kind> Point<N, Kind> {
 
     /// Upscale this [`Point`] by a specified [`Scale`]
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn upscale(self, scale: impl Into<Scale<N>>) -> Point<N, Kind> {
         let scale = scale.into();
         Point {
@@ -443,6 +455,7 @@ impl<N: Coordinate, Kind> Point<N, Kind> {
 
     /// Downscale this [`Point`] by a specified [`Scale`]
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn downscale(self, scale: impl Into<Scale<N>>) -> Point<N, Kind> {
         let scale = scale.into();
         Point {
@@ -473,6 +486,7 @@ impl<N: Coordinate, Kind> Point<N, Kind> {
 impl<N: Coordinate, Kind> Point<N, Kind> {
     /// Convert the underlying numerical type to f64 for floating point manipulations
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_f64(self) -> Point<f64, Kind> {
         Point {
             x: self.x.to_f64(),
@@ -485,6 +499,7 @@ impl<N: Coordinate, Kind> Point<N, Kind> {
 impl<Kind> Point<f64, Kind> {
     /// Convert to i32 for integer-space manipulations by rounding float values
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_i32_round<N: Coordinate>(self) -> Point<N, Kind> {
         Point {
             x: N::from_f64(self.x.round()),
@@ -495,6 +510,7 @@ impl<Kind> Point<f64, Kind> {
 
     /// Convert to i32 for integer-space manipulations by flooring float values
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_i32_floor<N: Coordinate>(self) -> Point<N, Kind> {
         Point {
             x: N::from_f64(self.x.floor()),
@@ -505,6 +521,7 @@ impl<Kind> Point<f64, Kind> {
 
     /// Convert to i32 for integer-space manipulations by ceiling float values
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_i32_ceil<N: Coordinate>(self) -> Point<N, Kind> {
         Point {
             x: N::from_f64(self.x.ceil()),
@@ -545,8 +562,9 @@ impl<N: Coordinate> Point<N, Logical> {
         self.to_f64().to_client(scale.into().to_f64()).to_i32_round()
     }
 
-    #[inline]
     /// Convert this logical point to physical coordinate space according to given scale factor
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical(self, scale: impl Into<Scale<N>>) -> Point<N, Physical> {
         let scale = scale.into();
         Point {
@@ -559,6 +577,7 @@ impl<N: Coordinate> Point<N, Logical> {
     /// Convert this logical point to physical coordinate space according to given scale factor
     /// and round the result
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical_precise_round<S: Coordinate, R: Coordinate>(
         self,
         scale: impl Into<Scale<S>>,
@@ -569,6 +588,7 @@ impl<N: Coordinate> Point<N, Logical> {
     /// Convert this logical point to physical coordinate space according to given scale factor
     /// and ceil the result
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical_precise_ceil<S: Coordinate, R: Coordinate>(
         &self,
         scale: impl Into<Scale<S>>,
@@ -579,6 +599,7 @@ impl<N: Coordinate> Point<N, Logical> {
     /// Convert this logical point to physical coordinate space according to given scale factor
     /// and floor the result
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical_precise_floor<S: Coordinate, R: Coordinate>(
         &self,
         scale: impl Into<Scale<S>>,
@@ -586,8 +607,9 @@ impl<N: Coordinate> Point<N, Logical> {
         self.to_f64().to_physical(scale.into().to_f64()).to_i32_floor()
     }
 
-    #[inline]
     /// Convert this logical point to buffer coordinate space according to given scale factor
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_buffer(
         self,
         scale: impl Into<Scale<N>>,
@@ -607,6 +629,7 @@ impl<N: Coordinate> Point<N, Logical> {
 #[cfg(feature = "wayland_frontend")]
 impl<N: Coordinate> Point<N, Client> {
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub(crate) fn to_logical(self, scale: impl Into<Scale<N>>) -> Point<N, Logical> {
         let scale = scale.into();
         Point {
@@ -618,8 +641,9 @@ impl<N: Coordinate> Point<N, Client> {
 }
 
 impl<N: Coordinate> Point<N, Physical> {
-    #[inline]
     /// Convert this physical point to logical coordinate space according to given scale factor
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_logical(self, scale: impl Into<Scale<N>>) -> Point<N, Logical> {
         let scale = scale.into();
         Point {
@@ -631,8 +655,9 @@ impl<N: Coordinate> Point<N, Physical> {
 }
 
 impl<N: Coordinate> Point<N, Buffer> {
-    #[inline]
     /// Convert this physical point to logical coordinate space according to given scale factor
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_logical(
         self,
         scale: impl Into<Scale<N>>,
@@ -775,6 +800,7 @@ impl<N: Coordinate, Kind> Size<N, Kind> {
 impl<N: Coordinate, Kind> Size<N, Kind> {
     /// Convert this [`Size`] to a [`Point`] with the same coordinates
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_point(self) -> Point<N, Kind> {
         Point {
             x: self.w,
@@ -786,6 +812,7 @@ impl<N: Coordinate, Kind> Size<N, Kind> {
 
 impl<N: Coordinate, Kind> Size<N, Kind> {
     /// Restrict this [`Size`] to min and max [`Size`] with the same coordinates
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn clamp(self, min: impl Into<Size<N, Kind>>, max: impl Into<Size<N, Kind>>) -> Size<N, Kind> {
         let min = min.into();
         let max = max.into();
@@ -801,6 +828,7 @@ impl<N: Coordinate, Kind> Size<N, Kind> {
 impl<N: Coordinate, Kind> Size<N, Kind> {
     /// Convert the underlying numerical type to f64 for floating point manipulations
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_f64(self) -> Size<f64, Kind> {
         Size {
             w: self.w.to_f64(),
@@ -813,6 +841,7 @@ impl<N: Coordinate, Kind> Size<N, Kind> {
 impl<N: Coordinate, Kind> Size<N, Kind> {
     /// Upscale this [`Size`] by a specified [`Scale`]
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn upscale(self, scale: impl Into<Scale<N>>) -> Size<N, Kind> {
         let scale = scale.into();
         Size {
@@ -824,6 +853,7 @@ impl<N: Coordinate, Kind> Size<N, Kind> {
 
     /// Downscale this [`Size`] by a specified [`Scale`]
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn downscale(self, scale: impl Into<Scale<N>>) -> Size<N, Kind> {
         let scale = scale.into();
         Size {
@@ -845,6 +875,7 @@ impl<N: Coordinate, Kind> Size<N, Kind> {
 impl<Kind> Size<f64, Kind> {
     /// Convert to i32 for integer-space manipulations by rounding float values
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_i32_round<N: Coordinate>(self) -> Size<N, Kind> {
         Size {
             w: N::from_f64(self.w.round()),
@@ -855,6 +886,7 @@ impl<Kind> Size<f64, Kind> {
 
     /// Convert to i32 for integer-space manipulations by flooring float values
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_i32_floor<N: Coordinate>(self) -> Size<N, Kind> {
         Size {
             w: N::from_f64(self.w.floor()),
@@ -865,6 +897,7 @@ impl<Kind> Size<f64, Kind> {
 
     /// Convert to i32 for integer-space manipulations by ceiling float values
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_i32_ceil<N: Coordinate>(self) -> Size<N, Kind> {
         Size {
             w: N::from_f64(self.w.ceil()),
@@ -896,8 +929,9 @@ impl<N: Coordinate> Size<N, Logical> {
         }
     }
 
-    #[inline]
     /// Convert this logical size to physical coordinate space according to given scale factor
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical(self, scale: impl Into<Scale<N>>) -> Size<N, Physical> {
         let scale = scale.into();
         Size {
@@ -910,6 +944,7 @@ impl<N: Coordinate> Size<N, Logical> {
     /// Convert this logical size to physical coordinate space according to given scale factor
     /// and round the result
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical_precise_round<S: Coordinate, R: Coordinate>(
         self,
         scale: impl Into<Scale<S>>,
@@ -920,6 +955,7 @@ impl<N: Coordinate> Size<N, Logical> {
     /// Convert this logical size to physical coordinate space according to given scale factor
     /// and ceil the result
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical_precise_ceil<S: Coordinate, R: Coordinate>(
         &self,
         scale: impl Into<Scale<S>>,
@@ -930,6 +966,7 @@ impl<N: Coordinate> Size<N, Logical> {
     /// Convert this logical size to physical coordinate space according to given scale factor
     /// and floor the result
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical_precise_floor<S: Coordinate, R: Coordinate>(
         &self,
         scale: impl Into<Scale<S>>,
@@ -937,8 +974,9 @@ impl<N: Coordinate> Size<N, Logical> {
         self.to_f64().to_physical(scale.into().to_f64()).to_i32_floor()
     }
 
-    #[inline]
     /// Convert this logical size to buffer coordinate space according to given scale factor
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_buffer(self, scale: impl Into<Scale<N>>, transformation: Transform) -> Size<N, Buffer> {
         let scale = scale.into();
         transformation.transform_size(Size {
@@ -952,6 +990,7 @@ impl<N: Coordinate> Size<N, Logical> {
 #[cfg(feature = "wayland_frontend")]
 impl<N: Coordinate> Size<N, Client> {
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub(crate) fn to_logical(self, scale: impl Into<Scale<N>>) -> Size<N, Logical> {
         let scale = scale.into();
         Size {
@@ -963,8 +1002,9 @@ impl<N: Coordinate> Size<N, Client> {
 }
 
 impl<N: Coordinate> Size<N, Physical> {
-    #[inline]
     /// Convert this physical point to logical coordinate space according to given scale factor
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_logical(self, scale: impl Into<Scale<N>>) -> Size<N, Logical> {
         let scale = scale.into();
         Size {
@@ -976,8 +1016,9 @@ impl<N: Coordinate> Size<N, Physical> {
 }
 
 impl<N: Coordinate> Size<N, Buffer> {
-    #[inline]
     /// Convert this physical point to logical coordinate space according to given scale factor
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_logical(self, scale: impl Into<Scale<N>>, transformation: Transform) -> Size<N, Logical> {
         let scale = scale.into();
         transformation.invert().transform_size(Size {
@@ -1150,6 +1191,7 @@ pub struct Rectangle<N, Kind> {
 
 impl<N: Coordinate, Kind> Rectangle<N, Kind> {
     /// Convert the underlying numerical type to another
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_f64(self) -> Rectangle<f64, Kind> {
         Rectangle {
             loc: self.loc.to_f64(),
@@ -1160,6 +1202,7 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
 
 impl<N: Coordinate, Kind> Rectangle<N, Kind> {
     /// Upscale this [`Rectangle`] by the supplied [`Scale`]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn upscale(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Kind> {
         let scale = scale.into();
         Rectangle {
@@ -1169,6 +1212,7 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
     }
 
     /// Downscale this [`Rectangle`] by the supplied [`Scale`]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn downscale(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Kind> {
         let scale = scale.into();
         Rectangle {
@@ -1189,6 +1233,7 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
 impl<Kind> Rectangle<f64, Kind> {
     /// Convert to i32 for integer-space manipulations by rounding float values
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_i32_round<N: Coordinate>(self) -> Rectangle<N, Kind> {
         Rectangle {
             loc: self.loc.to_i32_round(),
@@ -1198,12 +1243,14 @@ impl<Kind> Rectangle<f64, Kind> {
 
     /// Convert to i32 by returning the largest integer-space rectangle fitting into the float-based rectangle
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_i32_down<N: Coordinate>(self) -> Rectangle<N, Kind> {
         Rectangle::from_extremities(self.loc.to_i32_ceil(), (self.loc + self.size).to_i32_floor())
     }
 
     /// Convert to i32 by returning the smallest integet-space rectangle encapsulating the float-based rectangle
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_i32_up<N: Coordinate>(self) -> Rectangle<N, Kind> {
         Rectangle::from_extremities(self.loc.to_i32_floor(), (self.loc + self.size).to_i32_ceil())
     }
@@ -1326,6 +1373,7 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
     ///
     /// Returns `None` if the two rectangles don't overlap
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn intersection(self, other: impl Into<Rectangle<N, Kind>>) -> Option<Self> {
         let other = other.into();
         if !self.overlaps(other) {
@@ -1358,6 +1406,7 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
 
     /// Merge two [`Rectangle`] by producing the smallest rectangle that contains both
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn merge(self, other: Self) -> Self {
         Self::bounding_box([self.loc, self.loc + self.size, other.loc, other.loc + other.size])
     }
@@ -1368,11 +1417,13 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
     /// be returned.
     /// If the other rectangle contains self no rectangle will be returned,
     /// otherwise up to 4 rectangles will be returned.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn subtract_rect(self, other: Self) -> Vec<Self> {
         self.subtract_rects([other])
     }
 
     /// Subtract a set of [`Rectangle`]s from this [`Rectangle`]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn subtract_rects(self, others: impl IntoIterator<Item = Self>) -> Vec<Self> {
         let mut remaining = Vec::with_capacity(4);
         remaining.push(self);
@@ -1380,6 +1431,7 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
     }
 
     /// Subtract a set of [`Rectangle`]s from a set [`Rectangle`]s
+    #[must_use = "to modify the results in-place, use `subtract_rects_many_in_place`"]
     pub fn subtract_rects_many(
         rects: impl IntoIterator<Item = Self>,
         others: impl IntoIterator<Item = Self>,
@@ -1496,6 +1548,7 @@ impl<N: Coordinate> Rectangle<N, Logical> {
 
     /// Convert this logical rectangle to physical coordinate space according to given scale factor
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Physical> {
         let scale = scale.into();
         Rectangle {
@@ -1507,6 +1560,7 @@ impl<N: Coordinate> Rectangle<N, Logical> {
     /// Convert this logical rectangle to physical coordinate space according to given scale factor
     /// and round the result
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical_precise_round<S: Coordinate, R: Coordinate>(
         self,
         scale: impl Into<Scale<S>>,
@@ -1519,6 +1573,7 @@ impl<N: Coordinate> Rectangle<N, Logical> {
     ///
     /// This will ceil the location and floor the size after applying the scale
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical_precise_down<S: Coordinate, R: Coordinate>(
         &self,
         scale: impl Into<Scale<S>>,
@@ -1531,6 +1586,7 @@ impl<N: Coordinate> Rectangle<N, Logical> {
     ///
     /// This will floor the location and ceil the size after applying the scale
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_physical_precise_up<S: Coordinate, R: Coordinate>(
         &self,
         scale: impl Into<Scale<S>>,
@@ -1540,6 +1596,7 @@ impl<N: Coordinate> Rectangle<N, Logical> {
 
     /// Convert this logical rectangle to buffer coordinate space according to given scale factor
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_buffer(
         self,
         scale: impl Into<Scale<N>>,
@@ -1566,6 +1623,7 @@ impl<N: Coordinate> Rectangle<N, Logical> {
 #[cfg(feature = "wayland_frontend")]
 impl<N: Coordinate> Rectangle<N, Client> {
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub(crate) fn to_logical(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Logical> {
         let scale = scale.into();
         Rectangle {
@@ -1578,6 +1636,7 @@ impl<N: Coordinate> Rectangle<N, Client> {
 impl<N: Coordinate> Rectangle<N, Physical> {
     /// Convert this physical rectangle to logical coordinate space according to given scale factor
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_logical(self, scale: impl Into<Scale<N>>) -> Rectangle<N, Logical> {
         let scale = scale.into();
         Rectangle {
@@ -1590,6 +1649,7 @@ impl<N: Coordinate> Rectangle<N, Physical> {
 impl<N: Coordinate> Rectangle<N, Buffer> {
     /// Convert this physical rectangle to logical coordinate space according to given scale factor
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_logical(
         self,
         scale: impl Into<Scale<N>>,
@@ -1684,6 +1744,7 @@ impl Transform {
     ///
     /// Flipping is preserved and 180/Normal transformation are uneffected.
     #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn invert(&self) -> Transform {
         match self {
             Transform::Normal => Transform::Normal,


### PR DESCRIPTION
This patch liberally sprinkles #[must_use] annotations on all geometry functions which return `Self` without modifying `self`.

---

I just wasted 3 seconds testing a patch just to realize I called `downscale` without assigning it to anything. This patch certainly takes a bit of a lazy approach just copy-pasting the annotations everywhere, but I do think that it's likely to save at least a couple minutes of developer headache in the long term.