### PR TITLE
desktop/popup: fix focus not updating after popup dismiss

### DIFF
--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -64,8 +64,12 @@ struct PopupGrabInternal {
 }
 
 impl PopupGrabInternal {
-    fn active(&self) -> bool {
+    fn has_any_grabs(&self) -> bool {
         !self.active_grabs.is_empty() || !self.dismissed_grabs.is_empty()
+    }
+
+    fn has_active_grabs(&self) -> bool {
+        !self.active_grabs.is_empty()
     }
 
     fn current_grab(&self) -> Option<&WlSurface> {
@@ -105,9 +109,14 @@ pub(super) struct PopupGrabInner {
 }
 
 impl PopupGrabInner {
-    pub(super) fn active(&self) -> bool {
+    pub(super) fn has_any_grabs(&self) -> bool {
         let guard = self.internal.lock().unwrap();
-        guard.active()
+        guard.has_any_grabs()
+    }
+
+    pub(super) fn has_active_grabs(&self) -> bool {
+        let guard = self.internal.lock().unwrap();
+        guard.has_active_grabs()
     }
 
     fn current_grab(&self) -> Option<PopupKind> {
@@ -322,14 +331,7 @@ where
     /// This will also return [`false`] if the root
     /// of the grab has been destroyed.
     pub fn has_ended(&self) -> bool {
-        !self.root.alive()
-            || self
-                .toplevel_grab
-                .internal
-                .lock()
-                .unwrap()
-                .active_grabs
-                .is_empty()
+        !self.root.alive() || !self.toplevel_grab.has_active_grabs()
     }
 
     /// Returns the current grabbed [`WlSurface`].

--- a/src/desktop/wayland/popup/manager.rs
+++ b/src/desktop/wayland/popup/manager.rs
@@ -89,7 +89,7 @@ impl PopupManager {
         // that it either is new and have never been
         // added to the popupmanager or that it has been
         // cleaned up.
-        if !toplevel_popups.active() {
+        if !toplevel_popups.has_any_grabs() {
             self.popup_grabs.push(toplevel_popups.clone());
         }
 
@@ -198,7 +198,7 @@ impl PopupManager {
     pub fn cleanup(&mut self) {
         self.popup_grabs.retain_mut(|grabs| {
             grabs.cleanup();
-            grabs.active()
+            grabs.has_any_grabs()
         });
         self.popup_trees.retain_mut(|tree| {
             let alive = tree.cleanup_and_get_alive();


### PR DESCRIPTION
`PopupGrab::has_ended` previously considered both active and dismissed grabs as keeping the grab alive. This caused the grab to remain "active" even after all popups were dismissed with `PopupGrab::ungrab(All)`.

According to the documentation, a grab has ended once all popups associated with it have been dismissed or destroyed. Including dismissed grabs in the active check prevented focus from updating after popup dismissal.

This change makes `has_ended` return true once all *active* grabs are gone, aligning the behavior with its documented intent.

This resolves a focus transfer issue observed in [pop-os/cosmic-panel#483](https://github.com/pop-os/cosmic-panel/issues/483)
(**tiling mode**, when an application is opened or focused via a popup it did not receive focus)

[src/shell/focus/mod.rs](https://github.com/pop-os/cosmic-comp/blob/master/src/shell/focus/mod.rs)
`popup_grab.ungrab(PopupUngrabStrategy::All);` is called in `append_focus_stack`.
`keyboard.set_focus(state, target.cloned(), serial);` is called in `update_focus_state` afterwards. At this point the focus should have been passed along. But because the popup was still considered active it was blocked.