### PR TITLE
fix: Documentation of `Transform`

### DIFF
--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -1717,25 +1717,29 @@ impl<N: Default, Kind> Default for Rectangle<N, Kind> {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-/// Possible transformations to two-dimensional planes
+/// [wl_output::transform](https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_output-enum-transform) - transformation applied to buffer contents
+///
+/// Note that it is a [dihedral group](https://en.wikipedia.org/wiki/Dihedral_group) `D_4`. In the
+/// below, we assume it's acting on the mathematcal coordinate system. Let `r` denote the rotation
+/// 90 degrees conter-clockwise, `f` denote the flip across y-axis.
 #[derive(Default)]
 pub enum Transform {
-    /// Identity transformation (plane is unaltered when applied)
+    /// Identity
     #[default]
     Normal,
-    /// Plane is rotated by 90 degrees
+    /// Rotation 90-degrees counter-clockwise: `r`
     _90,
-    /// Plane is rotated by 180 degrees
+    /// Rotation 180-degrees counter-clockwise: `r^2`
     _180,
-    /// Plane is rotated by 270 degrees
+    /// Rotation 270-degrees counter-clockwise: `r^3`
     _270,
-    /// Plane is flipped vertically
+    /// Flip across y-axis: `f`
     Flipped,
-    /// Plane is flipped vertically and rotated by 90 degrees
+    /// Flip followed by rotate 90-degrees counter-clockwise: `r . f`
     Flipped90,
-    /// Plane is flipped vertically and rotated by 180 degrees
+    /// Flip followed by rotate 180-degrees counter-clockwise: `r^2 . f`
     Flipped180,
-    /// Plane is flipped vertically and rotated by 270 degrees
+    /// Flip followed by rotate 270-degrees counter-clockwise: `r^3 . f`
     Flipped270,
 }
 


### PR DESCRIPTION
The current documentation for `Flipped` states that the "Plane is flipped vertically", but the [wl_output::transform] specification describes it as a "180 degree flip around a vertical axis". The implementation follows the latter. Therefore, the documentation for `Transform::Flipped` is incorrect and needs to be updated.

This patch corrects the documentation for `Transform` to remove ambiguity and align with the implementation and the Wayland specification.

For more details, see
https://github.com/kenoss/sabiniwm/blob/a4364ca211f97b672f92fb4de78f570f74404b90/note/issue-transform.md and #Transform-Flipped-doc-wrong.

[wl_output::transform] https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_output-enum-transform