### PR TITLE
wayland/layer: Add check that `exclusive_edge` has only one edge

### DIFF
--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -383,6 +383,7 @@ impl LayerMap {
                         Some(Anchor::RIGHT) => {
                             zone.size.w -= amount + Saturating(data.margin.right);
                         }
+                        // Exclusive edge is always exactly one edge
                         Some(_) => unreachable!(),
                         None => {}
                     }

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -254,9 +254,16 @@ where
             zwlr_layer_surface_v1::Request::SetExclusiveEdge { edge } => {
                 match Anchor::try_from(edge) {
                     Ok(edge) => {
-                        let _ = with_surface_pending_state(layer_surface, |data| {
-                            data.exclusive_edge = Some(edge);
-                        });
+                        if edge.bits().count_ones() == 1 {
+                            let _ = with_surface_pending_state(layer_surface, |data| {
+                                data.exclusive_edge = Some(edge);
+                            });
+                        } else {
+                            layer_surface.post_error(
+                                zwlr_layer_surface_v1::Error::InvalidExclusiveEdge,
+                                "exclusive edge cannot have multiple edges",
+                            );
+                        }
                     }
                     Err((err, msg)) => {
                         layer_surface.post_error(err, msg);


### PR DESCRIPTION
We already have checks that the exclusive edge `Anchor` is valid, and contained in the anchors of the surface, but not a check that it doesn't contain multiple edges.