### PR TITLE
Add add_keyboard_from_keymap_string to avoid xkeyboard-config dependency

### DIFF
--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -269,6 +269,41 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
         })
     }
 
+    fn new_from_keymap_string(
+        keymap_str: String,
+        repeat_rate: i32,
+        repeat_delay: i32,
+    ) -> Result<KbdInternal<D>, ()> {
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let keymap = xkb::Keymap::new_from_string(
+            &context,
+            keymap_str,
+            xkb::KEYMAP_FORMAT_TEXT_V1,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        )
+        .ok_or(())?;
+        let state = xkb::State::new(&keymap);
+        let led_mapping = LedMapping::from_keymap(&keymap);
+        let led_state = LedState::from_state(&state, &led_mapping);
+        Ok(KbdInternal {
+            focus: None,
+            pending_focus: None,
+            pressed_keys: HashSet::new(),
+            forwarded_pressed_keys: HashSet::new(),
+            mods_state: ModifiersState::default(),
+            xkb: Arc::new(Mutex::new(Xkb {
+                context,
+                keymap,
+                state,
+            })),
+            repeat_rate,
+            repeat_delay,
+            led_mapping,
+            led_state,
+            grab: GrabStatus::None,
+        })
+    }
+
     // returns whether the modifiers or led state has changed
     fn key_input(&mut self, keycode: Keycode, state: KeyState) -> (bool, bool) {
         // track pressed keys as xkbcommon does not seem to expose it :(
@@ -674,6 +709,49 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
             debug!("Loading keymap failed");
             Error::BadKeymap
         })?;
+
+        let xkb = internal.xkb.lock().unwrap();
+
+        info!(name = xkb.keymap.layouts().next(), "Loaded Keymap");
+
+        #[cfg(feature = "wayland_frontend")]
+        let keymap_file = KeymapFile::new(&xkb.keymap);
+        #[cfg(feature = "wayland_frontend")]
+        let active_keymap = keymap_file.id();
+
+        drop(xkb);
+        drop(_guard);
+        Ok(Self {
+            arc: Arc::new(KbdRc {
+                #[cfg(feature = "wayland_frontend")]
+                keymap: Mutex::new(keymap_file),
+                internal: Mutex::new(internal),
+                #[cfg(feature = "wayland_frontend")]
+                known_kbds: Mutex::new(Vec::new()),
+                #[cfg(feature = "wayland_frontend")]
+                last_enter: Mutex::new(None),
+                #[cfg(feature = "wayland_frontend")]
+                active_keymap: RwLock::new(active_keymap),
+                span,
+            }),
+        })
+    }
+
+    /// Create a keyboard handler from a pre-compiled keymap string
+    pub(crate) fn new_from_keymap_string(
+        keymap_str: String,
+        repeat_delay: i32,
+        repeat_rate: i32,
+    ) -> Result<Self, Error> {
+        let span = info_span!("input_keyboard");
+        let _guard = span.enter();
+
+        info!("Initializing a xkbcommon handler with keymap string");
+        let internal =
+            KbdInternal::new_from_keymap_string(keymap_str, repeat_rate, repeat_delay).map_err(|_| {
+                debug!("Loading keymap from string failed");
+                Error::BadKeymap
+            })?;
 
         let xkb = internal.xkb.lock().unwrap();
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -579,6 +579,33 @@ impl<D: SeatHandler + 'static> Seat<D> {
         Ok(keyboard)
     }
 
+    /// Add a keyboard with a pre-compiled keymap string (XKB_KEYMAP_FORMAT_TEXT_V1).
+    ///
+    /// This bypasses the RMLVO rules lookup, so it does not require xkeyboard-config
+    /// data files on disk.
+    pub fn add_keyboard_from_keymap_string(
+        &mut self,
+        keymap_str: String,
+        repeat_delay: i32,
+        repeat_rate: i32,
+    ) -> Result<KeyboardHandle<D>, KeyboardError> {
+        let mut inner = self.arc.inner.lock().unwrap();
+        let keyboard = self::keyboard::KeyboardHandle::new_from_keymap_string(
+            keymap_str,
+            repeat_delay,
+            repeat_rate,
+        )?;
+        if inner.keyboard.is_some() {
+            inner.keyboard = None;
+            #[cfg(feature = "wayland_frontend")]
+            inner.send_all_caps();
+        }
+        inner.keyboard = Some(keyboard.clone());
+        #[cfg(feature = "wayland_frontend")]
+        inner.send_all_caps();
+        Ok(keyboard)
+    }
+
     /// Access the keyboard of this seat if any
     pub fn get_keyboard(&self) -> Option<KeyboardHandle<D>> {
         self.arc.inner.lock().unwrap().keyboard.clone()


### PR DESCRIPTION
## Description

Adds Seat::add_keyboard_from_keymap_string() which creates a keyboard from a pre-compiled XKB keymap string instead of RMLVO rules, eliminating the runtime dependency on xkeyboard-config data files.

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
