### PR TITLE
xwm: flush X11 connection when setting _NET_SHOWING_DESKTOP

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1322,6 +1322,7 @@ impl X11Wm {
                 AtomEnum::CARDINAL,
                 &[value],
             )?;
+            self.conn.flush()?;
             self.is_showing_desktop = is_showing_desktop;
         }
 


### PR DESCRIPTION
## Description

Otherwise it won't actually show up until X11Wm does something else with the connection and flushes it.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
