### PR TITLE
drm/surface: Make sure we also reset `pending`

### DIFF
--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -994,6 +994,7 @@ impl AtomicDrmSurface {
         if res.is_ok() {
             self.used_planes.lock().unwrap().clear();
             self.state.write().unwrap().clear();
+            self.pending.write().unwrap().clear();
         }
 
         res
@@ -1008,6 +1009,7 @@ impl AtomicDrmSurface {
         } else {
             State::current_state(&*self.fd, self.crtc, &mut self.prop_mapping.write().unwrap())?
         };
+        *self.pending.write().unwrap() = self.state.read().unwrap().clone();
         Ok(())
     }
 

--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -462,6 +462,7 @@ impl LegacyDrmSurface {
         } else {
             State::current_state(&*self.fd, self.crtc)?
         };
+        *self.pending.write().unwrap() = self.state.read().unwrap().clone();
         Ok(())
     }
 


### PR DESCRIPTION
It is possible to end up in the very unfortunate situation of just setting the `pending` state of a `DrmSurface` before a call to `DrmDevice::pause`.

This *seems* like a good thing, because after `activate`, we presumably will transition to the new pending state without loosing any user operation. However a suspend/resume cycle might render the `Mode`-blob created and set in the pending state invalid... Theoretically a connector could also disappear (with MST).

Since most compositor will re-evaluate the current state and then apply their output configuration anew after a suspend/resume cycle anyway, I argue we should simply reset `pending` to the current state as well.


## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
