### PR TITLE
fix: release buffer reference after image copy capture completes

### DIFF
--- a/src/wayland/image_copy_capture/mod.rs
+++ b/src/wayland/image_copy_capture/mod.rs
@@ -610,6 +610,7 @@ impl FrameInner {
             return;
         }
         self.failed = Some(reason);
+        self.buffer.take();
         if self.capture_requested {
             frame.failed(reason);
         }
@@ -714,7 +715,11 @@ impl Frame {
         let tv_nsec = time.subsec_nanos();
         self.0.obj.presentation_time(tv_sec_hi, tv_sec_lo, tv_nsec);
 
-        self.0.inner.lock().unwrap().ready = true;
+        {
+            let mut inner = self.0.inner.lock().unwrap();
+            inner.ready = true;
+            inner.buffer.take();
+        }
         self.0.obj.ready();
 
         // Prevent drop from sending fail


### PR DESCRIPTION
`FrameInner` retains a reference to the client's `WlBuffer` after `Frame::success()` and `Frame::fail()` complete. 

Over time, with clients that rapidly create and destroy capture sessions, this causes thousands of leaked memfd file descriptors and tens of gigabytes of unreclaimable shared memory.

**Reproduction**
From https://github.com/pop-os/cosmic-comp/issues/2073:

```bash
$ ls -la /proc/$(pgrep cosmic-comp)/fd/ | grep 'memfd.*deleted' | wc -l
7809

$ cat /proc/$(pgrep cosmic-comp)/smaps_rollup | grep Pss_Shmem
Pss_Shmem: 16882370 kB    # 16.1 GB
```

After the fix: memfd count drops to 0.