### PR TITLE
dnd: Add `DndGrabHandler::cancelled()`, and fix touch drop

### DIFF
--- a/src/input/dnd/grab.rs
+++ b/src/input/dnd/grab.rs
@@ -195,8 +195,7 @@ pub trait DndGrabHandler: SeatHandler + Sized {
     /// At this point, any icon should be removed.
     ///
     /// * `target` - The target that the contents were dropped on.
-    /// * `validated` - Whether the drop offer was negotiated and accepted. If `false`, the drop
-    ///   was cancelled or otherwise not successful.
+    /// * `validated` - Whether the drop offer was negotiated and accepted.
     /// * `seat` - The seat on which the DnD action was finished.
     /// * `location` - The location the drop was finished at
     fn dropped(
@@ -207,6 +206,12 @@ pub trait DndGrabHandler: SeatHandler + Sized {
         location: Point<f64, Logical>,
     ) {
         let _ = (target, validated, seat, location);
+    }
+
+    /// The grab was cancelled by removing the grab by some means other than releasing the mouse
+    /// button or touch up.
+    fn cancelled(&mut self, seat: Seat<Self>, location: Point<f64, Logical>) {
+        let _ = (seat, location);
     }
 }
 
@@ -284,6 +289,8 @@ where
         }
 
         self.data_source.cancel();
+
+        DndGrabHandler::cancelled(data, self.seat.clone(), self.last_position);
 
         if let Some(ref focus) = self.current_focus {
             focus.leave(data, self.offer_data.as_mut(), &self.seat);

--- a/src/input/dnd/grab.rs
+++ b/src/input/dnd/grab.rs
@@ -486,6 +486,8 @@ where
             return;
         }
 
+        // the user dropped, proceed to the drop
+        self.should_drop = true;
         handle.unset_grab(self, data);
     }
 
@@ -519,7 +521,6 @@ where
     }
 
     fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, _seq: Serial) {
-        // TODO: should we cancel something here?
         handle.unset_grab(self, data);
     }
 


### PR DESCRIPTION
## Description

Method suggested in https://github.com/Smithay/smithay/issues/1996.

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
