### PR TITLE
wayland/xdg-shell: Expose xdg-surface

### DIFF
--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -351,6 +351,13 @@ pub struct XdgShellSurfaceUserData {
     pub(crate) alive_tracker: AliveTracker,
 }
 
+impl XdgShellSurfaceUserData {
+    /// Associated xdg_surface
+    pub fn xdg_surface(&self) -> &xdg_surface::XdgSurface {
+        &self.xdg_surface
+    }
+}
+
 impl IsAlive for XdgToplevel {
     #[inline]
     fn alive(&self) -> bool {


### PR DESCRIPTION
## Description

We already had `XdgShellSurfaceUserData` public, but none of it's fields.

This allows comparing against the underlying xdg-surface for implementing protocols, which depend on it, out of tree.

E.g. https://github.com/pop-os/cosmic-protocols/pull/77/changes

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
