### PR TITLE
Anvil: Fix wrong DnD offset

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -30,7 +30,7 @@ use smithay::{
     },
     input::{
         keyboard::{Keysym, LedState, XkbConfig},
-        pointer::{CursorImageStatus, CursorImageSurfaceData, PointerHandle},
+        pointer::{CursorImageStatus, PointerHandle},
         Seat, SeatHandler, SeatState,
     },
     output::Output,
@@ -195,21 +195,7 @@ impl<BackendData: Backend> DataDeviceHandler for AnvilState<BackendData> {
 
 impl<BackendData: Backend> ClientDndGrabHandler for AnvilState<BackendData> {
     fn started(&mut self, _source: Option<WlDataSource>, icon: Option<WlSurface>, _seat: Seat<Self>) {
-        let offset = if let CursorImageStatus::Surface(ref surface) = self.cursor_status {
-            with_states(surface, |states| {
-                let hotspot = states
-                    .data_map
-                    .get::<CursorImageSurfaceData>()
-                    .unwrap()
-                    .lock()
-                    .unwrap()
-                    .hotspot;
-                Point::from((-hotspot.x, -hotspot.y))
-            })
-        } else {
-            (0, 0).into()
-        };
-        self.dnd_icon = icon.map(|surface| DndIcon { surface, offset });
+        self.dnd_icon = icon.map(|surface| DndIcon { surface, offset: (0, 0).into() });
     }
     fn dropped(&mut self, _target: Option<WlSurface>, _validated: bool, _seat: Seat<Self>) {
         self.dnd_icon = None;


### PR DESCRIPTION
The DnD should start at the hotspot aka the pointer location. The (0, 0) coordinate already corresponds to the pointer location. By offseting by -hotspot, the dnd is initiated at the top-left of the cursor's surface instead of the hotspot.

You can verify the behaviour is incorrect by running weston-dnd:
Without the patch, when initiating the dnd the element gets offset to the left.
With the patch, the element does not get offset.

(P.S. Even with this patch, there is still a very tiny offset when doing the DnD for me. I believe this is due to conversions between integer and floating point locations using round() instead of floor(). In my experience, floor() produces more correct results than round(). But that's an entirely separate and it might just be my setup.)