### PR TITLE
dnd: Send only events supported by client

### DIFF
--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -350,7 +350,9 @@ fn handle_dnd<D, S>(
                 );
                 if chosen_action != data.chosen_action {
                     data.chosen_action = chosen_action;
-                    offer.action(chosen_action);
+                    if offer.version() >= wl_data_offer::EVT_ACTION_SINCE {
+                        offer.action(chosen_action);
+                    }
                     source.choose_action(
                         DndAction::unwrap_single(&DndAction::vec_from_wl(chosen_action))
                             .expect("We have selected a single value at this point."),
@@ -467,7 +469,9 @@ impl<D: SeatHandler + DataDeviceHandler + 'static> DndFocus<D> for WlSurface {
                 for mime_type in metadata.mime_types.iter().cloned() {
                     offer.offer(mime_type);
                 }
-                offer.source_actions(DndAction::convert_slice(&metadata.dnd_actions));
+                if offer.version() >= wl_data_offer::EVT_SOURCE_ACTIONS_SINCE {
+                    offer.source_actions(DndAction::convert_slice(&metadata.dnd_actions));
+                }
 
                 device.enter((*serial).into(), self, location.x, location.y, Some(&offer));
 
@@ -503,7 +507,9 @@ impl<D: SeatHandler + DataDeviceHandler + 'static> DndFocus<D> for WlSurface {
             if let Some(new_metadata) = offer.source.metadata() {
                 if offer.last_source_actions != new_metadata.dnd_actions {
                     for wl_offer in &offer.wl_offers {
-                        wl_offer.source_actions(DndAction::convert_slice(&new_metadata.dnd_actions));
+                        if wl_offer.version() >= wl_data_offer::EVT_SOURCE_ACTIONS_SINCE {
+                            wl_offer.source_actions(DndAction::convert_slice(&new_metadata.dnd_actions));
+                        }
                     }
 
                     offer.last_source_actions = new_metadata.dnd_actions;


### PR DESCRIPTION
## Description
Hi!

This PR fixes https://github.com/Smithay/smithay/issues/2026 (shout out to [bczhc](https://github.com/bczhc) for providing so much relevant info).

I have reproduced the issue in Anvil by DnD a file into GLFW window, and with these changes the crash is gone.

This feels out of place however, looking at the other protocols, some of them have nice abstractions with such check baked into: https://github.com/Smithay/smithay/blob/060e9cd9c8ae2633947bdb72cffa1748ac53922d/src/wayland/selection/data_device/source.rs#L137
Perhaps I should add simple abstraction that checks the version similarly?

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
