### PR TITLE
drm_syncobj: expose timeline fd and point accessors

### DIFF
--- a/src/wayland/drm_syncobj/sync_point.rs
+++ b/src/wayland/drm_syncobj/sync_point.rs
@@ -81,6 +81,12 @@ impl PartialEq for DrmTimeline {
     }
 }
 
+impl AsFd for DrmTimeline {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.timeline_fd.as_fd()
+    }
+}
+
 impl DrmTimeline {
     /// Import DRM timeline from file descriptor
     pub fn new(device: &DrmDeviceFd, fd: OwnedFd) -> io::Result<Self> {
@@ -113,6 +119,16 @@ pub struct DrmSyncPoint {
 }
 
 impl DrmSyncPoint {
+    /// Borrow the [`DrmTimeline`] this point lives on.
+    pub fn timeline(&self) -> &DrmTimeline {
+        &self.timeline
+    }
+
+    /// Numeric timeline value for this point.
+    pub fn point(&self) -> u64 {
+        self.point
+    }
+
     /// Create an eventfd that will be signaled by the syncpoint
     pub fn eventfd(&self) -> io::Result<Arc<OwnedFd>> {
         let fd = rustix::event::eventfd(


### PR DESCRIPTION
## Description

External renderers that don't go through smithay's built-in RendererSurfaceState path need access to:

- `DrmTimeline`'s underlying syncobj fd, so they can import the same timeline into a `VkSemaphore` via `VK_KHR_external_semaphore_fd` and chain timeline wait/signal values into `VkTimelineSemaphoreSubmitInfo`.
- `DrmSyncPoint`'s timeline value (u64), needed as the wait/signal value in the same submit chain.
- A reference to the `DrmTimeline` a `DrmSyncPoint` belongs to, so an external cache can key semaphore imports per-timeline.

Using these is probably not idiomatic usage of Smithay for a normal compositor, but it is useful nonetheless for things using Smithay for less typical use cases.

Might end up being useful if Smithay ever gets an official Vulkan render backend, I'm using these to manually set up explicit sync with my own renderer. 

I'm not sure if it's possible or useful to add a test for this, if you have some suggestion I'm happy to add it.

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
