### PR TITLE
wayland/xdg-decoration: Validate destroy order of objects

### DIFF
--- a/src/wayland/shell/xdg/decoration.rs
+++ b/src/wayland/shell/xdg/decoration.rs
@@ -241,6 +241,14 @@ where
             Request::GetToplevelDecoration { id, toplevel } => {
                 let data = toplevel.data::<XdgShellSurfaceUserData>().unwrap();
 
+                if !data.alive_tracker.alive() {
+                    resource.post_error(
+                        zxdg_toplevel_decoration_v1::Error::Orphaned,
+                        "toplevel is already destroyed",
+                    );
+                    return;
+                }
+
                 let mut decoration_guard = data.decoration.lock().unwrap();
 
                 if decoration_guard.is_some() {

--- a/src/wayland/shell/xdg/handlers/surface/toplevel.rs
+++ b/src/wayland/shell/xdg/handlers/surface/toplevel.rs
@@ -11,7 +11,10 @@ use crate::{
     },
 };
 
-use wayland_protocols::xdg::shell::server::xdg_toplevel::{self, XdgToplevel};
+use wayland_protocols::xdg::{
+    decoration::zv1::server::zxdg_toplevel_decoration_v1,
+    shell::server::xdg_toplevel::{self, XdgToplevel},
+};
 
 use wayland_server::{
     backend::ClientId, protocol::wl_surface, DataInit, Dispatch, DisplayHandle, Resource, WEnum,
@@ -41,6 +44,13 @@ where
             xdg_toplevel::Request::Destroy => {
                 if let Some(surface_data) = data.xdg_surface.data::<XdgSurfaceUserData>() {
                     surface_data.has_active_role.store(false, Ordering::Release);
+                }
+
+                if let Some(decoration) = data.decoration.lock().unwrap().clone() {
+                    decoration.post_error(
+                        zxdg_toplevel_decoration_v1::Error::Orphaned,
+                        "The xdg_toplevel_decoration object must be destroyed before its xdg_toplevel.",
+                    );
                 }
             }
             xdg_toplevel::Request::SetParent { parent } => {


### PR DESCRIPTION
closes #1698

> The xdg_toplevel_decoration object must be destroyed before its xdg_toplevel.