### PR TITLE
wayland/xdg-shell: Validate invalid geometry size

### DIFF
--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -252,6 +252,14 @@ where
                     );
                 }
 
+                if width <= 0 || height <= 0 {
+                    xdg_surface.post_error(
+                        xdg_surface::Error::InvalidSize,
+                        "width and height of the window geometry must be greater than zero.",
+                    );
+                    return;
+                }
+
                 compositor::with_states(surface, |states| {
                     states.cached_state.get::<SurfaceCachedState>().pending().geometry =
                         Some(Rectangle::new((x, y).into(), (width, height).into()));


### PR DESCRIPTION
closes #1712

> The width and height of the effective window geometry must be greater than zero. Setting an invalid size will raise an invalid_size error.