### PR TITLE
compositor: prevent adding hooks and blockers on destroyed surfaces

### DIFF
--- a/anvil/src/shell/mod.rs
+++ b/anvil/src/shell/mod.rs
@@ -115,7 +115,7 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
     }
 
     fn new_surface(&mut self, surface: &WlSurface) {
-        add_pre_commit_hook::<Self, _>(surface, move |state, _dh, surface| {
+        let _ = add_pre_commit_hook::<Self, _>(surface, move |state, _dh, surface| {
             #[cfg(feature = "udev")]
             let mut acquire_point = None;
             let maybe_dmabuf = with_states(surface, |surface_data| {
@@ -149,7 +149,7 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
                             Ok(())
                         });
                         if res.is_ok() {
-                            add_blocker(surface, blocker);
+                            let _ = add_blocker(surface, blocker);
                             return;
                         }
                     }
@@ -162,7 +162,7 @@ impl<BackendData: Backend> CompositorHandler for AnvilState<BackendData> {
                             Ok(())
                         });
                         if res.is_ok() {
-                            add_blocker(surface, blocker);
+                            let _ = add_blocker(surface, blocker);
                         }
                     }
                 }

--- a/anvil/src/shell/xdg.rs
+++ b/anvil/src/shell/xdg.rs
@@ -50,7 +50,8 @@ impl<BackendData: Backend> XdgShellHandler for AnvilState<BackendData> {
         let window = WindowElement(Window::new_wayland_window(surface.clone()));
         place_new_window(&mut self.space, self.pointer.current_location(), &window, true);
 
-        compositor::add_post_commit_hook(surface.wl_surface(), |state: &mut Self, _, surface| {
+        // FIXME: On role re-usage this might be problematic
+        let _ = compositor::add_post_commit_hook(surface.wl_surface(), |state: &mut Self, _, surface| {
             handle_toplevel_commit(&mut state.space, surface);
         });
     }

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -391,7 +391,7 @@ pub fn on_commit_buffer_handler<D: 'static>(surface: &WlSurface) {
             |_, _, _| true,
         );
         for surf in &new_surfaces {
-            add_destruction_hook(surf, |_: &mut D, surface| {
+            let _ = add_destruction_hook(surf, |_: &mut D, surface| {
                 // We reset the state on destruction before the user_data is dropped
                 // to prevent a deadlock which can happen if we try to send a buffer
                 // release during drop. This also enables us to free resources earlier

--- a/src/wayland/commit_timing/mod.rs
+++ b/src/wayland/commit_timing/mod.rs
@@ -210,7 +210,7 @@ where
 
                 // Make sure we do not install the hook more then once in case the surface is being reused
                 if is_managed && is_initial {
-                    add_pre_commit_hook::<D, _>(&surface, |_, _, surface| {
+                    let _ = add_pre_commit_hook::<D, _>(&surface, |_, _, surface| {
                         let timestamp = with_states(surface, |states| {
                             states
                                 .data_map
@@ -226,7 +226,7 @@ where
                                 barrier_state.lock().unwrap().register(timestamp)
                             });
 
-                            add_blocker(surface, barrier);
+                            let _ = add_blocker(surface, barrier);
                         }
                     });
                 }

--- a/src/wayland/drm_syncobj/mod.rs
+++ b/src/wayland/drm_syncobj/mod.rs
@@ -308,9 +308,15 @@ where
                     );
                     return;
                 }
-                let commit_hook_id = compositor::add_pre_commit_hook::<D, _>(&surface, commit_hook);
-                let destruction_hook_id =
-                    compositor::add_destruction_hook::<D, _>(&surface, destruction_hook);
+                let Ok(commit_hook_id) = compositor::add_pre_commit_hook::<D, _>(&surface, commit_hook)
+                else {
+                    return;
+                };
+                let Ok(destruction_hook_id) =
+                    compositor::add_destruction_hook::<D, _>(&surface, destruction_hook)
+                else {
+                    return;
+                };
                 let syncobj_surface = data_init.init::<_, _>(
                     id,
                     DrmSyncobjSurfaceData {

--- a/src/wayland/fifo/mod.rs
+++ b/src/wayland/fifo/mod.rs
@@ -206,7 +206,7 @@ where
 
                 // Make sure we do not install the hook more then once in case the surface is being reused
                 if is_managed && is_initial {
-                    add_pre_commit_hook::<D, _>(&surface, |_, _, surface| {
+                    let _ = add_pre_commit_hook::<D, _>(&surface, |_, _, surface| {
                         let fifo_barrier = with_states(surface, |states| {
                             let fifo_state = *states.cached_state.get::<FifoCachedState>().pending();
 
@@ -253,7 +253,7 @@ where
                             // sync subsurfaces
                             let skip = barrier.is_signaled() || is_sync_subsurface(surface);
                             if !skip {
-                                add_blocker(surface, barrier);
+                                let _ = add_blocker(surface, barrier);
                             }
                         }
                     });

--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -340,7 +340,7 @@ fn add_constraint<D: SeatHandler + PointerConstraintsHandler + 'static>(
     });
 
     if added {
-        compositor::add_post_commit_hook(surface, commit_hook::<D>);
+        let _ = compositor::add_post_commit_hook(surface, commit_hook::<D>);
     }
 }
 

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -122,7 +122,7 @@ where
                 });
 
                 if initial {
-                    compositor::add_pre_commit_hook::<D, _>(
+                    let _ = compositor::add_pre_commit_hook::<D, _>(
                         &wl_surface,
                         super::LayerSurface::pre_commit_hook,
                     );

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -124,7 +124,7 @@ where
                 });
 
                 if initial {
-                    compositor::add_pre_commit_hook::<D, _>(
+                    let _ = compositor::add_pre_commit_hook::<D, _>(
                         surface,
                         super::super::ToplevelSurface::pre_commit_hook,
                     );
@@ -202,7 +202,7 @@ where
                 });
 
                 if initial {
-                    compositor::add_pre_commit_hook::<D, _>(
+                    let _ = compositor::add_pre_commit_hook::<D, _>(
                         surface,
                         super::super::PopupSurface::pre_commit_hook,
                     );

--- a/src/wayland/viewporter/mod.rs
+++ b/src/wayland/viewporter/mod.rs
@@ -177,7 +177,7 @@ where
 
                 // only add the pre-commit hook once for the surface
                 if initial {
-                    compositor::add_pre_commit_hook::<D, _>(&surface, viewport_pre_commit_hook);
+                    let _ = compositor::add_pre_commit_hook::<D, _>(&surface, viewport_pre_commit_hook);
                 }
             }
             wp_viewporter::Request::Destroy => {

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -264,7 +264,9 @@ where
                     return;
                 }
 
-                compositor::add_pre_commit_hook::<D, _>(&surface, serial_commit_hook);
+                // TODO: Can the xwayland shell role be re-used? In this case we should guard the pre-commit hook
+                // to avoid duplicates.
+                let _ = compositor::add_pre_commit_hook::<D, _>(&surface, serial_commit_hook);
 
                 data_init.init(id, XWaylandSurfaceUserData { wl_surface: surface });
                 // We call the handler callback once the serial is set.


### PR DESCRIPTION
technically it shouldn't be an issue to add those to destroyed surfaces, but preventing it might make
catching logic issues easier.

might fix #1562 (at least it looks like to be the case for niri when I tested it)