### PR TITLE
Fix: wl_data_offer accept when the last call isn't a known mime-type

### DIFF
--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -248,10 +248,21 @@ fn handle_dnd<D, S>(
     let mut data = data.state.lock().unwrap();
     match request {
         Request::Accept { mime_type, .. } => {
-            if source.is_some() {
-                // A non-NULL mime type means the client accepts the drag.
-                // NULL means it does not.
-                data.accepted = mime_type.is_some();
+            if let Some(source) = source.as_ref() {
+                if let Some(mtype) = mime_type {
+                    // Only set accepted when the mime type matches what the
+                    // source offers. Non-matching types are ignored so they
+                    // do not override a previous valid match.
+                    if !data.accepted
+                        && source
+                            .metadata()
+                            .is_some_and(|meta| meta.mime_types.contains(&mtype))
+                    {
+                        data.accepted = true;
+                    }
+                } else {
+                    data.accepted = false;
+                }
             } else if data.finished {
                 offer.post_error(
                     wl_data_offer::Error::InvalidFinish,
@@ -417,7 +428,9 @@ impl<D: SeatHandler + DataDeviceHandler + 'static> DndFocus<D> for WlSurface {
         let offer_state = Arc::new(Mutex::new(WlOfferState {
             active: true,
             dropped: false,
-            accepted: true,
+            // Set true once any accept matches.
+            // Reset per-enter since each enter creates a new offer state.
+            accepted: false,
             finished: false,
             chosen_action: WlDndAction::empty(),
         }));


### PR DESCRIPTION
The Request::Accept handler checks whether the accepted mime type is in the source's offered list, setting accepted=false when it isn't.

This causes DnD drops to silently fail when the target client sends accept("text/plain") but the source only offers  "text/plain;charset=utf-8" - the last accept() sets accepted=false, and validated() returns false at drop time.

---

This breaks dropping *.jpg images into Blender on cosmic desktop (for example).

## Description
Fixes dropping with Blender (tested with 5.0).

## Checklist
[x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
