### PR TITLE
Add support for missing _NET_WM_STATE atoms

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -244,6 +244,7 @@ mod atoms {
             _NET_WM_STATE_MAXIMIZED_HORZ,
             _NET_WM_STATE_HIDDEN,
             _NET_WM_STATE_FULLSCREEN,
+            _NET_WM_STATE_DEMANDS_ATTENTION,
             _NET_WM_STATE_FOCUSED,
             _NET_WM_STATE_ABOVE,
             _NET_WM_STATE_BELOW,
@@ -442,6 +443,14 @@ pub trait XwmHandler {
     }
     /// Window requests to be unstuck.
     fn unstick_request(&mut self, xwm: XwmId, window: X11Surface) {
+        let _ = (xwm, window);
+    }
+    /// Window indicates it requires the user's attention.
+    fn demands_attention_request(&mut self, xwm: XwmId, window: X11Surface) {
+        let _ = (xwm, window);
+    }
+    /// Window no longer indicates it requires the user's attention.
+    fn undemands_attention_request(&mut self, xwm: XwmId, window: X11Surface) {
         let _ = (xwm, window);
     }
 
@@ -764,6 +773,7 @@ impl X11Wm {
                 atoms._NET_WM_STATE_SKIP_TASKBAR,
                 atoms._NET_WM_STATE_SKIP_PAGER,
                 atoms._NET_WM_STATE_STICKY,
+                atoms._NET_WM_STATE_DEMANDS_ATTENTION,
                 atoms._NET_ACTIVE_WINDOW,
                 atoms._NET_WM_MOVERESIZE,
                 atoms._NET_CLIENT_LIST,
@@ -2319,6 +2329,20 @@ where
                                 }
                                 _ => {}
                             },
+                            actions if actions.contains(&xwm.atoms._NET_WM_STATE_DEMANDS_ATTENTION) => {
+                                match data[0] {
+                                    0 => state.undemands_attention_request(xwm_id, surface),
+                                    1 => state.demands_attention_request(xwm_id, surface),
+                                    2 => {
+                                        if surface.demands_attention() {
+                                            state.undemands_attention_request(xwm_id, surface)
+                                        } else {
+                                            state.demands_attention_request(xwm_id, surface)
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
                             _ => {}
                         }
                     }

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -249,6 +249,7 @@ mod atoms {
             _NET_WM_STATE_BELOW,
             _NET_WM_STATE_SKIP_TASKBAR,
             _NET_WM_STATE_SKIP_PAGER,
+            _NET_WM_STATE_STICKY,
             _NET_SUPPORTING_WM_CHECK,
             _XSETTINGS_SETTINGS,
 
@@ -431,6 +432,16 @@ pub trait XwmHandler {
     }
     /// Window requests to no longer be placed below other windows.
     fn unbelow_request(&mut self, xwm: XwmId, window: X11Surface) {
+        let _ = (xwm, window);
+    }
+    /// Window requests to be made sticky.
+    ///
+    /// This is usually used to indicate that the window should be shown on all workspaces.
+    fn stick_request(&mut self, xwm: XwmId, window: X11Surface) {
+        let _ = (xwm, window);
+    }
+    /// Window requests to be unstuck.
+    fn unstick_request(&mut self, xwm: XwmId, window: X11Surface) {
         let _ = (xwm, window);
     }
 
@@ -752,6 +763,7 @@ impl X11Wm {
                 atoms._NET_WM_STATE_BELOW,
                 atoms._NET_WM_STATE_SKIP_TASKBAR,
                 atoms._NET_WM_STATE_SKIP_PAGER,
+                atoms._NET_WM_STATE_STICKY,
                 atoms._NET_ACTIVE_WINDOW,
                 atoms._NET_WM_MOVERESIZE,
                 atoms._NET_CLIENT_LIST,
@@ -2291,6 +2303,18 @@ where
                                         state.unbelow_request(xwm_id, surface)
                                     } else {
                                         state.below_request(xwm_id, surface)
+                                    }
+                                }
+                                _ => {}
+                            },
+                            actions if actions.contains(&xwm.atoms._NET_WM_STATE_STICKY) => match data[0] {
+                                0 => state.unstick_request(xwm_id, surface),
+                                1 => state.stick_request(xwm_id, surface),
+                                2 => {
+                                    if surface.is_sticky() {
+                                        state.unstick_request(xwm_id, surface)
+                                    } else {
+                                        state.stick_request(xwm_id, surface)
                                     }
                                 }
                                 _ => {}

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -248,6 +248,7 @@ mod atoms {
             _NET_WM_STATE_FOCUSED,
             _NET_WM_STATE_ABOVE,
             _NET_WM_STATE_BELOW,
+            _NET_WM_STATE_SHADED,
             _NET_WM_STATE_SKIP_TASKBAR,
             _NET_WM_STATE_SKIP_PAGER,
             _NET_WM_STATE_STICKY,
@@ -443,6 +444,14 @@ pub trait XwmHandler {
     }
     /// Window requests to be unstuck.
     fn unstick_request(&mut self, xwm: XwmId, window: X11Surface) {
+        let _ = (xwm, window);
+    }
+    /// Window requests to be shaded.
+    fn shade_request(&mut self, xwm: XwmId, window: X11Surface) {
+        let _ = (xwm, window);
+    }
+    /// Window requests to be unshaded.
+    fn unshade_request(&mut self, xwm: XwmId, window: X11Surface) {
         let _ = (xwm, window);
     }
     /// Window indicates it requires the user's attention.
@@ -770,6 +779,7 @@ impl X11Wm {
                 atoms._NET_WM_STATE_FOCUSED,
                 atoms._NET_WM_STATE_ABOVE,
                 atoms._NET_WM_STATE_BELOW,
+                atoms._NET_WM_STATE_SHADED,
                 atoms._NET_WM_STATE_SKIP_TASKBAR,
                 atoms._NET_WM_STATE_SKIP_PAGER,
                 atoms._NET_WM_STATE_STICKY,
@@ -2325,6 +2335,18 @@ where
                                         state.unstick_request(xwm_id, surface)
                                     } else {
                                         state.stick_request(xwm_id, surface)
+                                    }
+                                }
+                                _ => {}
+                            },
+                            actions if actions.contains(&xwm.atoms._NET_WM_STATE_SHADED) => match data[0] {
+                                0 => state.unshade_request(xwm_id, surface),
+                                1 => state.shade_request(xwm_id, surface),
+                                2 => {
+                                    if surface.is_shaded() {
+                                        state.unshade_request(xwm_id, surface)
+                                    } else {
+                                        state.shade_request(xwm_id, surface)
                                     }
                                 }
                                 _ => {}

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -588,6 +588,15 @@ impl X11Surface {
             .contains(&self.atoms._NET_WM_STATE_STICKY)
     }
 
+    /// Returns if the window demands attention.
+    pub fn demands_attention(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .net_state
+            .contains(&self.atoms._NET_WM_STATE_DEMANDS_ATTENTION)
+    }
+
     /// Returns true if the window is client-side decorated
     pub fn is_decorated(&self) -> bool {
         let state = self.state.lock().unwrap();
@@ -689,6 +698,18 @@ impl X11Surface {
             self.change_net_state(&[self.atoms._NET_WM_STATE_STICKY], &[])?;
         } else {
             self.change_net_state(&[], &[self.atoms._NET_WM_STATE_STICKY])?;
+        }
+        Ok(())
+    }
+
+    /// Sets the window's demands-attention state.
+    ///
+    /// A client might flash the client-side decorations when demanding attention.
+    pub fn set_demands_attention(&self, demands_attention: bool) -> Result<(), ConnectionError> {
+        if demands_attention {
+            self.change_net_state(&[self.atoms._NET_WM_STATE_DEMANDS_ATTENTION], &[])?;
+        } else {
+            self.change_net_state(&[], &[self.atoms._NET_WM_STATE_DEMANDS_ATTENTION])?;
         }
         Ok(())
     }

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -577,6 +577,17 @@ impl X11Surface {
             .contains(&self.atoms._NET_WM_STATE_SKIP_PAGER)
     }
 
+    /// Returns if the window is sticky.
+    ///
+    /// This is usually used to mean that the window should be shown on all workspaces.
+    pub fn is_sticky(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .net_state
+            .contains(&self.atoms._NET_WM_STATE_STICKY)
+    }
+
     /// Returns true if the window is client-side decorated
     pub fn is_decorated(&self) -> bool {
         let state = self.state.lock().unwrap();
@@ -666,6 +677,18 @@ impl X11Surface {
             self.change_net_state(&[self.atoms._NET_WM_STATE_BELOW], &[])?;
         } else {
             self.change_net_state(&[], &[self.atoms._NET_WM_STATE_BELOW])?;
+        }
+        Ok(())
+    }
+
+    /// Sets the window's sticky state.
+    ///
+    /// This is usually used to mean that the window should be shown on all workspaces.
+    pub fn set_sticky(&self, sticky: bool) -> Result<(), ConnectionError> {
+        if sticky {
+            self.change_net_state(&[self.atoms._NET_WM_STATE_STICKY], &[])?;
+        } else {
+            self.change_net_state(&[], &[self.atoms._NET_WM_STATE_STICKY])?;
         }
         Ok(())
     }

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -588,6 +588,15 @@ impl X11Surface {
             .contains(&self.atoms._NET_WM_STATE_STICKY)
     }
 
+    /// Returns if the window is shaded.
+    pub fn is_shaded(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .net_state
+            .contains(&self.atoms._NET_WM_STATE_SHADED)
+    }
+
     /// Returns if the window demands attention.
     pub fn demands_attention(&self) -> bool {
         self.state
@@ -698,6 +707,16 @@ impl X11Surface {
             self.change_net_state(&[self.atoms._NET_WM_STATE_STICKY], &[])?;
         } else {
             self.change_net_state(&[], &[self.atoms._NET_WM_STATE_STICKY])?;
+        }
+        Ok(())
+    }
+
+    /// Sets the window's shaded state.
+    pub fn set_shaded(&self, shaded: bool) -> Result<(), ConnectionError> {
+        if shaded {
+            self.change_net_state(&[self.atoms._NET_WM_STATE_SHADED], &[])?;
+        } else {
+            self.change_net_state(&[], &[self.atoms._NET_WM_STATE_SHADED])?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Description

Adds support for `_NET_WM_STATE_SHADED`, `_NET_WM_STATE_STICKY`, and `_NET_WM_STATE_DEMANDS_ATTENTION`.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
