### PR TITLE
utils/geometry: use swap_remove instead of remove

### DIFF
--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -1466,7 +1466,7 @@ impl<N: Coordinate, Kind> Rectangle<N, Kind> {
                 };
 
                 // We now know that we have to subtract the other rect
-                let item = rects.remove(index);
+                let item = rects.swap_remove(index);
 
                 // If we are completely contained then nothing is left
                 if other.contains_rect(item) {


### PR DESCRIPTION
Given that we push/remove things, the order doesn't really matter at this point, so use function that is O(1) instead of O(n).

--

I haven't done deep testing, but it seems fine given how function works in general?

cc @cmeissl 