### PR TITLE
Enable `unsafe_op_in_unsafe_fn` except in certain places

### DIFF
--- a/src/backend/allocator/vulkan/mod.rs
+++ b/src/backend/allocator/vulkan/mod.rs
@@ -16,8 +16,6 @@
 //! To get the required extensions a device must support to use the Vulkan allocator, use
 //! [`VulkanAllocator::required_extensions`].
 
-#![forbid(unsafe_op_in_unsafe_fn)]
-
 pub mod format;
 
 use std::{

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -99,8 +99,8 @@ impl EGLContext {
         assert!(!config_id.is_null(), "EGL configuration id pointer is null");
         assert!(!context.is_null(), "EGLContext pointer is null");
 
-        let display = EGLDisplay::from_raw(display, config_id)?;
-        let pixel_format = display.get_pixel_format(config_id)?;
+        let display = unsafe { EGLDisplay::from_raw(display, config_id)? };
+        let pixel_format = unsafe { display.get_pixel_format(config_id)? };
 
         let span = info_span!(parent: &display.span, "egl_context", ptr = context as usize);
 
@@ -361,7 +361,7 @@ impl EGLContext {
     #[instrument(level = "trace", skip_all, parent = &self.span, err)]
     #[profiling::function]
     pub unsafe fn make_current(&self) -> Result<(), MakeCurrentError> {
-        wrap_egl_call_bool(|| {
+        wrap_egl_call_bool(|| unsafe {
             ffi::egl::MakeCurrent(
                 **self.display.get_display_handle(),
                 ffi::egl::NO_SURFACE,
@@ -382,7 +382,7 @@ impl EGLContext {
     /// being unbound again (see [`EGLContext::unbind`]).
     #[profiling::function]
     pub unsafe fn make_current_with_surface(&self, surface: &EGLSurface) -> Result<(), MakeCurrentError> {
-        self.make_current_with_draw_and_read_surface(surface, surface)
+        unsafe { self.make_current_with_draw_and_read_surface(surface, surface) }
     }
 
     /// Makes the OpenGL context the current context in the current thread with surfaces to
@@ -401,7 +401,7 @@ impl EGLContext {
     ) -> Result<(), MakeCurrentError> {
         let draw_surface_ptr = draw_surface.surface.load(Ordering::SeqCst);
         let read_surface_ptr = read_surface.surface.load(Ordering::SeqCst);
-        wrap_egl_call_bool(|| {
+        wrap_egl_call_bool(|| unsafe {
             ffi::egl::MakeCurrent(
                 **self.display.get_display_handle(),
                 draw_surface_ptr,

--- a/src/backend/egl/device.rs
+++ b/src/backend/egl/device.rs
@@ -261,7 +261,7 @@ impl EGLDevice {
 ///     - [`EGL_EXT_device_base`](https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_device_base.txt)
 ///     - [`EGL_EXT_device_query`](https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_device_query.txt)
 unsafe fn device_extensions(device: EGLDeviceEXT) -> Result<Vec<String>, EGLError> {
-    let raw_extensions = wrap_egl_call_ptr(|| {
+    let raw_extensions = wrap_egl_call_ptr(|| unsafe {
         ffi::egl::QueryDeviceStringEXT(device, ffi::egl::EXTENSIONS as ffi::egl::types::EGLint)
     })?;
 
@@ -269,7 +269,7 @@ unsafe fn device_extensions(device: EGLDeviceEXT) -> Result<Vec<String>, EGLErro
     // 1) The string returned by `eglQueryDeviceStringEXT` is string which will exist as long
     //    as the EGLDisplay is valid. Safety requirements for the function ensure this.
     // 2) The string returned by EGL is null terminated.
-    let c_extensions = CStr::from_ptr(raw_extensions);
+    let c_extensions = unsafe { CStr::from_ptr(raw_extensions) };
 
     Ok(c_extensions
         .to_str()

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -188,7 +188,7 @@ unsafe fn select_platform_display<N: EGLNativeDisplay + 'static>(
             continue;
         }
 
-        let display = wrap_egl_call_ptr(|| {
+        let display = wrap_egl_call_ptr(|| unsafe {
             ffi::egl::GetPlatformDisplayEXT(
                 platform.platform,
                 platform.native_display,
@@ -344,10 +344,12 @@ impl EGLDisplay {
         debug!("Supported EGL client extensions: {:?}", dp_extensions);
 
         let egl_version = {
-            let p = CStr::from_ptr(
-                wrap_egl_call_ptr(|| ffi::egl::QueryString(display, ffi::egl::VERSION as i32))
-                    .map_err(|_| Error::DisplayQueryResultInvalid)?,
-            );
+            let p = unsafe {
+                CStr::from_ptr(
+                    wrap_egl_call_ptr(|| ffi::egl::QueryString(display, ffi::egl::VERSION as i32))
+                        .map_err(|_| Error::DisplayQueryResultInvalid)?,
+                )
+            };
 
             let version_string = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| String::new());
             let mut version_iterator = version_string
@@ -376,7 +378,7 @@ impl EGLDisplay {
         let (dmabuf_import_formats, dmabuf_render_formats) =
             get_dmabuf_formats(&display, &extensions).map_err(Error::DisplayCreationError)?;
 
-        let egl_api = ffi::egl::QueryAPI();
+        let egl_api = unsafe { ffi::egl::QueryAPI() };
         if egl_api != ffi::egl::OPENGL_ES_API {
             return Err(Error::OpenGlesNotSupported(None));
         }
@@ -384,7 +386,7 @@ impl EGLDisplay {
         let surface_type = {
             let mut surface_type: MaybeUninit<ffi::egl::types::EGLint> = MaybeUninit::uninit();
 
-            wrap_egl_call_bool(|| {
+            wrap_egl_call_bool(|| unsafe {
                 ffi::egl::GetConfigAttrib(
                     display,
                     config_id,
@@ -394,7 +396,7 @@ impl EGLDisplay {
             })
             .map_err(|_| Error::OpenGlesNotSupported(None))?;
 
-            surface_type.assume_init()
+            unsafe { surface_type.assume_init() }
         };
 
         Ok(EGLDisplay {
@@ -574,7 +576,7 @@ impl EGLDisplay {
         macro_rules! attrib {
             ($display:expr, $config:expr, $attr:expr) => {{
                 let mut value = MaybeUninit::uninit();
-                wrap_egl_call_bool(|| {
+                wrap_egl_call_bool(|| unsafe {
                     ffi::egl::GetConfigAttrib(
                         **$display,
                         $config,
@@ -583,7 +585,7 @@ impl EGLDisplay {
                     )
                 })
                 .map_err(Error::ConfigFailed)?;
-                value.assume_init()
+                unsafe { value.assume_init() }
             }};
         }
 

--- a/src/backend/egl/ffi.rs
+++ b/src/backend/egl/ffi.rs
@@ -138,7 +138,7 @@ pub fn make_sure_egl_is_loaded() -> Result<Vec<String>, Error> {
 }
 
 /// Module containing raw egl function bindings
-#[allow(clippy::all, missing_debug_implementations)]
+#[allow(clippy::all, missing_debug_implementations, unsafe_op_in_unsafe_fn)]
 pub mod egl {
     use super::*;
     use libloading::Library;

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -84,7 +84,7 @@ impl ::std::error::Error for EglExtensionNotSupportedError {}
 pub unsafe fn get_proc_address(symbol: &str) -> *const c_void {
     let addr = CString::new(symbol.as_bytes()).unwrap();
     let addr = addr.as_ptr();
-    ffi::egl::GetProcAddress(addr) as *const _
+    unsafe { ffi::egl::GetProcAddress(addr) as *const _ }
 }
 
 /// Error that can occur when accessing an EGL buffer

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1,5 +1,8 @@
 //! Implementation of the rendering traits using OpenGL ES 2
 
+// GL calls are all unsafe, so not very helpful in this module.
+#![allow(unsafe_op_in_unsafe_fn)]
+
 use cgmath::{Matrix3, Vector2, prelude::*};
 use core::slice;
 use std::{

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
 //! Integration for using [`glow`] on top of smithays OpenGL ES 2 renderer
 use tracing::warn;
 

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -63,7 +63,6 @@
 //! instance and have the same physical device handle.
 
 #![warn(missing_debug_implementations)]
-#![forbid(unsafe_op_in_unsafe_fn)]
 
 use std::{
     env::{self, VarError},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
-#![allow(unsafe_op_in_unsafe_fn)]
 // Allow acronyms like EGL
 #![allow(clippy::upper_case_acronyms)]
 

--- a/src/utils/fd.rs
+++ b/src/utils/fd.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_op_in_unsafe_fn)]
-
 use std::{
     os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd},
     path::PathBuf,

--- a/src/utils/user_data.rs
+++ b/src/utils/user_data.rs
@@ -252,7 +252,7 @@ mod list {
             if ptr.is_null() {
                 None
             } else {
-                Some(Box::from_raw(ptr))
+                Some(unsafe { Box::from_raw(ptr) })
             }
         }
 
@@ -280,7 +280,7 @@ mod list {
                     Ok(_) => return,
                     Err(head) => {
                         if !head.is_null() {
-                            return (*head).next.append_ptr(p);
+                            return unsafe { (*head).next.append_ptr(p) };
                         }
                     }
                 }

--- a/src/wayland/shm/pool.rs
+++ b/src/wayland/shm/pool.rs
@@ -1,5 +1,3 @@
-#![deny(unsafe_op_in_unsafe_fn)]
-
 use std::{
     cell::Cell,
     mem,

--- a/src/xwayland/xserver.rs
+++ b/src/xwayland/xserver.rs
@@ -396,7 +396,7 @@ impl XWaylandClientData {
 /// Removes the `O_CLOEXEC` flag from a `RawFd`, causing it to leak when we
 /// `exec` XWayland
 unsafe fn unset_cloexec(fd: RawFd) -> std::io::Result<()> {
-    let fd = BorrowedFd::borrow_raw(fd);
+    let fd = unsafe { BorrowedFd::borrow_raw(fd) };
     rustix::io::fcntl_setfd(fd, rustix::io::FdFlags::empty())?;
     Ok(())
 }


### PR DESCRIPTION


## Description
`unsafe_op_in_unsafe_fn` is enabled by default in the 2024 edition. Previously, we already used it in some specific areas.

If we disable this for the generated EGL bindings, and for the GLES code, it's fairly manageable.

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
