### PR TITLE
x11: X11Surface bbox/geometry should match committed buffer

### DIFF
--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -5,9 +5,11 @@ use crate::{
             Kind,
             surface::{WaylandSurfaceRenderElement, render_elements_from_surface_tree},
         },
+        utils::RendererSurfaceStateUserData,
     },
     desktop::{WindowSurfaceType, space::SpaceElement},
     utils::{Logical, Physical, Point, Rectangle, Scale},
+    wayland::compositor,
     xwayland::X11Surface,
 };
 
@@ -15,8 +17,17 @@ use super::{WindowOutputUserData, output_update};
 
 impl SpaceElement for X11Surface {
     fn bbox(&self) -> Rectangle<i32, Logical> {
-        let geo = X11Surface::geometry(self);
-        Rectangle::from_size(geo.size)
+        let size = X11Surface::wl_surface(self)
+            .and_then(|surface| {
+                compositor::with_states(&surface, |states| {
+                    states
+                        .data_map
+                        .get::<RendererSurfaceStateUserData>()
+                        .and_then(|s| s.lock().unwrap().surface_size())
+                })
+            })
+            .unwrap_or_else(|| X11Surface::geometry(self).size);
+        Rectangle::from_size(size)
     }
 
     fn is_in_input_region(&self, point: &Point<f64, Logical>) -> bool {


### PR DESCRIPTION
## Description

`X11Surface::bbox()` returns the geometry stored internally by `X11Surface`, which is based on the last committed configure attempted by the compositor (via `configure()`).  The problem here is that the client is free to reject that size (size increments, min size, max size, etc.).

In these cases, we can mis-render the window (placement or size) if the last configured rect is not the same as the actual committed buffer.

Instead, use the surface/buffer size, and only fall back to `X11Surface`'s geometry if that's not available.

(This used to be a part of #2018 but I decided to split it off since it's not strictly related.)

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
