### PR TITLE
xwm: clean up by_serial hash map when surface is destroyed

### DIFF
--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -367,6 +367,12 @@ fn serial_commit_hook<D: XWaylandShellHandler + XwmHandler + SeatHandler + 'stat
                     XWaylandShellHandler::xwayland_shell_state(state)
                         .by_serial
                         .insert(serial, surface.clone());
+
+                    compositor::add_destruction_hook::<D, _>(surface, move |state, _| {
+                        XWaylandShellHandler::xwayland_shell_state(state)
+                            .by_serial
+                            .remove(&serial);
+                    });
                 }
             }
         }


### PR DESCRIPTION
## Description

In a compositor that restarts XWayland on a crash, the new XWayland instance will start off with a fresh serial counter.  As new X11 windows are created, they can have the same serial as a window created on the previous XWayland instance.  Without this cleanup, the lookup in surface_for_serial() will return a stale/dead wl_surface, and the xwayland machinery will be unable to properly associate new windows with a surface.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
