### PR TITLE
OpenBSD: Fix remaining build issues

### DIFF
--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -145,7 +145,7 @@ pub mod egl {
     use std::sync::{LazyLock, Once};
 
     pub static LIB: LazyLock<Library> =
-        LazyLock::new(|| unsafe { Library::new("libEGL.so.1") }.expect("Failed to load LibEGL"));
+        LazyLock::new(|| unsafe { Library::new("libEGL.so") }.expect("Failed to load LibEGL"));
 
     pub static LOAD: Once = Once::new();
     pub static DEBUG: Once = Once::new();

--- a/src/wayland/drm_syncobj/mod.rs
+++ b/src/wayland/drm_syncobj/mod.rs
@@ -66,6 +66,7 @@ pub use sync_point::*;
 
 /// Test if DRM device supports `syncobj_eventfd`.
 // Similar to test used in Mutter
+#[cfg(not(target_os = "openbsd"))]
 pub fn supports_syncobj_eventfd(device: &DrmDeviceFd) -> bool {
     // Pass device as placeholder for eventfd as well, since `drm_ffi` requires
     // a valid fd.
@@ -73,6 +74,11 @@ pub fn supports_syncobj_eventfd(device: &DrmDeviceFd) -> bool {
         Ok(_) => unreachable!(),
         Err(err) => err.kind() == std::io::ErrorKind::NotFound,
     }
+}
+
+#[cfg(target_os = "openbsd")]
+pub fn supports_syncobj_eventfd(device: &DrmDeviceFd) -> bool {
+    false
 }
 
 /// Handler trait for DRM syncobj protocol.

--- a/src/wayland/drm_syncobj/sync_point.rs
+++ b/src/wayland/drm_syncobj/sync_point.rs
@@ -114,6 +114,7 @@ pub struct DrmSyncPoint {
 
 impl DrmSyncPoint {
     /// Create an eventfd that will be signaled by the syncpoint
+    #[cfg(not(target_os = "openbsd"))]
     pub fn eventfd(&self) -> io::Result<Arc<OwnedFd>> {
         let fd = rustix::event::eventfd(
             0,
@@ -129,6 +130,11 @@ impl DrmSyncPoint {
         ctx.event_fds.retain(|(_, fd)| fd.upgrade().is_some());
         ctx.event_fds.push((self.point, Arc::downgrade(&fd)));
         Ok(fd)
+    }
+
+    #[cfg(target_os = "openbsd")]
+    pub fn eventfd(&self) -> io::Result<Arc<OwnedFd>> {
+        Err(io::Error::other("oh no!"))
     }
 
     /// Signal the sync point.


### PR DESCRIPTION
There are two remaining issues which I currently carry out of tree patches for to build on OpenBSD.

# OpenBSD doesn't support eventfd

 Since eventfd is entirely optional and smithay already has a supports_syncobj_eventfd runtime switch it is easy enough to conditionally disable.
Currently I use `#[cfg(not(target_os = "openbsd"))]` but maybe this would better be a feature?

# libEGL loading is too strict

The libEGL backend hardcodes a libEGL.so.1 library name which doesn't work on OpenBSD where the current base libEGL is `/usr/X11R6/lib/libEGL.so.2.0`. Dropping the .1 suffix seems like the appropriate fix since that should generally find the right version automatically on both platforms. Alternatively we could just conditionally hardcode either version.