### PR TITLE
xwm: Fix unscaled create geometry

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1523,7 +1523,9 @@ where
                 (geo.x as i32, geo.y as i32).into(),
                 (geo.width as i32, geo.height as i32).into(),
             )
-            .to_logical(xwm.client_scale.load(Ordering::Acquire) as i32);
+            .to_f64()
+            .to_logical(xwm.client_scale.load(Ordering::Acquire))
+            .to_i32_round();
 
             let surface = X11Surface::new(
                 Some(xwm),


### PR DESCRIPTION
This one slipped through in https://github.com/Smithay/smithay/pull/1702.

While not critical as most compositors will ignore the position and use their own logic, this will likely cause override-redirect windows (e.g. popups) to be offset from the parent/pointer position.