### PR TITLE
fix: update enum usage after Falliable - Fallible rename

### DIFF
--- a/src/wayland/dmabuf/dispatch.rs
+++ b/src/wayland/dmabuf/dispatch.rs
@@ -304,7 +304,7 @@ where
                             params.clone(),
                             dh.clone(),
                             dmabuf.clone(),
-                            Import::Falliable,
+                            Import::Fallible,
                         );
                         state.dmabuf_imported(&DmabufGlobal { id: data.id }, dmabuf, notifier);
                     } else {

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -863,7 +863,7 @@ pub struct ImportNotifier {
 #[derive(Debug)]
 enum Import {
     /// The import can fail or create a WlBuffer.
-    Falliable,
+    Fallible,
 
     /// A WlBuffer object has already been created. Failure causes client death.
     Infallible(WlBuffer),
@@ -889,7 +889,7 @@ impl ImportNotifier {
         let client = self.inner.client();
 
         let result = match self.import {
-            Import::Falliable => {
+            Import::Fallible => {
                 if let Some(client) = client {
                     match client.create_resource::<wl_buffer::WlBuffer, Dmabuf, D>(
                         &self.display,
@@ -955,7 +955,7 @@ impl ImportNotifier {
 
     /// Import failed for an implementation dependent reason.
     pub fn failed(mut self) {
-        if matches!(self.import, Import::Falliable) {
+        if matches!(self.import, Import::Fallible) {
             self.inner.failed();
         } else {
             self.inner.post_error(


### PR DESCRIPTION
Updated all enum usages as suggested. This completes the previously approved change where Falliable was renamed to Fallible https://github.com/Smithay/smithay/pull/1802