### PR TITLE
xdg-shell, layer-shell, session-lock: Track last acked configure in MultiCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 *.bk
 .vscode
 .vagga
+/wlcs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ struct XdgPopupSurfaceRoleAttributes {
 -    configure_serial: Option<Serial>,
 -    current: PopupState,
 -    current_serial: Option<Serial>,
+-    committed: bool,
 -    last_acked: Option<PopupState>,
 +    last_acked: Option<PopupConfigure>,
     // ...

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -24,10 +24,9 @@ use smithay::{
     },
     utils::{Logical, Point, Serial, Transform, SERIAL_COUNTER as SCOUNTER},
     wayland::{
-        compositor::with_states,
         input_method::InputMethodSeat,
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
-        shell::wlr_layer::{KeyboardInteractivity, Layer as WlrLayer, LayerSurfaceCachedState},
+        shell::wlr_layer::{KeyboardInteractivity, Layer as WlrLayer},
     },
 };
 
@@ -146,12 +145,11 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         let keyboard = self.seat.get_keyboard().unwrap();
 
         for layer in self.layer_shell_state.layer_surfaces().rev() {
-            let data = with_states(layer.wl_surface(), |states| {
-                *states.cached_state.get::<LayerSurfaceCachedState>().current()
+            let exclusive = layer.with_cached_state(|data| {
+                data.keyboard_interactivity == KeyboardInteractivity::Exclusive
+                    && (data.layer == WlrLayer::Top || data.layer == WlrLayer::Overlay)
             });
-            if data.keyboard_interactivity == KeyboardInteractivity::Exclusive
-                && (data.layer == WlrLayer::Top || data.layer == WlrLayer::Overlay)
-            {
+            if exclusive {
                 let surface = self.space.outputs().find_map(|o| {
                     let map = layer_map_for_output(o);
                     let cloned = map.layers().find(|l| l.layer_surface() == &layer).cloned();

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -264,49 +264,43 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
     }
 
     fn fullscreen_request(&mut self, surface: ToplevelSurface, mut wl_output: Option<wl_output::WlOutput>) {
-        if surface
-            .current_state()
-            .capabilities
-            .contains(xdg_toplevel::WmCapabilities::Fullscreen)
-        {
-            // NOTE: This is only one part of the solution. We can set the
-            // location and configure size here, but the surface should be rendered fullscreen
-            // independently from its buffer size
-            let wl_surface = surface.wl_surface();
+        // NOTE: This is only one part of the solution. We can set the
+        // location and configure size here, but the surface should be rendered fullscreen
+        // independently from its buffer size
+        let wl_surface = surface.wl_surface();
 
-            let output_geometry = fullscreen_output_geometry(wl_surface, wl_output.as_ref(), &mut self.space);
+        let output_geometry = fullscreen_output_geometry(wl_surface, wl_output.as_ref(), &mut self.space);
 
-            if let Some(geometry) = output_geometry {
-                let output = wl_output
-                    .as_ref()
-                    .and_then(Output::from_resource)
-                    .unwrap_or_else(|| self.space.outputs().next().unwrap().clone());
-                let client = match self.display_handle.get_client(wl_surface.id()) {
-                    Ok(client) => client,
-                    Err(_) => return,
-                };
-                for output in output.client_outputs(&client) {
-                    wl_output = Some(output);
-                }
-                let window = self
-                    .space
-                    .elements()
-                    .find(|window| window.wl_surface().map(|s| &*s == wl_surface).unwrap_or(false))
-                    .unwrap();
-
-                surface.with_pending_state(|state| {
-                    state.states.set(xdg_toplevel::State::Fullscreen);
-                    state.size = Some(geometry.size);
-                    state.fullscreen_output = wl_output;
-                });
-                output.user_data().insert_if_missing(FullscreenSurface::default);
-                output
-                    .user_data()
-                    .get::<FullscreenSurface>()
-                    .unwrap()
-                    .set(window.clone());
-                trace!("Fullscreening: {:?}", window);
+        if let Some(geometry) = output_geometry {
+            let output = wl_output
+                .as_ref()
+                .and_then(Output::from_resource)
+                .unwrap_or_else(|| self.space.outputs().next().unwrap().clone());
+            let client = match self.display_handle.get_client(wl_surface.id()) {
+                Ok(client) => client,
+                Err(_) => return,
+            };
+            for output in output.client_outputs(&client) {
+                wl_output = Some(output);
             }
+            let window = self
+                .space
+                .elements()
+                .find(|window| window.wl_surface().map(|s| &*s == wl_surface).unwrap_or(false))
+                .unwrap();
+
+            surface.with_pending_state(|state| {
+                state.states.set(xdg_toplevel::State::Fullscreen);
+                state.size = Some(geometry.size);
+                state.fullscreen_output = wl_output;
+            });
+            output.user_data().insert_if_missing(FullscreenSurface::default);
+            output
+                .user_data()
+                .get::<FullscreenSurface>()
+                .unwrap()
+                .set(window.clone());
+            trace!("Fullscreening: {:?}", window);
         }
 
         // The protocol demands us to always reply with a configure,
@@ -345,27 +339,21 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
     fn maximize_request(&mut self, surface: ToplevelSurface) {
         // NOTE: This should use layer-shell when it is implemented to
         // get the correct maximum size
-        if surface
-            .current_state()
-            .capabilities
-            .contains(xdg_toplevel::WmCapabilities::Maximize)
-        {
-            let window = self.window_for_surface(surface.wl_surface()).unwrap();
-            let outputs_for_window = self.space.outputs_for_element(&window);
-            let output = outputs_for_window
-                .first()
-                // The window hasn't been mapped yet, use the primary output instead
-                .or_else(|| self.space.outputs().next())
-                // Assumes that at least one output exists
-                .expect("No outputs found");
-            let geometry = self.space.output_geometry(output).unwrap();
+        let window = self.window_for_surface(surface.wl_surface()).unwrap();
+        let outputs_for_window = self.space.outputs_for_element(&window);
+        let output = outputs_for_window
+            .first()
+            // The window hasn't been mapped yet, use the primary output instead
+            .or_else(|| self.space.outputs().next())
+            // Assumes that at least one output exists
+            .expect("No outputs found");
+        let geometry = self.space.output_geometry(output).unwrap();
 
-            surface.with_pending_state(|state| {
-                state.states.set(xdg_toplevel::State::Maximized);
-                state.size = Some(geometry.size);
-            });
-            self.space.map_element(window, geometry.loc, true);
-        }
+        surface.with_pending_state(|state| {
+            state.states.set(xdg_toplevel::State::Maximized);
+            state.size = Some(geometry.size);
+        });
+        self.space.map_element(window, geometry.loc, true);
 
         // The protocol demands us to always reply with a configure,
         // regardless of we fulfilled the request or not

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -454,13 +454,15 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 let mut initial_window_location = self.space.element_location(&window).unwrap();
 
                 // If surface is maximized then unmaximize it
-                let current_state = surface.current_state();
-                if current_state.states.contains(xdg_toplevel::State::Maximized) {
-                    surface.with_pending_state(|state| {
-                        state.states.unset(xdg_toplevel::State::Maximized);
+                let changed = surface.with_pending_state(|state| {
+                    if state.states.unset(xdg_toplevel::State::Maximized) {
                         state.size = None;
-                    });
-
+                        true
+                    } else {
+                        false
+                    }
+                });
+                if changed {
                     surface.send_configure();
 
                     // NOTE: In real compositor mouse location should be mapped to a new window size
@@ -518,13 +520,15 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         let mut initial_window_location = self.space.element_location(&window).unwrap();
 
         // If surface is maximized then unmaximize it
-        let current_state = surface.current_state();
-        if current_state.states.contains(xdg_toplevel::State::Maximized) {
-            surface.with_pending_state(|state| {
-                state.states.unset(xdg_toplevel::State::Maximized);
+        let changed = surface.with_pending_state(|state| {
+            if state.states.unset(xdg_toplevel::State::Maximized) {
                 state.size = None;
-            });
-
+                true
+            } else {
+                false
+            }
+        });
+        if changed {
             surface.send_configure();
 
             // NOTE: In real compositor mouse location should be mapped to a new window size

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -20,8 +20,8 @@ use smithay::{
         compositor::{self, with_states},
         seat::WaylandFocus,
         shell::xdg::{
-            Configure, PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler, XdgShellState,
-            XdgToplevelSurfaceData,
+            Configure, PopupSurface, PositionerState, ToplevelCachedState, ToplevelSurface, XdgShellHandler,
+            XdgShellState,
         },
     },
 };
@@ -221,14 +221,12 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
                 // will no longer have the resize state set
                 let is_resizing = with_states(&surface, |states| {
                     states
-                        .data_map
-                        .get::<XdgToplevelSurfaceData>()
-                        .unwrap()
-                        .lock()
-                        .unwrap()
-                        .current
-                        .states
-                        .contains(xdg_toplevel::State::Resizing)
+                        .cached_state
+                        .get::<ToplevelCachedState>()
+                        .current()
+                        .last_acked
+                        .as_ref()
+                        .is_some_and(|c| c.state.states.contains(xdg_toplevel::State::Resizing))
                 });
 
                 if configure.serial >= serial && is_resizing {

--- a/compile_wlcs.sh
+++ b/compile_wlcs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-WLCS_SHA=12234affdc0a4cc104fbaf8a502efc5f822b973b
+WLCS_SHA=2b385328366de5db19521b9b3eef81861430d984
 
 if [ -f "./wlcs/wlcs" ] && [ "$(cd wlcs; git rev-parse HEAD)" = "${WLCS_SHA}" ] ; then
     echo "Using cached WLCS."

--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -297,9 +297,7 @@ impl LayerMap {
                     )
                 }
 
-                let data = with_states(surface, |states| {
-                    *states.cached_state.get::<LayerSurfaceCachedState>().current()
-                });
+                let data = layer.cached_state();
 
                 let mut source = match data.exclusive_zone {
                     ExclusiveZone::Exclusive(_) | ExclusiveZone::Neutral => zone,
@@ -551,37 +549,24 @@ impl LayerSurface {
         self.0.surface.wl_surface()
     }
 
-    /// Returns the cached protocol state
+    /// Returns a clone of the cached protocol state
     pub fn cached_state(&self) -> LayerSurfaceCachedState {
-        with_states(self.0.surface.wl_surface(), |states| {
-            *states.cached_state.get::<LayerSurfaceCachedState>().current()
-        })
+        self.0.surface.with_cached_state(Clone::clone)
     }
 
     /// Returns true, if the surface has indicated, that it is able to process keyboard events.
     pub fn can_receive_keyboard_focus(&self) -> bool {
-        with_states(self.0.surface.wl_surface(), |states| {
-            match states
-                .cached_state
-                .get::<LayerSurfaceCachedState>()
-                .current()
-                .keyboard_interactivity
-            {
+        self.0
+            .surface
+            .with_cached_state(|state| match state.keyboard_interactivity {
                 KeyboardInteractivity::Exclusive | KeyboardInteractivity::OnDemand => true,
                 KeyboardInteractivity::None => false,
-            }
-        })
+            })
     }
 
     /// Returns the layer this surface resides on, if any yet.
     pub fn layer(&self) -> WlrLayer {
-        with_states(self.0.surface.wl_surface(), |states| {
-            states
-                .cached_state
-                .get::<LayerSurfaceCachedState>()
-                .current()
-                .layer
-        })
+        self.0.surface.with_cached_state(|state| state.layer)
     }
 
     /// Returns the namespace of this surface

--- a/src/desktop/wayland/popup/manager.rs
+++ b/src/desktop/wayland/popup/manager.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use std::sync::{Arc, Mutex};
 use tracing::trace;
-use wayland_protocols::xdg::shell::server::{xdg_popup, xdg_wm_base};
+use wayland_protocols::xdg::shell::server::xdg_wm_base;
 use wayland_server::{protocol::wl_surface::WlSurface, Resource};
 
 use super::{PopupGrab, PopupGrabError, PopupGrabInner, PopupKind};
@@ -74,23 +74,7 @@ impl PopupManager {
         );
 
         match popup {
-            PopupKind::Xdg(ref xdg) => {
-                let surface = xdg.wl_surface();
-                let committed = with_states(surface, |states| {
-                    states
-                        .data_map
-                        .get::<XdgPopupSurfaceData>()
-                        .unwrap()
-                        .lock()
-                        .unwrap()
-                        .committed
-                });
-
-                if committed {
-                    surface.post_error(xdg_popup::Error::InvalidGrab, "xdg_popup already is mapped");
-                    return Err(PopupGrabError::InvalidGrab);
-                }
-            }
+            PopupKind::Xdg(ref _xdg) => (),
             PopupKind::InputMethod(ref _input_method) => {
                 return Err(PopupGrabError::InvalidGrab);
             }

--- a/src/desktop/wayland/popup/manager.rs
+++ b/src/desktop/wayland/popup/manager.rs
@@ -4,7 +4,7 @@ use crate::{
     wayland::{
         compositor::{get_role, with_states},
         seat::WaylandFocus,
-        shell::xdg::{XdgPopupSurfaceData, XdgPopupSurfaceRoleAttributes, XDG_POPUP_ROLE},
+        shell::xdg::{PopupCachedState, XdgPopupSurfaceData, XdgPopupSurfaceRoleAttributes, XDG_POPUP_ROLE},
     },
 };
 use std::sync::{Arc, Mutex};
@@ -249,14 +249,12 @@ pub fn get_popup_toplevel_coords(popup: &PopupKind) -> Point<i32, Logical> {
     while get_role(&parent) == Some(XDG_POPUP_ROLE) {
         offset += with_states(&parent, |states| {
             states
-                .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
-                .unwrap()
-                .lock()
-                .unwrap()
-                .current
-                .geometry
-                .loc
+                .cached_state
+                .get::<PopupCachedState>()
+                .current()
+                .last_acked
+                .map(|c| c.state.geometry.loc)
+                .unwrap_or_default()
         });
         parent = with_states(&parent, |states| {
             states

--- a/src/desktop/wayland/popup/mod.rs
+++ b/src/desktop/wayland/popup/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     wayland::{
         compositor::with_states,
         input_method,
-        shell::xdg::{self, SurfaceCachedState, XdgPopupSurfaceData},
+        shell::xdg::{self, SurfaceCachedState},
     },
 };
 
@@ -81,21 +81,9 @@ impl PopupKind {
     }
 
     fn location(&self) -> Point<i32, Logical> {
-        let wl_surface = self.wl_surface();
-
         match *self {
-            PopupKind::Xdg(_) => {
-                with_states(wl_surface, |states| {
-                    states
-                        .data_map
-                        .get::<XdgPopupSurfaceData>()
-                        .unwrap()
-                        .lock()
-                        .unwrap()
-                        .current
-                        .geometry
-                })
-                .loc
+            PopupKind::Xdg(ref t) => {
+                t.with_committed_state(|current| current.map(|state| state.geometry.loc).unwrap_or_default())
             }
             PopupKind::InputMethod(ref t) => t.location(),
         }

--- a/src/wayland/session_lock/mod.rs
+++ b/src/wayland/session_lock/mod.rs
@@ -58,13 +58,14 @@ use wayland_server::protocol::wl_output::WlOutput;
 use wayland_server::protocol::wl_surface::WlSurface;
 use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New};
 
-use crate::wayland::session_lock::surface::LockSurfaceConfigure;
-
 mod lock;
 mod surface;
 
 pub use lock::SessionLockState;
-pub use surface::{ExtLockSurfaceUserData, LockSurface, LockSurfaceState};
+pub use surface::{
+    ExtLockSurfaceUserData, LockSurface, LockSurfaceAttributes, LockSurfaceCachedState, LockSurfaceConfigure,
+    LockSurfaceData, LockSurfaceState,
+};
 
 const MANAGER_VERSION: u32 = 1;
 

--- a/src/wayland/session_lock/surface.rs
+++ b/src/wayland/session_lock/surface.rs
@@ -2,9 +2,12 @@
 
 use std::sync::Mutex;
 
+use crate::backend::renderer::buffer_dimensions;
 use crate::utils::{IsAlive, Logical, Serial, Size, SERIAL_COUNTER};
-use crate::wayland::compositor;
+use crate::wayland::compositor::{self, BufferAssignment, Cacheable, SurfaceAttributes};
+use crate::wayland::viewporter::{ViewportCachedState, ViewporterSurfaceState};
 use _session_lock::ext_session_lock_surface_v1::{Error, ExtSessionLockSurfaceV1, Request};
+use tracing::trace_span;
 use wayland_protocols::ext::session_lock::v1::server::{self as _session_lock, ext_session_lock_surface_v1};
 use wayland_server::protocol::wl_surface::WlSurface;
 use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, Resource, Weak};
@@ -76,18 +79,32 @@ where
                     .lock()
                     .unwrap();
                 attributes.reset();
+
+                let mut guard = states.cached_state.get::<LockSurfaceCachedState>();
+                *guard.pending() = Default::default();
+                *guard.current() = Default::default();
             });
         }
     }
 }
 
+/// Data associated with session lock surface
+///
+/// ```no_run
+/// use smithay::wayland::compositor;
+/// use smithay::wayland::session_lock::LockSurfaceData;
+///
+/// # let wl_surface = todo!();
+/// compositor::with_states(&wl_surface, |states| {
+///     states.data_map.get::<LockSurfaceData>();
+/// });
+/// ```
+pub type LockSurfaceData = Mutex<LockSurfaceAttributes>;
+
 /// Attributes for ext-session-lock surfaces.
 #[derive(Debug)]
 pub struct LockSurfaceAttributes {
     pub(crate) surface: ext_session_lock_surface_v1::ExtSessionLockSurfaceV1,
-
-    /// The serial of the last acked configure
-    pub configure_serial: Option<Serial>,
 
     /// Holds the pending state as set by the server.
     pub server_pending: Option<LockSurfaceState>,
@@ -98,23 +115,19 @@ pub struct LockSurfaceAttributes {
     /// layer_surface.ack_configure.
     pub pending_configures: Vec<LockSurfaceConfigure>,
 
-    /// Holds the last server_pending state that has been acknowledged by the
-    /// client. This state should be cloned to the current during a commit.
-    pub last_acked: Option<LockSurfaceState>,
-
-    /// Holds the current state of the layer after a successful commit.
-    pub current: LockSurfaceState,
+    /// Holds the last configure that has been acknowledged by the client. This state should be
+    /// cloned to the current during a commit. Note that this state can be newer than the last
+    /// acked state at the time of the last commit.
+    pub last_acked: Option<LockSurfaceConfigure>,
 }
 
 impl LockSurfaceAttributes {
     pub(crate) fn new(surface: ext_session_lock_surface_v1::ExtSessionLockSurfaceV1) -> Self {
         Self {
             surface,
-            configure_serial: None,
             server_pending: None,
             pending_configures: vec![],
             last_acked: None,
-            current: Default::default(),
         }
     }
 
@@ -127,18 +140,22 @@ impl LockSurfaceAttributes {
 
         self.pending_configures
             .retain(|configure| configure.serial > serial);
-        self.last_acked = Some(configure.state);
-        self.configure_serial = Some(serial);
+        self.last_acked = Some(configure);
 
         Some(configure)
     }
 
     fn reset(&mut self) {
-        self.configure_serial = None;
         self.server_pending = None;
         self.pending_configures = Vec::new();
         self.last_acked = None;
-        self.current = Default::default();
+    }
+
+    fn current_server_state(&self) -> Option<&LockSurfaceState> {
+        self.pending_configures
+            .last()
+            .map(|c| &c.state)
+            .or(self.last_acked.as_ref().map(|c| &c.state))
     }
 }
 
@@ -174,12 +191,8 @@ impl LockSurface {
     pub fn get_pending_state(&self, attributes: &mut LockSurfaceAttributes) -> Option<LockSurfaceState> {
         let server_pending = attributes.server_pending.take()?;
 
-        // Get the last pending state.
-        let pending = attributes.pending_configures.last();
-        let last_state = pending.map(|c| &c.state).or(attributes.last_acked.as_ref());
-
         // Check if last state matches pending state.
-        match last_state {
+        match attributes.current_server_state() {
             Some(state) if state == &server_pending => None,
             _ => Some(server_pending),
         }
@@ -230,25 +243,118 @@ impl LockSurface {
             let mut attributes = attributes.unwrap().lock().unwrap();
 
             // Ensure pending state is initialized.
-            let current = attributes.current;
-            let server_pending = attributes.server_pending.get_or_insert(current);
+            if attributes.server_pending.is_none() {
+                attributes.server_pending =
+                    Some(attributes.current_server_state().cloned().unwrap_or_default());
+            }
 
+            let server_pending = attributes.server_pending.as_mut().unwrap();
             f(server_pending)
         })
     }
 
-    /// Get the current pending state.
-    #[allow(unused)]
-    pub fn current_state(&self) -> LockSurfaceState {
+    /// Provides access to the current committed cached state.
+    pub fn with_cached_state<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&LockSurfaceCachedState) -> T,
+    {
         compositor::with_states(&self.surface, |states| {
-            states
-                .data_map
-                .get::<Mutex<LockSurfaceAttributes>>()
-                .unwrap()
-                .lock()
-                .unwrap()
-                .current
+            let mut guard = states.cached_state.get::<LockSurfaceCachedState>();
+            f(guard.current())
         })
+    }
+
+    /// Provides access to the current committed state.
+    ///
+    /// This is the state that the client last acked before making the current commit.
+    pub fn with_committed_state<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(Option<&LockSurfaceState>) -> T,
+    {
+        self.with_cached_state(move |state| f(state.last_acked.as_ref().map(|c| &c.state)))
+    }
+
+    /// Handles the role specific commit error checking
+    ///
+    /// This should be called when the underlying WlSurface
+    /// handles a wl_surface.commit request.
+    pub(crate) fn pre_commit_hook<D: 'static>(_state: &mut D, _dh: &DisplayHandle, surface: &WlSurface) {
+        let _span = trace_span!("session-lock-surface pre-commit", surface = %surface.id()).entered();
+
+        compositor::with_states(surface, |states| {
+            let role = states.data_map.get::<LockSurfaceData>().unwrap().lock().unwrap();
+
+            let Some(last_acked) = role.last_acked else {
+                role.surface.post_error(
+                    ext_session_lock_surface_v1::Error::CommitBeforeFirstAck,
+                    "Committed before the first ack_configure.",
+                );
+                return;
+            };
+            let LockSurfaceConfigure { state, serial: _ } = &last_acked;
+
+            let mut guard_layer = states.cached_state.get::<LockSurfaceCachedState>();
+            let pending = guard_layer.pending();
+
+            // The presence of last_acked always follows the buffer assignment because the
+            // surface is not allowed to attach a buffer without acking the initial configure.
+            let had_buffer_before = pending.last_acked.is_some();
+
+            let mut guard_surface = states.cached_state.get::<SurfaceAttributes>();
+            let surface_attrs = guard_surface.pending();
+            let has_buffer = match &surface_attrs.buffer {
+                Some(BufferAssignment::NewBuffer(buffer)) => {
+                    // Verify buffer size.
+                    if let Some(buf_size) = buffer_dimensions(buffer) {
+                        let viewport = states
+                            .data_map
+                            .get::<ViewporterSurfaceState>()
+                            .map(|v| v.lock().unwrap());
+                        let surface_size = if let Some(dest) = viewport.as_ref().and_then(|_| {
+                            let mut guard = states.cached_state.get::<ViewportCachedState>();
+                            let viewport_state = guard.pending();
+                            viewport_state.dst
+                        }) {
+                            Size::from((dest.w as u32, dest.h as u32))
+                        } else {
+                            let scale = surface_attrs.buffer_scale;
+                            let transform = surface_attrs.buffer_transform.into();
+                            let surface_size = buf_size.to_logical(scale, transform);
+
+                            Size::from((surface_size.w as u32, surface_size.h as u32))
+                        };
+
+                        if Some(surface_size) != state.size {
+                            role.surface.post_error(
+                                ext_session_lock_surface_v1::Error::DimensionsMismatch,
+                                "Surface dimensions do not match acked configure.",
+                            );
+                            return;
+                        }
+                    }
+
+                    true
+                }
+                Some(BufferAssignment::Removed) => {
+                    role.surface.post_error(
+                        ext_session_lock_surface_v1::Error::NullBuffer,
+                        "Surface attached a NULL buffer.",
+                    );
+                    return;
+                }
+                None => had_buffer_before,
+            };
+
+            if has_buffer {
+                // The surface remains, or became mapped, track the last acked state.
+                pending.last_acked = Some(last_acked);
+            } else {
+                // The surface remains unmapped, meaning that it's in the initial configure stage.
+                pending.last_acked = None;
+            }
+
+            // Lock surfaces aren't allowed to attach a null buffer, and therefore to unmap.
+        });
     }
 }
 
@@ -275,5 +381,23 @@ impl LockSurfaceConfigure {
             serial: SERIAL_COUNTER.next_serial(),
             state,
         }
+    }
+}
+
+/// Represents the client pending state
+#[derive(Debug, Default, Copy, Clone)]
+pub struct LockSurfaceCachedState {
+    /// Configure last acknowledged by the client at the time of the commit.
+    ///
+    /// Reset to `None` when the surface unmaps.
+    pub last_acked: Option<LockSurfaceConfigure>,
+}
+
+impl Cacheable for LockSurfaceCachedState {
+    fn commit(&mut self, _dh: &DisplayHandle) -> Self {
+        *self
+    }
+    fn merge_into(self, into: &mut Self, _dh: &DisplayHandle) {
+        *into = self;
     }
 }

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -122,49 +122,10 @@ where
                 });
 
                 if initial {
-                    compositor::add_pre_commit_hook::<D, _>(&wl_surface, |_state, _dh, surface| {
-                        compositor::with_states(surface, |states| {
-                            let guard = states
-                                .data_map
-                                .get::<Mutex<LayerSurfaceAttributes>>()
-                                .unwrap()
-                                .lock()
-                                .unwrap();
-
-                            let mut cached_guard = states.cached_state.get::<LayerSurfaceCachedState>();
-                            let pending = cached_guard.pending();
-
-                            if pending.size.w == 0 && !pending.anchor.anchored_horizontally() {
-                                guard.surface.post_error(
-                                    zwlr_layer_surface_v1::Error::InvalidSize,
-                                    "width 0 requested without setting left and right anchors",
-                                );
-                                return;
-                            }
-
-                            if pending.size.h == 0 && !pending.anchor.anchored_vertically() {
-                                guard.surface.post_error(
-                                    zwlr_layer_surface_v1::Error::InvalidSize,
-                                    "height 0 requested without setting top and bottom anchors",
-                                );
-                            }
-                        });
-                    });
-
-                    compositor::add_post_commit_hook::<D, _>(&wl_surface, |_state, _dh, surface| {
-                        compositor::with_states(surface, |states| {
-                            let mut guard = states
-                                .data_map
-                                .get::<Mutex<LayerSurfaceAttributes>>()
-                                .unwrap()
-                                .lock()
-                                .unwrap();
-
-                            if let Some(state) = guard.last_acked.clone() {
-                                guard.current = state;
-                            }
-                        });
-                    });
+                    compositor::add_pre_commit_hook::<D, _>(
+                        &wl_surface,
+                        super::LayerSurface::pre_commit_hook,
+                    );
                 }
 
                 let handle = super::LayerSurface {

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -496,6 +496,17 @@ impl LayerSurface {
         })
     }
 
+    /// Provides access to the current committed cached state.
+    pub fn with_cached_state<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&LayerSurfaceCachedState) -> T,
+    {
+        compositor::with_states(&self.wl_surface, |states| {
+            let mut guard = states.cached_state.get::<LayerSurfaceCachedState>();
+            f(guard.current())
+        })
+    }
+
     /// Access the underlying `zwlr_layer_surface_v1` of this layer surface
     ///
     pub fn shell_surface(&self) -> &zwlr_layer_surface_v1::ZwlrLayerSurfaceV1 {

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -74,7 +74,7 @@ pub use types::{Anchor, ExclusiveZone, KeyboardInteractivity, Layer, Margins};
 /// The role of a wlr_layer_shell_surface
 pub const LAYER_SURFACE_ROLE: &str = "zwlr_layer_surface_v1";
 
-/// Data associated with XDG popup surface  
+/// Data associated with layer surface
 ///
 /// ```no_run
 /// use smithay::wayland::compositor;

--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::Serial,
     wayland::{
         compositor,
-        shell::xdg::{SurfaceCachedState, XdgPopupSurfaceData, XdgPositionerUserData},
+        shell::xdg::{PopupCachedState, SurfaceCachedState, XdgPopupSurfaceData, XdgPositionerUserData},
     },
 };
 
@@ -88,6 +88,10 @@ where
                     .unwrap() = Default::default();
 
                 let mut guard = states.cached_state.get::<SurfaceCachedState>();
+                *guard.pending() = Default::default();
+                *guard.current() = Default::default();
+
+                let mut guard = states.cached_state.get::<PopupCachedState>();
                 *guard.pending() = Default::default();
                 *guard.current() = Default::default();
             })

--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -4,7 +4,7 @@ use crate::{
     input::SeatHandler,
     utils::Serial,
     wayland::{
-        compositor,
+        compositor::{self, with_states},
         shell::xdg::{PopupCachedState, SurfaceCachedState, XdgPopupSurfaceData, XdgPositionerUserData},
     },
 };
@@ -45,7 +45,15 @@ where
 
                 let serial = Serial::from(serial);
 
-                XdgShellHandler::grab(state, handle, seat, serial);
+                with_states(handle.wl_surface(), |states| {
+                    states
+                        .data_map
+                        .get::<XdgPopupSurfaceData>()
+                        .unwrap()
+                        .lock()
+                        .unwrap()
+                        .requested_grab = Some((seat, serial));
+                });
             }
             xdg_popup::Request::Reposition { positioner, token } => {
                 let handle = crate::wayland::shell::xdg::PopupSurface {

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -4,7 +4,10 @@ use crate::{
     utils::Serial,
     wayland::{
         compositor,
-        shell::{is_valid_parent, xdg::XdgToplevelSurfaceData},
+        shell::{
+            is_valid_parent,
+            xdg::{ToplevelCachedState, XdgToplevelSurfaceData},
+        },
     },
 };
 
@@ -180,6 +183,10 @@ where
                     .unwrap() = Default::default();
 
                 let mut guard = states.cached_state.get::<SurfaceCachedState>();
+                *guard.pending() = Default::default();
+                *guard.current() = Default::default();
+
+                let mut guard = states.cached_state.get::<ToplevelCachedState>();
                 *guard.pending() = Default::default();
                 *guard.current() = Default::default();
             })


### PR DESCRIPTION
Corresponding niri update: https://github.com/YaLTeR/niri/commit/5a4d794b17791386f4103415de95b7557cb369ad

Fixes my fullscreen anim bugs that I found with mpv and adwaita-1-demo.

----

The last-acked configure is part of the committed state, and should be tracked as such. Before this commit, it would be possible to observe a newer "current state" in a commit handler if the surface acked the next state while the compositor was waiting on a blocker set in a pre-commit handler.

As part of the change, the current_state() getter was removed, because it's confusing and likely not what you actually want. For instance, several uses in Anvil actually needed to access a different state.

The WmCapabilities checks in Anvil were removed because they are serverside and don't change; not sure what the intention was with those.

Also, added forced configures in unmaximize() and unfullscreen() because they too are required by the protocol.

----

If this is good I'll do a similar refactor for layer-shell and session-lock.

One kinda weird part is `current_server_state()` that I had to change to owned return, tbh I would change it to return an `Option<&State>`, but that would involve changing a bunch of callers. I can do that though if that's better.

Also, there's a question of whether any other state needs to be moved into Cached?