### PR TITLE
fix(gles): use STREAM_DRAW for PIXEL_PACK_BUFFER (fixes #1595)

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1370,7 +1370,7 @@ impl ExportMem for GlesRenderer {
             let bpp = gl_bpp(format, layout).ok_or(GlesError::UnsupportedPixelLayout)? / 8;
             let size = (region.size.w * region.size.h * bpp as i32) as isize;
             self.gl
-                .BufferData(ffi::PIXEL_PACK_BUFFER, size, ptr::null(), ffi::STREAM_READ);
+                .BufferData(ffi::PIXEL_PACK_BUFFER, size, ptr::null(), ffi::STREAM_DRAW);
             self.gl
                 .ReadBuffer(if matches!(target.0, GlesTargetInternal::Surface { .. }) {
                     ffi::BACK
@@ -1434,7 +1434,7 @@ impl ExportMem for GlesRenderer {
                 ffi::PIXEL_PACK_BUFFER,
                 (region.size.w * region.size.h * bpp as i32) as isize,
                 ptr::null(),
-                ffi::STREAM_READ,
+                ffi::STREAM_DRAW,
             );
             self.gl.ReadBuffer(ffi::COLOR_ATTACHMENT0);
             self.gl.ReadPixels(


### PR DESCRIPTION
## Description

The GLES renderer was using GL_STREAM_READ when allocating PBOs for
glReadPixels operations (i don't know if this was a bug or intentional). However, PIXEL_PACK_BUFFER is used to pack
pixel data FROM the GPU (GPU writes, CPU reads), so using GL_STREAM_DRAW fixed it.

This caused screenshots in [niri](https://github.com/niri-wm/niri/issues/807) to fail with "failed to copy to output" and with debug logs:
```
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_ENUM in glBufferData(invalid usage: GL_STREAM_READ)
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_OPERATION in glReadPixels(out of bounds PBO access)
```
 on older CPUs (particularly Intel integrated graphics), where drivers
enforce the usage hint more strictly.

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
