### PR TITLE
multigpu: Consider other formats for transfer than the original

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -2308,7 +2308,7 @@ where
                     .map_err(Error::Render)?,
             ) as Box<dyn Any + 'static>
         };
-        (slot.get_or_insert((shadow_buffer, target_texture, None)), true)
+        (slot.insert((shadow_buffer, target_texture, None)), true)
     };
 
     let src_renderer = src.renderer_mut();


### PR DESCRIPTION
This is an attempt to make the multigpu renderer a bit more flexible, if the sets of formats of two gpus just don't align.

Firstly it makes the `dma_shadow_copy` try more formats, if the original one isn't available. First it tries to find one with the same bpp (falling back to 8, if it can't be determined, which allows us to finally display *something* for YUV-formats, even if not accurate) and then it accepts losing precision down to 8-bits per color.

Secondly if the `mem_copy`-code fails to read from a texture, we currently have no fall back. `ExportMem::can_read_texture` is meant to prevent that, but on OpenGL ES we can only try to truly see if reading works. Sadly the nvidia driver doesn't allow us to read with `GL_RGBA` and `GL_UNSIGNED_INT_2_10_10_10_REV` (it falls with `INVALID_OPERATION`) even though the spec says it should(?): https://docs.gl/es3/glReadPixels.

This is in particular a problem with games not going through PRIME (e.g. via wine-wayland) which like to allocate their framebuffer in `XBGR2101010`. So as a fall back we render these into a `Abgr8888` shadow buffer and copy from there (which works fine in my testing, even though we obviously lose some precision).

Ideally we should have a vulkan renderer, where none of this is an issue and we can use dmabuf-sharing even with nvidia with `Linear`-modifiers, but in the meantime this is better than a black window.