### PR TITLE
xwm: lazily update opaque regions when the property changes

### DIFF
--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -97,6 +97,7 @@ pub(crate) struct SharedSurfaceState {
     window_type: Vec<Atom>,
     pub(crate) opacity: Option<u32>,
     opaque_region: Option<RegionAttributes>,
+    opaque_region_dirty: bool,
     pending_enter: Option<(
         Box<dyn std::any::Any + Send + 'static>,
         Vec<Keycode>,
@@ -244,6 +245,7 @@ impl X11Surface {
                 window_type: Vec::new(),
                 opacity: None,
                 opaque_region: None,
+                opaque_region_dirty: true,
                 pending_enter: None,
             })),
             xdnd_active,
@@ -420,9 +422,35 @@ impl X11Surface {
         if let Some(wl_surface) = state.wl_surface.as_ref() {
             let hook_id = {
                 let state = Arc::downgrade(&self.state);
+                let conn = self.conn.clone();
+                let window = self.window;
+                let property_atom = self.atoms._NET_WM_OPAQUE_REGION;
+                let client_scale = self.client_scale.clone();
+
                 compositor::add_pre_commit_hook::<D, _>(wl_surface, move |_, _, wl_surface| {
                     if let Some(state) = state.upgrade() {
-                        let opaque_region = state.lock().unwrap().opaque_region.clone();
+                        let update_opaque_region_if_needed = || {
+                            if state.lock().unwrap().opaque_region_dirty {
+                                if let Some(conn) = conn.upgrade() {
+                                    if let Ok(opaque_region) = fetch_opaque_regions(
+                                        &conn,
+                                        window,
+                                        property_atom,
+                                        client_scale.as_ref(),
+                                    ) {
+                                        let mut state = state.lock().unwrap();
+                                        state.opaque_region = opaque_region;
+                                        state.opaque_region_dirty = false;
+                                        return Some(state.opaque_region.clone());
+                                    }
+                                }
+                            }
+                            None
+                        };
+
+                        let opaque_region = update_opaque_region_if_needed()
+                            .unwrap_or_else(|| state.lock().unwrap().opaque_region.clone());
+
                         compositor::with_states(wl_surface, |states| {
                             let mut guard = states.cached_state.get::<SurfaceAttributes>();
                             let attrs = guard.pending();
@@ -862,7 +890,16 @@ impl X11Surface {
         self.update_startup_id()?;
         self.update_pid()?;
         self.update_opacity()?;
-        self.update_opaque_regions()?;
+        if let Some(conn) = self.conn.upgrade() {
+            let mut state = self.state.lock().unwrap();
+            state.opaque_region = fetch_opaque_regions(
+                &conn,
+                self.window,
+                self.atoms._NET_WM_OPAQUE_REGION,
+                self.client_scale.as_ref(),
+            )?;
+            state.opaque_region_dirty = false;
+        }
         Ok(())
     }
 
@@ -913,7 +950,9 @@ impl X11Surface {
                 Ok(Some(WmWindowProperty::Opacity))
             }
             atom if atom == self.atoms._NET_WM_OPAQUE_REGION => {
-                self.update_opaque_regions()?;
+                let mut state = self.state.lock().unwrap();
+                state.opaque_region = None;
+                state.opaque_region_dirty = true;
                 Ok(None)
             }
 
@@ -1011,55 +1050,6 @@ impl X11Surface {
             let mut state = self.state.lock().unwrap();
             state.opacity = Some(opacity);
         }
-        Ok(())
-    }
-
-    fn update_opaque_regions(&self) -> Result<(), ConnectionError> {
-        let conn = self.conn.upgrade().ok_or(ConnectionError::UnknownError)?;
-        let reply = conn
-            .get_property(
-                false,
-                self.window,
-                self.atoms._NET_WM_OPAQUE_REGION,
-                AtomEnum::CARDINAL,
-                0,
-                u32::MAX,
-            )?
-            .reply_unchecked()?;
-
-        let opaque_region = reply
-            .and_then(|reply| {
-                reply.value32().map(|values| {
-                    let client_scale = self
-                        .client_scale
-                        .as_ref()
-                        .map(|s| s.load(Ordering::Acquire))
-                        .unwrap_or(1.);
-
-                    values
-                        .collect::<Vec<_>>()
-                        .chunks_exact(4)
-                        .flat_map(|rect_values| {
-                            let phys_rect = Rectangle::<i32, Physical>::new(
-                                (rect_values[0] as i32, rect_values[1] as i32).into(),
-                                ((rect_values[2] as i32).max(0), (rect_values[3] as i32).max(0)).into(),
-                            );
-                            if phys_rect.is_empty() {
-                                None
-                            } else {
-                                Some((
-                                    RectangleKind::Add,
-                                    phys_rect.to_f64().to_logical(client_scale).to_i32_round::<i32>(),
-                                ))
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                })
-            })
-            .map(|rects| RegionAttributes { rects });
-
-        self.state.lock().unwrap().opaque_region = opaque_region;
-
         Ok(())
     }
 
@@ -1566,4 +1556,47 @@ impl WaylandFocus for X11Surface {
     fn wl_surface(&self) -> Option<Cow<'_, WlSurface>> {
         X11Surface::wl_surface(self).map(Cow::Owned)
     }
+}
+
+fn fetch_opaque_regions(
+    conn: &Arc<RustConnection>,
+    window: X11Window,
+    property_atom: Atom,
+    client_scale: Option<&Arc<AtomicF64>>,
+) -> Result<Option<RegionAttributes>, ConnectionError> {
+    let reply = conn
+        .get_property(false, window, property_atom, AtomEnum::CARDINAL, 0, u32::MAX)?
+        .reply_unchecked()?;
+
+    let opaque_region = reply
+        .and_then(|reply| {
+            reply.value32().map(|values| {
+                let client_scale = client_scale
+                    .as_ref()
+                    .map(|s| s.load(Ordering::Acquire))
+                    .unwrap_or(1.);
+
+                values
+                    .collect::<Vec<_>>()
+                    .chunks_exact(4)
+                    .flat_map(|rect_values| {
+                        let phys_rect = Rectangle::<i32, Physical>::new(
+                            (rect_values[0] as i32, rect_values[1] as i32).into(),
+                            ((rect_values[2] as i32).max(0), (rect_values[3] as i32).max(0)).into(),
+                        );
+                        if phys_rect.is_empty() {
+                            None
+                        } else {
+                            Some((
+                                RectangleKind::Add,
+                                phys_rect.to_f64().to_logical(client_scale).to_i32_round::<i32>(),
+                            ))
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+        })
+        .map(|rects| RegionAttributes { rects });
+
+    Ok(opaque_region)
 }


### PR DESCRIPTION
## Description

During resize, a client with _NET_WM_OPAQUE_REGION set will send a flood of changes to this property as the window changes size and the opaque regions move and change size.  Profiling shows that processing all of these updates can take 10-15ms, causing missed vblanks.

Not only does it take a while to process the flood of updates, fetching the updated property value from the XWayland server can be very slow during this period (I've observed a median of 3ms and P90 of 12ms, with a P99 of 27ms!).  My theory is that x11rb's socket processing architecture appears to be working against us here: in this flood of updates during a resize, a lot of other things are also going on: configure requests, configure notify events, etc.  This causes x11rb's incoming event processing to back up, and with the property fetch reply far down the queue of events to process, it takes a while for it to get there.

Instead, when receiving a PropertyNotify event for _NET_WM_OPAQUE_REGION, simply None-out the stored value and mark it as dirty.  In the pre-commit hook, if the value is dirty, re-fetch the property.  This avoids several tens of slow property fetches per frame, coalescing it down to one per frame at most.

I've also taken pains to avoid holding the mutex on SharedSurfaceState across the XWayland server round-trip; since that call can take several milliseconds when there's a flood of events, a multi-threaded compositor might experience lock contention if it's trying to do anything else with the X11Surface.

This doesn't fully fix the problem: the property fetch in the pre-commit handler can still be slow to the tune of several milliseconds (and sometimes worse) during resize.  But this change does eliminate most of the missed vblanks and skipped frames.  (If x11rb were to expose poll_for_reply(), we could do this in a non-blocking manner, and completely eliminate this issue, but it's a private function.)

In normal non-resize situations, the opaque region will change only rarely (if ever), and even when it does, it should presumably be at a time when there isn't a flood of traffic with the XWayland server, so the lazy re-fetch in the pre-commit handler should complete in microseconds.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
