### PR TITLE
xwm: implement support for _NET_WM_PING

### DIFF
--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "wayland_frontend")]
+use crate::utils::Serial;
 #[cfg(feature = "xwayland")]
 use crate::{desktop::space::SpaceElement, xwayland::X11Surface};
 use crate::{
@@ -50,6 +52,50 @@ pub(crate) struct WindowInner {
 impl Drop for WindowInner {
     fn drop(&mut self) {
         window_id::remove(self.id);
+    }
+}
+
+/// Represents possible errors returned from a window ping
+#[derive(Debug, thiserror::Error)]
+#[cfg(feature = "wayland_frontend")]
+pub enum PingError {
+    /// This window's underlying surface does not support a ping protocol
+    #[error("Ping not supported for this window")]
+    NotSupported,
+    /// The operation failed because the underlying surface has been destroyed
+    #[error("The ping failed because the underlying surface has been destroyed")]
+    DeadSurface,
+    /// The provided serial cannot be used for a ping
+    #[error("Invalid serial for ping")]
+    InvalidSerial,
+    /// There is already a ping pending
+    #[error("There is already a ping pending `{0:?}`")]
+    PingAlreadyPending(Serial),
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl From<crate::wayland::shell::PingError> for PingError {
+    fn from(value: crate::wayland::shell::PingError) -> Self {
+        use crate::wayland::shell::PingError;
+
+        match value {
+            PingError::DeadSurface => Self::DeadSurface,
+            PingError::PingAlreadyPending(serial) => Self::PingAlreadyPending(serial),
+        }
+    }
+}
+
+#[cfg(feature = "xwayland")]
+impl From<crate::xwayland::xwm::PingError> for PingError {
+    fn from(value: crate::xwayland::xwm::PingError) -> Self {
+        use crate::xwayland::xwm::PingError;
+
+        match value {
+            PingError::NotSupported => Self::NotSupported,
+            PingError::InvalidTimestamp => Self::InvalidSerial,
+            PingError::PingAlreadyPending(timestamp) => Self::PingAlreadyPending(Serial(timestamp)),
+            PingError::Connection(_) => Self::DeadSurface,
+        }
     }
 }
 
@@ -245,6 +291,28 @@ impl Window {
                 }
             }
         }
+    }
+
+    /// Sends a ping to the window to check that the client is still responding.
+    ///
+    /// For `xdg_toplevel` surfaces, you can implement
+    /// [`XdgShellHandler::client_pong`](crate::wayland::shell::xdg::XdgShellHandler::client_pong)
+    /// to be notified of replies.
+    ///
+    /// For X11/XWayland surfaces, you can implement
+    /// [`XwmHandler::ping_acked`](crate::xwayland::XwmHandler::ping_acked) to be notified of
+    /// replies.
+    ///
+    /// Fails if the window's underlying surface does not support a ping protocol, is dead, or
+    /// already has a pending ping.
+    #[cfg(feature = "wayland_frontend")]
+    pub fn send_ping(&self, serial: Serial) -> Result<(), PingError> {
+        match &self.0.surface {
+            WindowSurface::Wayland(s) => s.client().send_ping(serial)?,
+            #[cfg(feature = "xwayland")]
+            WindowSurface::X11(s) => s.send_ping(serial.0)?,
+        }
+        Ok(())
     }
 
     /// Sends the frame callback to all the subsurfaces in this window that requested it

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -489,6 +489,11 @@ pub trait XwmHandler {
         let _ = (xwm, window, timestamp, currently_active_window);
     }
 
+    /// Window has responded to a `_NET_WM_PING` request.
+    fn ping_acked(&mut self, xwm: XwmId, window: X11Surface, timestamp: u32) {
+        let _ = (xwm, window, timestamp);
+    }
+
     /// Window requests access to the given selection.
     fn allow_selection_access(&mut self, xwm: XwmId, selection: SelectionTarget) -> bool {
         let _ = (xwm, selection);
@@ -805,6 +810,7 @@ impl X11Wm {
                 atoms._NET_CLIENT_LIST_STACKING,
                 atoms._NET_SHOWING_DESKTOP,
                 atoms._NET_WM_OPAQUE_REGION,
+                atoms._NET_WM_PING,
             ],
         )?;
         conn.change_property32(
@@ -2479,6 +2485,47 @@ where
                     if let Some(surface) = xwm.windows.iter().find(|x| x.window_id() == msg.window).cloned() {
                         drop(_guard);
                         state.active_window_request(xwm_id, surface, timestamp, currently_active_window);
+                    }
+                }
+                x if x == xwm.atoms.WM_PROTOCOLS => {
+                    let data = msg.data.as_data32();
+
+                    match data[0] {
+                        x if x == xwm.atoms._NET_WM_PING => {
+                            let timestamp = data[1];
+                            // Some older clients will not faithfully copy the data back to us, and
+                            // will only set the timestamp, so `data[2]` may be zero or unreliable.
+                            let window_id = data[2];
+
+                            let surface = (window_id != x11rb::NONE)
+                                .then(|| xwm.windows.iter().find(|x| x.window_id() == window_id))
+                                .flatten()
+                                .filter(|surface| {
+                                    surface.state.lock().unwrap().pending_ping_timestamp == Some(timestamp)
+                                })
+                                .or_else(|| {
+                                    xwm.windows.iter().find(|x| {
+                                        x.state.lock().unwrap().pending_ping_timestamp == Some(timestamp)
+                                    })
+                                })
+                                .cloned();
+
+                            if let Some(surface) = surface {
+                                surface.state.lock().unwrap().pending_ping_timestamp = None;
+                                drop(_guard);
+                                state.ping_acked(xwm_id, surface.clone(), timestamp);
+                            }
+                        }
+
+                        _ => {
+                            debug!(
+                                "Unhandled WM_PROTOCOLS client msg of type {:?}",
+                                String::from_utf8(
+                                    conn.get_atom_name(data[0])?.reply_unchecked()?.unwrap().name
+                                )
+                                .ok()
+                            )
+                        }
                     }
                 }
                 x if x == xwm.atoms._NET_SHOWING_DESKTOP => {

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -66,6 +66,23 @@ pub struct X11Surface {
     user_data: Arc<UserDataMap>,
 }
 
+/// Possible errors when calling [X11Surface::send_ping]
+#[derive(Debug, thiserror::Error)]
+pub enum PingError {
+    /// Not supported
+    #[error("Ping protocol is not supported for this window")]
+    NotSupported,
+    /// Invalid timestamp (must not be `0`/`CURRENT_TIME`)
+    #[error("Invalid timestamp provided")]
+    InvalidTimestamp,
+    /// Another ping is already in flight.
+    #[error("Ping with timestamp {0} is still in flight")]
+    PingAlreadyPending(u32),
+    /// Error on the underlying X11 Connection
+    #[error(transparent)]
+    Connection(#[from] ConnectionError),
+}
+
 const MWM_HINTS_FLAGS_FIELD: usize = 0;
 const MWM_HINTS_DECORATIONS_FIELD: usize = 2;
 const MWM_HINTS_DECORATIONS: u32 = 1 << 1;
@@ -104,6 +121,7 @@ pub(crate) struct SharedSurfaceState {
         Option<ModifiersState>,
         Serial,
     )>,
+    pub(super) pending_ping_timestamp: Option<u32>,
 }
 
 pub(super) type Protocols = Vec<WMProtocol>;
@@ -112,6 +130,7 @@ pub(super) type Protocols = Vec<WMProtocol>;
 pub(super) enum WMProtocol {
     TakeFocus,
     DeleteWindow,
+    NetWmPing,
 }
 
 impl PartialEq for X11Surface {
@@ -247,6 +266,7 @@ impl X11Surface {
                 opaque_region: None,
                 opaque_region_dirty: true,
                 pending_enter: None,
+                pending_ping_timestamp: None,
             })),
             xdnd_active,
             user_data: Arc::new(UserDataMap::new()),
@@ -1079,6 +1099,7 @@ impl X11Surface {
             .filter_map(|atom| match atom {
                 x if x == self.atoms.WM_TAKE_FOCUS => Some(WMProtocol::TakeFocus),
                 x if x == self.atoms.WM_DELETE_WINDOW => Some(WMProtocol::DeleteWindow),
+                x if x == self.atoms._NET_WM_PING => Some(WMProtocol::NetWmPing),
                 _ => None,
             })
             .collect::<Vec<_>>();
@@ -1193,6 +1214,42 @@ impl X11Surface {
     /// Retrieve user_data associated with this X11 window
     pub fn user_data(&self) -> &UserDataMap {
         &self.user_data
+    }
+
+    /// Sends a `_NET_WM_PING` message to the window.
+    ///
+    /// The passed `timestamp` must be unique, as older clients may only send the timestamp in the
+    /// ping reply for use in matching the reply to the correct window.  In particular, do not pass
+    /// `x11rb::CURRENT_TIME`.
+    ///
+    /// You can implement the
+    /// [`XwmHandler::ping_acked()`](crate::xwayland::xwm::XwmHandler::ping_acked) trait item in
+    /// order to be notified when the client responds.
+    pub fn send_ping(&self, timestamp: u32) -> Result<(), PingError> {
+        if timestamp == x11rb::CURRENT_TIME {
+            Err(PingError::InvalidTimestamp)
+        } else {
+            let mut state = self.state.lock().unwrap();
+            if let Some(timestamp) = &state.pending_ping_timestamp {
+                Err(PingError::PingAlreadyPending(*timestamp))
+            } else {
+                let conn = self.conn.upgrade().ok_or(ConnectionError::UnknownError)?;
+                if state.protocols.contains(&WMProtocol::NetWmPing) && timestamp != x11rb::CURRENT_TIME {
+                    let event = ClientMessageEvent::new(
+                        32,
+                        self.window,
+                        self.atoms.WM_PROTOCOLS,
+                        [self.atoms._NET_WM_PING, timestamp, self.window, 0, 0],
+                    );
+                    conn.send_event(false, self.window, EventMask::NO_EVENT, event)?;
+                    conn.flush()?;
+                    state.pending_ping_timestamp = Some(timestamp);
+                    Ok(())
+                } else {
+                    Err(PingError::NotSupported)
+                }
+            }
+        }
     }
 
     /// Send a close request to this window.


### PR DESCRIPTION
## Description

This adds `X11Surface::ping()`, which, if supported by the client, sends a `_NET_WM_PING` message to the window.  When the client responds, `XwmHandler::ping_acked()` is called.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
