### PR TITLE
fix(xwm): Defer X11 focus release between same-client transitions

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -136,7 +136,7 @@ use crate::{
     },
 };
 use atomic_float::AtomicF64;
-use calloop::{Interest, LoopHandle, Mode, PostAction, generic::Generic};
+use calloop::{Interest, LoopHandle, Mode, PostAction, generic::Generic, ping};
 use rustix::fs::OFlags;
 use std::{
     cell::RefCell,
@@ -147,7 +147,10 @@ use std::{
         io::{AsFd, OwnedFd},
         net::UnixStream,
     },
-    sync::{Arc, Weak, atomic::Ordering},
+    sync::{
+        Arc, Weak,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 use tracing::{debug, debug_span, info, trace, warn};
 use wayland_server::{DisplayHandle, Resource};
@@ -163,9 +166,9 @@ use x11rb::{
         render::{ConnectionExt as _, CreatePictureAux, PictureWrapper},
         xfixes::ConnectionExt as _,
         xproto::{
-            AtomEnum, CONFIGURE_NOTIFY_EVENT, ChangeWindowAttributesAux, Colormap, ColormapAlloc,
+            Atom, AtomEnum, CONFIGURE_NOTIFY_EVENT, ChangeWindowAttributesAux, Colormap, ColormapAlloc,
             ConfigWindow, ConfigureNotifyEvent, ConfigureWindowAux, ConnectionExt, CreateGCAux,
-            CreateWindowAux, CursorWrapper, EventMask, FontWrapper, GcontextWrapper, ImageFormat,
+            CreateWindowAux, CursorWrapper, EventMask, FontWrapper, GcontextWrapper, ImageFormat, InputFocus,
             PixmapWrapper, PropMode, Property, QueryExtensionReply, Screen, StackMode, Visualid, WindowClass,
         },
     },
@@ -567,12 +570,72 @@ pub struct X11Wm {
 
     is_showing_desktop: bool,
 
+    pub(super) focus_release: FocusReleaseHandle,
+
     span: tracing::Span,
 }
 
 impl Drop for X11Wm {
     fn drop(&mut self) {
         xwm_id::remove(self.id.0);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct FocusReleaseHandle {
+    pending: Arc<AtomicBool>,
+    signal: ping::Ping,
+    conn: Weak<RustConnection>,
+    root: X11Window,
+    active_window: Atom,
+}
+
+impl FocusReleaseHandle {
+    fn new(
+        conn: &Arc<RustConnection>,
+        root: X11Window,
+        active_window: Atom,
+    ) -> std::io::Result<(Self, ping::PingSource)> {
+        let (signal, source) = ping::make_ping()?;
+        Ok((
+            Self {
+                pending: Arc::new(AtomicBool::new(false)),
+                signal,
+                conn: Arc::downgrade(conn),
+                root,
+                active_window,
+            },
+            source,
+        ))
+    }
+
+    fn schedule(&self) {
+        self.pending.store(true, Ordering::Release);
+        self.signal.ping();
+    }
+
+    fn cancel(&self) {
+        self.pending.store(false, Ordering::Release);
+    }
+
+    fn dispatch(&self) {
+        if !self.pending.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        let Some(conn) = self.conn.upgrade() else { return };
+        if let Err(err) = conn.set_input_focus(InputFocus::NONE, x11rb::NONE, x11rb::CURRENT_TIME) {
+            warn!("Unable to release X11 keyboard focus: {}", err);
+        }
+        if let Err(err) = conn.change_property32(
+            PropMode::REPLACE,
+            self.root,
+            self.active_window,
+            AtomEnum::WINDOW,
+            &[x11rb::NONE],
+        ) {
+            warn!("Unable to clear _NET_ACTIVE_WINDOW: {}", err);
+        }
+        let _ = conn.flush();
     }
 }
 
@@ -890,6 +953,13 @@ impl X11Wm {
         let dnd = XWmDnd::new(&conn, &screen, &atoms)?;
         let wm_window = OwnedX11Window::new(win, &conn);
 
+        let (focus_release, focus_release_source) =
+            FocusReleaseHandle::new(&conn, screen.root, atoms._NET_ACTIVE_WINDOW)?;
+        {
+            let release = focus_release.clone();
+            handle.insert_source(focus_release_source, move |_, _, _| release.dispatch())?;
+        }
+
         drop(_guard);
         let wm = Self {
             id,
@@ -911,6 +981,7 @@ impl X11Wm {
             client_list: Vec::new(),
             client_list_stacking: Vec::new(),
             is_showing_desktop: false,
+            focus_release,
             span,
         };
 
@@ -2224,17 +2295,6 @@ where
                     xwm.atoms._NET_ACTIVE_WINDOW,
                     AtomEnum::WINDOW,
                     &[n.event],
-                )?;
-            }
-        }
-        Event::FocusOut(n) => {
-            if xwm.windows.iter().any(|x| x.window_id() == n.event) {
-                conn.change_property32(
-                    PropMode::REPLACE,
-                    xwm.screen.root,
-                    xwm.atoms._NET_ACTIVE_WINDOW,
-                    AtomEnum::WINDOW,
-                    &[x11rb::NONE],
                 )?;
             }
         }

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -166,10 +166,11 @@ use x11rb::{
         render::{ConnectionExt as _, CreatePictureAux, PictureWrapper},
         xfixes::ConnectionExt as _,
         xproto::{
-            Atom, AtomEnum, CONFIGURE_NOTIFY_EVENT, ChangeWindowAttributesAux, Colormap, ColormapAlloc,
+            AtomEnum, CONFIGURE_NOTIFY_EVENT, ChangeWindowAttributesAux, Colormap, ColormapAlloc,
             ConfigWindow, ConfigureNotifyEvent, ConfigureWindowAux, ConnectionExt, CreateGCAux,
             CreateWindowAux, CursorWrapper, EventMask, FontWrapper, GcontextWrapper, ImageFormat, InputFocus,
-            PixmapWrapper, PropMode, Property, QueryExtensionReply, Screen, StackMode, Visualid, WindowClass,
+            NotifyDetail, PixmapWrapper, PropMode, Property, QueryExtensionReply, Screen, StackMode,
+            Visualid, WindowClass,
         },
     },
     rust_connection::{ConnectionError, DefaultStream, RustConnection},
@@ -586,24 +587,16 @@ pub(super) struct FocusReleaseHandle {
     pending: Arc<AtomicBool>,
     signal: ping::Ping,
     conn: Weak<RustConnection>,
-    root: X11Window,
-    active_window: Atom,
 }
 
 impl FocusReleaseHandle {
-    fn new(
-        conn: &Arc<RustConnection>,
-        root: X11Window,
-        active_window: Atom,
-    ) -> std::io::Result<(Self, ping::PingSource)> {
+    fn new(conn: &Arc<RustConnection>) -> std::io::Result<(Self, ping::PingSource)> {
         let (signal, source) = ping::make_ping()?;
         Ok((
             Self {
                 pending: Arc::new(AtomicBool::new(false)),
                 signal,
                 conn: Arc::downgrade(conn),
-                root,
-                active_window,
             },
             source,
         ))
@@ -625,15 +618,6 @@ impl FocusReleaseHandle {
         let Some(conn) = self.conn.upgrade() else { return };
         if let Err(err) = conn.set_input_focus(InputFocus::NONE, x11rb::NONE, x11rb::CURRENT_TIME) {
             warn!("Unable to release X11 keyboard focus: {}", err);
-        }
-        if let Err(err) = conn.change_property32(
-            PropMode::REPLACE,
-            self.root,
-            self.active_window,
-            AtomEnum::WINDOW,
-            &[x11rb::NONE],
-        ) {
-            warn!("Unable to clear _NET_ACTIVE_WINDOW: {}", err);
         }
         let _ = conn.flush();
     }
@@ -953,8 +937,7 @@ impl X11Wm {
         let dnd = XWmDnd::new(&conn, &screen, &atoms)?;
         let wm_window = OwnedX11Window::new(win, &conn);
 
-        let (focus_release, focus_release_source) =
-            FocusReleaseHandle::new(&conn, screen.root, atoms._NET_ACTIVE_WINDOW)?;
+        let (focus_release, focus_release_source) = FocusReleaseHandle::new(&conn)?;
         {
             let release = focus_release.clone();
             handle.insert_source(focus_release_source, move |_, _, _| release.dispatch())?;
@@ -2295,6 +2278,17 @@ where
                     xwm.atoms._NET_ACTIVE_WINDOW,
                     AtomEnum::WINDOW,
                     &[n.event],
+                )?;
+            }
+        }
+        Event::FocusOut(n) if n.detail == NotifyDetail::NONE => {
+            if xwm.windows.iter().any(|x| x.window_id() == n.event) {
+                conn.change_property32(
+                    PropMode::REPLACE,
+                    xwm.screen.root,
+                    xwm.atoms._NET_ACTIVE_WINDOW,
+                    AtomEnum::WINDOW,
+                    &[x11rb::NONE],
                 )?;
             }
         }

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -58,6 +58,7 @@ pub struct X11Surface {
     xwm: Option<XwmId>,
     client_scale: Option<Arc<AtomicF64>>,
     window: X11Window,
+    focus_release: Option<super::FocusReleaseHandle>,
     pub(super) conn: Weak<RustConnection>,
     pub(super) atoms: super::Atoms,
     pub(crate) state: Arc<Mutex<SharedSurfaceState>>,
@@ -269,6 +270,7 @@ impl X11Surface {
                 pending_ping_timestamp: None,
             })),
             xdnd_active,
+            focus_release: xwm.map(|wm| wm.focus_release.clone()),
             user_data: Arc::new(UserDataMap::new()),
         }
     }
@@ -1375,6 +1377,10 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for X11Surface {
             WmInputModel::GloballyActive => (false, true),
         };
 
+        if let Some(release) = &self.focus_release {
+            release.cancel();
+        }
+
         if let Some(conn) = self.conn.upgrade() {
             if set_input_focus {
                 if let Err(err) = conn.set_input_focus(InputFocus::NONE, self.window, x11rb::CURRENT_TIME) {
@@ -1417,11 +1423,10 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for X11Surface {
     fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial) {
         if self.input_model() == WmInputModel::None {
             return;
-        } else if let Some(conn) = self.conn.upgrade() {
-            if let Err(err) = conn.set_input_focus(InputFocus::NONE, x11rb::NONE, x11rb::CURRENT_TIME) {
-                warn!("Unable to unfocus X11Surface ({:?}): {}", self.window, err);
-            }
-            let _ = conn.flush();
+        }
+
+        if let Some(release) = &self.focus_release {
+            release.schedule();
         }
 
         let mut state = self.state.lock().unwrap();


### PR DESCRIPTION
## Description
`X11Wm` set `_NET_ACTIVE_WINDOW = NONE` for any FocusOut event on a tracked top-level window, ignoring `detail` field. It breaks X11 clients like Unity Editor. 

Mechanism of the flaw: 
- the client gets focus at the top level and...
- almost instantly switches focus to its sub-window. 
- X-server generates FocusOut(detail=inferior) for the top-level window. 
- code without fix just set `_NET_ACTIVE_WINDOW` to none, and...
- there is no one to receive `FocusIn`.

But that's not the whole issue. `X11Surface` also synchronously calls `set_input_focus(NONE, NONE)`, producing the intermediate state "focus is nowhere".

Fixes: 
- https://github.com/pop-os/cosmic-comp/issues/2006, 
- https://github.com/pop-os/cosmic-epoch/issues/2311
- and potentially many more issues overall for X11 apps related to focus out, like: https://github.com/pop-os/cosmic-comp/issues/1211

Works not only for cosmic-comp but also for other compositors based on Smithay, all of which suffer the same issue.

### Symptoms
Symptoms are exactly as described in https://github.com/pop-os/cosmic-comp/issues/2006:
- Open a project in Unity
- It's smooth and nice
- Press Play, and experience a framerate dropped to 10 frames per second (Unity turns on throttling when losing focus, to not waste resources).
- More than that, the keyboard and mouse are unresponsive inside Game view
- Alt+tab and back - helps to return focus, but framerate is still down.

And many other related to input-unresponsiveness and sluggish experience, which cannot always be resolved by clicking other panels/alt-tabbing. 

### Diagnostics
Instrumentation wired into Smithay showed that:
```
  02:06:02.408  X11Surface::enter                          WINDOW=29360433 MODEL=LocallyActive
  02:06:02.412  xwm Event::FocusIn   WINDOW=29360433 detail=NONLINEAR tracked=true
  02:06:02.412  xwm: _NET_ACTIVE_WINDOW = window           WINDOW=29360433 
  02:06:02.462  xwm Event::FocusOut  WINDOW=29360433 detail=INFERIOR tracked=true
  02:06:02.462  xwm: _NET_ACTIVE_WINDOW = NONE             WINDOW=29360433   <-- issue
```
Meaning that Unity switched focus from the top level to a sub-window, but _NET_ACTIVE_WINDOW became **none**.

### How the fix works
- `FocusOut` now doesn't touch `_NET_ACTIVE_WINDOW`
- Losing focus now deferred to the next event loop, leaving a space to cancel focus leaving for `X11Wm`.

## What I've checked
- Checked locally with cosmic-comp (no code was changed in cosmic-comp, only path to local version of smithay)
- Unity Editor is no longer throttling
- Switching between X11<->Wayland apps works as expected
- No regression issues found

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
