### PR TITLE
feat: implement TabletPadButtonEvent support

### DIFF
--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -7,8 +7,9 @@ pub use xkbcommon::xkb::Keycode;
 mod tablet;
 
 pub use tablet::{
-    ProximityState, TabletToolAxisEvent, TabletToolButtonEvent, TabletToolCapabilities, TabletToolDescriptor,
-    TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent, TabletToolTipState, TabletToolType,
+    ProximityState, TabletPadButtonEvent, TabletToolAxisEvent, TabletToolButtonEvent, TabletToolCapabilities,
+    TabletToolDescriptor, TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent, TabletToolTipState,
+    TabletToolType,
 };
 
 #[cfg(feature = "wayland_frontend")]
@@ -671,6 +672,8 @@ pub trait InputBackend: Sized {
     type TabletToolTipEvent: TabletToolTipEvent<Self>;
     /// Type representing button events on tablet tool devices
     type TabletToolButtonEvent: TabletToolButtonEvent<Self>;
+    /// Type representing button events on tablet pad devices
+    type TabletPadButtonEvent: TabletPadButtonEvent<Self>;
     /// Type representing switch toggle events
     type SwitchToggleEvent: SwitchToggleEvent<Self>;
 
@@ -807,6 +810,12 @@ pub enum InputEvent<B: InputBackend> {
     TabletToolButton {
         /// The pointer button event
         event: B::TabletToolButtonEvent,
+    },
+
+    /// A tablet pad button was pressed or released
+    TabletPadButton {
+        /// The tablet pad button event
+        event: B::TabletPadButtonEvent,
     },
 
     /// A switch was toggled

--- a/src/backend/input/tablet.rs
+++ b/src/backend/input/tablet.rs
@@ -334,3 +334,24 @@ impl<B: InputBackend> TabletToolButtonEvent<B> for UnusedEvent {
         match *self {}
     }
 }
+
+/// Common methods tablet pad button events implement
+pub trait TabletPadButtonEvent<B: InputBackend>: Event<B> {
+    /// Returns the numerical button code of the tablet pad button.
+    ///
+    /// Buttons on tablet pads are numbered sequentially starting from 0.
+    fn button(&self) -> u32;
+
+    /// State of the button
+    fn state(&self) -> ButtonState;
+}
+
+impl<B: InputBackend> TabletPadButtonEvent<B> for UnusedEvent {
+    fn button(&self) -> u32 {
+        match *self {}
+    }
+
+    fn state(&self) -> ButtonState {
+        match *self {}
+    }
+}

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -606,6 +606,7 @@ impl InputBackend for LibinputInputBackend {
     type TabletToolProximityEvent = event::tablet_tool::TabletToolProximityEvent;
     type TabletToolTipEvent = event::tablet_tool::TabletToolTipEvent;
     type TabletToolButtonEvent = event::tablet_tool::TabletToolButtonEvent;
+    type TabletPadButtonEvent = event::tablet_pad::TabletPadButtonEvent;
 
     type SwitchToggleEvent = event::switch::SwitchToggleEvent;
 
@@ -855,6 +856,22 @@ impl EventSource for LibinputInputBackend {
                         }
                         _ => {
                             trace!("Unknown libinput tablet event");
+                        }
+                    },
+                    libinput::Event::TabletPad(tablet_pad_event) => match tablet_pad_event {
+                        event::TabletPadEvent::Button(event) => {
+                            callback(InputEvent::TabletPadButton { event }, &mut ());
+                        }
+                        event::TabletPadEvent::Ring(event) => {
+                            // Handle ring events if needed
+                            trace!("Tablet pad ring event: {:?}", event);
+                        }
+                        event::TabletPadEvent::Strip(event) => {
+                            // Handle strip events if needed
+                            trace!("Tablet pad strip event: {:?}", event);
+                        }
+                        _ => {
+                            trace!("Unknown libinput tablet pad event");
                         }
                     },
                     libinput::Event::Switch(switch_event) => match switch_event {

--- a/src/backend/libinput/tablet.rs
+++ b/src/backend/libinput/tablet.rs
@@ -192,3 +192,23 @@ impl backend::TabletToolButtonEvent<LibinputInputBackend> for tablet_tool::Table
         tablet_tool::TabletToolButtonEvent::button_state(self).into()
     }
 }
+
+impl backend::Event<LibinputInputBackend> for event::tablet_pad::TabletPadButtonEvent {
+    fn time(&self) -> u64 {
+        event::tablet_pad::TabletPadEventTrait::time_usec(self)
+    }
+
+    fn device(&self) -> libinput::Device {
+        event::EventTrait::device(self)
+    }
+}
+
+impl backend::TabletPadButtonEvent<LibinputInputBackend> for event::tablet_pad::TabletPadButtonEvent {
+    fn button(&self) -> u32 {
+        self.button_number()
+    }
+
+    fn state(&self) -> backend::ButtonState {
+        self.button_state().into()
+    }
+}

--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -407,6 +407,7 @@ impl InputBackend for WinitInput {
     type TabletToolProximityEvent = UnusedEvent;
     type TabletToolTipEvent = UnusedEvent;
     type TabletToolButtonEvent = UnusedEvent;
+    type TabletPadButtonEvent = UnusedEvent;
 
     type SwitchToggleEvent = UnusedEvent;
 

--- a/src/backend/x11/input.rs
+++ b/src/backend/x11/input.rs
@@ -255,6 +255,7 @@ impl InputBackend for X11Input {
     type TabletToolProximityEvent = UnusedEvent;
     type TabletToolTipEvent = UnusedEvent;
     type TabletToolButtonEvent = UnusedEvent;
+    type TabletPadButtonEvent = UnusedEvent;
 
     type SwitchToggleEvent = UnusedEvent;
 


### PR DESCRIPTION
This pull request adds support for tablet pad button events to the input backend system. It introduces a new trait for tablet pad button events, updates the input event enum to handle these events, and implements the necessary plumbing for the `LibinputInputBackend` to process tablet pad button events. Backends that do not support tablet pad buttons are updated to use the `UnusedEvent` type.

**Tablet Pad Button Event Support**

* Added a new trait `TabletPadButtonEvent` with methods for button code and state in `src/backend/input/tablet.rs`, along with an implementation for the `UnusedEvent` type.
* Extended the `InputBackend` trait to include an associated type for tablet pad button events.
* Updated the `InputEvent` enum to include a new variant `TabletPadButton` for tablet pad button events.

**Libinput Backend Integration**

* Implemented `TabletPadButtonEvent` for `event::tablet_pad::TabletPadButtonEvent` and integrated event handling for tablet pad button events in `LibinputInputBackend`. [[1]](diffhunk://#diff-ac484734324000504fefd71c4a70af9e368922ea700921687c3e950066d35d1fR609) [[2]](diffhunk://#diff-728f9aca4abec1147c351bf0f9933512742fe560e8f53c59be8fa93b582be13bR195-R214) [[3]](diffhunk://#diff-ac484734324000504fefd71c4a70af9e368922ea700921687c3e950066d35d1fR861-R876)

**Backend Compatibility**

* Updated the `WinitInput` and `X11Input` backends to use `UnusedEvent` for the new tablet pad button event type to maintain compatibility. [[1]](diffhunk://#diff-cd378a6e5fd4c287ee75a30c64386f917a271b8b14cf02b51041c349d98ad161R410) [[2]](diffhunk://#diff-97ac18da32b79b23153f498d309f255c8fa8373712bb0bdc4bf8ea449d94b907R258)

**Public API Update**

* Added `TabletPadButtonEvent` to the list of publicly re-exported tablet input types in `src/backend/input/mod.rs`.