### PR TITLE
xdg-toplevel-icon: allow replacing previously-set icon sizes

### DIFF
--- a/src/wayland/xdg_toplevel_icon.rs
+++ b/src/wayland/xdg_toplevel_icon.rs
@@ -231,6 +231,17 @@ impl XdgToplevelIconManager {
         self.data.lock().unwrap().sizes.insert(size);
     }
 
+    /// Replaces previously-set icon sizes with those in `sizes`
+    ///
+    /// The new icon sizes will only be sent to newly-bound globals, not to existing binds.
+    ///
+    /// - `sizes` an iterator over `i32` icon size values
+    pub fn replace_icon_sizes(&mut self, sizes: impl IntoIterator<Item = i32>) {
+        let mut guard = self.data.lock().unwrap();
+        guard.sizes.clear();
+        guard.sizes.extend(sizes);
+    }
+
     /// Returns the [XdgToplevelIconManagerV1] global id.
     pub fn global(&self) -> GlobalId {
         self.global.clone()


### PR DESCRIPTION
## Description

The icon sizes are replaced atomically with the newly-provided icons. Clients that bind to the interface in the future will get the new set of icons.  However, existing client binds will not be notified, as it's unclear if this is allowed by the protocol.

Closes #1944

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
[x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
