### PR TITLE
wayland: don't scale non-accelerated pointer values

### DIFF
--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -128,7 +128,7 @@ impl WpRelativePointerHandle {
                 .client_scale
                 .load(Ordering::Acquire);
             let delta = event.delta.to_client(client_scale);
-            let delta_unaccel = event.delta_unaccel.to_client(client_scale);
+            let delta_unaccel = event.delta_unaccel;
 
             let utime_hi = (event.utime >> 32) as u32;
             let utime_lo = (event.utime & 0xffffffff) as u32;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->
While investigating why relative pointer events in XWayland games may no longer be handled correctly, I noticed that the previous implementation in [Smithay PR #1508](https://github.com/Smithay/smithay/pull/1508) was based on KWin’s earlier design.

However, KWin has since removed this unnecessary acceleration handling to fix related bugs in [KWin commit 47f800c12786d4b04a2e812785784d41e39bbfbc](https://invent.kde.org/plasma/kwin/-/commit/47f800c12786d4b04a2e812785784d41e39bbfbc)

Additionally, the [protocol specification](https://wayland.app/protocols/relative-pointer-unstable-v1#zwp_relative_pointer_v1:event:relative_motion:arg:dx_unaccel) states:

“The non-accelerated delta is, when applicable, the regular pointer motion delta as it was before having applied motion acceleration and other transformations such as normalization.”

So this change also aligns with the protocol’s intended definition and behavior.

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
