### PR TITLE
allocator/dumb: impl Clone

### DIFF
--- a/src/backend/allocator/dumb.rs
+++ b/src/backend/allocator/dumb.rs
@@ -30,7 +30,7 @@ impl fmt::Debug for DumbBuffer {
 }
 
 /// Light wrapper around an [`DrmDeviceFd`] to implement the [`Allocator`]-trait
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DumbAllocator {
     fd: DrmDeviceFd,
 }


### PR DESCRIPTION
We have a requirement for the allocator being `Clone` in e.g. the `DrmOutputManager`.

There is no reason for the `DumbAllocator` to not be `Clone`.