### PR TITLE
fix: duplicated "the" in desktop space/grab/tablet input comments

### DIFF
--- a/src/backend/input/tablet.rs
+++ b/src/backend/input/tablet.rs
@@ -314,7 +314,7 @@ pub trait TabletToolButtonEvent<B: InputBackend>: TabletToolEvent<B> + Event<B> 
     fn button(&self) -> u32;
 
     /// For the button of a TabletToolButtonEvent,
-    /// return the total number of buttons pressed on all devices on the associated seat after the the event was triggered.
+    /// return the total number of buttons pressed on all devices on the associated seat after the event was triggered.
     fn seat_button_count(&self) -> u32;
 
     /// Return the button state of the event.

--- a/src/desktop/space/wayland/mod.rs
+++ b/src/desktop/space/wayland/mod.rs
@@ -72,7 +72,7 @@ pub fn output_update(output: &Output, output_overlap: Option<Rectangle<i32, Logi
                     output.leave(wl_surface);
                 }
             } else {
-                // Maybe the the surface got unmapped, send leave on output
+                // Maybe the surface got unmapped, send leave on output
                 output.leave(wl_surface);
             }
         },

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -598,7 +598,7 @@ where
             return;
         }
 
-        // Check if the the client of the focused surface is still equal to the grabbed surface client
+        // Check if the client of the focused surface is still equal to the grabbed surface client
         // if not the popup will be dismissed
         if state == ButtonState::Pressed
             && !handle


### PR DESCRIPTION
Three one-line typo fixes for duplicated "the" in source comments:
- `src/desktop/space/wayland/mod.rs` — "// Maybe the the surface got unmapped, send leave on output" → "// Maybe the surface got unmapped, send leave on output"
- `src/desktop/wayland/popup/grab.rs` — "// Check if the the client of the focused surface is still equal to the grabbed surface client" → "// Check if the client of the focused surface..."
- `src/backend/input/tablet.rs` — "/// return the total number of buttons pressed on all devices on the associated seat after the the event was triggered." → "...after the event was triggered."

No code/behavior change.