### PR TITLE
element/damage: Better support effects on framebuffer contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,12 @@ struct LockSurfaceConfigure {
 }
 ```
 
+Added `Element::is_framebuffer_effect` and `RenderElement::capture_framebuffer` to better support render elements,
+that take the current framebuffers contents and modify them, e.g. blurring the backgrounds of windows.
+See the documentation for these functions for how to make use of them, but note, that they provide
+default implementations, which result in skipping the new functionality. As such any custom `RenderElements` wrappers
+(not using `crate::render_elements!`) need to be updated.
+
 ## 0.7.0
 
 ### Breaking changes

--- a/anvil/src/drawing.rs
+++ b/anvil/src/drawing.rs
@@ -20,7 +20,7 @@ use smithay::{
         utils::CommitCounter,
         Frame,
     },
-    utils::{Buffer, Logical, Rectangle, Size, Transform},
+    utils::{user_data::UserDataMap, Buffer, Logical, Rectangle, Size, Transform},
 };
 
 pub static CLEAR_COLOR: Color32F = Color32F::new(0.8, 0.8, 0.9, 1.0);
@@ -203,6 +203,7 @@ where
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         // FIXME: respect the src for cropping
         let scale = dst.size.to_f64() / self.src().size;

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -1131,6 +1131,7 @@ pub fn update_primary_scanout_output(
                 surface,
                 output,
                 states,
+                None,
                 render_element_states,
                 default_primary_scanout_output_compare,
             );
@@ -1143,6 +1144,7 @@ pub fn update_primary_scanout_output(
                 surface,
                 output,
                 states,
+                None,
                 render_element_states,
                 default_primary_scanout_output_compare,
             );
@@ -1155,6 +1157,7 @@ pub fn update_primary_scanout_output(
                 surface,
                 output,
                 states,
+                None,
                 render_element_states,
                 default_primary_scanout_output_compare,
             );
@@ -1167,6 +1170,7 @@ pub fn update_primary_scanout_output(
                 surface,
                 output,
                 states,
+                None,
                 render_element_states,
                 default_primary_scanout_output_compare,
             );
@@ -1193,7 +1197,9 @@ pub fn take_presentation_feedback(
             window.take_presentation_feedback(
                 &mut output_presentation_feedback,
                 surface_primary_scanout_output,
-                |surface, _| surface_presentation_feedback_flags_from_states(surface, render_element_states),
+                |surface, _| {
+                    surface_presentation_feedback_flags_from_states(surface, None, render_element_states)
+                },
             );
         }
     });
@@ -1202,7 +1208,9 @@ pub fn take_presentation_feedback(
         layer_surface.take_presentation_feedback(
             &mut output_presentation_feedback,
             surface_primary_scanout_output,
-            |surface, _| surface_presentation_feedback_flags_from_states(surface, render_element_states),
+            |surface, _| {
+                surface_presentation_feedback_flags_from_states(surface, None, render_element_states)
+            },
         );
     }
 

--- a/src/backend/drm/compositor/elements.rs
+++ b/src/backend/drm/compositor/elements.rs
@@ -5,7 +5,7 @@ use crate::{
         Color32F, Frame, Renderer,
     },
     render_elements,
-    utils::{Buffer, Physical, Rectangle, Scale, Transform},
+    utils::{user_data::UserDataMap, Buffer, Physical, Rectangle, Scale, Transform},
 };
 
 render_elements! {
@@ -44,6 +44,7 @@ where
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         frame.clear(
             Color32F::TRANSPARENT,
@@ -177,6 +178,7 @@ where
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         // We do not actually draw anything here
         Ok(())

--- a/src/backend/drm/compositor/frame_result.rs
+++ b/src/backend/drm/compositor/frame_result.rs
@@ -406,7 +406,7 @@ where
                 tracing::trace!("drawing frame element with damage: {:#?}", element_damage);
 
                 element
-                    .draw(&mut frame, src, dst, &element_damage, &[])
+                    .draw(&mut frame, src, dst, &element_damage, &[], None)
                     .map_err(BlitFrameResultError::Rendering)?;
             }
 

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -193,6 +193,7 @@ impl RenderElementState {
         RenderElementState {
             visible_area,
             presentation_state: RenderElementPresentationState::ZeroCopy,
+            needs_capture: false,
         }
     }
 
@@ -200,6 +201,7 @@ impl RenderElementState {
         RenderElementState {
             visible_area: 0,
             presentation_state: RenderElementPresentationState::Rendering { reason: Some(reason) },
+            needs_capture: false,
         }
     }
 }
@@ -2829,6 +2831,9 @@ where
             );
             return Err(None);
         };
+        if element.is_framebuffer_effect() {
+            return Err(None);
+        }
 
         let mut rendering_reason: Option<RenderingReason> = None;
 

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -438,7 +438,7 @@ impl OutputDamageTracker {
                     .element_render_state(element_id.clone())
                     .is_some_and(|state| state.needs_capture)
                 {
-                    element.capture_framebuffer(&mut frame, element_geometry)?;
+                    element.capture_framebuffer(&mut frame, element.src(), element_geometry)?;
                 }
 
                 element.draw(

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -96,16 +96,17 @@
 use std::{
     collections::{HashMap, VecDeque},
     ops::Range,
+    sync::Once,
 };
 
 use indexmap::IndexMap;
 use smallvec::{smallvec, SmallVec};
-use tracing::{info_span, instrument, trace};
+use tracing::{info_span, instrument, trace, warn};
 
 use crate::{
     backend::renderer::{element::RenderElementPresentationState, Frame},
     output::{Output, OutputModeSource, OutputNoMode},
-    utils::{Buffer as BufferCoords, Physical, Rectangle, Scale, Size, Transform},
+    utils::{user_data::UserDataMap, Buffer as BufferCoords, Physical, Rectangle, Scale, Size, Transform},
 };
 
 use super::{
@@ -181,6 +182,7 @@ struct RendererState {
     transform: Option<Transform>,
     size: Option<Size<i32, Physical>>,
     elements: IndexMap<Id, ElementState>,
+    effects_cache: HashMap<Id, UserDataMap>,
     old_damage: VecDeque<Vec<Rectangle<i32, Physical>>>,
     opaque_regions: Vec<Rectangle<i32, Physical>>,
     clear_color: Option<Color32F>,
@@ -438,7 +440,12 @@ impl OutputDamageTracker {
                     .element_render_state(element_id.clone())
                     .is_some_and(|state| state.needs_capture)
                 {
-                    element.capture_framebuffer(&mut frame, element.src(), element_geometry)?;
+                    let cache = self
+                        .last_state
+                        .effects_cache
+                        .entry(element.id().clone())
+                        .or_default();
+                    element.capture_framebuffer(&mut frame, element.src(), element_geometry, cache)?;
                 }
 
                 element.draw(
@@ -646,6 +653,15 @@ impl OutputDamageTracker {
                 } else {
                     state.visible_area += element_visible_area;
                 }
+                if element_is_framebuffer_effect {
+                    // if we have multiple instance of the same Id, we need to force a call
+                    // to `capture_framebuffer` before both `draw`-calls, as we can't rely on the cache.
+                    static WARN_ONCE: Once = Once::new();
+                    WARN_ONCE.call_once(|| {
+                        warn!("Duplicated FramebufferEffect element. Re-capturing every frame");
+                    });
+                    state.needs_capture = true;
+                }
             } else {
                 element_render_states.states.insert(
                     element_id.clone(),
@@ -729,21 +745,22 @@ impl OutputDamageTracker {
             };
             let element_geometry = element.geometry(output_scale);
             let intersection = element_geometry.intersection(output_geo);
+            let element_state = element_render_states.states.get_mut(element.id()).unwrap();
 
-            if intersection.is_some_and(|i| self.damage.iter().skip(damage_index).any(|d| d.overlaps(i))) {
-                if let Some(state) = element_render_states.states.get_mut(element.id()) {
-                    state.needs_capture = true;
-                    self.damage.push(intersection.unwrap());
-                    // also drop all opaque regions on top, so they don't block re-drawing below the blur element
-                    for region in self.opaque_regions.iter_mut().take(opaque_regions_index) {
-                        // we want to leave `self.opaque_regions_index` intact,
-                        // fixing it up would be very involved, so lets do the next best thing
-                        // and keep at least part of the opaque region, if possible.
-                        *region = Rectangle::subtract_rect(*region, intersection.unwrap())
-                            .into_iter()
-                            .next()
-                            .unwrap_or_default();
-                    }
+            if element_state.needs_capture
+                || intersection.is_some_and(|i| self.damage.iter().skip(damage_index).any(|d| d.overlaps(i)))
+            {
+                element_state.needs_capture = true;
+                self.damage.push(intersection.unwrap());
+                // also drop all opaque regions on top, so they don't block re-drawing below the blur element
+                for region in self.opaque_regions.iter_mut().take(opaque_regions_index) {
+                    // we want to leave `self.opaque_regions_index` intact,
+                    // fixing it up would be very involved, so lets do the next best thing
+                    // and keep at least part of the opaque region, if possible.
+                    *region = Rectangle::subtract_rect(*region, intersection.unwrap())
+                        .into_iter()
+                        .next()
+                        .unwrap_or_default();
                 }
             }
         }
@@ -838,6 +855,9 @@ impl OutputDamageTracker {
                     map
                 });
 
+        self.last_state
+            .effects_cache
+            .retain(|id, _| new_elements_state.contains_key(id));
         self.last_state.size = Some(output_geo.size);
         self.last_state.transform = Some(output_transform);
         self.last_state.elements = new_elements_state;

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -454,6 +454,7 @@ impl OutputDamageTracker {
                     element_geometry,
                     &element_damage,
                     &element_opaque_regions,
+                    self.last_state.effects_cache.get(element.id()),
                 )?;
             }
 

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -366,117 +366,63 @@ impl OutputDamageTracker {
             return Ok(RenderOutputResult::skipped(states));
         }
 
-        trace!(
-            "rendering with damage {:?} and opaque regions {:?}",
-            self.damage,
-            self.opaque_regions
+        self.render_output_internal(renderer, framebuffer, &render_elements, clear_color, states)
+    }
+
+    /// Render this output with the provided [`Renderer`] and provided states.
+    ///
+    /// Note: This is meant for cases, where rendering should happen with a different
+    /// age value, but `damage_output` was used previously to reflect some internal
+    /// damage tracking.
+    ///
+    /// - `elements` for this output in front-to-back order
+    #[instrument(level = "trace", parent = &self.span, skip(renderer, framebuffer, elements, clear_color, states))]
+    #[profiling::function]
+    pub fn render_output_with_states<E, R>(
+        &mut self,
+        renderer: &mut R,
+        framebuffer: &mut R::Framebuffer<'_>,
+        age: usize,
+        elements: &[E],
+        clear_color: impl Into<Color32F>,
+        states: RenderElementStates,
+    ) -> Result<RenderOutputResult<'_>, Error<R::Error>>
+    where
+        E: RenderElement<R>,
+        R: Renderer,
+        R::TextureId: Texture,
+    {
+        let clear_color = clear_color.into();
+        let (output_size, output_scale, output_transform) =
+            std::convert::TryInto::<(Size<i32, Physical>, Scale<f64>, Transform)>::try_into(&self.mode)?;
+
+        // Output transform is specified in surface-rotation, so inversion gives us the
+        // render transform for the output itself.
+        let output_transform = output_transform.invert();
+
+        // We have to apply to output transform to the output size so that the intersection
+        // tests in damage_output_internal produces the correct results and do not crop
+        // damage with the wrong size
+        let output_geo = Rectangle::from_size(output_transform.transform_size(output_size));
+
+        // This will hold all the damage we need for this rendering step
+        let mut render_elements: Vec<&E> = Vec::with_capacity(elements.len());
+        let _ = self.damage_output_internal(
+            age,
+            elements,
+            output_scale,
+            output_transform,
+            output_geo,
+            Some(clear_color),
+            &mut render_elements,
         );
 
-        let render_res = (|| {
-            // we have to take the element damage to be able to move it around
-            let mut element_damage = std::mem::take(&mut self.element_damage);
-            let mut element_opaque_regions = std::mem::take(&mut self.element_opaque_regions);
-            let mut frame = renderer.render(framebuffer, output_size, output_transform)?;
-
-            element_damage.clear();
-            element_damage.extend_from_slice(&self.damage);
-            element_damage =
-                Rectangle::subtract_rects_many_in_place(element_damage, self.opaque_regions.iter().copied());
-
-            trace!("clearing damage {:?}", element_damage);
-            frame.clear(clear_color, &element_damage)?;
-
-            for (z_index, element) in render_elements.iter().rev().enumerate() {
-                let element_id = element.id();
-                let element_geometry = element.geometry(output_scale);
-
-                element_damage.clear();
-                element_damage.extend(
-                    self.damage
-                        .iter()
-                        .filter_map(|d| d.intersection(element_geometry)),
-                );
-
-                let element_opaque_regions_range =
-                    self.opaque_regions_index.iter().rev().nth(z_index).unwrap();
-                element_damage = Rectangle::subtract_rects_many_in_place(
-                    element_damage,
-                    self.opaque_regions[..element_opaque_regions_range.start]
-                        .iter()
-                        .copied(),
-                );
-                element_damage.iter_mut().for_each(|d| {
-                    d.loc -= element_geometry.loc;
-                });
-
-                if element_damage.is_empty() {
-                    trace!(
-                        "skipping rendering element {:?} with geometry {:?}, no damage",
-                        element_id,
-                        element_geometry
-                    );
-                    continue;
-                }
-
-                element_opaque_regions.clear();
-                element_opaque_regions.extend(
-                    self.opaque_regions[element_opaque_regions_range.start..element_opaque_regions_range.end]
-                        .iter()
-                        .copied()
-                        .map(|mut rect| {
-                            rect.loc -= element_geometry.loc;
-                            rect
-                        }),
-                );
-
-                trace!(
-                    "rendering element {:?} with geometry {:?} and damage {:?}",
-                    element_id,
-                    element_geometry,
-                    element_damage,
-                );
-
-                if states
-                    .element_render_state(element_id.clone())
-                    .is_some_and(|state| state.needs_capture)
-                {
-                    let cache = self
-                        .last_state
-                        .effects_cache
-                        .entry(element.id().clone())
-                        .or_default();
-                    element.capture_framebuffer(&mut frame, element.src(), element_geometry, cache)?;
-                }
-
-                element.draw(
-                    &mut frame,
-                    element.src(),
-                    element_geometry,
-                    &element_damage,
-                    &element_opaque_regions,
-                    self.last_state.effects_cache.get(element.id()),
-                )?;
-            }
-
-            // return the element damage so that we can re-use the allocation
-            std::mem::swap(&mut self.element_damage, &mut element_damage);
-            std::mem::swap(&mut self.element_opaque_regions, &mut element_opaque_regions);
-            frame.finish()
-        })();
-
-        match render_res {
-            Ok(sync) => Ok(RenderOutputResult {
-                sync,
-                damage: Some(&self.damage),
-                states,
-            }),
-            Err(err) => {
-                // if the rendering errors on us, we need to be prepared, that this whole buffer was partially updated and thus now unusable.
-                // thus clean our old states before returning
-                self.last_state = Default::default();
-                Err(Error::Rendering(err))
-            }
+        if self.damage.is_empty() {
+            trace!("no damage, skipping rendering");
+            return Ok(RenderOutputResult::skipped(states));
         }
+
+        self.render_output_internal(renderer, framebuffer, &render_elements, clear_color, states)
     }
 
     /// Damage this output and return the damage without actually rendering the difference
@@ -871,5 +817,139 @@ impl OutputDamageTracker {
         self.last_state.clear_color = clear_color;
 
         element_render_states
+    }
+
+    #[instrument(level = "trace", parent = &self.span, skip(renderer, framebuffer, render_elements, clear_color, states))]
+    #[profiling::function]
+    fn render_output_internal<E, R>(
+        &mut self,
+        renderer: &mut R,
+        framebuffer: &mut R::Framebuffer<'_>,
+        render_elements: &[E],
+        clear_color: Color32F,
+        states: RenderElementStates,
+    ) -> Result<RenderOutputResult<'_>, Error<R::Error>>
+    where
+        E: RenderElement<R>,
+        R: Renderer,
+        R::TextureId: Texture,
+    {
+        let (output_size, output_scale, output_transform) =
+            std::convert::TryInto::<(Size<i32, Physical>, Scale<f64>, Transform)>::try_into(&self.mode)?;
+        // Output transform is specified in surface-rotation, so inversion gives us the
+        // render transform for the output itself.
+        let output_transform = output_transform.invert();
+
+        trace!(
+            "rendering with damage {:?} and opaque regions {:?}",
+            self.damage,
+            self.opaque_regions
+        );
+
+        let render_res = (|| {
+            // we have to take the element damage to be able to move it around
+            let mut element_damage = std::mem::take(&mut self.element_damage);
+            let mut element_opaque_regions = std::mem::take(&mut self.element_opaque_regions);
+            let mut frame = renderer.render(framebuffer, output_size, output_transform)?;
+
+            element_damage.clear();
+            element_damage.extend_from_slice(&self.damage);
+            element_damage =
+                Rectangle::subtract_rects_many_in_place(element_damage, self.opaque_regions.iter().copied());
+
+            trace!("clearing damage {:?}", element_damage);
+            frame.clear(clear_color, &element_damage)?;
+
+            for (z_index, element) in render_elements.iter().rev().enumerate() {
+                let element_id = element.id();
+                let element_geometry = element.geometry(output_scale);
+
+                element_damage.clear();
+                element_damage.extend(
+                    self.damage
+                        .iter()
+                        .filter_map(|d| d.intersection(element_geometry)),
+                );
+
+                let element_opaque_regions_range =
+                    self.opaque_regions_index.iter().rev().nth(z_index).unwrap();
+                element_damage = Rectangle::subtract_rects_many_in_place(
+                    element_damage,
+                    self.opaque_regions[..element_opaque_regions_range.start]
+                        .iter()
+                        .copied(),
+                );
+                element_damage.iter_mut().for_each(|d| {
+                    d.loc -= element_geometry.loc;
+                });
+
+                if element_damage.is_empty() {
+                    trace!(
+                        "skipping rendering element {:?} with geometry {:?}, no damage",
+                        element_id,
+                        element_geometry
+                    );
+                    continue;
+                }
+
+                element_opaque_regions.clear();
+                element_opaque_regions.extend(
+                    self.opaque_regions[element_opaque_regions_range.start..element_opaque_regions_range.end]
+                        .iter()
+                        .copied()
+                        .map(|mut rect| {
+                            rect.loc -= element_geometry.loc;
+                            rect
+                        }),
+                );
+
+                trace!(
+                    "rendering element {:?} with geometry {:?} and damage {:?}",
+                    element_id,
+                    element_geometry,
+                    element_damage,
+                );
+
+                if states
+                    .element_render_state(element_id.clone())
+                    .is_some_and(|state| state.needs_capture)
+                {
+                    let cache = self
+                        .last_state
+                        .effects_cache
+                        .entry(element.id().clone())
+                        .or_default();
+                    element.capture_framebuffer(&mut frame, element.src(), element_geometry, cache)?;
+                }
+
+                element.draw(
+                    &mut frame,
+                    element.src(),
+                    element_geometry,
+                    &element_damage,
+                    &element_opaque_regions,
+                    self.last_state.effects_cache.get(element.id()),
+                )?;
+            }
+
+            // return the element damage so that we can re-use the allocation
+            std::mem::swap(&mut self.element_damage, &mut element_damage);
+            std::mem::swap(&mut self.element_opaque_regions, &mut element_opaque_regions);
+            frame.finish()
+        })();
+
+        match render_res {
+            Ok(sync) => Ok(RenderOutputResult {
+                sync,
+                damage: Some(&self.damage),
+                states,
+            }),
+            Err(err) => {
+                // if the rendering errors on us, we need to be prepared, that this whole buffer was partially updated and thus now unusable.
+                // thus clean our old states before returning
+                self.last_state = Default::default();
+                Err(Error::Rendering(err))
+            }
+        }
     }
 }

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -628,16 +628,24 @@ impl OutputDamageTracker {
         let mut force_effect_redraw = false;
 
         // add the damage for elements gone that are not covered an opaque region
-        let elements_gone = self.last_state.elements.iter().filter(|(id, _)| {
-            element_render_states
-                .states
-                .get(id)
-                .map(|state| state.presentation_state == RenderElementPresentationState::Skipped)
-                .unwrap_or(true)
-        });
+        let mut elements_gone = self
+            .last_state
+            .elements
+            .iter()
+            .filter(|(id, _)| {
+                element_render_states
+                    .states
+                    .get(id)
+                    .map(|state| state.presentation_state == RenderElementPresentationState::Skipped)
+                    .unwrap_or(true)
+            })
+            .peekable();
+
+        if elements_gone.peek().is_some() {
+            force_effect_redraw = true;
+        }
 
         for (_, state) in elements_gone {
-            force_effect_redraw = true;
             self.damage.extend(
                 state
                     .last_instances
@@ -695,7 +703,8 @@ impl OutputDamageTracker {
                 self.opaque_regions_index[z_index].start
             };
             let element_geometry = element.geometry(output_scale);
-            let intersection = element_geometry.intersection(output_geo);
+            // SAFETY: render_elements only contains elements overlapping with the output geometry
+            let intersection = element_geometry.intersection(output_geo).unwrap();
             let element_state = element_render_states.states.get_mut(element.id()).unwrap();
             let with_element_state = with_states
                 .as_ref()
@@ -703,16 +712,20 @@ impl OutputDamageTracker {
 
             if element_state.needs_capture
                 || with_element_state.is_some_and(|state| state.needs_capture)
-                || intersection.is_some_and(|i| self.damage.iter().skip(damage_index).any(|d| d.overlaps(i)))
+                || self
+                    .damage
+                    .iter()
+                    .skip(damage_index)
+                    .any(|d| d.overlaps(intersection))
             {
                 element_state.needs_capture = true;
-                self.damage.push(intersection.unwrap());
+                self.damage.push(intersection);
                 // also drop all opaque regions on top, so they don't block re-drawing below the blur element
                 for region in self.opaque_regions.iter_mut().take(opaque_regions_index) {
                     // we want to leave `self.opaque_regions_index` intact,
                     // fixing it up would be very involved, so lets do the next best thing
                     // and keep at least part of the opaque region, if possible.
-                    *region = Rectangle::subtract_rect(*region, intersection.unwrap())
+                    *region = Rectangle::subtract_rect(*region, intersection)
                         .into_iter()
                         .next()
                         .unwrap_or_default();
@@ -918,6 +931,7 @@ impl OutputDamageTracker {
                     element_damage,
                 );
 
+                let element_src = element.src();
                 if states
                     .element_render_state(element_id.clone())
                     .is_some_and(|state| state.needs_capture)
@@ -925,18 +939,18 @@ impl OutputDamageTracker {
                     let cache = self
                         .last_state
                         .effects_cache
-                        .entry(element.id().clone())
+                        .entry(element_id.clone())
                         .or_default();
-                    element.capture_framebuffer(&mut frame, element.src(), element_geometry, cache)?;
+                    element.capture_framebuffer(&mut frame, element_src, element_geometry, cache)?;
                 }
 
                 element.draw(
                     &mut frame,
-                    element.src(),
+                    element_src,
                     element_geometry,
                     &element_damage,
                     &element_opaque_regions,
-                    self.last_state.effects_cache.get(element.id()),
+                    self.last_state.effects_cache.get(element_id),
                 )?;
             }
 

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -359,6 +359,7 @@ impl OutputDamageTracker {
             output_geo,
             Some(clear_color),
             &mut render_elements,
+            None,
         );
 
         if self.damage.is_empty() {
@@ -415,6 +416,7 @@ impl OutputDamageTracker {
             output_geo,
             Some(clear_color),
             &mut render_elements,
+            Some(&states),
         );
 
         if self.damage.is_empty() {
@@ -458,6 +460,7 @@ impl OutputDamageTracker {
             output_geo,
             self.last_state.clear_color,
             &mut render_elements,
+            None,
         );
 
         if self.damage.is_empty() {
@@ -478,6 +481,7 @@ impl OutputDamageTracker {
         output_geo: Rectangle<i32, Physical>,
         clear_color: Option<Color32F>,
         render_elements: &mut Vec<&'a E>,
+        with_states: Option<&RenderElementStates>,
     ) -> RenderElementStates
     where
         E: Element,
@@ -693,8 +697,12 @@ impl OutputDamageTracker {
             let element_geometry = element.geometry(output_scale);
             let intersection = element_geometry.intersection(output_geo);
             let element_state = element_render_states.states.get_mut(element.id()).unwrap();
+            let with_element_state = with_states
+                .as_ref()
+                .and_then(|states| states.states.get(element.id()));
 
             if element_state.needs_capture
+                || with_element_state.is_some_and(|state| state.needs_capture)
                 || intersection.is_some_and(|i| self.damage.iter().skip(damage_index).any(|d| d.overlaps(i)))
             {
                 element_state.needs_capture = true;

--- a/src/backend/renderer/element/memory.rs
+++ b/src/backend/renderer/element/memory.rs
@@ -119,7 +119,7 @@ use crate::{
             ErasedContextId, Frame, ImportMem, Renderer,
         },
     },
-    utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
+    utils::{user_data::UserDataMap, Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
 };
 
 use super::{Element, Id, Kind, RenderElement, UnderlyingStorage};
@@ -642,6 +642,7 @@ where
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         frame.render_texture_from_to(
             &self.texture,

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -540,9 +540,10 @@ pub trait RenderElement<R: Renderer>: Element {
     fn capture_framebuffer(
         &self,
         frame: &mut R::Frame<'_, '_>,
+        src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
     ) -> Result<(), R::Error> {
-        let _ = (frame, dst);
+        let _ = (frame, src, dst);
         unimplemented!("error: is_framebuffer_effect without capture_framebuffer implementation!");
     }
 }
@@ -637,9 +638,10 @@ where
     fn capture_framebuffer(
         &self,
         frame: &mut <R>::Frame<'_, '_>,
+        src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
     ) -> Result<(), <R>::Error> {
-        (*self).capture_framebuffer(frame, dst)
+        (*self).capture_framebuffer(frame, src, dst)
     }
 }
 
@@ -986,6 +988,7 @@ macro_rules! render_elements_internal {
         fn capture_framebuffer(
             &self,
             frame: &mut <$renderer as $crate::backend::renderer::RendererSuper>::Frame<'_, '_>,
+            src: $crate::utils::Rectangle<f64, $crate::utils::Buffer>,
             dst: $crate::utils::Rectangle<i32, $crate::utils::Physical>,
         ) -> Result<(), <$renderer as $crate::backend::renderer::RendererSuper>::Error>
         where
@@ -1003,7 +1006,7 @@ macro_rules! render_elements_internal {
                     $(
                         #[$meta]
                     )*
-                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; capture_framebuffer; x, frame, dst)
+                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; capture_framebuffer; x, frame, src, dst)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -1049,6 +1052,7 @@ macro_rules! render_elements_internal {
         fn capture_framebuffer(
             &self,
             frame: &mut <$renderer as $crate::backend::renderer::RendererSuper>::Frame<'_, '_>,
+            src: $crate::utils::Rectangle<f64, $crate::utils::Buffer>,
             dst: $crate::utils::Rectangle<i32, $crate::utils::Physical>,
         ) -> Result<(), <$renderer as $crate::backend::renderer::RendererSuper>::Error>
         {
@@ -1058,7 +1062,7 @@ macro_rules! render_elements_internal {
                     $(
                         #[$meta]
                     )*
-                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; capture_framebuffer; x, frame, dst)
+                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; capture_framebuffer; x, frame, src, dst)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -1641,9 +1645,10 @@ where
     fn capture_framebuffer(
         &self,
         frame: &mut <R>::Frame<'_, '_>,
+        src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
     ) -> Result<(), <R>::Error> {
-        self.0.capture_framebuffer(frame, dst)
+        self.0.capture_framebuffer(frame, src, dst)
     }
 }
 

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -567,6 +567,8 @@ pub trait Element {
 /// A single render element
 pub trait RenderElement<R: Renderer>: Element {
     /// Draw this element
+    ///
+    /// `cache` will only be `Some` if [`Element::is_framebuffer_effect`] returns `true`.
     fn draw(
         &self,
         frame: &mut R::Frame<'_, '_>,
@@ -574,6 +576,7 @@ pub trait RenderElement<R: Renderer>: Element {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error>;
 
     /// Get the underlying storage of this element, may be used to optimize rendering (eg. drm planes)
@@ -682,8 +685,9 @@ where
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
-        (*self).draw(frame, src, dst, damage, opaque_regions)
+        (*self).draw(frame, src, dst, damage, opaque_regions, cache)
     }
 
     fn capture_framebuffer(
@@ -789,8 +793,9 @@ impl<R: Renderer, E: Element + RenderElement<R>> RenderElement<R> for Namespaced
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), <R>::Error> {
-        self.inner.draw(frame, src, dst, damage, opaque_regions)
+        self.inner.draw(frame, src, dst, damage, opaque_regions, cache)
     }
 
     fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage<'_>> {
@@ -1111,6 +1116,7 @@ macro_rules! render_elements_internal {
             dst: $crate::utils::Rectangle<i32, $crate::utils::Physical>,
             damage: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
             opaque_regions: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
+            cache: Option<&$crate::utils::user_data::UserDataMap>,
         ) -> Result<(), <$renderer as $crate::backend::renderer::RendererSuper>::Error>
         where
         $(
@@ -1127,7 +1133,7 @@ macro_rules! render_elements_internal {
                     $(
                         #[$meta]
                     )*
-                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, frame, src, dst, damage, opaque_regions)
+                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, frame, src, dst, damage, opaque_regions, cache)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -1184,6 +1190,7 @@ macro_rules! render_elements_internal {
             dst: $crate::utils::Rectangle<i32, $crate::utils::Physical>,
             damage: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
             opaque_regions: &[$crate::utils::Rectangle<i32, $crate::utils::Physical>],
+            cache: Option<&$crate::utils::user_data::UserDataMap>,
         ) -> Result<(), <$renderer as $crate::backend::renderer::RendererSuper>::Error>
         {
             match self {
@@ -1192,7 +1199,7 @@ macro_rules! render_elements_internal {
                     $(
                         #[$meta]
                     )*
-                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, frame, src, dst, damage, opaque_regions)
+                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; draw; x, frame, src, dst, damage, opaque_regions, cache)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -1515,7 +1522,10 @@ macro_rules! render_elements_internal {
 /// #             Renderer,
 /// #         },
 /// #     },
-/// #     utils::{Buffer, Point, Physical, Rectangle, Scale, Transform},
+/// #     utils::{
+/// #         user_data::UserDataMap,
+/// #         Buffer, Point, Physical, Rectangle, Scale, Transform,
+/// #     },
 /// # };
 /// #
 /// # struct MyRenderElement1;
@@ -1547,6 +1557,7 @@ macro_rules! render_elements_internal {
 /// #         _dst: Rectangle<i32, Physical>,
 /// #         _damage: &[Rectangle<i32, Physical>],
 /// #         _opaque_regions: &[Rectangle<i32, Physical>],
+/// #         _cache: Option<&UserDataMap>,
 /// #     ) -> Result<(), R::Error> {
 /// #         unimplemented!()
 /// #     }
@@ -1578,6 +1589,7 @@ macro_rules! render_elements_internal {
 /// #         _dst: Rectangle<i32, Physical>,
 /// #         _damage: &[Rectangle<i32, Physical>],
 /// #         _opaque_regions: &[Rectangle<i32, Physical>],
+/// #         _cache: Option<&UserDataMap>,
 /// #     ) -> Result<(), R::Error> {
 /// #         unimplemented!()
 /// #     }
@@ -1798,8 +1810,9 @@ where
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
-        self.0.draw(frame, src, dst, damage, opaque_regions)
+        self.0.draw(frame, src, dst, damage, opaque_regions, cache)
     }
 
     #[inline]

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -334,6 +334,7 @@ impl PrimaryScanoutOutput {
         &mut self,
         element_id: impl Into<Id>,
         output: &Output,
+        namespace: Option<usize>,
         states: &RenderElementStates,
         compare: F,
     ) -> Option<Output>
@@ -341,6 +342,9 @@ impl PrimaryScanoutOutput {
         F: for<'a> Fn(&'a Output, &'a RenderElementState, &'a Output, &'a RenderElementState) -> &'a Output,
     {
         let element_id = element_id.into();
+        let element_id = namespace
+            .map(|val| element_id.namespaced(val))
+            .unwrap_or(element_id);
         let element_was_presented = states.element_was_presented(element_id.clone());
         let element_state = states.element_render_state(element_id);
         let primary_scanout_output = &mut self.0;

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -29,7 +29,7 @@ use wayland_server::{backend::ObjectId, Resource};
 
 use crate::{
     output::{Output, WeakOutput},
-    utils::{Buffer as BufferCoords, Physical, Point, Rectangle, Scale, Transform},
+    utils::{user_data::UserDataMap, Buffer as BufferCoords, Physical, Point, Rectangle, Scale, Transform},
 };
 
 #[cfg(feature = "wayland_frontend")]
@@ -542,8 +542,9 @@ pub trait RenderElement<R: Renderer>: Element {
         frame: &mut R::Frame<'_, '_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
+        cache: &UserDataMap,
     ) -> Result<(), R::Error> {
-        let _ = (frame, src, dst);
+        let _ = (frame, src, dst, cache);
         unimplemented!("error: is_framebuffer_effect without capture_framebuffer implementation!");
     }
 }
@@ -640,8 +641,9 @@ where
         frame: &mut <R>::Frame<'_, '_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
+        cache: &UserDataMap,
     ) -> Result<(), <R>::Error> {
-        (*self).capture_framebuffer(frame, src, dst)
+        (*self).capture_framebuffer(frame, src, dst, cache)
     }
 }
 
@@ -990,6 +992,7 @@ macro_rules! render_elements_internal {
             frame: &mut <$renderer as $crate::backend::renderer::RendererSuper>::Frame<'_, '_>,
             src: $crate::utils::Rectangle<f64, $crate::utils::Buffer>,
             dst: $crate::utils::Rectangle<i32, $crate::utils::Physical>,
+            cache: &$crate::utils::user_data::UserDataMap,
         ) -> Result<(), <$renderer as $crate::backend::renderer::RendererSuper>::Error>
         where
         $(
@@ -1006,7 +1009,7 @@ macro_rules! render_elements_internal {
                     $(
                         #[$meta]
                     )*
-                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; capture_framebuffer; x, frame, src, dst)
+                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; capture_framebuffer; x, frame, src, dst, cache)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -1054,6 +1057,7 @@ macro_rules! render_elements_internal {
             frame: &mut <$renderer as $crate::backend::renderer::RendererSuper>::Frame<'_, '_>,
             src: $crate::utils::Rectangle<f64, $crate::utils::Buffer>,
             dst: $crate::utils::Rectangle<i32, $crate::utils::Physical>,
+            cache: &$crate::utils::user_data::UserDataMap,
         ) -> Result<(), <$renderer as $crate::backend::renderer::RendererSuper>::Error>
         {
             match self {
@@ -1062,7 +1066,7 @@ macro_rules! render_elements_internal {
                     $(
                         #[$meta]
                     )*
-                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; capture_framebuffer; x, frame, src, dst)
+                    Self::$body(x) => $crate::render_elements_internal!(@call $renderer $(as $other_renderer)?; capture_framebuffer; x, frame, src, dst, cache)
                 ),*,
                 Self::_GenericCatcher(_) => unreachable!(),
             }
@@ -1647,8 +1651,9 @@ where
         frame: &mut <R>::Frame<'_, '_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
+        cache: &UserDataMap,
     ) -> Result<(), <R>::Error> {
-        self.0.capture_framebuffer(frame, src, dst)
+        self.0.capture_framebuffer(frame, src, dst, cache)
     }
 }
 

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -50,7 +50,10 @@ crate::utils::ids::id_gen!(external_id);
 
 #[derive(Debug, Clone)]
 /// A unique id for a [`RenderElement`]
-pub struct Id(InnerId);
+pub struct Id {
+    inner: InnerId,
+    namespace: Option<usize>,
+}
 
 #[derive(Debug, Clone)]
 enum InnerId {
@@ -61,7 +64,10 @@ enum InnerId {
 
 #[derive(Debug, Clone)]
 /// A weak reference to a unique id for a [`RenderElement`]
-pub struct WeakId(InnerWeakId);
+pub struct WeakId {
+    inner: InnerWeakId,
+    namespace: Option<usize>,
+}
 
 #[derive(Debug, Clone)]
 enum InnerWeakId {
@@ -87,32 +93,34 @@ impl Drop for ExternalId {
 
 impl PartialEq for Id {
     fn eq(&self, other: &Self) -> bool {
-        match (&self.0, &other.0) {
-            #[cfg(feature = "wayland_frontend")]
-            (InnerId::WaylandResource(this_obj), InnerId::WaylandResource(other_obj)) => {
-                this_obj == other_obj
+        self.namespace == other.namespace
+            && match (&self.inner, &other.inner) {
+                #[cfg(feature = "wayland_frontend")]
+                (InnerId::WaylandResource(this_obj), InnerId::WaylandResource(other_obj)) => {
+                    this_obj == other_obj
+                }
+                (InnerId::External(this_id), InnerId::External(other_id)) => Arc::ptr_eq(this_id, other_id),
+                #[allow(unreachable_patterns)]
+                _ => false,
             }
-            (InnerId::External(this_id), InnerId::External(other_id)) => Arc::ptr_eq(this_id, other_id),
-            #[allow(unreachable_patterns)]
-            _ => false,
-        }
     }
 }
 impl Eq for Id {}
 
 impl PartialEq for WeakId {
     fn eq(&self, other: &Self) -> bool {
-        match (&self.0, &other.0) {
-            #[cfg(feature = "wayland_frontend")]
-            (InnerWeakId::WaylandResource(this_obj), InnerWeakId::WaylandResource(other_obj)) => {
-                this_obj == other_obj
+        self.namespace == other.namespace
+            && match (&self.inner, &other.inner) {
+                #[cfg(feature = "wayland_frontend")]
+                (InnerWeakId::WaylandResource(this_obj), InnerWeakId::WaylandResource(other_obj)) => {
+                    this_obj == other_obj
+                }
+                (InnerWeakId::External(this_id), InnerWeakId::External(other_id)) => {
+                    Weak::ptr_eq(this_id, other_id)
+                }
+                #[allow(unreachable_patterns)]
+                _ => false,
             }
-            (InnerWeakId::External(this_id), InnerWeakId::External(other_id)) => {
-                Weak::ptr_eq(this_id, other_id)
-            }
-            #[allow(unreachable_patterns)]
-            _ => false,
-        }
     }
 }
 impl Eq for WeakId {}
@@ -129,11 +137,14 @@ impl std::hash::Hash for Id {
     where
         H: std::hash::Hasher,
     {
-        match &self.0 {
+        match &self.inner {
             #[cfg(feature = "wayland_frontend")]
             InnerId::WaylandResource(obj) => obj.hash(state),
-            InnerId::External(arc) => (Arc::as_ptr(arc) as usize).hash(state),
+            InnerId::External(arc) => {
+                (Arc::as_ptr(arc) as usize).hash(state);
+            }
         }
+        self.namespace.hash(state);
     }
 }
 
@@ -142,11 +153,14 @@ impl std::hash::Hash for WeakId {
     where
         H: std::hash::Hasher,
     {
-        match &self.0 {
+        match &self.inner {
             #[cfg(feature = "wayland_frontend")]
             InnerWeakId::WaylandResource(obj) => obj.hash(state),
-            InnerWeakId::External(arc) => (Weak::as_ptr(arc) as usize).hash(state),
+            InnerWeakId::External(arc) => {
+                (Weak::as_ptr(arc) as usize).hash(state);
+            }
         }
+        self.namespace.hash(state);
     }
 }
 
@@ -157,7 +171,10 @@ impl Id {
     /// multiple times will return the same id.
     #[cfg(feature = "wayland_frontend")]
     pub fn from_wayland_resource<R: Resource>(resource: &R) -> Self {
-        Id(InnerId::WaylandResource(resource.id()))
+        Id {
+            inner: InnerId::WaylandResource(resource.id()),
+            namespace: None,
+        }
     }
 
     /// Create a new unique id
@@ -166,27 +183,60 @@ impl Id {
     /// are dropped.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        Id(InnerId::External(Arc::new(ExternalId::new())))
+        Id {
+            inner: InnerId::External(Arc::new(ExternalId::new())),
+            namespace: None,
+        }
+    }
+
+    /// Add a namespace to this id.
+    ///
+    /// This allows re-use of an `Id`, while still differentiating
+    /// between multiple instances with a stable Hash.
+    ///
+    /// This is especially useful for elements implementing
+    /// [`Element::is_framebuffer_effect`], where multiple instances
+    /// of the same id in a single `DamageTracker`-call will
+    /// degrade performance.
+    pub fn namespaced(&self, namespace: usize) -> Self {
+        Id {
+            inner: self.inner.clone(),
+            namespace: Some(namespace),
+        }
+    }
+
+    /// Remove a previously applied namespace from the `Id`.
+    pub fn unnamespaced(&self) -> Self {
+        Id {
+            inner: self.inner.clone(),
+            namespace: None,
+        }
     }
 
     /// Create a weak reference to this Id, which won't keep it from being re-used internally.
     pub fn downgrade(&self) -> WeakId {
-        WeakId(match &self.0 {
-            #[cfg(feature = "wayland_frontend")]
-            InnerId::WaylandResource(id) => InnerWeakId::WaylandResource(id.clone()),
-            InnerId::External(arc) => InnerWeakId::External(Arc::downgrade(arc)),
-        })
+        WeakId {
+            inner: match &self.inner {
+                #[cfg(feature = "wayland_frontend")]
+                InnerId::WaylandResource(id) => InnerWeakId::WaylandResource(id.clone()),
+                InnerId::External(arc) => InnerWeakId::External(Arc::downgrade(arc)),
+            },
+            namespace: self.namespace,
+        }
     }
 }
 
 impl WeakId {
     /// Create `Id` from this weak handle, if it still exist
     pub fn upgrade(&self) -> Option<Id> {
-        Some(Id(match &self.0 {
-            #[cfg(feature = "wayland_frontend")]
-            InnerWeakId::WaylandResource(obj) => InnerId::WaylandResource(obj.clone()),
-            InnerWeakId::External(weak) => InnerId::External(weak.upgrade()?),
-        }))
+        Some(Id {
+            inner: match &self.inner {
+                #[cfg(feature = "wayland_frontend")]
+                InnerWeakId::WaylandResource(obj) => InnerId::WaylandResource(obj.clone()),
+                InnerWeakId::External(weak) => InnerId::External(weak.upgrade()?),
+            },
+            namespace: self.namespace,
+        })
     }
 }
 
@@ -644,6 +694,117 @@ where
         cache: &UserDataMap,
     ) -> Result<(), <R>::Error> {
         (*self).capture_framebuffer(frame, src, dst, cache)
+    }
+}
+
+/// [`Element`] wrapper namespacing the [`Id`] of the internal element.
+///
+/// See [`Id::namespaced`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NamespacedElement<E: Element> {
+    inner: E,
+    namespace: Id,
+}
+
+impl<E: Element> NamespacedElement<E> {
+    /// Create a new `NamespacedElement` wrapping `elem` and using
+    /// `namespace` to namespace the elements id.
+    pub fn new(elem: E, namespace: usize) -> Self {
+        let namespace = elem.id().namespaced(namespace);
+        NamespacedElement {
+            inner: elem,
+            namespace,
+        }
+    }
+
+    /// Extract the inner element
+    pub fn into_inner(self) -> E {
+        self.inner
+    }
+}
+
+impl<E: Element> AsRef<E> for NamespacedElement<E> {
+    fn as_ref(&self) -> &E {
+        &self.inner
+    }
+}
+
+impl<E: Element> AsMut<E> for NamespacedElement<E> {
+    fn as_mut(&mut self) -> &mut E {
+        &mut self.inner
+    }
+}
+
+impl<E: Element> Element for NamespacedElement<E> {
+    fn id(&self) -> &Id {
+        &self.namespace
+    }
+
+    fn current_commit(&self) -> CommitCounter {
+        self.inner.current_commit()
+    }
+
+    fn src(&self) -> Rectangle<f64, BufferCoords> {
+        self.inner.src()
+    }
+
+    fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
+        self.inner.geometry(scale)
+    }
+
+    fn location(&self, scale: Scale<f64>) -> Point<i32, Physical> {
+        self.inner.location(scale)
+    }
+
+    fn transform(&self) -> Transform {
+        self.inner.transform()
+    }
+
+    fn damage_since(&self, scale: Scale<f64>, commit: Option<CommitCounter>) -> DamageSet<i32, Physical> {
+        self.inner.damage_since(scale, commit)
+    }
+
+    fn opaque_regions(&self, scale: Scale<f64>) -> OpaqueRegions<i32, Physical> {
+        self.inner.opaque_regions(scale)
+    }
+
+    fn alpha(&self) -> f32 {
+        self.inner.alpha()
+    }
+
+    fn kind(&self) -> Kind {
+        self.inner.kind()
+    }
+
+    fn is_framebuffer_effect(&self) -> bool {
+        self.inner.is_framebuffer_effect()
+    }
+}
+
+impl<R: Renderer, E: Element + RenderElement<R>> RenderElement<R> for NamespacedElement<E> {
+    fn draw(
+        &self,
+        frame: &mut <R>::Frame<'_, '_>,
+        src: Rectangle<f64, BufferCoords>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
+    ) -> Result<(), <R>::Error> {
+        self.inner.draw(frame, src, dst, damage, opaque_regions)
+    }
+
+    fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage<'_>> {
+        self.inner.underlying_storage(renderer)
+    }
+
+    fn capture_framebuffer(
+        &self,
+        frame: &mut <R>::Frame<'_, '_>,
+        src: Rectangle<f64, BufferCoords>,
+        dst: Rectangle<i32, Physical>,
+        cache: &UserDataMap,
+    ) -> Result<(), <R>::Error> {
+        self.inner.capture_framebuffer(frame, src, dst, cache)
     }
 }
 

--- a/src/backend/renderer/element/solid.rs
+++ b/src/backend/renderer/element/solid.rs
@@ -49,7 +49,7 @@ use crate::{
         utils::{CommitCounter, OpaqueRegions},
         Color32F, Frame, Renderer,
     },
-    utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
+    utils::{user_data::UserDataMap, Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
 };
 
 use super::{AsRenderElements, Element, Id, Kind, RenderElement};
@@ -226,6 +226,7 @@ impl<R: Renderer> RenderElement<R> for SolidColorRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         frame.draw_solid(dst, damage, self.color)
     }

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -133,7 +133,8 @@ impl KindEvaluation {
         KindEvaluation::Dynamic(func)
     }
 
-    fn eval(&self, data: &SurfaceData) -> Kind {
+    /// Evaluates the `Kind` for a given `SurfaceData` struct.
+    pub fn eval(&self, data: &SurfaceData) -> Kind {
         match self {
             KindEvaluation::Static(res) => *res,
             KindEvaluation::Dynamic(func) => func(data),

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -75,7 +75,10 @@ use crate::{
         },
         Color32F, Frame, ImportAll, Renderer, Texture,
     },
-    utils::{Buffer as BufferCoords, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
+    utils::{
+        user_data::UserDataMap, Buffer as BufferCoords, Logical, Physical, Point, Rectangle, Scale, Size,
+        Transform,
+    },
     wayland::{
         alpha_modifier::AlphaModifierSurfaceCachedState,
         compositor::{self, SurfaceData, TraversalAction},
@@ -448,6 +451,7 @@ where
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         match self.texture {
             WaylandSurfaceTexture::Texture(ref texture) => frame.render_texture_from_to(

--- a/src/backend/renderer/element/tests.rs
+++ b/src/backend/renderer/element/tests.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::{
     backend::renderer::{gles::GlesRenderer, ImportDma, ImportMem, Renderer, Texture},
-    utils::{Buffer, Physical, Point, Rectangle, Scale},
+    utils::{user_data::UserDataMap, Buffer, Physical, Point, Rectangle, Scale},
 };
 
 use super::{CommitCounter, Element, Id, RenderElement, Wrap};
@@ -150,6 +150,7 @@ where
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         todo!()
     }
@@ -188,6 +189,7 @@ where
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         todo!()
     }
@@ -235,6 +237,7 @@ where
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         todo!()
     }
@@ -281,6 +284,7 @@ where
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         todo!()
     }

--- a/src/backend/renderer/element/texture.rs
+++ b/src/backend/renderer/element/texture.rs
@@ -206,7 +206,10 @@ use crate::{
             ContextId, Frame, ImportMem, Renderer, Texture,
         },
     },
-    utils::{Buffer, Coordinate, Logical, Physical, Point, Rectangle, Scale, Size, Transform},
+    utils::{
+        user_data::UserDataMap, Buffer, Coordinate, Logical, Physical, Point, Rectangle, Scale, Size,
+        Transform,
+    },
 };
 
 use super::{CommitCounter, Element, Id, Kind, RenderElement};
@@ -693,6 +696,7 @@ where
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         if frame.context_id() != self.context_id {
             warn!("trying to render texture from different renderer context");

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -90,6 +90,10 @@ impl<E: Element> Element for RescaleRenderElement<E> {
     fn kind(&self) -> Kind {
         self.element.kind()
     }
+
+    fn is_framebuffer_effect(&self) -> bool {
+        self.element.is_framebuffer_effect()
+    }
 }
 
 impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RescaleRenderElement<E> {
@@ -107,6 +111,14 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RescaleRenderElement
     #[inline]
     fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage<'_>> {
         self.element.underlying_storage(renderer)
+    }
+
+    fn capture_framebuffer(
+        &self,
+        frame: &mut <R>::Frame<'_, '_>,
+        dst: Rectangle<i32, Physical>,
+    ) -> Result<(), <R>::Error> {
+        self.element.capture_framebuffer(frame, dst)
     }
 }
 
@@ -274,6 +286,10 @@ impl<E: Element> Element for CropRenderElement<E> {
     fn kind(&self) -> Kind {
         self.element.kind()
     }
+
+    fn is_framebuffer_effect(&self) -> bool {
+        self.element.is_framebuffer_effect()
+    }
 }
 
 impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for CropRenderElement<E> {
@@ -291,6 +307,14 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for CropRenderElement<E>
     #[inline]
     fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage<'_>> {
         self.element.underlying_storage(renderer)
+    }
+
+    fn capture_framebuffer(
+        &self,
+        frame: &mut <R>::Frame<'_, '_>,
+        dst: Rectangle<i32, Physical>,
+    ) -> Result<(), <R>::Error> {
+        self.element.capture_framebuffer(frame, dst)
     }
 }
 
@@ -376,6 +400,10 @@ impl<E: Element> Element for RelocateRenderElement<E> {
     fn kind(&self) -> Kind {
         self.element.kind()
     }
+
+    fn is_framebuffer_effect(&self) -> bool {
+        self.element.is_framebuffer_effect()
+    }
 }
 
 impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RelocateRenderElement<E> {
@@ -393,6 +421,14 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RelocateRenderElemen
     #[inline]
     fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage<'_>> {
         self.element.underlying_storage(renderer)
+    }
+
+    fn capture_framebuffer(
+        &self,
+        frame: &mut <R>::Frame<'_, '_>,
+        dst: Rectangle<i32, Physical>,
+    ) -> Result<(), <R>::Error> {
+        self.element.capture_framebuffer(frame, dst)
     }
 }
 

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -116,9 +116,10 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RescaleRenderElement
     fn capture_framebuffer(
         &self,
         frame: &mut <R>::Frame<'_, '_>,
-        dst: Rectangle<i32, Physical>,
+        src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
+        dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
     ) -> Result<(), <R>::Error> {
-        self.element.capture_framebuffer(frame, dst)
+        self.element.capture_framebuffer(frame, src, dst)
     }
 }
 
@@ -312,9 +313,10 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for CropRenderElement<E>
     fn capture_framebuffer(
         &self,
         frame: &mut <R>::Frame<'_, '_>,
+        src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
     ) -> Result<(), <R>::Error> {
-        self.element.capture_framebuffer(frame, dst)
+        self.element.capture_framebuffer(frame, src, dst)
     }
 }
 
@@ -426,9 +428,10 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RelocateRenderElemen
     fn capture_framebuffer(
         &self,
         frame: &mut <R>::Frame<'_, '_>,
+        src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
     ) -> Result<(), <R>::Error> {
-        self.element.capture_framebuffer(frame, dst)
+        self.element.capture_framebuffer(frame, src, dst)
     }
 }
 

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -6,7 +6,7 @@ use crate::{
         utils::{DamageSet, OpaqueRegions},
         Renderer,
     },
-    utils::{Buffer, Physical, Point, Rectangle, Scale},
+    utils::{user_data::UserDataMap, Buffer, Physical, Point, Rectangle, Scale},
 };
 
 /// A element that allows to re-scale another element
@@ -41,14 +41,11 @@ impl<E: Element> Element for RescaleRenderElement<E> {
         self.element.current_commit()
     }
 
-    fn src(&self) -> crate::utils::Rectangle<f64, crate::utils::Buffer> {
+    fn src(&self) -> Rectangle<f64, Buffer> {
         self.element.src()
     }
 
-    fn geometry(
-        &self,
-        scale: crate::utils::Scale<f64>,
-    ) -> crate::utils::Rectangle<i32, crate::utils::Physical> {
+    fn geometry(&self, scale: crate::utils::Scale<f64>) -> Rectangle<i32, Physical> {
         let mut element_geometry = self.element.geometry(scale);
         // First we make the element relative to the origin
         element_geometry.loc -= self.origin;
@@ -100,10 +97,10 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RescaleRenderElement
     fn draw(
         &self,
         frame: &mut R::Frame<'_, '_>,
-        src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
-        dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
-        damage: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
-        opaque_regions: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), R::Error> {
         self.element.draw(frame, src, dst, damage, opaque_regions)
     }
@@ -116,10 +113,11 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RescaleRenderElement
     fn capture_framebuffer(
         &self,
         frame: &mut <R>::Frame<'_, '_>,
-        src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
-        dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        cache: &UserDataMap,
     ) -> Result<(), <R>::Error> {
-        self.element.capture_framebuffer(frame, src, dst)
+        self.element.capture_framebuffer(frame, src, dst, cache)
     }
 }
 
@@ -220,11 +218,11 @@ impl<E: Element> Element for CropRenderElement<E> {
         self.element.current_commit()
     }
 
-    fn src(&self) -> crate::utils::Rectangle<f64, crate::utils::Buffer> {
+    fn src(&self) -> Rectangle<f64, Buffer> {
         self.src
     }
 
-    fn geometry(&self, scale: Scale<f64>) -> crate::utils::Rectangle<i32, Physical> {
+    fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
         let element_geometry = self.element.geometry(scale);
         if let Some(intersection) = element_geometry.intersection(self.crop_rect) {
             // FIXME: intersection sometimes return a 0 size element
@@ -297,10 +295,10 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for CropRenderElement<E>
     fn draw(
         &self,
         frame: &mut R::Frame<'_, '_>,
-        src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
-        dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
-        damage: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
-        opaque_regions: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), R::Error> {
         self.element.draw(frame, src, dst, damage, opaque_regions)
     }
@@ -315,8 +313,9 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for CropRenderElement<E>
         frame: &mut <R>::Frame<'_, '_>,
         src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
+        cache: &UserDataMap,
     ) -> Result<(), <R>::Error> {
-        self.element.capture_framebuffer(frame, src, dst)
+        self.element.capture_framebuffer(frame, src, dst, cache)
     }
 }
 
@@ -412,10 +411,10 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RelocateRenderElemen
     fn draw(
         &self,
         frame: &mut R::Frame<'_, '_>,
-        src: crate::utils::Rectangle<f64, crate::utils::Buffer>,
-        dst: crate::utils::Rectangle<i32, crate::utils::Physical>,
-        damage: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
-        opaque_regions: &[crate::utils::Rectangle<i32, crate::utils::Physical>],
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), R::Error> {
         self.element.draw(frame, src, dst, damage, opaque_regions)
     }
@@ -430,8 +429,9 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RelocateRenderElemen
         frame: &mut <R>::Frame<'_, '_>,
         src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
+        cache: &UserDataMap,
     ) -> Result<(), <R>::Error> {
-        self.element.capture_framebuffer(frame, src, dst)
+        self.element.capture_framebuffer(frame, src, dst, cache)
     }
 }
 

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -101,8 +101,9 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RescaleRenderElement
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
-        self.element.draw(frame, src, dst, damage, opaque_regions)
+        self.element.draw(frame, src, dst, damage, opaque_regions, cache)
     }
 
     #[inline]
@@ -299,8 +300,9 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for CropRenderElement<E>
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
-        self.element.draw(frame, src, dst, damage, opaque_regions)
+        self.element.draw(frame, src, dst, damage, opaque_regions, cache)
     }
 
     #[inline]
@@ -415,8 +417,9 @@ impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for RelocateRenderElemen
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
-        self.element.draw(frame, src, dst, damage, opaque_regions)
+        self.element.draw(frame, src, dst, damage, opaque_regions, cache)
     }
 
     #[inline]

--- a/src/backend/renderer/gles/element.rs
+++ b/src/backend/renderer/gles/element.rs
@@ -5,7 +5,7 @@ use crate::{
         element::{texture::TextureRenderElement, Element, Id, Kind, RenderElement, UnderlyingStorage},
         utils::{CommitCounter, DamageSet, OpaqueRegions},
     },
-    utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Transform},
+    utils::{user_data::UserDataMap, Buffer, Logical, Physical, Point, Rectangle, Scale, Transform},
 };
 
 use super::{GlesError, GlesFrame, GlesPixelProgram, GlesRenderer, GlesTexProgram, GlesTexture, Uniform};
@@ -112,6 +112,7 @@ impl RenderElement<GlesRenderer> for PixelShaderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         frame.render_pixel_shader_to(
             &self.shader,
@@ -209,6 +210,7 @@ impl RenderElement<GlesRenderer> for TextureShaderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         frame.render_texture_from_to(
             &self.inner.texture,

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -2458,6 +2458,10 @@ impl Frame for GlesFrame<'_, '_> {
         self.transform
     }
 
+    fn output_size(&self) -> Size<i32, Physical> {
+        self.size
+    }
+
     #[profiling::function]
     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> {
         self.renderer.wait(sync)

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -20,7 +20,7 @@ use crate::{
             Renderer, RendererSuper, TextureFilter,
         },
     },
-    utils::{Buffer as BufferCoord, Physical, Rectangle, Size, Transform},
+    utils::{user_data::UserDataMap, Buffer as BufferCoord, Physical, Rectangle, Size, Transform},
 };
 
 #[cfg(feature = "wayland_frontend")]
@@ -632,8 +632,9 @@ impl RenderElement<GlowRenderer> for PixelShaderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
-        RenderElement::<GlesRenderer>::draw(self, frame.borrow_mut(), src, dst, damage, opaque_regions)
+        RenderElement::<GlesRenderer>::draw(self, frame.borrow_mut(), src, dst, damage, opaque_regions, cache)
     }
 
     fn underlying_storage(&self, renderer: &mut GlowRenderer) -> Option<UnderlyingStorage<'_>> {
@@ -650,8 +651,9 @@ impl RenderElement<GlowRenderer> for TextureShaderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
-        RenderElement::<GlesRenderer>::draw(self, frame.borrow_mut(), src, dst, damage, opaque_regions)
+        RenderElement::<GlesRenderer>::draw(self, frame.borrow_mut(), src, dst, damage, opaque_regions, cache)
     }
 
     fn underlying_storage(&self, renderer: &mut GlowRenderer) -> Option<UnderlyingStorage<'_>> {

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -331,6 +331,9 @@ impl Frame for GlowFrame<'_, '_> {
     fn transformation(&self) -> Transform {
         self.frame.as_ref().unwrap().transformation()
     }
+    fn output_size(&self) -> Size<i32, Physical> {
+        self.frame.as_ref().unwrap().output_size()
+    }
 
     #[profiling::function]
     fn render_texture_at(

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -343,6 +343,9 @@ pub trait Frame {
     /// Output transformation that is applied to this frame
     fn transformation(&self) -> Transform;
 
+    /// Output size this frame was initialized for.
+    fn output_size(&self) -> Size<i32, Physical>;
+
     /// Wait for a [`SyncPoint`] to be signaled
     fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error>;
 

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1990,6 +1990,9 @@ where
     fn transformation(&self) -> Transform {
         self.frame.as_ref().unwrap().transformation()
     }
+    fn output_size(&self) -> Size<i32, Physical> {
+        self.frame.as_ref().unwrap().output_size()
+    }
 
     #[profiling::function]
     fn wait(&mut self, sync: &sync::SyncPoint) -> Result<(), Self::Error> {

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -649,6 +649,10 @@ impl Frame for PixmanFrame<'_, '_> {
         self.transform
     }
 
+    fn output_size(&self) -> Size<i32, Physical> {
+        self.output_size
+    }
+
     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> {
         sync.wait().map_err(|_| PixmanError::SyncInterrupted)
     }

--- a/src/backend/renderer/test.rs
+++ b/src/backend/renderer/test.rs
@@ -268,6 +268,9 @@ impl Frame for DummyFrame {
     fn transformation(&self) -> Transform {
         Transform::Normal
     }
+    fn output_size(&self) -> Size<i32, Physical> {
+        Size::default()
+    }
 
     fn wait(&mut self, sync: &SyncPoint) -> Result<(), Self::Error> {
         sync.wait().map_err(|_| DummyError::SyncInterrupted)

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -677,7 +677,7 @@ where
             continue;
         }
 
-        element.draw(frame, element.src(), element_geometry, &element_damage, &[])?;
+        element.draw(frame, element.src(), element_geometry, &element_damage, &[], None)?;
     }
 
     Ok(Some(render_damage))

--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -3,7 +3,7 @@
 use crate::{
     backend::renderer::{
         element::{
-            PrimaryScanoutOutput, RenderElementPresentationState, RenderElementState, RenderElementStates,
+            Id, PrimaryScanoutOutput, RenderElementPresentationState, RenderElementState, RenderElementStates,
         },
         utils::{RendererSurfaceState, RendererSurfaceStateUserData},
     },
@@ -186,6 +186,7 @@ pub fn update_surface_primary_scanout_output<F>(
     surface: &wl_surface::WlSurface,
     output: &Output,
     surface_data: &SurfaceData,
+    namespace: Option<usize>,
     states: &RenderElementStates,
     compare: F,
 ) -> Option<Output>
@@ -202,7 +203,7 @@ where
     surface_primary_scanout_output
         .lock()
         .unwrap()
-        .update_from_render_element_states(surface, output, states, compare)
+        .update_from_render_element_states(surface, output, namespace, states, compare)
 }
 
 /// Sends frame callbacks for a surface and its subsurfaces with the given `time`.
@@ -466,10 +467,15 @@ pub fn take_presentation_feedback_surface_tree<F1, F2>(
 /// in the provided [`RenderElementStates`]
 pub fn surface_presentation_feedback_flags_from_states(
     surface: &wl_surface::WlSurface,
+    namespace: Option<usize>,
     states: &RenderElementStates,
 ) -> wp_presentation_feedback::Kind {
     let zero_copy = states
-        .element_render_state(surface)
+        .element_render_state(
+            namespace
+                .map(|val| Id::from(surface).namespaced(val))
+                .unwrap_or(surface.into()),
+        )
         .map(|state| state.presentation_state == RenderElementPresentationState::ZeroCopy)
         .unwrap_or(false);
 


### PR DESCRIPTION
This is an attempt add changing `Element`/`RenderElement` alongside the damage algorithms to better support effects on the underlying framebuffer, more specifically blurring the background. But similar effects are imaginable and this tries to be generic towards whatever future versions of `ext-background-effects-v1` might allow.

An implementation of a `BlurElement`, that makes use of this code, can be found here: https://github.com/pop-os/cosmic-comp/blob/frosted-glass_noble/src/backend/render/blur.rs#L206

To facilitate this, we need two things:
- We need to inform the element, when it's underlying framebuffer is dirty, so that it can re-capture the framebuffer and doesn't have to do that on every draw-call as these effects can be quite costly.
  - Most importantly we don't want to update the effect, if the surface on top of it updates or the a cursor passes over. (Assuming the element caches it's results, which makes sense for blurring but might not for others, which likely can be trivially implemented today.)
- We need to make sure to damage the whole element, whenever we want to allow the element to capture the framebuffer, so that everything below it is re-draw on that same cycle.

Facilitating the latter is easy. `Element` gets a new `is_framebuffer_effect` method. We use that for both "damaging the whole element" and figuring out, if we need the more expensive logic in the first place.

For the former, I introduced a `damage_index` to our `OutputDamageTracker` per element. Since we iterate through the elements top-to-bottom, we can record the index of all damage collected so far when we hit a new element to have a clean cut-off of damage above and below our element. We can then use that later to figure out, if any damage below the object occurred, which prompts `capture` to be called.