### PR TITLE
xkbcommon: allow for user-specifed xkb::ContextFlags when adding keyboard

### DIFF
--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 use tracing::{debug, info, info_span, instrument, trace};
 
 use xkbcommon::xkb::ffi::XKB_STATE_LAYOUT_EFFECTIVE;
-pub use xkbcommon::xkb::{self, ContextFlags, keysyms, Keycode, Keysym};
+pub use xkbcommon::xkb::{self, keysyms, ContextFlags, Keycode, Keysym};
 
 use super::{GrabStatus, Seat, SeatHandler};
 
@@ -238,12 +238,12 @@ impl<D: SeatHandler> fmt::Debug for KbdInternal<D> {
 unsafe impl<D: SeatHandler> Send for KbdInternal<D> {}
 
 impl<D: SeatHandler + 'static> KbdInternal<D> {
-    #[allow(dead_code)]
-    fn new(xkb_config: XkbConfig<'_>, repeat_rate: i32, repeat_delay: i32) -> Result<KbdInternal<D>, ()> {
-        Self::with_context_flags(xkb_config, repeat_rate, repeat_delay, xkb::CONTEXT_NO_FLAGS)
-    }
-
-    fn with_context_flags(xkb_config: XkbConfig<'_>, repeat_rate: i32, repeat_delay: i32, context_flags: ContextFlags) -> Result<KbdInternal<D>, ()> {
+    fn new(
+        xkb_config: XkbConfig<'_>,
+        repeat_rate: i32,
+        repeat_delay: i32,
+        context_flags: ContextFlags,
+    ) -> Result<KbdInternal<D>, ()> {
         // we create a new context for each keyboard because libxkbcommon is actually NOT threadsafe
         // so confining it inside the KbdInternal allows us to use Rusts mutability rules to make
         // sure nothing goes wrong.
@@ -670,21 +670,21 @@ impl<D: SeatHandler> ::std::cmp::PartialEq for KeyboardHandle<D> {
 
 impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     /// Create a keyboard handler from a set of RMLVO rules
-    #[allow(dead_code)]
-    pub(crate) fn new(xkb_config: XkbConfig<'_>, repeat_delay: i32, repeat_rate: i32) -> Result<Self, Error> {
-        Self::with_context_flags(xkb_config, repeat_delay, repeat_rate, xkb::CONTEXT_NO_FLAGS)
-    }
-
-    /// Create a keyboard handler from a set of RMLVO rules
-    pub(crate) fn with_context_flags(xkb_config: XkbConfig<'_>, repeat_delay: i32, repeat_rate: i32, context_flags: ContextFlags) -> Result<Self, Error> {
+    pub(crate) fn new(
+        xkb_config: XkbConfig<'_>,
+        repeat_delay: i32,
+        repeat_rate: i32,
+        context_flags: ContextFlags,
+    ) -> Result<Self, Error> {
         let span = info_span!("input_keyboard");
         let _guard = span.enter();
 
         info!("Initializing a xkbcommon handler with keymap query");
-        let internal = KbdInternal::with_context_flags(xkb_config, repeat_rate, repeat_delay, context_flags).map_err(|_| {
-            debug!("Loading keymap failed");
-            Error::BadKeymap
-        })?;
+        let internal =
+            KbdInternal::new(xkb_config, repeat_rate, repeat_delay, context_flags).map_err(|_| {
+                debug!("Loading keymap failed");
+                Error::BadKeymap
+            })?;
 
         let xkb = internal.xkb.lock().unwrap();
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -572,11 +572,18 @@ impl<D: SeatHandler + 'static> Seat<D> {
         repeat_delay: i32,
         repeat_rate: i32,
     ) -> Result<KeyboardHandle<D>, KeyboardError> {
-        Self::add_keyboard_with_context_flags(self, xkb_config, repeat_delay, repeat_rate, xkbcommon::xkb::CONTEXT_NO_FLAGS)
+        Self::add_keyboard_with_context_flags(
+            self,
+            xkb_config,
+            repeat_delay,
+            repeat_rate,
+            xkbcommon::xkb::CONTEXT_NO_FLAGS,
+        )
     }
 
-    /// Inner helper function for `add_keyboard` which allowed for overwriting default context
-    /// flags passed to creation of xkb::Context.
+    /// [`Self::add_keyboard`] equivalent, that allows for overwriting default xkb::Context flags.
+    ///
+    /// For more info read [`Self::add_keyboard`] docs.
     #[instrument(parent = &self.arc.span, skip(self))]
     pub fn add_keyboard_with_context_flags(
         &mut self,
@@ -586,7 +593,8 @@ impl<D: SeatHandler + 'static> Seat<D> {
         context_flags: ContextFlags,
     ) -> Result<KeyboardHandle<D>, KeyboardError> {
         let mut inner = self.arc.inner.lock().unwrap();
-        let keyboard = self::keyboard::KeyboardHandle::with_context_flags(xkb_config, repeat_delay, repeat_rate, context_flags)?;
+        let keyboard =
+            self::keyboard::KeyboardHandle::new(xkb_config, repeat_delay, repeat_rate, context_flags)?;
         if inner.keyboard.is_some() {
             // there is already a keyboard, remove it and notify the clients
             // of the change


### PR DESCRIPTION
## Description
When using smithay in settings that e.g. do not have standard include paths, adding a keyboard to a seat can result in a crash. To prevent this, allow users to specify their own `xkb` context flags when adding a keyboard.

A side effect of this change is the `new` functions are now dead code internally, but I figured it would be better to not potentially break other projects by removing them, and so allow pragmas have been added.

## Checklist
[x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
