### PR TITLE
unpin indexmap from 2.11.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ errno = "0.3.5"
 gbm = { version = "0.18.0", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.16", optional = true }
 input = { version = "0.9.0", default-features = false, features=["libinput_1_19"], optional = true }
-indexmap = "~2.11"
+indexmap = "2.11"
 libc = "0.2.103"
 libseat = { version = "0.2.3", optional = true, default-features = false }
 libloading = { version="0.8.0", optional = true }


### PR DESCRIPTION
pinned in #1843 due to indexmap 2.12 having an msrv of 1.82, but since #1854 the msrv is 1.85, so it can be unpinned again.

note: i am personally not in favor of pinning dependencies to keep msrv, that should in my opinion be the responsibility of downstream compositors, that use the library and smithay should use a local `Cargo.lock` file to fix ci. due to #1843, it was previously impossible for me to use features of indexmap 2.12 if i wanted, as that would conflict with smithays `~2.11`.