### PR TITLE
tablet: Send pressure(0) before pen up events

### DIFF
--- a/src/wayland/tablet_manager/tablet_tool.rs
+++ b/src/wayland/tablet_manager/tablet_tool.rs
@@ -118,7 +118,7 @@ impl TabletTool {
             }
         }
 
-        self.is_down = false; 
+        self.is_down = false;
     }
 
     fn motion(


### PR DESCRIPTION
Send a pressure(0) event before sending the pen up event in both tip_up() and proximity_out() handlers. This improves compatibility with applications like Wine and MyPaint that expect the pressure to be explicitly set to zero before a pen up event.

While the tablet-v2 protocol does not strictly require this, major compositors like GNOME and Sway send this event for compatibility. Without it, some applications continue drawing strokes even after the pen is lifted.

Fixes compatibility issues reported in:
- https://bugs.winehq.org/show_bug.cgi?id=58463
- https://github.com/YaLTeR/niri/issues/2722
- https://github.com/YaLTeR/niri/issues/2576

**Note:** This patch has been tested manually on Arch Linux with WINE-git and Clip Studio Paint.
Automated CI cannot reproduce the exact environment (WINE + CSP), but the patch is low-risk
and only affects the pressure event sent before pen up.