### PR TITLE
fix: Remove unnecessary SeatHandler bound in xdg

### DIFF
--- a/src/wayland/shell/xdg/handlers/surface/popup.rs
+++ b/src/wayland/shell/xdg/handlers/surface/popup.rs
@@ -1,7 +1,6 @@
 use std::sync::atomic::Ordering;
 
 use crate::{
-    input::SeatHandler,
     utils::Serial,
     wayland::{
         compositor::{self, with_states},
@@ -19,7 +18,6 @@ impl<D> Dispatch<XdgPopup, XdgShellSurfaceUserData, D> for XdgShellState
 where
     D: Dispatch<XdgPopup, XdgShellSurfaceUserData>,
     D: XdgShellHandler,
-    D: SeatHandler,
     D: 'static,
 {
     fn request(


### PR DESCRIPTION
The Dispatch<XdgPopup, ...> impl for XdgShellState required a SeatHandler trait bound. This bound is not required and unnecessarily ties together the seat and xdg shell modules.