### PR TITLE
image-capture-source: Don't send error on closed output/toplevel

### DIFF
--- a/src/wayland/image_capture_source/mod.rs
+++ b/src/wayland/image_capture_source/mod.rs
@@ -414,6 +414,9 @@ pub trait OutputCaptureSourceHandler:
     ///
     /// Use [`ImageCaptureSource::user_data()`] to store your representation
     /// of this output.
+    ///
+    /// This method is **not** called if the output handle is invalid at the time the
+    /// source was created.
     fn output_source_created(&mut self, source: ImageCaptureSource, output: &Output) {
         let _ = (source, output);
     }
@@ -447,7 +450,7 @@ where
     fn request(
         state: &mut D,
         _client: &Client,
-        resource: &ExtOutputImageCaptureSourceManagerV1,
+        _resource: &ExtOutputImageCaptureSourceManagerV1,
         request: ext_output_image_capture_source_manager_v1::Request,
         _data: &(),
         _dh: &DisplayHandle,
@@ -455,10 +458,7 @@ where
     ) {
         match request {
             ext_output_image_capture_source_manager_v1::Request::CreateSource { source, output } => {
-                let Some(output_inner) = Output::from_resource(&output) else {
-                    resource.post_error(0u32, "invalid output");
-                    return;
-                };
+                let output_inner = Output::from_resource(&output);
 
                 let capture_source = ImageCaptureSource::new();
 
@@ -470,7 +470,9 @@ where
                 );
 
                 capture_source.add_instance(&source_resource);
-                state.output_source_created(capture_source, &output_inner);
+                if let Some(output_inner) = output_inner {
+                    state.output_source_created(capture_source, &output_inner);
+                }
             }
             ext_output_image_capture_source_manager_v1::Request::Destroy => {}
             _ => unreachable!(),
@@ -551,6 +553,9 @@ pub trait ToplevelCaptureSourceHandler:
     ///
     /// Use [`ImageCaptureSource::user_data()`] to store your representation
     /// of this toplevel.
+    ///
+    /// This method is **not** called if the toplevel handle is invalid at the time the
+    /// source was created.
     fn toplevel_source_created(&mut self, source: ImageCaptureSource, toplevel: ForeignToplevelHandle) {
         let _ = (source, toplevel);
     }
@@ -584,7 +589,7 @@ where
     fn request(
         state: &mut D,
         _client: &Client,
-        resource: &ExtForeignToplevelImageCaptureSourceManagerV1,
+        _resource: &ExtForeignToplevelImageCaptureSourceManagerV1,
         request: ext_foreign_toplevel_image_capture_source_manager_v1::Request,
         _data: &(),
         _dh: &DisplayHandle,
@@ -595,15 +600,7 @@ where
                 source,
                 toplevel_handle,
             } => {
-                let Some(handle) = ForeignToplevelHandle::from_resource(&toplevel_handle) else {
-                    resource.post_error(0u32, "invalid toplevel handle");
-                    return;
-                };
-
-                if handle.is_closed() {
-                    resource.post_error(0u32, "toplevel has been closed");
-                    return;
-                }
+                let handle = ForeignToplevelHandle::from_resource(&toplevel_handle);
 
                 let capture_source = ImageCaptureSource::new();
 
@@ -615,7 +612,9 @@ where
                 );
 
                 capture_source.add_instance(&source_resource);
-                state.toplevel_source_created(capture_source, handle);
+                if let Some(handle) = handle {
+                    state.toplevel_source_created(capture_source, handle);
+                }
             }
             ext_foreign_toplevel_image_capture_source_manager_v1::Request::Destroy => {}
             _ => unreachable!(),


### PR DESCRIPTION
## Description

I believe these tests are inherently racy, so we can't be sending a protocol error.

Instead this should work, but creating a capture session should immediately result in a `stopped` event.

Should we have an alternative to `output_source_created` and `toplevel_source_created` that is called when a source is created with this? (To add any user data the compositor expects, etc.) Or should we just document that the compositor shouldn't assume either of these have been called?

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
[x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
