### PR TITLE
 backend/winit: Use winit `0.31.0-beta.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ wayland-protocols-misc = { version = "0.3.12", features = ["server"], optional =
 wayland-server = { version = "0.31.13", optional = true }
 wayland-sys = { version = "0.31.11", optional = true }
 wayland-backend = { version = "0.3.15", optional = true }
-winit = { version = "0.30.0", default-features = false, features = ["wayland", "wayland-dlopen", "x11", "rwh_06"], optional = true }
+winit = { version = "0.31.0-beta.2", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
 x11rb = { version = "0.13.0", optional = true, features = ["res", "sync"]}
 xkbcommon = { version = "0.9.0", features = ["wayland"]}
 encoding_rs = { version = "0.8.33", optional = true }

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -9,13 +9,14 @@ use smithay::backend::renderer::DebugFlags;
 
 use smithay::{
     backend::input::{
-        self, Axis, AxisSource, Event, InputBackend, InputEvent, KeyState, KeyboardKeyEvent,
-        PointerAxisEvent, PointerButtonEvent,
+        self, Axis, AxisSource, Device, DeviceCapability, Event, InputBackend, InputEvent, KeyState,
+        KeyboardKeyEvent, PointerAxisEvent, PointerButtonEvent, TouchEvent,
     },
     desktop::{WindowSurfaceType, layer_map_for_output},
     input::{
         keyboard::{FilterResult, Keysym, ModifiersState, keysyms as xkb},
         pointer::{AxisFrame, ButtonEvent, MotionEvent},
+        touch::{DownEvent, UpEvent},
     },
     output::Scale,
     reexports::{
@@ -27,10 +28,10 @@ use smithay::{
         input_method::InputMethodSeat,
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
         shell::wlr_layer::{KeyboardInteractivity, Layer as WlrLayer},
+        tablet_manager::{TabletDescriptor, TabletSeatTrait},
     },
 };
 
-#[cfg(any(feature = "winit", feature = "x11", feature = "udev"))]
 use smithay::backend::input::AbsolutePositionEvent;
 
 #[cfg(any(feature = "winit", feature = "x11"))]
@@ -42,25 +43,21 @@ use crate::state::Backend;
 use smithay::{
     backend::{
         input::{
-            Device, DeviceCapability, GestureBeginEvent, GestureEndEvent, GesturePinchUpdateEvent as _,
-            GestureSwipeUpdateEvent as _, PointerMotionEvent, ProximityState, TabletToolButtonEvent,
-            TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent, TabletToolTipState, TouchEvent,
+            GestureBeginEvent, GestureEndEvent, GesturePinchUpdateEvent as _, GestureSwipeUpdateEvent as _,
+            PointerMotionEvent, ProximityState, TabletToolButtonEvent, TabletToolEvent,
+            TabletToolProximityEvent, TabletToolTipEvent, TabletToolTipState,
         },
         session::Session,
     },
-    input::{
-        pointer::{
-            GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent,
-            GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent,
-            RelativeMotionEvent,
-        },
-        touch::{DownEvent, UpEvent},
+    input::pointer::{
+        GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent,
+        GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent,
+        RelativeMotionEvent,
     },
     reexports::wayland_server::DisplayHandle,
     wayland::{
         pointer_constraints::{PointerConstraint, with_pointer_constraint},
         seat::WaylandFocus,
-        tablet_manager::{TabletDescriptor, TabletSeatTrait},
     },
 };
 
@@ -436,6 +433,126 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             pointer.frame(self);
         }
     }
+
+    fn touch_location_transformed<B: InputBackend, E: AbsolutePositionEvent<B>>(
+        &self,
+        evt: &E,
+    ) -> Option<Point<f64, Logical>> {
+        let output = self
+            .space
+            .outputs()
+            .find(|output| output.name().starts_with("eDP"))
+            .or_else(|| self.space.outputs().next());
+
+        let output = output?;
+        let output_geometry = self.space.output_geometry(output)?;
+
+        let transform = output.current_transform();
+        let size = transform.invert().transform_size(output_geometry.size);
+        Some(
+            transform.transform_point_in(evt.position_transformed(size), &size.to_f64())
+                + output_geometry.loc.to_f64(),
+        )
+    }
+
+    fn on_touch_down<B: InputBackend>(&mut self, evt: B::TouchDownEvent) {
+        let Some(handle) = self.seat.get_touch() else {
+            return;
+        };
+
+        let Some(touch_location) = self.touch_location_transformed(&evt) else {
+            return;
+        };
+
+        let serial = SCOUNTER.next_serial();
+        self.update_keyboard_focus(touch_location, serial);
+
+        let under = self.surface_under(touch_location);
+        handle.down(
+            self,
+            under,
+            &DownEvent {
+                slot: evt.slot(),
+                location: touch_location,
+                serial,
+                time: evt.time_msec(),
+            },
+        );
+    }
+
+    fn on_touch_up<B: InputBackend>(&mut self, evt: B::TouchUpEvent) {
+        let Some(handle) = self.seat.get_touch() else {
+            return;
+        };
+        let serial = SCOUNTER.next_serial();
+        handle.up(
+            self,
+            &UpEvent {
+                slot: evt.slot(),
+                serial,
+                time: evt.time_msec(),
+            },
+        )
+    }
+
+    fn on_touch_motion<B: InputBackend>(&mut self, evt: B::TouchMotionEvent) {
+        let Some(handle) = self.seat.get_touch() else {
+            return;
+        };
+        let Some(touch_location) = self.touch_location_transformed(&evt) else {
+            return;
+        };
+
+        let under = self.surface_under(touch_location);
+        handle.motion(
+            self,
+            under,
+            &smithay::input::touch::MotionEvent {
+                slot: evt.slot(),
+                location: touch_location,
+                time: evt.time_msec(),
+            },
+        );
+    }
+
+    fn on_touch_frame<B: InputBackend>(&mut self, _evt: B::TouchFrameEvent) {
+        let Some(handle) = self.seat.get_touch() else {
+            return;
+        };
+        handle.frame(self);
+    }
+
+    fn on_touch_cancel<B: InputBackend>(&mut self, _evt: B::TouchCancelEvent) {
+        let Some(handle) = self.seat.get_touch() else {
+            return;
+        };
+        handle.cancel(self);
+    }
+
+    fn on_device_added<B: InputBackend>(&mut self, device: B::Device) {
+        let dh = &self.display_handle;
+        if device.has_capability(DeviceCapability::TabletTool) {
+            self.seat
+                .tablet_seat()
+                .add_tablet::<Self>(dh, &TabletDescriptor::from(&device));
+        }
+        if device.has_capability(DeviceCapability::Touch) && self.seat.get_touch().is_none() {
+            self.seat.add_touch();
+        }
+    }
+
+    fn on_device_removed<B: InputBackend>(&mut self, device: B::Device) {
+        if device.has_capability(DeviceCapability::TabletTool) {
+            let tablet_seat = self.seat.tablet_seat();
+
+            tablet_seat.remove_tablet(&TabletDescriptor::from(&device));
+
+            // If there are no tablets in seat we can remove all tools
+            if tablet_seat.count_tablets() == 0 {
+                tablet_seat.clear_tools();
+            }
+        }
+    }
 }
 
 #[cfg(any(feature = "winit", feature = "x11"))]
@@ -526,6 +643,13 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             }
             InputEvent::PointerButton { event } => self.on_pointer_button::<B>(event),
             InputEvent::PointerAxis { event } => self.on_pointer_axis::<B>(event),
+            InputEvent::TouchDown { event } => self.on_touch_down::<B>(event),
+            InputEvent::TouchUp { event } => self.on_touch_up::<B>(event),
+            InputEvent::TouchMotion { event } => self.on_touch_motion::<B>(event),
+            InputEvent::TouchFrame { event } => self.on_touch_frame::<B>(event),
+            InputEvent::TouchCancel { event } => self.on_touch_cancel::<B>(event),
+            InputEvent::DeviceAdded { device } => self.on_device_added::<B>(device),
+            InputEvent::DeviceRemoved { device } => self.on_device_removed::<B>(device),
             _ => (), // other events are not handled in anvil (yet)
         }
     }
@@ -748,28 +872,8 @@ impl AnvilState<UdevData> {
             InputEvent::TouchFrame { event } => self.on_touch_frame::<B>(event),
             InputEvent::TouchCancel { event } => self.on_touch_cancel::<B>(event),
 
-            InputEvent::DeviceAdded { device } => {
-                if device.has_capability(DeviceCapability::TabletTool) {
-                    self.seat
-                        .tablet_seat()
-                        .add_tablet::<Self>(dh, &TabletDescriptor::from(&device));
-                }
-                if device.has_capability(DeviceCapability::Touch) && self.seat.get_touch().is_none() {
-                    self.seat.add_touch();
-                }
-            }
-            InputEvent::DeviceRemoved { device } => {
-                if device.has_capability(DeviceCapability::TabletTool) {
-                    let tablet_seat = self.seat.tablet_seat();
-
-                    tablet_seat.remove_tablet(&TabletDescriptor::from(&device));
-
-                    // If there are no tablets in seat we can remove all tools
-                    if tablet_seat.count_tablets() == 0 {
-                        tablet_seat.clear_tools();
-                    }
-                }
-            }
+            InputEvent::DeviceAdded { device } => self.on_device_added::<B>(device),
+            InputEvent::DeviceRemoved { device } => self.on_device_removed::<B>(device),
             _ => {
                 // other events are not handled in anvil (yet)
             }
@@ -1151,97 +1255,6 @@ impl AnvilState<UdevData> {
                 cancelled: evt.cancelled(),
             },
         );
-    }
-
-    fn touch_location_transformed<B: InputBackend, E: AbsolutePositionEvent<B>>(
-        &self,
-        evt: &E,
-    ) -> Option<Point<f64, Logical>> {
-        let output = self
-            .space
-            .outputs()
-            .find(|output| output.name().starts_with("eDP"))
-            .or_else(|| self.space.outputs().next());
-
-        let output = output?;
-        let output_geometry = self.space.output_geometry(output)?;
-
-        let transform = output.current_transform();
-        let size = transform.invert().transform_size(output_geometry.size);
-        Some(
-            transform.transform_point_in(evt.position_transformed(size), &size.to_f64())
-                + output_geometry.loc.to_f64(),
-        )
-    }
-
-    fn on_touch_down<B: InputBackend>(&mut self, evt: B::TouchDownEvent) {
-        let Some(handle) = self.seat.get_touch() else {
-            return;
-        };
-
-        let Some(touch_location) = self.touch_location_transformed(&evt) else {
-            return;
-        };
-
-        let serial = SCOUNTER.next_serial();
-        self.update_keyboard_focus(touch_location, serial);
-
-        let under = self.surface_under(touch_location);
-        handle.down(
-            self,
-            under,
-            &DownEvent {
-                slot: evt.slot(),
-                location: touch_location,
-                serial,
-                time: evt.time_msec(),
-            },
-        );
-    }
-    fn on_touch_up<B: InputBackend>(&mut self, evt: B::TouchUpEvent) {
-        let Some(handle) = self.seat.get_touch() else {
-            return;
-        };
-        let serial = SCOUNTER.next_serial();
-        handle.up(
-            self,
-            &UpEvent {
-                slot: evt.slot(),
-                serial,
-                time: evt.time_msec(),
-            },
-        )
-    }
-    fn on_touch_motion<B: InputBackend>(&mut self, evt: B::TouchMotionEvent) {
-        let Some(handle) = self.seat.get_touch() else {
-            return;
-        };
-        let Some(touch_location) = self.touch_location_transformed(&evt) else {
-            return;
-        };
-
-        let under = self.surface_under(touch_location);
-        handle.motion(
-            self,
-            under,
-            &smithay::input::touch::MotionEvent {
-                slot: evt.slot(),
-                location: touch_location,
-                time: evt.time_msec(),
-            },
-        );
-    }
-    fn on_touch_frame<B: InputBackend>(&mut self, _evt: B::TouchFrameEvent) {
-        let Some(handle) = self.seat.get_touch() else {
-            return;
-        };
-        handle.frame(self);
-    }
-    fn on_touch_cancel<B: InputBackend>(&mut self, _evt: B::TouchCancelEvent) {
-        let Some(handle) = self.seat.get_touch() else {
-            return;
-        };
-        handle.cancel(self);
     }
 
     fn clamp_coords(&self, pos: Point<f64, Logical>) -> Point<f64, Logical> {

--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -33,7 +33,7 @@ use smithay::{
         calloop::EventLoop,
         wayland_protocols::wp::presentation_time::server::wp_presentation_feedback,
         wayland_server::{Display, protocol::wl_surface},
-        winit::platform::pump_events::PumpStatus,
+        winit::event_loop::pump_events::PumpStatus,
     },
     utils::{IsAlive, Scale, Transform},
     wayland::{

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ::winit::platform::pump_events::PumpStatus;
+use ::winit::event_loop::pump_events::PumpStatus;
 use smithay::{
     backend::{
         input::{InputEvent, KeyboardKeyEvent},

--- a/src/backend/egl/native.rs
+++ b/src/backend/egl/native.rs
@@ -161,7 +161,7 @@ impl<A: AsFd + Send + 'static> EGLNativeDisplay for GbmDevice<A> {
 }
 
 #[cfg(feature = "backend_winit")]
-impl EGLNativeDisplay for Arc<WinitWindow> {
+impl EGLNativeDisplay for Arc<dyn WinitWindow> {
     fn supported_platforms(&self) -> Vec<EGLPlatform<'_>> {
         use winit::raw_window_handle::{self, HasDisplayHandle};
 

--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -190,11 +190,11 @@ impl PointerButtonEvent<WinitInput> for WinitMouseInputEvent {
             WinitMouseButton::Middle => 0x112,
             WinitMouseButton::Forward => 0x115,
             WinitMouseButton::Back => 0x116,
-            WinitMouseButton::Other(b) => {
+            _ => {
                 if self.is_x11 {
-                    input::xorg_mouse_to_libinput(b as u32)
+                    input::xorg_mouse_to_libinput(self.button as u32 + 1)
                 } else {
-                    b as u32
+                    self.button as u32 + 1
                 }
             }
         }

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -111,14 +111,36 @@ where
     let _guard = span.enter();
     info!("Initializing a winit backend");
 
-    let event_loop = EventLoop::builder().build().map_err(Error::EventLoopCreation)?;
+    let mut event_loop = EventLoop::builder().build().map_err(Error::EventLoopCreation)?;
 
-    // TODO: Create window in `resumed`?
-    #[allow(deprecated)]
-    let window = Arc::new(
-        event_loop
-            .create_window(attributes)
-            .map_err(Error::WindowCreation)?,
+    let mut window_event_loop_inner = WinitEventLoopInner {
+        window_attributes: attributes,
+        scale_factor: 1.0,
+        clock: Clock::<Monotonic>::new(),
+        key_counter: 0,
+        // Will be initialized after window creation
+        window: None,
+        window_create_error: None,
+        is_x11: false,
+    };
+    let mut initial_events = Vec::new();
+    while window_event_loop_inner.window.is_none() {
+        event_loop.pump_app_events(
+            None,
+            &mut WinitEventLoopApp {
+                inner: &mut window_event_loop_inner,
+                callback: |evt| initial_events.push(evt),
+            },
+        );
+        if let Some(err) = window_event_loop_inner.window_create_error {
+            return Err(err);
+        }
+    }
+    let window = window_event_loop_inner.window.clone().unwrap();
+
+    window_event_loop_inner.is_x11 = matches!(
+        window.window_handle().map(|handle| handle.as_raw()),
+        Ok(RawWindowHandle::Xlib(_))
     );
 
     span.record("window", Into::<u64>::into(window.id()));
@@ -132,23 +154,13 @@ where
     event_loop.set_control_flow(winit::event_loop::ControlFlow::Poll);
     let event_loop = Generic::new(event_loop, Interest::READ, calloop::Mode::Level);
 
-    let is_x11 = matches!(
-        window.window_handle().map(|handle| handle.as_raw()),
-        Ok(RawWindowHandle::Xlib(_))
-    );
-
     Ok((
         winit_graphics_backend,
         WinitEventLoop {
-            inner: WinitEventLoopInner {
-                scale_factor: window.scale_factor(),
-                clock: Clock::<Monotonic>::new(),
-                key_counter: 0,
-                window: Some(window),
-                is_x11,
-            },
+            inner: window_event_loop_inner,
             fake_token: None,
             event_loop,
+            initial_events,
             pending_events: Vec::new(),
             span,
         },
@@ -373,7 +385,9 @@ where
 
 #[derive(Debug)]
 struct WinitEventLoopInner {
+    window_attributes: WindowAttributes,
     window: Option<Arc<WinitWindow>>,
+    window_create_error: Option<Error>,
     clock: Clock<Monotonic>,
     key_counter: u32,
     is_x11: bool,
@@ -389,6 +403,7 @@ struct WinitEventLoopInner {
 pub struct WinitEventLoop {
     inner: WinitEventLoopInner,
     fake_token: Option<Token>,
+    initial_events: Vec<WinitEvent>,
     pending_events: Vec<WinitEvent>,
     event_loop: Generic<EventLoop<()>>,
     span: tracing::Span,
@@ -408,10 +423,15 @@ impl WinitEventLoop {
     /// not be used anymore as well.
     #[instrument(level = "trace", parent = &self.span, skip_all)]
     #[profiling::function]
-    pub fn dispatch_new_events<F>(&mut self, callback: F) -> PumpStatus
+    pub fn dispatch_new_events<F>(&mut self, mut callback: F) -> PumpStatus
     where
         F: FnMut(WinitEvent),
     {
+        // On first call, handle events produced during window creation
+        for event in std::mem::take(&mut self.initial_events) {
+            callback(event);
+        }
+
         // SAFETY: we don't drop event loop ourselves.
         let event_loop = unsafe { self.event_loop.get_mut() };
 
@@ -437,10 +457,17 @@ impl<F: FnMut(WinitEvent)> WinitEventLoopApp<'_, F> {
 }
 
 impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
-    fn resumed(&mut self, _event_loop: &ActiveEventLoop) {
-        (self.callback)(WinitEvent::Input(InputEvent::DeviceAdded {
-            device: WinitVirtualDevice,
-        }));
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.inner.window.is_none() {
+            match event_loop.create_window(self.inner.window_attributes.clone()) {
+                Ok(window) => self.inner.window = Some(Arc::new(window)),
+                Err(err) => self.inner.window_create_error = Some(err.into()),
+            }
+
+            (self.callback)(WinitEvent::Input(InputEvent::DeviceAdded {
+                device: WinitVirtualDevice,
+            }));
+        }
     }
 
     fn window_event(&mut self, _event_loop: &ActiveEventLoop, _window_id: WindowId, event: WindowEvent) {

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -203,7 +203,7 @@ where
                 scale_factor: window.scale_factor(),
                 clock: Clock::<Monotonic>::new(),
                 key_counter: 0,
-                window,
+                window: Some(window),
                 is_x11,
             },
             fake_token: None,
@@ -356,7 +356,7 @@ where
 
 #[derive(Debug)]
 struct WinitEventLoopInner {
-    window: Arc<WinitWindow>,
+    window: Option<Arc<WinitWindow>>,
     clock: Clock<Monotonic>,
     key_counter: u32,
     is_x11: bool,
@@ -427,6 +427,10 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
     }
 
     fn window_event(&mut self, _event_loop: &ActiveEventLoop, _window_id: WindowId, event: WindowEvent) {
+        let Some(window) = self.inner.window.as_ref() else {
+            return;
+        };
+
         match event {
             WindowEvent::Resized(size) => {
                 trace!("Resizing window to {size:?}");
@@ -443,7 +447,7 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
             } => {
                 trace!("Scale factor changed to {new_scale_factor}");
                 self.inner.scale_factor = new_scale_factor;
-                let (w, h): (i32, i32) = self.inner.window.inner_size().into();
+                let (w, h): (i32, i32) = window.inner_size().into();
                 (self.callback)(WinitEvent::Resized {
                     size: (w, h).into(),
                     scale_factor: self.inner.scale_factor,
@@ -480,7 +484,7 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
                 (self.callback)(WinitEvent::Input(event));
             }
             WindowEvent::CursorMoved { position, .. } => {
-                let size = self.inner.window.inner_size();
+                let size = window.inner_size();
                 let x = position.x / size.width as f64;
                 let y = position.y / size.height as f64;
                 let event = InputEvent::PointerMotionAbsolute {
@@ -518,7 +522,7 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
                 id,
                 ..
             }) => {
-                let size = self.inner.window.inner_size();
+                let size = window.inner_size();
                 let x = location.x / size.width as f64;
                 let y = location.y / size.width as f64;
                 let event = InputEvent::TouchDown {
@@ -538,7 +542,7 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
                 id,
                 ..
             }) => {
-                let size = self.inner.window.inner_size();
+                let size = window.inner_size();
                 let x = location.x / size.width as f64;
                 let y = location.y / size.width as f64;
                 let event = InputEvent::TouchMotion {
@@ -559,7 +563,7 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
                 id,
                 ..
             }) => {
-                let size = self.inner.window.inner_size();
+                let size = window.inner_size();
                 let x = location.x / size.width as f64;
                 let y = location.y / size.width as f64;
                 let event = InputEvent::TouchMotion {

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -124,80 +124,21 @@ where
     span.record("window", Into::<u64>::into(window.id()));
     debug!("Window created");
 
-    let (display, context, surface, is_x11) = {
-        let display = unsafe { EGLDisplay::new(window.clone())? };
-
-        let context =
-            EGLContext::new_with_config(&display, gl_attributes, PixelFormatRequirements::_10_bit())
-                .or_else(|_| {
-                    EGLContext::new_with_config(&display, gl_attributes, PixelFormatRequirements::_8_bit())
-                })?;
-
-        let (surface, is_x11) = match window.window_handle().map(|handle| handle.as_raw()) {
-            Ok(RawWindowHandle::Wayland(handle)) => {
-                debug!("Winit backend: Wayland");
-                let size = window.inner_size();
-                let surface = unsafe {
-                    wegl::WlEglSurface::new_from_raw(
-                        handle.surface.as_ptr() as *mut _,
-                        size.width as i32,
-                        size.height as i32,
-                    )
-                }
-                .map_err(|err| Error::Surface(err.into()))?;
-                unsafe {
-                    (
-                        EGLSurface::new(
-                            &display,
-                            context.pixel_format().unwrap(),
-                            context.config_id(),
-                            surface,
-                        )
-                        .map_err(EGLError::CreationFailed)?,
-                        false,
-                    )
-                }
-            }
-            Ok(RawWindowHandle::Xlib(handle)) => {
-                debug!("Winit backend: X11");
-                unsafe {
-                    (
-                        EGLSurface::new(
-                            &display,
-                            context.pixel_format().unwrap(),
-                            context.config_id(),
-                            native::XlibWindow(handle.window),
-                        )
-                        .map_err(EGLError::CreationFailed)?,
-                        true,
-                    )
-                }
-            }
-            _ => panic!("only running on Wayland or with Xlib is supported"),
-        };
-
-        let _ = context.unbind();
-        (display, context, surface, is_x11)
-    };
-
-    let renderer = unsafe { GlesRenderer::new(context)?.into() };
-    let damage_tracking = display.supports_damage();
+    let winit_graphics_backend =
+        WinitGraphicsBackend::new_with_gl_attr(window.clone(), &span, gl_attributes)?;
 
     drop(_guard);
 
     event_loop.set_control_flow(winit::event_loop::ControlFlow::Poll);
     let event_loop = Generic::new(event_loop, Interest::READ, calloop::Mode::Level);
 
+    let is_x11 = matches!(
+        window.window_handle().map(|handle| handle.as_raw()),
+        Ok(RawWindowHandle::Xlib(_))
+    );
+
     Ok((
-        WinitGraphicsBackend {
-            window: window.clone(),
-            span: span.clone(),
-            _display: display,
-            egl_surface: surface,
-            damage_tracking,
-            bind_size: None,
-            renderer,
-        },
+        winit_graphics_backend,
         WinitEventLoop {
             inner: WinitEventLoopInner {
                 scale_factor: window.scale_factor(),
@@ -255,6 +196,82 @@ where
     R: Bind<EGLSurface>,
     crate::backend::SwapBuffersError: From<R::Error>,
 {
+    fn new_with_gl_attr(
+        window: Arc<winit::window::Window>,
+        span: &tracing::Span,
+        gl_attributes: GlAttributes,
+    ) -> Result<Self, Error>
+    where
+        R: From<GlesRenderer>,
+    {
+        let (display, context, surface) = {
+            let display = unsafe { EGLDisplay::new(window.clone())? };
+
+            let context =
+                EGLContext::new_with_config(&display, gl_attributes, PixelFormatRequirements::_10_bit())
+                    .or_else(|_| {
+                        EGLContext::new_with_config(
+                            &display,
+                            gl_attributes,
+                            PixelFormatRequirements::_8_bit(),
+                        )
+                    })?;
+
+            let surface = match window.window_handle().map(|handle| handle.as_raw()) {
+                Ok(RawWindowHandle::Wayland(handle)) => {
+                    debug!("Winit backend: Wayland");
+                    let size = window.inner_size();
+                    let surface = unsafe {
+                        wegl::WlEglSurface::new_from_raw(
+                            handle.surface.as_ptr() as *mut _,
+                            size.width as i32,
+                            size.height as i32,
+                        )
+                    }
+                    .map_err(|err| Error::Surface(err.into()))?;
+                    unsafe {
+                        EGLSurface::new(
+                            &display,
+                            context.pixel_format().unwrap(),
+                            context.config_id(),
+                            surface,
+                        )
+                        .map_err(EGLError::CreationFailed)?
+                    }
+                }
+                Ok(RawWindowHandle::Xlib(handle)) => {
+                    debug!("Winit backend: X11");
+                    unsafe {
+                        EGLSurface::new(
+                            &display,
+                            context.pixel_format().unwrap(),
+                            context.config_id(),
+                            native::XlibWindow(handle.window),
+                        )
+                        .map_err(EGLError::CreationFailed)?
+                    }
+                }
+                _ => panic!("only running on Wayland or with Xlib is supported"),
+            };
+
+            let _ = context.unbind();
+            (display, context, surface)
+        };
+
+        let renderer = unsafe { GlesRenderer::new(context)?.into() };
+        let damage_tracking = display.supports_damage();
+
+        Ok(WinitGraphicsBackend {
+            window: window.clone(),
+            span: span.clone(),
+            _display: display,
+            egl_surface: surface,
+            damage_tracking,
+            bind_size: None,
+            renderer,
+        })
+    }
+
     /// Window size of the underlying window
     pub fn window_size(&self) -> Size<i32, Physical> {
         let (w, h): (i32, i32) = self.window.inner_size().into();

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -26,15 +26,16 @@ use calloop::generic::Generic;
 use calloop::{EventSource, Interest, PostAction, Readiness, Token};
 use tracing::{debug, info, info_span, instrument, trace, warn};
 use wayland_egl as wegl;
-use winit::platform::pump_events::PumpStatus;
 use winit::platform::scancode::PhysicalKeyExtScancode;
 use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use winit::{
     application::ApplicationHandler,
     dpi::LogicalSize,
-    event::{ElementState, Touch, TouchPhase, WindowEvent},
-    event_loop::{ActiveEventLoop, EventLoop},
-    platform::pump_events::EventLoopExtPumpEvents,
+    event::{ButtonSource, ElementState, PointerKind, PointerSource, WindowEvent},
+    event_loop::{
+        ActiveEventLoop, EventLoop,
+        pump_events::{EventLoopExtPumpEvents, PumpStatus},
+    },
     window::{Window as WinitWindow, WindowAttributes, WindowId},
 };
 
@@ -67,8 +68,8 @@ where
     crate::backend::SwapBuffersError: From<R::Error>,
 {
     init_from_attributes(
-        WinitWindow::default_attributes()
-            .with_inner_size(LogicalSize::new(1280.0, 800.0))
+        WindowAttributes::default()
+            .with_surface_size(LogicalSize::new(1280.0, 800.0))
             .with_title("Smithay")
             .with_visible(true),
     )
@@ -143,7 +144,7 @@ where
         Ok(RawWindowHandle::Xlib(_))
     );
 
-    span.record("window", Into::<u64>::into(window.id()));
+    span.record("window", window.id().into_raw());
     debug!("Window created");
 
     let winit_graphics_backend =
@@ -175,7 +176,7 @@ pub enum Error {
     EventLoopCreation(#[from] winit::error::EventLoopError),
     /// Failed to initialize a window.
     #[error("Failed to initialize a window")]
-    WindowCreation(#[from] winit::error::OsError),
+    WindowCreation(#[from] winit::error::RequestError),
     #[error("Failed to create a surface for the window")]
     /// Surface creation error.
     Surface(Box<dyn std::error::Error>),
@@ -197,7 +198,7 @@ pub struct WinitGraphicsBackend<R> {
     // The display isn't used past this point but must be kept alive.
     _display: EGLDisplay,
     egl_surface: EGLSurface,
-    window: Arc<WinitWindow>,
+    window: Arc<dyn WinitWindow>,
     damage_tracking: bool,
     bind_size: Option<Size<i32, Physical>>,
     span: tracing::Span,
@@ -209,7 +210,7 @@ where
     crate::backend::SwapBuffersError: From<R::Error>,
 {
     fn new_with_gl_attr(
-        window: Arc<winit::window::Window>,
+        window: Arc<dyn winit::window::Window>,
         span: &tracing::Span,
         gl_attributes: GlAttributes,
     ) -> Result<Self, Error>
@@ -232,7 +233,7 @@ where
             let surface = match window.window_handle().map(|handle| handle.as_raw()) {
                 Ok(RawWindowHandle::Wayland(handle)) => {
                     debug!("Winit backend: Wayland");
-                    let size = window.inner_size();
+                    let size = window.surface_size();
                     let surface = unsafe {
                         wegl::WlEglSurface::new_from_raw(
                             handle.surface.as_ptr() as *mut _,
@@ -286,7 +287,7 @@ where
 
     /// Window size of the underlying window
     pub fn window_size(&self) -> Size<i32, Physical> {
-        let (w, h): (i32, i32) = self.window.inner_size().into();
+        let (w, h): (i32, i32) = self.window.surface_size().into();
         (w, h).into()
     }
 
@@ -296,8 +297,8 @@ where
     }
 
     /// Reference to the underlying window
-    pub fn window(&self) -> &WinitWindow {
-        &self.window
+    pub fn window(&self) -> &dyn WinitWindow {
+        &*self.window
     }
 
     /// Access the underlying renderer
@@ -386,7 +387,7 @@ where
 #[derive(Debug)]
 struct WinitEventLoopInner {
     window_attributes: WindowAttributes,
-    window: Option<Arc<WinitWindow>>,
+    window: Option<Arc<dyn WinitWindow>>,
     window_create_error: Option<Error>,
     clock: Clock<Monotonic>,
     key_counter: u32,
@@ -405,7 +406,7 @@ pub struct WinitEventLoop {
     fake_token: Option<Token>,
     initial_events: Vec<WinitEvent>,
     pending_events: Vec<WinitEvent>,
-    event_loop: Generic<EventLoop<()>>,
+    event_loop: Generic<EventLoop>,
     span: tracing::Span,
 }
 
@@ -457,10 +458,10 @@ impl<F: FnMut(WinitEvent)> WinitEventLoopApp<'_, F> {
 }
 
 impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
-    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+    fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
         if self.inner.window.is_none() {
             match event_loop.create_window(self.inner.window_attributes.clone()) {
-                Ok(window) => self.inner.window = Some(Arc::new(window)),
+                Ok(window) => self.inner.window = Some(Arc::from(window)),
                 Err(err) => self.inner.window_create_error = Some(err.into()),
             }
 
@@ -470,13 +471,13 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
         }
     }
 
-    fn window_event(&mut self, _event_loop: &ActiveEventLoop, _window_id: WindowId, event: WindowEvent) {
+    fn window_event(&mut self, _event_loop: &dyn ActiveEventLoop, _window_id: WindowId, event: WindowEvent) {
         let Some(window) = self.inner.window.as_ref() else {
             return;
         };
 
         match event {
-            WindowEvent::Resized(size) => {
+            WindowEvent::SurfaceResized(size) => {
                 trace!("Resizing window to {size:?}");
                 let (w, h): (i32, i32) = size.into();
 
@@ -491,7 +492,7 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
             } => {
                 trace!("Scale factor changed to {new_scale_factor}");
                 self.inner.scale_factor = new_scale_factor;
-                let (w, h): (i32, i32) = window.inner_size().into();
+                let (w, h): (i32, i32) = window.surface_size().into();
                 (self.callback)(WinitEvent::Resized {
                     size: (w, h).into(),
                     scale_factor: self.inner.scale_factor,
@@ -527,18 +528,38 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
                 };
                 (self.callback)(WinitEvent::Input(event));
             }
-            WindowEvent::CursorMoved { position, .. } => {
-                let size = window.inner_size();
+            WindowEvent::PointerMoved { position, source, .. } => {
+                let size = window.surface_size();
                 let x = position.x / size.width as f64;
                 let y = position.y / size.height as f64;
-                let event = InputEvent::PointerMotionAbsolute {
-                    event: WinitMouseMovedEvent {
-                        time: self.timestamp(),
-                        position: RelativePosition::new(x, y),
-                        global_position: position,
-                    },
-                };
-                (self.callback)(WinitEvent::Input(event));
+                let relative_position = RelativePosition::new(x, y);
+
+                match source {
+                    PointerSource::Mouse => {
+                        let event = InputEvent::PointerMotionAbsolute {
+                            event: WinitMouseMovedEvent {
+                                time: self.timestamp(),
+                                position: relative_position,
+                                global_position: position,
+                            },
+                        };
+                        (self.callback)(WinitEvent::Input(event));
+                    }
+                    PointerSource::Touch { finger_id, force: _ } => {
+                        let event = InputEvent::TouchMotion {
+                            event: WinitTouchMovedEvent {
+                                time: self.timestamp(),
+                                position: relative_position,
+                                global_position: position,
+                                id: finger_id.into_raw() as u64,
+                            },
+                        };
+                        (self.callback)(WinitEvent::Input(event));
+                    }
+                    // TODO Handle tablet events
+                    PointerSource::TabletTool { .. } => {}
+                    PointerSource::Unknown => {}
+                }
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 let event = InputEvent::PointerAxis {
@@ -549,109 +570,90 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
                 };
                 (self.callback)(WinitEvent::Input(event));
             }
-            WindowEvent::MouseInput { state, button, .. } => {
-                let event = InputEvent::PointerButton {
-                    event: WinitMouseInputEvent {
-                        time: self.timestamp(),
-                        button,
-                        state,
-                        is_x11: self.inner.is_x11,
-                    },
-                };
-                (self.callback)(WinitEvent::Input(event));
-            }
-            WindowEvent::Touch(Touch {
-                phase: TouchPhase::Started,
-                location,
-                id,
+            WindowEvent::PointerButton {
+                state,
+                button,
+                position,
                 ..
-            }) => {
-                let size = window.inner_size();
-                let x = location.x / size.width as f64;
-                let y = location.y / size.width as f64;
-                let event = InputEvent::TouchDown {
-                    event: WinitTouchStartedEvent {
-                        time: self.timestamp(),
-                        global_position: location,
-                        position: RelativePosition::new(x, y),
-                        id,
-                    },
-                };
+            } => {
+                match button {
+                    ButtonSource::Mouse(button) => {
+                        let event = InputEvent::PointerButton {
+                            event: WinitMouseInputEvent {
+                                time: self.timestamp(),
+                                button,
+                                state,
+                                is_x11: self.inner.is_x11,
+                            },
+                        };
+                        (self.callback)(WinitEvent::Input(event));
+                    }
+                    ButtonSource::Touch { finger_id, force: _ } => match state {
+                        ElementState::Pressed => {
+                            let size = window.surface_size();
+                            let x = position.x / size.width as f64;
+                            let y = position.y / size.width as f64;
+                            let event = InputEvent::TouchDown {
+                                event: WinitTouchStartedEvent {
+                                    time: self.timestamp(),
+                                    global_position: position,
+                                    position: RelativePosition::new(x, y),
+                                    id: finger_id.into_raw() as u64,
+                                },
+                            };
 
-                (self.callback)(WinitEvent::Input(event));
+                            (self.callback)(WinitEvent::Input(event));
+                        }
+                        ElementState::Released => {
+                            let size = window.surface_size();
+                            let x = position.x / size.width as f64;
+                            let y = position.y / size.width as f64;
+                            let event = InputEvent::TouchMotion {
+                                event: WinitTouchMovedEvent {
+                                    time: self.timestamp(),
+                                    position: RelativePosition::new(x, y),
+                                    global_position: position,
+                                    id: finger_id.into_raw() as u64,
+                                },
+                            };
+                            (self.callback)(WinitEvent::Input(event));
+
+                            let event = InputEvent::TouchUp {
+                                event: WinitTouchEndedEvent {
+                                    time: self.timestamp(),
+                                    id: finger_id.into_raw() as u64,
+                                },
+                            };
+
+                            (self.callback)(WinitEvent::Input(event));
+                        }
+                    },
+                    // TODO Handle tablet events
+                    ButtonSource::TabletTool { .. } => {}
+                    ButtonSource::Unknown(_) => {}
+                }
             }
-            WindowEvent::Touch(Touch {
-                phase: TouchPhase::Moved,
-                location,
-                id,
+            WindowEvent::PointerLeft {
+                kind: PointerKind::Touch(finger_id),
                 ..
-            }) => {
-                let size = window.inner_size();
-                let x = location.x / size.width as f64;
-                let y = location.y / size.width as f64;
-                let event = InputEvent::TouchMotion {
-                    event: WinitTouchMovedEvent {
-                        time: self.timestamp(),
-                        position: RelativePosition::new(x, y),
-                        global_position: location,
-                        id,
-                    },
-                };
-
-                (self.callback)(WinitEvent::Input(event));
-            }
-
-            WindowEvent::Touch(Touch {
-                phase: TouchPhase::Ended,
-                location,
-                id,
-                ..
-            }) => {
-                let size = window.inner_size();
-                let x = location.x / size.width as f64;
-                let y = location.y / size.width as f64;
-                let event = InputEvent::TouchMotion {
-                    event: WinitTouchMovedEvent {
-                        time: self.timestamp(),
-                        position: RelativePosition::new(x, y),
-                        global_position: location,
-                        id,
-                    },
-                };
-                (self.callback)(WinitEvent::Input(event));
-
-                let event = InputEvent::TouchUp {
-                    event: WinitTouchEndedEvent {
-                        time: self.timestamp(),
-                        id,
-                    },
-                };
-
-                (self.callback)(WinitEvent::Input(event));
-            }
-
-            WindowEvent::Touch(Touch {
-                phase: TouchPhase::Cancelled,
-                id,
-                ..
-            }) => {
+            } => {
                 let event = InputEvent::TouchCancel {
                     event: WinitTouchCancelledEvent {
                         time: self.timestamp(),
-                        id,
+                        id: finger_id.into_raw() as u64,
                     },
                 };
                 (self.callback)(WinitEvent::Input(event));
             }
-            WindowEvent::DroppedFile(_)
+            WindowEvent::DragDropped { .. }
             | WindowEvent::Destroyed
-            | WindowEvent::CursorEntered { .. }
-            | WindowEvent::AxisMotion { .. }
-            | WindowEvent::CursorLeft { .. }
+            | WindowEvent::PointerEntered { .. }
+            | WindowEvent::PointerLeft { .. }
             | WindowEvent::ModifiersChanged(_)
             | WindowEvent::KeyboardInput { .. }
-            | WindowEvent::HoveredFile(_)
-            | WindowEvent::HoveredFileCancelled
+            | WindowEvent::DragEntered { .. }
+            | WindowEvent::DragLeft { .. }
+            | WindowEvent::DragMoved { .. }
             | WindowEvent::Ime(_)
             | WindowEvent::Moved(_)
             | WindowEvent::Occluded(_)


### PR DESCRIPTION
Uses hacky solution to handle change to need `ActiveEventLoop` to create a window. May be okay? But a different solution, and API change, will be needed if we want the backend to work on Android.

This also still needs changes to handle touch events.