### PR TITLE
popup/manager: Fix toplevel popup iteration order

### DIFF
--- a/src/desktop/wayland/popup/manager.rs
+++ b/src/desktop/wayland/popup/manager.rs
@@ -290,6 +290,10 @@ impl PopupTree {
             .lock()
             .unwrap()
             .iter()
+            // A newly created xdg_popup is stacked on top of all previously created xdg_popups. We
+            // push new ones to the end of the vector, so we should iterate in reverse, from newest
+            // to oldest.
+            .rev()
             .filter(|node| node.surface.alive())
             .flat_map(|n| n.iter_popups_relative_to((0, 0)).map(|(p, l)| (p.clone(), l)))
             .collect::<Vec<_>>()
@@ -351,6 +355,10 @@ impl PopupNode {
         let relative_to = loc.into() + self.surface.location();
         self.children
             .iter()
+            // A newly created xdg_popup is stacked on top of all previously created xdg_popups. We
+            // push new ones to the end of the vector, so we should iterate in reverse, from newest
+            // to oldest.
+            .rev()
             .filter(|node| node.surface.alive())
             .flat_map(move |x| {
                 Box::new(x.iter_popups_relative_to(relative_to))


### PR DESCRIPTION
Protocol says:

> A newly created xdg_popup will be stacked on top of all previously created
> xdg_popup surfaces associated with the same xdg_toplevel.

New toplevel popups are pushed to the end of the vector, so iteration should go from the end to the start, since this function returns popups in topmost-first order.

Fixes various cases of tooltip opening after a popup menu, and ending up below. Also fixes multi-level popups in xwayland-satellite. Also fixes IME popups appearing below normal popups if there's an input field in a popup.

Issue-wise, fixes https://github.com/Smithay/smithay/issues/1729, https://github.com/Supreeeme/xwayland-satellite/issues/153, https://github.com/YaLTeR/niri/issues/125.

This fix is still not 100% sufficient I guess since it doesn't handle ordering across different popup trees, but I'm yet to encounter a situation where that would be needed.