### PR TITLE
chore: Clippy warning fixes

### DIFF
--- a/anvil/src/lib.rs
+++ b/anvil/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![allow(clippy::collapsible_match)]
 // If no backend is enabled, a large portion of the codebase is unused.
 // So silence this useless warning for the CI.
 #![cfg_attr(

--- a/src/backend/egl/display.rs
+++ b/src/backend/egl/display.rs
@@ -980,7 +980,7 @@ fn get_dmabuf_formats(
                 external.set_len(num as usize);
             }
 
-            for (modifier, external_only) in mods.into_iter().zip(external.into_iter()) {
+            for (modifier, external_only) in mods.into_iter().zip(external) {
                 let format = DrmFormat {
                     code: fourcc,
                     modifier: Modifier::from(modifier),

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -224,8 +224,7 @@ impl<E: SpaceElement + PartialEq> Space<E> {
         }
 
         self.elements.insert(index, elem);
-        self.elements
-            .sort_by(|e1, e2| e1.element.z_index().cmp(&e2.element.z_index()));
+        self.elements.sort_by_key(|e1| e1.element.z_index());
     }
 
     /// Changes the location of an already-mapped [`SpaceElement`] in this space

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 // Allow acronyms like EGL
-#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::upper_case_acronyms, clippy::collapsible_match)]
 
 //! # Smithay: the Wayland compositor smithy
 //!

--- a/src/wayland/commit_timing/mod.rs
+++ b/src/wayland/commit_timing/mod.rs
@@ -385,11 +385,8 @@ impl CommitTimerBarrierState {
         let deadline = deadline.into();
 
         let num_barriers = self.barriers.len();
-        loop {
-            let Some(barrier) = self.barriers.peek() else {
-                break;
-            };
 
+        while let Some(barrier) = self.barriers.peek() {
             if barrier.timestamp > deadline {
                 break;
             }


### PR DESCRIPTION
## Description

Just clippy fiexes.
I have disabled the [clippy::collapsible_match](https://rust-lang.github.io/rust-clippy/stable/index.html?search=clippy%3A%3Acollapsible_match#collapsible_match) lint tho, even tho it's trivial to change the code to fulfill it, I believe it will just cause needles code churn. 
It disallows using single branch ifs in match statements like so:
```rs
match todo!() {
    1 => {
        if true {
           // Clippy will force us to move the if to the match level
        }
    }
    2 => {}
    _ => {
        // If anything is to be added here the lint will no longer apply,
        // and worst case scenario the changes it forced might need to be reverted
    }
}
```

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
