### PR TITLE
Add PointerConstraintsHandler trait for remove_constraint

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -172,6 +172,7 @@ pub struct AnvilState<BackendData: Backend + 'static> {
     pub seat: Seat<AnvilState<BackendData>>,
     pub clock: Clock<Monotonic>,
     pub pointer: PointerHandle<AnvilState<BackendData>>,
+    pub cursor_position_hint: Option<(WlSurface, Point<f64, Logical>)>,
 
     #[cfg(feature = "xwayland")]
     pub xwm: Option<X11Wm>,
@@ -376,6 +377,25 @@ impl<BackendData: Backend> PointerConstraintsHandler for AnvilState<BackendData>
         }
     }
 
+    fn remove_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>) {
+        if with_pointer_constraint(surface, pointer, |constraint| constraint.is_none()) {
+            if let Some((hint_surface, hint_location)) = &self.cursor_position_hint {
+                let origin = self
+                    .space
+                    .elements()
+                    .find_map(|window| {
+                        (window.wl_surface().as_deref() == Some(hint_surface)).then(|| window.geometry())
+                    })
+                    .unwrap_or_default()
+                    .loc
+                    .to_f64();
+
+                pointer.set_location(origin + *hint_location);
+            }
+            self.cursor_position_hint = None;
+        }
+    }
+
     fn cursor_position_hint(
         &mut self,
         surface: &WlSurface,
@@ -385,17 +405,7 @@ impl<BackendData: Backend> PointerConstraintsHandler for AnvilState<BackendData>
         if with_pointer_constraint(surface, pointer, |constraint| {
             constraint.is_some_and(|c| c.is_active())
         }) {
-            let origin = self
-                .space
-                .elements()
-                .find_map(|window| {
-                    (window.wl_surface().as_deref() == Some(surface)).then(|| window.geometry())
-                })
-                .unwrap_or_default()
-                .loc
-                .to_f64();
-
-            pointer.set_location(origin + location);
+            self.cursor_position_hint = Some((surface.clone(), location));
         }
     }
 }
@@ -749,6 +759,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
             seat_name,
             seat,
             pointer,
+            cursor_position_hint: None,
             clock,
 
             #[cfg(feature = "xwayland")]

--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -37,6 +37,11 @@ pub trait PointerConstraintsHandler: SeatHandler {
     /// Use [`with_pointer_constraint`] to access the constraint.
     fn new_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>);
 
+    /// Constraint removed for `pointer` on `surface`
+    ///
+    /// Use [`with_pointer_constraint`] to access the constraint.
+    fn remove_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>);
+
     /// The client holding a LockedPointer has committed a cursor position hint.
     ///
     /// This is emitted upon a surface commit if the cursor position hint has been updated.
@@ -344,12 +349,23 @@ fn add_constraint<D: SeatHandler + PointerConstraintsHandler + 'static>(
     }
 }
 
-fn remove_constraint<D: SeatHandler + 'static>(surface: &WlSurface, pointer: &PointerHandle<D>) {
-    with_constraint_data::<D, _, _>(surface, |data| {
+fn remove_constraint<D: SeatHandler + PointerConstraintsHandler + 'static>(
+    state: &mut D,
+    surface: &WlSurface,
+    pointer: &PointerHandle<D>,
+) {
+    let is_removed = with_constraint_data::<D, _, _>(surface, |data| {
         if let Some(data) = data {
-            data.constraints.remove(pointer);
+            if let Some(_constraint) = data.constraints.remove(pointer) {
+                return true;
+            }
         }
+        false
     });
+
+    if is_removed {
+        state.remove_constraint(surface, pointer);
+    }
 }
 
 impl<D> Dispatch2<ZwpPointerConstraintsV1, D> for GlobalData
@@ -460,7 +476,7 @@ where
 
 impl<D> Dispatch2<ZwpConfinedPointerV1, D> for PointerConstraintUserData<D>
 where
-    D: SeatHandler,
+    D: SeatHandler + PointerConstraintsHandler,
     D: 'static,
 {
     fn request(
@@ -493,7 +509,7 @@ where
 
     fn destroyed(
         &self,
-        _state: &mut D,
+        state: &mut D,
         _client: wayland_server::backend::ClientId,
         _resource: &ZwpConfinedPointerV1,
     ) {
@@ -501,13 +517,13 @@ where
             return;
         };
 
-        remove_constraint(&self.surface, pointer);
+        remove_constraint(state, &self.surface, pointer);
     }
 }
 
 impl<D> Dispatch2<ZwpLockedPointerV1, D> for PointerConstraintUserData<D>
 where
-    D: SeatHandler,
+    D: SeatHandler + PointerConstraintsHandler,
     D: 'static,
 {
     fn request(
@@ -545,7 +561,7 @@ where
 
     fn destroyed(
         &self,
-        _state: &mut D,
+        state: &mut D,
         _client: wayland_server::backend::ClientId,
         _resource: &ZwpLockedPointerV1,
     ) {
@@ -553,6 +569,6 @@ where
             return;
         };
 
-        remove_constraint(&self.surface, pointer);
+        remove_constraint(state, &self.surface, pointer);
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->
According to the protocol [description](https://wayland.app/protocols/pointer-constraints-unstable-v1#zwp_locked_pointer_v1:request:set_cursor_position_hint): 

>If the client is drawing its own cursor, it should update the position hint to the position of its own cursor. A compositor may use this information to warp the pointer upon unlock in order to avoid pointer jumps.

Therefore, we need to ensure that there is a callback to notify the compositor when the constraint is removed.


<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
