### PR TITLE
feat: add drag and drop support inside xdg-popup surfaces.

### DIFF
--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 use thiserror::Error;
-
+use crate::input::pointer::Focus;
 use super::{PopupKind, PopupManager};
 
 /// Defines the possible errors that
@@ -608,6 +608,18 @@ where
         }
 
         handle.button(data, event);
+        if event.state == ButtonState::Pressed {
+            let grab = self.popup_grab.clone();
+            handle.set_grab(
+                self,
+                data,
+                event.serial,
+                Focus::Keep,
+                PopupPointerGrab {
+                    popup_grab: grab,
+                },
+            );
+        }
     }
 
     fn axis(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, details: AxisFrame) {


### PR DESCRIPTION
To my understanding smithay was not aware of the implicit grab on these kind of surfaces because of a missing set_grab in the pointer click handler. When the client then tried to [start a drag](https://wayland.app/protocols/wayland#wl_data_device:request:start_drag), smithay would not know of this grab on [serial](https://wayland.app/protocols/wayland#wl_data_device:request:start_drag:arg:serial) and just ignore it.

This can be tested in the gtk4-widget-factory -> page 3 -> Open button.
Inside this popup, there are 2 text input boxes, this text can be dragged and dropped now.

⚠️ I'm not well versed in smithay or wayland protocols, so please double check that I'm not doing something foolish :/
