### PR TITLE
drm/output: Fix blocked crtc on specific failure

### DIFF
--- a/src/backend/drm/output.rs
+++ b/src/backend/drm/output.rs
@@ -481,7 +481,10 @@ where
 
         let compositor = self.compositor.get_mut(&crtc).unwrap();
         let compositor = compositor.get_mut().unwrap();
-        render_elements.submit_composited_frame(&mut *compositor, renderer)?;
+        if let Err(err) = render_elements.submit_composited_frame(&mut *compositor, renderer) {
+            self.compositor.remove(&crtc);
+            return Err(err);
+        }
 
         Ok(DrmOutput {
             compositor: self.compositor_arc.clone(),


### PR DESCRIPTION
There is a code path, where we hit the `submit_composited_frame` in line 484 as the first actual render, after having already inserted the compositor and crtc into the compositor_list `HashMap`.

So if this fails, the crtc ends up being blocked from the `DrmOutputManager` instance permanently.

Lets fix that.