### PR TITLE
wayland/text_input: fix enter/leave sending

### DIFF
--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -31,7 +31,6 @@ impl TextInput {
                 let instance_id = text_input.instance.id();
                 if instance_id.same_client_as(&surface.id()) {
                     f(&text_input.instance, surface, text_input.serial);
-                    break;
                 }
             }
         };
@@ -142,7 +141,7 @@ impl TextInputHandle {
         });
     }
 
-    /// Access the text-input instance for the currently focused surface.
+    /// Access the text-input instances for the currently focused surface.
     pub fn with_focused_text_input<F>(&self, mut f: F)
     where
         F: FnMut(&ZwpTextInputV3, &WlSurface),


### PR DESCRIPTION
The enter/leave events were not sent for all the text_input objects created by the client, while it should have been.

Fixes #1884.