### PR TITLE
Return `SyncPoint` from blit methods of renderer

### DIFF
--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -548,7 +548,7 @@ impl Blit for GlowRenderer {
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), GlesError> {
+    ) -> Result<sync::SyncPoint, GlesError> {
         self.gl.blit(from, to, src, dst, filter)
     }
 }

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -59,6 +59,7 @@ pub mod element;
 pub mod damage;
 
 pub mod sync;
+use sync::SyncPoint;
 
 // Note: This doesn't fully work yet due to <https://github.com/rust-lang/rust/issues/67295>.
 // Use `--features renderer_test` when running doc tests manually.
@@ -342,7 +343,7 @@ pub trait Frame {
     /// Output transformation that is applied to this frame
     fn transformation(&self) -> Transform;
 
-    /// Wait for a [`SyncPoint`](sync::SyncPoint) to be signaled
+    /// Wait for a [`SyncPoint`] to be signaled
     fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error>;
 
     /// Finish this [`Frame`] returning any error that may happen during any cleanup.
@@ -419,7 +420,7 @@ pub trait Renderer: RendererSuper {
     where
         'buffer: 'frame;
 
-    /// Wait for a [`SyncPoint`](sync::SyncPoint) to be signaled
+    /// Wait for a [`SyncPoint`] to be signaled
     fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error>;
 
     /// Forcibly clean up the renderer internal texture cache
@@ -802,7 +803,7 @@ where
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<SyncPoint, Self::Error>;
 }
 
 /// Trait for frames supporting blitting contents from/to the current framebuffer to/from another.

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -2863,11 +2863,13 @@ where
             let MultiFramebufferInternal::Target(ref mut to_fb) = &mut to.0 else {
                 unreachable!()
             };
-            target
+            let sync = target
                 .device
                 .renderer_mut()
                 .blit(target.framebuffer, to_fb, src, dst, filter)
-                .map_err(Error::Target)
+                .map_err(Error::Target)?;
+            target.device.renderer_mut().wait(&sync).map_err(Error::Target)?;
+            Ok(())
         } else {
             let MultiFramebufferInternal::Render(ref mut to_fb) = &mut to.0 else {
                 unreachable!()
@@ -2894,11 +2896,13 @@ where
             let MultiFramebufferInternal::Target(ref from_fb) = &from.0 else {
                 unreachable!()
             };
-            target
+            let sync = target
                 .device
                 .renderer_mut()
                 .blit(from_fb, target.framebuffer, src, dst, filter)
-                .map_err(Error::Target)
+                .map_err(Error::Target)?;
+            target.device.renderer_mut().wait(&sync).map_err(Error::Target)?;
+            Ok(())
         } else {
             let MultiFramebufferInternal::Render(ref from_fb) = &from.0 else {
                 unreachable!()
@@ -2935,7 +2939,7 @@ where
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), <Self as RendererSuper>::Error> {
+    ) -> Result<SyncPoint, <Self as RendererSuper>::Error> {
         if let Some(target) = self.target.as_mut() {
             let MultiFramebufferInternal::Target(ref from_fb) = &from.0 else {
                 unreachable!()


### PR DESCRIPTION
These methods are not part of a frame, so if an explicit sync point is needed, they need to return one.

I assume creating a sync point will have quite a low cost. When we're not exporting to an fd or waiting on a different renderer. Otherwise we might need a more cumbersome API; like an `&mut Option<SyncPoint>` method that is filled only if the caller needs a sync point. The `glFinish` invoked if EGL fences aren't supported would be more costly though; but that generally shouldn't be needed.

I think some of the synchronization may get more complicated with a Vulkan renderer, since Vulkan allows commands to complete out of order from when they are started and be synchronized separately, as I understand? I don't have experience with Vulkan synchronization though.