### PR TITLE
Add set_default_mode() to KdeDecorationState

### DIFF
--- a/src/wayland/shell/kde/decoration.rs
+++ b/src/wayland/shell/kde/decoration.rs
@@ -130,6 +130,14 @@ impl KdeDecorationState {
     pub fn global(&self) -> GlobalId {
         self.kde_decoration_manager.clone()
     }
+
+    /// Updates the default decoration mode.
+    ///
+    /// The new default mode will only be sent to new binds to the manager object; it is up to you
+    /// to update any existing decoration instances with the new mode, if desired.
+    pub fn set_default_mode(&mut self, default_mode: DefaultMode) {
+        self.default_mode = default_mode;
+    }
 }
 
 #[allow(missing_docs)] // TODO


### PR DESCRIPTION
The docs for the default_mode event says, "The server may change the default mode at any time."  We (Xfce) allow the user to change the default decoration mode at runtime, and would like further binds to the manager object to reflect those changes.