### PR TITLE
Add WaylandSurfaceRenderElement::buffer()

### DIFF
--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -344,6 +344,11 @@ impl<R: Renderer + ImportAll> WaylandSurfaceRenderElement<R> {
     pub fn texture(&self) -> &WaylandSurfaceTexture<R> {
         &self.texture
     }
+
+    /// Get the buffer
+    pub fn buffer(&self) -> &Buffer {
+        &self.buffer
+    }
 }
 
 impl<R: Renderer + ImportAll> Element for WaylandSurfaceRenderElement<R> {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->
This is useful for example to get to `buffer_y_inverted()` as there's no other good way to do it from what I can find. The texture `is_y_inverted()` is only present on concrete `GlesTexture` and not on the generic `R::Texture`.

There's `WaylandSurfaceRenderElement::underlying_storage()` that gets painfully close, but it requires a renderer (that it doesn't even use).

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
