### PR TITLE
Clean up selection devices in `destroyed()` callback

### DIFF
--- a/src/wayland/selection/data_device/device.rs
+++ b/src/wayland/selection/data_device/device.rs
@@ -196,4 +196,20 @@ where
             _ => unreachable!(),
         }
     }
+
+    fn destroyed(
+        _state: &mut D,
+        _client: wayland_server::backend::ClientId,
+        resource: &WlDataDevice,
+        data: &DataDeviceUserData,
+    ) {
+        if let Some(seat) = Seat::<D>::from_resource(&data.wl_seat) {
+            if let Some(seat_data) = seat.user_data().get::<RefCell<SeatData<D::SelectionUserData>>>() {
+                seat_data.borrow_mut().retain_devices(|ndd| match ndd {
+                    SelectionDevice::DataDevice(ndd) => ndd != resource,
+                    _ => true,
+                });
+            }
+        }
+    }
 }

--- a/src/wayland/selection/ext_data_control/device.rs
+++ b/src/wayland/selection/ext_data_control/device.rs
@@ -130,4 +130,20 @@ where
             _ => unreachable!(),
         }
     }
+
+    fn destroyed(
+        _state: &mut D,
+        _client: wayland_server::backend::ClientId,
+        resource: &ExtDataControlDeviceV1,
+        data: &ExtDataControlDeviceUserData,
+    ) {
+        if let Some(seat) = Seat::<D>::from_resource(&data.wl_seat) {
+            if let Some(seat_data) = seat.user_data().get::<RefCell<SeatData<D::SelectionUserData>>>() {
+                seat_data.borrow_mut().retain_devices(|ndd| match ndd {
+                    SelectionDevice::ExtDataControl(ndd) => ndd != resource,
+                    _ => true,
+                });
+            }
+        }
+    }
 }

--- a/src/wayland/selection/primary_selection/device.rs
+++ b/src/wayland/selection/primary_selection/device.rs
@@ -101,4 +101,20 @@ where
             _ => unreachable!(),
         }
     }
+
+    fn destroyed(
+        _state: &mut D,
+        _client: wayland_server::backend::ClientId,
+        resource: &PrimaryDevice,
+        data: &PrimaryDeviceUserData,
+    ) {
+        if let Some(seat) = Seat::<D>::from_resource(&data.wl_seat) {
+            if let Some(seat_data) = seat.user_data().get::<RefCell<SeatData<D::SelectionUserData>>>() {
+                seat_data.borrow_mut().retain_devices(|ndd| match ndd {
+                    SelectionDevice::Primary(ndd) => ndd != resource,
+                    _ => true,
+                });
+            }
+        }
+    }
 }

--- a/src/wayland/selection/wlr_data_control/device.rs
+++ b/src/wayland/selection/wlr_data_control/device.rs
@@ -130,4 +130,20 @@ where
             _ => unreachable!(),
         }
     }
+
+    fn destroyed(
+        _state: &mut D,
+        _client: wayland_server::backend::ClientId,
+        resource: &ZwlrDataControlDeviceV1,
+        data: &DataControlDeviceUserData,
+    ) {
+        if let Some(seat) = Seat::<D>::from_resource(&data.wl_seat) {
+            if let Some(seat_data) = seat.user_data().get::<RefCell<SeatData<D::SelectionUserData>>>() {
+                seat_data.borrow_mut().retain_devices(|ndd| match ndd {
+                    SelectionDevice::WlrDataControl(ndd) => ndd != resource,
+                    _ => true,
+                });
+            }
+        }
+    }
 }


### PR DESCRIPTION
Ive been troubleshooting an [issue with lag in niri](https://github.com/niri-wm/niri/issues/2430#issuecomment-3919569581) when selecting text in the browser. it is noticable after hours/days and becomes progessively worse. I believe i traced it down to smithay not cleaning up devices of clients that do not call Release before exiting. in one of my cases smithay seemed to iterate over ~700k dead devices causing very noticable lag.

i added some debug statements and vibe-coded a 'test_polite_destroy' client to demonstrate the 'impolite' devices (wl-copy) not decrementing:
<img width="2011" height="841" alt="image" src="https://github.com/user-attachments/assets/27db38ad-155a-463e-9c22-ffdf80871874" />
(device 1&2 appear on init and devices 3-6 seem to belong to kitty-terminal)

then i implemented the destroyed() methods of all devices and repeated the test:
<img width="2011" height="841" alt="image" src="https://github.com/user-attachments/assets/e655f5b5-cbf8-4cbc-b63a-66fd8bea6f0e" />
(note that retain_devices is called twice, since for polite clients both release and destroyed are invoked. maybe only imlementing cleanup in destroyed would suffice?)

note that im new to rust and this project. im intentionally creating this PR early, i will be testing some more. any feedback is welcome.