### PR TITLE
selection: Don't protocol-error after disable

### DIFF
--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -374,7 +374,7 @@ fn handle_dnd<D, S>(
                             .expect("We have selected a single value at this point."),
                     );
                 }
-            } else {
+            } else if data.finished {
                 offer.post_error(
                     wl_data_offer::Error::InvalidFinish,
                     "SetActions request after Finish.",


### PR DESCRIPTION
So... [the change](https://github.com/Smithay/smithay/pull/1867) yesterday introduced a new condition on which `source` can be `None` (after disable), without updating the error condition leading to this protocol error. This *can* cause some clients to crash, ups...