### PR TITLE
window: add function to return the window id

### DIFF
--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -161,6 +161,11 @@ impl Window {
         }))
     }
 
+    /// Returns the window ID
+    pub fn id(&self) -> usize {
+        self.0.id
+    }
+
     /// Checks if the window is a wayland one.
     #[inline]
     pub fn is_wayland(&self) -> bool {


### PR DESCRIPTION
to make it easier to identify windows.

Example use case:
in a custom compositor to be able to implement a custom IPC to list and controls current windows

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
