### PR TITLE
multigpu: Don't constantly re-create slot

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -2228,10 +2228,7 @@ where
 
     let format = src_texture.format().unwrap_or(Fourcc::Abgr8888);
 
-    let ((shadow_buffer, _, existing_sync_point), is_new_buffer) = if slot
-        .as_ref()
-        .is_some_and(|(buffer, _, _)| buffer.format().code == format)
-    {
+    let ((shadow_buffer, _, existing_sync_point), is_new_buffer) = if slot.is_some() {
         (slot.as_mut().unwrap(), false)
     } else {
         let read_formats = if let Some(target) = target.as_ref() {


### PR DESCRIPTION
Fix up for https://github.com/Smithay/smithay/pull/1882.

Turns out the simple one-line fix actually caused the slot to be constantly re-created if we selected a different transfer format...

This now changes the semantics of `dma_shadow_copy` to never wipe the slot on it's own.
Instead this is the responsibility of the caller.

Luckily we already do the right thing, as `MultiTexture::from_surface` wipes it's textures (and this associated state like shadow buffers), if the format changes.