### PR TITLE
clamp the Size to 0 when constructing

### DIFF
--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -416,16 +416,7 @@ impl<N: Coordinate, Kind> Point<N, Kind> {
     #[inline]
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn to_size(self) -> Size<N, Kind> {
-        debug_assert!(
-            self.x.non_negative() && self.y.non_negative(),
-            "Attempting to create a `Size` of negative size: {:?}",
-            (self.x, self.y)
-        );
-        Size {
-            w: self.x,
-            h: self.y,
-            _kind: std::marker::PhantomData,
-        }
+        Size::new(self.x, self.y)
     }
 
     /// Convert this [`Point`] to a [`Size`] with the same coordinates
@@ -784,11 +775,8 @@ pub struct Size<N, Kind> {
 impl<N: Coordinate, Kind> Size<N, Kind> {
     /// Create a new Size
     pub fn new(w: N, h: N) -> Size<N, Kind> {
-        debug_assert!(
-            w.non_negative() && h.non_negative(),
-            "Attempting to create a `Size` of negative size: {:?}",
-            (w, h)
-        );
+        let w = w.max(N::ZERO);
+        let h = h.max(N::ZERO);
         Size {
             w,
             h,
@@ -1879,7 +1867,7 @@ impl From<Transform> for WlTransform {
 
 #[cfg(test)]
 mod tests {
-    use super::{Logical, Rectangle, Size, Transform};
+    use super::{Logical, Point, Rectangle, Size, Transform};
 
     #[test]
     fn transform_rect_ident() {
@@ -2134,5 +2122,14 @@ mod tests {
         assert_eq!(smaller - bigger, Size::from((0, 0)));
         smaller -= bigger;
         assert_eq!(smaller, Size::from((0, 0)));
+    }
+
+    #[test]
+    fn new_size_negative() {
+        let one = Size::<_, Logical>::new(-1, -2);
+        assert_eq!(one, Size::new(0, 0));
+
+        let two = Point::<_, Logical>::new(-1, 20).to_size();
+        assert_eq!(two, Size::new(0, 20));
     }
 }


### PR DESCRIPTION
had to work around this semi-recently in https://github.com/m4rch3n1ng/mayland/commit/91b00c003d67ab132448466e2b44fd575f9f9472 (and a year ago in https://github.com/m4rch3n1ng/mayland/commit/9a37f29b6461d32cd4f6153ae4a22b7fe25a61c4) and wasn't sure if that was wanted, but as there seemingly is at least some demand (see #873), i thought why not just quickly make this (since it's not a lot of work) and wait for reviewer feedback so here we are.

this does make size creation slightly more expensive in release mode without debug assertions, but that should be a pretty negligible difference i assume.

similar in spirit to #1586, fixes #873.