### PR TITLE
wayland/drm_syncobj: Allow temporarily close the device

### DIFF
--- a/src/wayland/drm_syncobj/mod.rs
+++ b/src/wayland/drm_syncobj/mod.rs
@@ -123,7 +123,7 @@ impl Cacheable for DrmSyncobjCachedState {
 #[derive(Debug)]
 pub struct DrmSyncobjState {
     global: GlobalId,
-    import_device: DrmDeviceFd,
+    import_device: Option<DrmDeviceFd>,
     known_timelines: Vec<Weak<DrmTimelineInner>>,
 }
 
@@ -157,22 +157,25 @@ impl DrmSyncobjState {
 
         Self {
             global,
-            import_device,
+            import_device: Some(import_device),
             known_timelines: Vec::new(),
         }
     }
 
+    /// Closes the current `import_device`, allowing compositors to acquire a new fd.
+    pub fn close_device<'a>(&'a mut self) -> CloseGuard<'a> {
+        self.import_device.take();
+        CloseGuard { state: self }
+    }
+
     /// Sets a new `import_device` to import the syncobj fds and wait on them.
-    ///
-    /// Note: This will not update already existing timeline objects,
-    /// which will continue to use the previous device.
     pub fn update_device(&mut self, import_device: DrmDeviceFd) {
         for timeline in self.known_timelines.iter().filter_map(Weak::upgrade) {
             if let Err(err) = timeline.update_device(&import_device) {
                 warn!(?err, "Failed to update existing timeline");
             }
         }
-        self.import_device = import_device;
+        self.import_device = Some(import_device);
     }
 
     /// Destroys the state and returns the `GlobalId` for compositors to disable/destroy.
@@ -184,6 +187,20 @@ impl DrmSyncobjState {
             timeline.invalidate();
         }
         self.global
+    }
+}
+
+/// Guard returned by [`DrmSyncobjState::close_device`] to allow temporarily closing the import device.
+#[derive(Debug)]
+#[must_use = "You need to assign a new import device to not break the drm_syncobj global."]
+pub struct CloseGuard<'a> {
+    state: &'a mut DrmSyncobjState,
+}
+
+impl<'a> CloseGuard<'a> {
+    /// Sets a new `import_device` to import the syncobj fds and wait on them.
+    pub fn update_device(self, import_device: DrmDeviceFd) {
+        self.state.update_device(import_device);
     }
 }
 
@@ -329,15 +346,21 @@ where
             }
             wp_linux_drm_syncobj_manager_v1::Request::ImportTimeline { id, fd } => {
                 if let Some(state) = state.drm_syncobj_state() {
-                    match DrmTimeline::new(&state.import_device, fd) {
-                        Ok(timeline) => {
+                    match state.import_device.as_ref().map(|dev| DrmTimeline::new(dev, fd)) {
+                        Some(Ok(timeline)) => {
                             state.known_timelines.push(Arc::downgrade(&timeline.0));
                             data_init.init::<_, _>(id, DrmSyncobjTimelineData { timeline });
                         }
-                        Err(err) => {
+                        Some(Err(err)) => {
                             resource.post_error(
                                 wp_linux_drm_syncobj_manager_v1::Error::InvalidTimeline as u32,
                                 format!("failed to import syncobj timeline: {err}"),
+                            );
+                        }
+                        None => {
+                            resource.post_error(
+                                wp_linux_drm_syncobj_manager_v1::Error::InvalidTimeline as u32,
+                                "failed to import syncobj timeline: No device".to_string(),
                             );
                         }
                     }


### PR DESCRIPTION
`libseat` [recommends to re-open file descriptors](https://git.sr.ht/~kennylevinsen/seatd/tree/master/item/include/libseat.h#L17) after suspend/resume, since they might have been permanently revoked.

Unfortunately it doesn't wire-up logind's resume event, which provides new file descriptors, to pass those on. As a result compositors need to issue a new open-call, which will not succeed unless the old file descriptor has been closed.

Since we put the `DrmDeviceFd` into internal `Arc`s (yes multiple), this can be a bit annoying and one part where we completely fail to provide a way to re-open the FD is our `drm_syncobj`-protocol implementation.

You can update the internal device in case it disappears and you want to select a new one. But if you simply want to re-open the file descriptor, there is no way to do that without invalidating all existing timelines in the process (which is obviously bad and will hang some clients due to unsignaled release points).

There isn't really an elegant way to do this, so this PR provides a way to temporarily close the internal file descriptor of the global's state.


## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
