### PR TITLE
xwm: Set `WM_STATE` to match `_NET_WM_STATE_HIDDEN`, instead of mapped

### DIFF
--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -263,29 +263,14 @@ impl X11Surface {
         if let Some(conn) = self.conn.upgrade() {
             if let Some(frame) = self.state.lock().unwrap().mapped_onto {
                 if mapped {
-                    let property = [1u32 /*NormalState*/, 0 /*WINDOW_NONE*/];
-                    conn.change_property32(
-                        PropMode::REPLACE,
-                        self.window,
-                        self.atoms.WM_STATE,
-                        self.atoms.WM_STATE,
-                        &property,
-                    )?;
                     conn.map_window(frame)?;
                 } else {
-                    let property = [3u32 /*IconicState*/, 0 /*WINDOW_NONE*/];
-                    conn.change_property32(
-                        PropMode::REPLACE,
-                        self.window,
-                        self.atoms.WM_STATE,
-                        self.atoms.WM_STATE,
-                        &property,
-                    )?;
                     conn.unmap_window(frame)?;
                 }
                 conn.flush()?;
             }
         }
+
         Ok(())
     }
 
@@ -789,6 +774,19 @@ impl X11Surface {
                 self.atoms._NET_WM_STATE,
                 AtomEnum::ATOM,
                 &new_props,
+            )?;
+
+            let wm_state = if state.net_state.contains(&self.atoms._NET_WM_STATE_HIDDEN) {
+                [3u32 /*IconicState*/, 0 /*WINDOW_NONE*/]
+            } else {
+                [1u32 /*NormalState*/, 0 /*WINDOW_NONE*/]
+            };
+            conn.change_property32(
+                PropMode::REPLACE,
+                self.window,
+                self.atoms.WM_STATE,
+                self.atoms.WM_STATE,
+                &wm_state,
             )?;
         }
 


### PR DESCRIPTION
## Description
This fixes an issue on cosmic-comp with Dishonored 2 (the GOG version started in Heroic Game Launcher, though that probably doesn't matter). Prior to this change, when the game loses focus it would auto-minmize, but when unminimized the window would remain black, and not restore itself to fullscreen. With this change, it becomes fullscreen again and works.

It's running through wine, so I'm not sure exactly how that's using `WM_STATE` vs other properties.

I'm not 100% sure this is the correct way to do this, though I guess it's a valid implementation anyway?

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
