### PR TITLE
wayland/shell/xdg: Reset toplevel state on surface reuse

### DIFF
--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -31,7 +31,7 @@ use super::{
 
 mod toplevel;
 use toplevel::make_toplevel_handle;
-pub use toplevel::{get_parent, send_toplevel_configure};
+pub use toplevel::{get_parent, reset_toplevel_surface_state, send_toplevel_configure};
 
 mod popup;
 pub use popup::{make_popup_handle, send_popup_configure};
@@ -92,6 +92,10 @@ where
                 // We now can assign a role to the surface
                 let surface = &data.wl_surface;
                 let shell = &data.wm_base;
+
+                // Sanitize the surface role data.
+                // This handles clients that reuse surfaces and might have left them dirty.
+                reset_toplevel_surface_state(surface, false);
 
                 if compositor::give_role(surface, XDG_TOPLEVEL_ROLE).is_err() {
                     shell.post_error(xdg_wm_base::Error::Role, "Surface already has a role.");


### PR DESCRIPTION
Clients like Telegram (via Qt) reuse wl_surface objects. They destroy the xdg_toplevel role and immediately create a new one on the same wl_surface.

Currently, Smithay retains stale XdgToplevelSurfaceData and ToplevelCachedState attached to the wl_surface after the previous role is destroyed. When the client requests a new xdg_toplevel, Smithay assumes the surface is already in a specific state (e.g., configured), causing it to miss necessary setup events (like the initial configure).

This PR introduces reset_toplevel_surface_state to sanitize the surface state.
It is called in destroy (cleanup).
It is called in get_toplevel (initialization) with include_generic_state: false.
This ensures that creating a new toplevel role always results in a fresh state.

I verified this behavior against the XDG Shell protocol lifecycle. When a client destroys an xdg_toplevel object but keeps the wl_surface, the protocol implies the role-specific state is reset.
Currently, reference implementations (Weston) and wlroots-based compositors (Sway) treat a new get_toplevel request as generating a fresh logical window state.
This PR brings Smithay's behavior in line with these implementations.

Fixes https://github.com/pop-os/cosmic-comp/issues/1816