### PR TITLE
wayland: document destruction order

### DIFF
--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -599,6 +599,10 @@ pub trait CompositorHandler {
     /// The surface was destroyed.
     ///
     /// This allows the compositor to clean up any uses of the surface.
+    ///
+    /// Note: Destruction might happen explicitly by the client, or implicitly
+    /// when the client quits. In case of implicit destruction the order the
+    /// callbacks are called in is undefined.
     fn destroyed(&mut self, _surface: &WlSurface) {}
 }
 

--- a/src/wayland/drm_lease/mod.rs
+++ b/src/wayland/drm_lease/mod.rs
@@ -325,6 +325,10 @@ pub trait DrmLeaseHandler:
     /// A new DRM lease is active. Dropping the provided [`DrmLease`] will revoke the lease.
     fn new_active_lease(&mut self, node: DrmNode, lease: DrmLease);
     /// A DRM lease was destroyed, the previously given [`DrmLease`] should be cleaned up, if not revoked already.
+    ///
+    /// Note: Destruction might happen explicitly by the client, or implicitly
+    /// when the client quits. In case of implicit destruction the order the
+    /// callbacks are called in is undefined.
     fn lease_destroyed(&mut self, node: DrmNode, lease_id: u32);
 }
 

--- a/src/wayland/image_capture_source/mod.rs
+++ b/src/wayland/image_capture_source/mod.rs
@@ -304,9 +304,13 @@ impl ImageCaptureSourceState {
 pub trait ImageCaptureSourceHandler:
     Dispatch<ExtImageCaptureSourceV1, ImageCaptureSourceData> + 'static
 {
-    /// Called when a capture source is destroyed by the client.
+    /// Called when a capture source is destroyed.
     ///
     /// Use this to clean up any compositor-side state associated with the source.
+    ///
+    /// Note: Destruction might happen explicitly by the client, or implicitly
+    /// when the client quits. In case of implicit destruction the order the
+    /// callbacks are called in is undefined.
     fn source_destroyed(&mut self, source: ImageCaptureSource) {
         let _ = source;
     }

--- a/src/wayland/image_copy_capture/mod.rs
+++ b/src/wayland/image_copy_capture/mod.rs
@@ -796,17 +796,29 @@ pub trait ImageCopyCaptureHandler:
         frame.fail(FailureReason::Unknown);
     }
 
-    /// Called when a frame is aborted (e.g., buffer destroyed before capture).
+    /// Called when a frame is aborted (e.g., buffer destroyed before capture)
+    /// or the client disconnects.
+    ///
+    /// Note: In case of implicit destruction the order is undefined and might
+    /// not follow explicit protocol definitions.
     fn frame_aborted(&mut self, frame: FrameRef) {
         let _ = frame;
     }
 
-    /// Called when a session is destroyed by the client.
+    /// Called when a session is destroyed.
+    ///
+    /// Note: Destruction might happen explicitly by the client, or implicitly
+    /// when the client quits. In case of implicit destruction the order the
+    /// callbacks are called in is undefined.
     fn session_destroyed(&mut self, session: SessionRef) {
         let _ = session;
     }
 
-    /// Called when a cursor session is destroyed by the client.
+    /// Called when a cursor session is destroyed.
+    ///
+    /// Note: Destruction might happen explicitly by the client, or implicitly
+    /// when the client quits. In case of implicit destruction the order the
+    /// callbacks are called in is undefined.
     fn cursor_session_destroyed(&mut self, session: CursorSessionRef) {
         let _ = session;
     }

--- a/src/wayland/shell/wlr_layer/handlers.rs
+++ b/src/wayland/shell/wlr_layer/handlers.rs
@@ -327,6 +327,9 @@ where
 
                 WlrLayerShellHandler::ack_configure(state, surface, configure);
             }
+            zwlr_layer_surface_v1::Request::Destroy => {
+                // Handled by destroyed handler
+            }
             _ => {}
         }
     }

--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -279,6 +279,10 @@ pub trait WlrLayerShellHandler {
     fn ack_configure(&mut self, surface: wl_surface::WlSurface, configure: LayerSurfaceConfigure) {}
 
     /// A layer surface was destroyed.
+    ///
+    /// Note: Destruction might happen explicitly by the client, or implicitly
+    /// when the client quits. In case of implicit destruction the order the
+    /// callbacks are called in is undefined.
     fn layer_destroyed(&mut self, surface: LayerSurface) {}
 }
 

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -1171,12 +1171,24 @@ pub trait XdgShellHandler {
     fn reposition_request(&mut self, surface: PopupSurface, positioner: PositionerState, token: u32);
 
     /// A shell client was destroyed.
+    ///
+    /// Note: Destruction might happen explicitly by the client, or implicitly
+    /// when the client quits. In case of implicit destruction the order the
+    /// callbacks are called in is undefined.
     fn client_destroyed(&mut self, client: ShellClient) {}
 
     /// A toplevel surface was destroyed.
+    ///
+    /// Note: Destruction might happen explicitly by the client, or implicitly
+    /// when the client quits. In case of implicit destruction the order the
+    /// callbacks are called in is undefined.
     fn toplevel_destroyed(&mut self, surface: ToplevelSurface) {}
 
     /// A popup surface was destroyed.
+    ///
+    /// Note: Destruction might happen explicitly by the client, or implicitly
+    /// when the client quits. In case of implicit destruction the order the
+    /// callbacks are called in is undefined.
     fn popup_destroyed(&mut self, surface: PopupSurface) {}
 
     /// The toplevel surface set a different app id.


### PR DESCRIPTION
when a client exits without properly destroying
resources the destroy callbacks will run in
undefined order.
this can happen in case the client does not wait
for resource destruction, exits without explicitly destroying resources or is disconnected by a
protocol error

for example see: https://gitlab.freedesktop.org/wayland/wayland/-/blob/e12bbe496941e546165055f9520745b7ba4366ce/src/wayland-server.c#L310