### PR TITLE
Don't explicitly use `as u32` for error enums

### DIFF
--- a/src/wayland/commit_timing/mod.rs
+++ b/src/wayland/commit_timing/mod.rs
@@ -278,7 +278,7 @@ where
             } => {
                 let Ok(surface) = self.0.upgrade() else {
                     resource.post_error(
-                        wp_commit_timer_v1::Error::SurfaceDestroyed as u32,
+                        wp_commit_timer_v1::Error::SurfaceDestroyed,
                         "the surface associated with this commit timer object has been destroyed".to_string(),
                     );
                     return;
@@ -307,7 +307,7 @@ where
 
                 if already_has_timestamp {
                     resource.post_error(
-                        wp_commit_timer_v1::Error::TimestampExists as u32,
+                        wp_commit_timer_v1::Error::TimestampExists,
                         "the surface already has a timestamp associated for this commit".to_string(),
                     );
                 }

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -1161,7 +1161,7 @@ impl DmabufParamsData {
 
             None => {
                 params.post_error(
-                    zwp_linux_buffer_params_v1::Error::Incomplete as u32,
+                    zwp_linux_buffer_params_v1::Error::Incomplete,
                     "Provided buffer is incomplete, it has zero planes",
                 );
                 return None;

--- a/src/wayland/drm_syncobj/mod.rs
+++ b/src/wayland/drm_syncobj/mod.rs
@@ -241,17 +241,17 @@ fn commit_hook<D: DrmSyncobjHandler>(_data: &mut D, _dh: &DisplayHandle, surface
                 let pending = cached.pending();
                 if pending.acquire_point.is_some() && new_buffer.is_none() {
                     syncobj_surface.post_error(
-                        wp_linux_drm_syncobj_surface_v1::Error::NoBuffer as u32,
+                        wp_linux_drm_syncobj_surface_v1::Error::NoBuffer,
                         "acquire point without buffer".to_string(),
                     );
                 } else if pending.acquire_point.is_some() && pending.release_point.is_none() {
                     syncobj_surface.post_error(
-                        wp_linux_drm_syncobj_surface_v1::Error::NoReleasePoint as u32,
+                        wp_linux_drm_syncobj_surface_v1::Error::NoReleasePoint,
                         "acquire point without release point".to_string(),
                     );
                 } else if pending.acquire_point.is_none() && pending.release_point.is_some() {
                     syncobj_surface.post_error(
-                        wp_linux_drm_syncobj_surface_v1::Error::NoAcquirePoint as u32,
+                        wp_linux_drm_syncobj_surface_v1::Error::NoAcquirePoint,
                         "release point without acquire point".to_string(),
                     );
                 } else if let (Some(acquire), Some(release)) =
@@ -259,7 +259,7 @@ fn commit_hook<D: DrmSyncobjHandler>(_data: &mut D, _dh: &DisplayHandle, surface
                 {
                     if acquire.timeline == release.timeline && release.point <= acquire.point {
                         syncobj_surface.post_error(
-                            wp_linux_drm_syncobj_surface_v1::Error::ConflictingPoints as u32,
+                            wp_linux_drm_syncobj_surface_v1::Error::ConflictingPoints,
                             format!(
                                 "release point {} is not greater than acquire point {}",
                                 release.point, acquire.point
@@ -269,7 +269,7 @@ fn commit_hook<D: DrmSyncobjHandler>(_data: &mut D, _dh: &DisplayHandle, surface
                     if let Some(buffer) = new_buffer {
                         if get_dmabuf(buffer).is_err() {
                             syncobj_surface.post_error(
-                                wp_linux_drm_syncobj_surface_v1::Error::UnsupportedBuffer as u32,
+                                wp_linux_drm_syncobj_surface_v1::Error::UnsupportedBuffer,
                                 "sync points with non-dmabuf buffer".to_string(),
                             );
                         }
@@ -322,7 +322,7 @@ where
                 });
                 if already_exists {
                     resource.post_error(
-                        wp_linux_drm_syncobj_manager_v1::Error::SurfaceExists as u32,
+                        wp_linux_drm_syncobj_manager_v1::Error::SurfaceExists,
                         "the surface already has a syncobj_surface object associated".to_string(),
                     );
                     return;
@@ -353,20 +353,20 @@ where
                         }
                         Some(Err(err)) => {
                             resource.post_error(
-                                wp_linux_drm_syncobj_manager_v1::Error::InvalidTimeline as u32,
+                                wp_linux_drm_syncobj_manager_v1::Error::InvalidTimeline,
                                 format!("failed to import syncobj timeline: {err}"),
                             );
                         }
                         None => {
                             resource.post_error(
-                                wp_linux_drm_syncobj_manager_v1::Error::InvalidTimeline as u32,
+                                wp_linux_drm_syncobj_manager_v1::Error::InvalidTimeline,
                                 "failed to import syncobj timeline: No device".to_string(),
                             );
                         }
                     }
                 } else {
                     resource.post_error(
-                        wp_linux_drm_syncobj_manager_v1::Error::InvalidTimeline as u32,
+                        wp_linux_drm_syncobj_manager_v1::Error::InvalidTimeline,
                         "global orphaned",
                     )
                 }

--- a/src/wayland/fifo/mod.rs
+++ b/src/wayland/fifo/mod.rs
@@ -303,7 +303,7 @@ where
             wp_fifo_v1::Request::SetBarrier => {
                 let Ok(surface) = self.0.upgrade() else {
                     resource.post_error(
-                        wp_fifo_v1::Error::SurfaceDestroyed as u32,
+                        wp_fifo_v1::Error::SurfaceDestroyed,
                         "the surface associated with this fifo object has been destroyed".to_string(),
                     );
                     return;
@@ -315,7 +315,7 @@ where
             wp_fifo_v1::Request::WaitBarrier => {
                 let Ok(surface) = self.0.upgrade() else {
                     resource.post_error(
-                        wp_fifo_v1::Error::SurfaceDestroyed as u32,
+                        wp_fifo_v1::Error::SurfaceDestroyed,
                         "the surface associated with this fifo object has been destroyed".to_string(),
                     );
                     return;

--- a/src/wayland/fractional_scale/mod.rs
+++ b/src/wayland/fractional_scale/mod.rs
@@ -150,7 +150,7 @@ where
 
                 if already_has_fractional_scale {
                     surface.post_error(
-                        wp_fractional_scale_manager_v1::Error::FractionalScaleExists as u32,
+                        wp_fractional_scale_manager_v1::Error::FractionalScaleExists,
                         "the surface already has a fractional_scale object associated".to_string(),
                     );
                     return;

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -324,7 +324,7 @@ where
                     }
                     Err(()) => {
                         self.wm_base.post_error(
-                            xdg_wm_base::Error::Role as u32,
+                            xdg_wm_base::Error::Role,
                             "xdg_surface must have a role of xdg_toplevel or xdg_popup.",
                         );
                         return;

--- a/src/wayland/viewporter/mod.rs
+++ b/src/wayland/viewporter/mod.rs
@@ -137,7 +137,7 @@ where
 
                 if already_has_viewport {
                     surface.post_error(
-                        wp_viewporter::Error::ViewportExists as u32,
+                        wp_viewporter::Error::ViewportExists,
                         "the surface already has a viewport object associated".to_string(),
                     );
                     return;
@@ -222,7 +222,7 @@ where
 
                 if !is_unset && !is_valid_src {
                     resource.post_error(
-                        wp_viewport::Error::BadValue as u32,
+                        wp_viewport::Error::BadValue,
                         "negative or zero values in width or height or negative values in x or y".to_string(),
                     );
                     return;
@@ -232,7 +232,7 @@ where
                 // all wp_viewport requests except 'destroy' raise the protocol error no_surface.
                 let Ok(surface) = self.surface.upgrade() else {
                     resource.post_error(
-                        wp_viewport::Error::NoSurface as u32,
+                        wp_viewport::Error::NoSurface,
                         "the wl_surface was destroyed".to_string(),
                     );
                     return;
@@ -260,7 +260,7 @@ where
 
                 if !is_unset && !is_valid_size {
                     resource.post_error(
-                        wp_viewport::Error::BadValue as u32,
+                        wp_viewport::Error::BadValue,
                         "negative or zero values in width or height".to_string(),
                     );
                     return;
@@ -270,7 +270,7 @@ where
                 // all wp_viewport requests except 'destroy' raise the protocol error no_surface.
                 let Ok(surface) = self.surface.upgrade() else {
                     resource.post_error(
-                        wp_viewport::Error::NoSurface as u32,
+                        wp_viewport::Error::NoSurface,
                         "the wl_surface was destroyed".to_string(),
                     );
                     return;
@@ -333,7 +333,7 @@ fn viewport_pre_commit_hook<D: 'static>(
             {
                 if let Ok(viewport) = viewport.0.upgrade() {
                     viewport.post_error(
-                        wp_viewport::Error::BadSize as u32,
+                        wp_viewport::Error::BadSize,
                         "destination size is not integer".to_string(),
                     );
                 }
@@ -367,7 +367,7 @@ pub fn ensure_viewport_valid(states: &SurfaceData, buffer_size: Size<i32, Logica
         if !valid {
             if let Ok(viewport) = viewport.0.upgrade() {
                 viewport.post_error(
-                    wp_viewport::Error::OutOfBuffer as u32,
+                    wp_viewport::Error::OutOfBuffer,
                     format!(
                         "source rectangle x={},y={},w={},h={} extends outside of the content area x={},y={},w={},h={}", 
                         src.loc.x, src.loc.y, src.size.w, src.size.h,

--- a/src/wayland/xdg_toplevel_icon.rs
+++ b/src/wayland/xdg_toplevel_icon.rs
@@ -342,7 +342,7 @@ impl<D: XdgToplevelIconHandler> Dispatch2<XdgToplevelIconV1, D> for XdgToplevelI
         _: &Client,
         icon: &XdgToplevelIconV1,
         request: xdg_toplevel_icon_v1::Request,
-        dh: &DisplayHandle,
+        _: &DisplayHandle,
         _: &mut DataInit<'_, D>,
     ) {
         use xdg_toplevel_icon_v1::Request;
@@ -350,9 +350,8 @@ impl<D: XdgToplevelIconHandler> Dispatch2<XdgToplevelIconV1, D> for XdgToplevelI
         match request {
             Request::SetName { icon_name } => {
                 if self.is_immutable() {
-                    dh.post_error(
-                        icon,
-                        xdg_toplevel_icon_v1::Error::Immutable as u32,
+                    icon.post_error(
+                        xdg_toplevel_icon_v1::Error::Immutable,
                         "Request made after the icon has been assigned to a toplevel via 'set_icon'"
                             .to_string(),
                     );
@@ -362,27 +361,24 @@ impl<D: XdgToplevelIconHandler> Dispatch2<XdgToplevelIconV1, D> for XdgToplevelI
             }
             Request::AddBuffer { buffer, scale } => {
                 if self.is_immutable() {
-                    dh.post_error(
-                        icon,
-                        xdg_toplevel_icon_v1::Error::Immutable as u32,
+                    icon.post_error(
+                        xdg_toplevel_icon_v1::Error::Immutable,
                         "Request made after the icon has been assigned to a toplevel via 'set_icon'"
                             .to_string(),
                     );
                 }
 
                 let Some(shm) = buffer.data::<ShmBufferUserData>() else {
-                    dh.post_error(
-                        icon,
-                        xdg_toplevel_icon_v1::Error::InvalidBuffer as u32,
+                    icon.post_error(
+                        xdg_toplevel_icon_v1::Error::InvalidBuffer,
                         "The wl_buffer must be backed by wl_shm".to_string(),
                     );
                     return;
                 };
 
                 if shm.data.width != shm.data.height {
-                    dh.post_error(
-                        icon,
-                        xdg_toplevel_icon_v1::Error::InvalidBuffer as u32,
+                    icon.post_error(
+                        xdg_toplevel_icon_v1::Error::InvalidBuffer,
                         "The wl_buffer must be a square".to_string(),
                     );
                     return;


### PR DESCRIPTION
## Description
`post_error()` takes `impl Into<u32>`.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
