### PR TITLE
Implement wlr virtual pointer unstable protocol

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -91,6 +91,7 @@ use smithay::{
         text_input::TextInputManagerState,
         viewporter::ViewporterState,
         virtual_keyboard::VirtualKeyboardManagerState,
+        virtual_pointer::{VirtualPointerHandler, VirtualPointerManagerState},
         xdg_activation::{
             XdgActivationHandler, XdgActivationState, XdgActivationToken, XdgActivationTokenData,
         },
@@ -349,6 +350,76 @@ impl<BackendData: Backend> InputMethodHandler for AnvilState<BackendData> {
             .elements()
             .find_map(|window| (window.wl_surface().as_deref() == Some(parent)).then(|| window.geometry()))
             .unwrap_or_default()
+    }
+}
+
+impl<BackendData: Backend> VirtualPointerHandler for AnvilState<BackendData> {
+    fn virtual_pointer_get_default_seat(&self) -> Option<Seat<Self>> {
+        Some(self.seat.clone())
+    }
+
+    fn virtual_pointer_motion(
+        &mut self,
+        _seat: Option<&Seat<Self>>,
+        time: u32,
+        delta: Point<f64, Logical>,
+    ) {
+        let pointer = self.pointer.clone();
+        let location = (pointer.current_location() + delta).constrain(
+            self.space
+                .outputs()
+                .filter_map(|o| self.space.output_geometry(o))
+                .fold(Rectangle::default(), |acc, r| acc.merge(r))
+                .to_f64(),
+        );
+        let under = self.surface_under(location);
+        pointer.motion(
+            self,
+            under,
+            &smithay::input::pointer::MotionEvent {
+                location,
+                serial: smithay::utils::SERIAL_COUNTER.next_serial(),
+                time,
+            },
+        );
+        pointer.frame(self);
+    }
+
+    fn virtual_pointer_motion_absolute(
+        &mut self,
+        _seat: Option<&Seat<Self>>,
+        time: u32,
+        x: u32,
+        y: u32,
+        x_extent: u32,
+        y_extent: u32,
+    ) {
+        if x_extent == 0 || y_extent == 0 {
+            return;
+        }
+        let output_geo = self
+            .space
+            .outputs()
+            .next()
+            .and_then(|o| self.space.output_geometry(o))
+            .unwrap_or_default()
+            .to_f64();
+        let location = Point::from((
+            output_geo.loc.x + (x as f64 / x_extent as f64) * output_geo.size.w,
+            output_geo.loc.y + (y as f64 / y_extent as f64) * output_geo.size.h,
+        ));
+        let under = self.surface_under(location);
+        let pointer = self.pointer.clone();
+        pointer.motion(
+            self,
+            under,
+            &smithay::input::pointer::MotionEvent {
+                location,
+                serial: smithay::utils::SERIAL_COUNTER.next_serial(),
+                time,
+            },
+        );
+        pointer.frame(self);
     }
 }
 
@@ -676,6 +747,7 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
         TextInputManagerState::new::<Self>(&dh);
         InputMethodManagerState::new::<Self, _>(&dh, |_client| true);
         VirtualKeyboardManagerState::new::<Self, _>(&dh, |_client| true);
+        VirtualPointerManagerState::new::<Self, _>(&dh, |_client| true);
         // Expose global only if backend supports relative motion events
         if BackendData::HAS_RELATIVE_MOTION {
             RelativePointerManagerState::new::<Self>(&dh);

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -89,6 +89,7 @@ pub mod tablet_manager;
 pub mod text_input;
 pub mod viewporter;
 pub mod virtual_keyboard;
+pub mod virtual_pointer;
 pub mod xdg_activation;
 pub mod xdg_foreign;
 pub mod xdg_system_bell;

--- a/src/wayland/virtual_pointer/mod.rs
+++ b/src/wayland/virtual_pointer/mod.rs
@@ -316,7 +316,7 @@ where
                         );
                     }
                 } else {
-                    warn!("virtual_pointer: button event dropped — no seat associated with virtual pointer and no default seat provided");
+                    warn!("virtual_pointer: button event dropped - no seat associated with virtual pointer and no default seat provided");
                 }
             }
 
@@ -347,7 +347,7 @@ where
                         ptr.frame(state);
                     }
                 } else if frame.is_some() {
-                    warn!("virtual_pointer: axis frame dropped — no seat associated with virtual pointer and no default seat provided");
+                    warn!("virtual_pointer: axis frame dropped - no seat associated with virtual pointer and no default seat provided");
                 }
             }
 

--- a/src/wayland/virtual_pointer/mod.rs
+++ b/src/wayland/virtual_pointer/mod.rs
@@ -1,0 +1,430 @@
+//! Utilities for wlr-virtual-pointer support
+//!
+//! This module provides utilities to handle virtual pointer instances, allowing
+//! clients to emulate a physical pointer device.
+//!
+//! ```
+//! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
+//! use smithay::wayland::virtual_pointer::{VirtualPointerManagerState, VirtualPointerHandler};
+//! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
+//! # use smithay::reexports::wayland_server::Client;
+//! use smithay::utils::{Logical, Point};
+//!
+//! # struct State { seat_state: SeatState<Self> };
+//!
+//! smithay::delegate_dispatch2!(State);
+//!
+//! # let mut display = Display::<State>::new().unwrap();
+//! # let display_handle = display.handle();
+//!
+//! let seat_state = SeatState::<State>::new();
+//!
+//! impl SeatHandler for State {
+//!     type KeyboardFocus = WlSurface;
+//!     type PointerFocus = WlSurface;
+//!     type TouchFocus = WlSurface;
+//!     fn seat_state(&mut self) -> &mut SeatState<Self> {
+//!         &mut self.seat_state
+//!     }
+//!     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
+//!     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
+//! }
+//!
+//! impl VirtualPointerHandler for State {
+//!     fn virtual_pointer_motion(
+//!         &mut self,
+//!         seat: Option<&Seat<Self>>,
+//!         time: u32,
+//!         delta: Point<f64, Logical>,
+//!     ) {
+//!         // Move the pointer by delta, update focus
+//!     }
+//!
+//!     fn virtual_pointer_motion_absolute(
+//!         &mut self,
+//!         seat: Option<&Seat<Self>>,
+//!         time: u32,
+//!         x: u32,
+//!         y: u32,
+//!         x_extent: u32,
+//!         y_extent: u32,
+//!     ) {
+//!         // Map (x/x_extent, y/y_extent) to compositor coordinates, update focus
+//!     }
+//! }
+//!
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &WlSurface) {}
+//! # }
+//!
+//! // Create the global, gating access behind a client filter
+//! VirtualPointerManagerState::new::<State, _>(&display_handle, |_client| true);
+//! ```
+
+use std::{fmt, sync::Mutex};
+
+use tracing::{debug, trace, warn};
+use wayland_protocols_wlr::virtual_pointer::v1::server::{
+    zwlr_virtual_pointer_manager_v1::{self, ZwlrVirtualPointerManagerV1},
+    zwlr_virtual_pointer_v1::{self, Error as VirtualPointerError, ZwlrVirtualPointerV1},
+};
+use wayland_server::{
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, WEnum,
+    backend::GlobalId,
+    protocol::wl_pointer,
+};
+
+use crate::{
+    backend::input::{Axis, AxisSource, ButtonState},
+    input::{
+        Seat, SeatHandler,
+        pointer::{AxisFrame, ButtonEvent},
+    },
+    utils::{Logical, Point, SERIAL_COUNTER},
+    wayland::{Dispatch2, GlobalData, GlobalDispatch2},
+};
+
+const MANAGER_VERSION: u32 = 2;
+
+/// Handler trait for wlr-virtual-pointer protocol events.
+///
+/// Compositors implement this trait to respond to virtual pointer motion events.
+/// Button, axis, and frame events are dispatched directly to the seat's pointer
+/// handle by Smithay.
+pub trait VirtualPointerHandler: SeatHandler + 'static {
+    /// Return the seat to use when a client creates a virtual pointer without
+    /// specifying one (`seat = null` in the protocol request).
+    ///
+    /// The wlr-virtual-pointer spec says: "If the seat is null, the compositor
+    /// SHOULD use a default seat." Implementing this method lets Smithay dispatch
+    /// button and axis events for seat-less virtual pointers.
+    ///
+    /// The default implementation returns `None`, which causes those events to be
+    /// dropped with a warning.
+    fn virtual_pointer_get_default_seat(&self) -> Option<Seat<Self>> {
+        None
+    }
+
+    /// Handle a relative motion event from a virtual pointer.
+    ///
+    /// `delta` is the displacement in compositor-space logical coordinates.
+    /// The compositor should add this to the current pointer position and update
+    /// the pointer focus accordingly.
+    fn virtual_pointer_motion(
+        &mut self,
+        seat: Option<&Seat<Self>>,
+        time: u32,
+        delta: Point<f64, Logical>,
+    );
+
+    /// Handle an absolute motion event from a virtual pointer.
+    ///
+    /// The `(x, y)` coordinates lie in the range `[0, x_extent)` x `[0, y_extent)`.
+    /// The compositor should map these to compositor-space coordinates and update
+    /// the pointer focus accordingly.
+    fn virtual_pointer_motion_absolute(
+        &mut self,
+        seat: Option<&Seat<Self>>,
+        time: u32,
+        x: u32,
+        y: u32,
+        x_extent: u32,
+        y_extent: u32,
+    );
+}
+
+/// User data of a [`ZwlrVirtualPointerV1`] object.
+pub struct VirtualPointerUserData<D: SeatHandler> {
+    seat: Option<Seat<D>>,
+    /// Axis events accumulate here until `frame` is received.
+    pending_axis: Mutex<Option<AxisFrame>>,
+}
+
+impl<D: SeatHandler> fmt::Debug for VirtualPointerUserData<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VirtualPointerUserData")
+            .field("pending_axis", &self.pending_axis)
+            .finish()
+    }
+}
+
+/// State of the wlr-virtual-pointer manager global.
+#[derive(Debug)]
+pub struct VirtualPointerManagerState {
+    global: GlobalId,
+}
+
+/// Data associated with a [`VirtualPointerManagerState`] global.
+#[allow(missing_debug_implementations)]
+pub struct VirtualPointerManagerGlobalData {
+    filter: Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>,
+}
+
+impl VirtualPointerManagerState {
+    /// Initialize a new wlr-virtual-pointer manager global.
+    ///
+    /// The `filter` closure controls which clients are allowed to bind the global.
+    pub fn new<D, F>(display: &DisplayHandle, filter: F) -> Self
+    where
+        D: GlobalDispatch<ZwlrVirtualPointerManagerV1, VirtualPointerManagerGlobalData>,
+        D: Dispatch<ZwlrVirtualPointerManagerV1, GlobalData>,
+        D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerUserData<D>>,
+        D: VirtualPointerHandler,
+        D: 'static,
+        F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
+    {
+        let data = VirtualPointerManagerGlobalData {
+            filter: Box::new(filter),
+        };
+        let global =
+            display.create_global::<D, ZwlrVirtualPointerManagerV1, _>(MANAGER_VERSION, data);
+        Self { global }
+    }
+
+    /// Get the [`GlobalId`] of the [`ZwlrVirtualPointerManagerV1`] global.
+    pub fn global(&self) -> GlobalId {
+        self.global.clone()
+    }
+}
+
+impl<D> GlobalDispatch2<ZwlrVirtualPointerManagerV1, D> for VirtualPointerManagerGlobalData
+where
+    D: Dispatch<ZwlrVirtualPointerManagerV1, GlobalData>,
+    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerUserData<D>>,
+    D: VirtualPointerHandler,
+    D: 'static,
+{
+    fn bind(
+        &self,
+        _state: &mut D,
+        _dh: &DisplayHandle,
+        _client: &Client,
+        resource: New<ZwlrVirtualPointerManagerV1>,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(resource, GlobalData);
+    }
+
+    fn can_view(&self, client: &Client) -> bool {
+        (self.filter)(client)
+    }
+}
+
+impl<D> Dispatch2<ZwlrVirtualPointerManagerV1, D> for GlobalData
+where
+    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerUserData<D>>,
+    D: VirtualPointerHandler,
+    D: 'static,
+{
+    fn request(
+        &self,
+        _state: &mut D,
+        _client: &Client,
+        _manager: &ZwlrVirtualPointerManagerV1,
+        request: zwlr_virtual_pointer_manager_v1::Request,
+        _dh: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        let (wl_seat, id) = match request {
+            zwlr_virtual_pointer_manager_v1::Request::CreateVirtualPointer { seat, id } => {
+                (seat, id)
+            }
+            zwlr_virtual_pointer_manager_v1::Request::CreateVirtualPointerWithOutput {
+                seat,
+                output: _,
+                id,
+            } => (seat, id),
+            zwlr_virtual_pointer_manager_v1::Request::Destroy => return,
+            _ => unreachable!(),
+        };
+
+        let seat = wl_seat.and_then(|s| Seat::<D>::from_resource(&s));
+        data_init.init(
+            id,
+            VirtualPointerUserData {
+                seat,
+                pending_axis: Mutex::new(None),
+            },
+        );
+    }
+}
+
+impl<D> Dispatch2<ZwlrVirtualPointerV1, D> for VirtualPointerUserData<D>
+where
+    D: VirtualPointerHandler + 'static,
+{
+    fn request(
+        &self,
+        state: &mut D,
+        _client: &Client,
+        resource: &ZwlrVirtualPointerV1,
+        request: zwlr_virtual_pointer_v1::Request,
+        _dh: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        let seat = self.seat.as_ref();
+        // Fall back to compositor-supplied default when no seat was specified at
+        // virtual pointer creation time (protocol allows seat = null).
+        let default_seat = if seat.is_none() {
+            state.virtual_pointer_get_default_seat()
+        } else {
+            None
+        };
+        let effective_seat = seat.or(default_seat.as_ref());
+
+        match request {
+            zwlr_virtual_pointer_v1::Request::Motion { time, dx, dy } => {
+                debug!("virtual_pointer: motion dx={dx} dy={dy} time={time}");
+                state.virtual_pointer_motion(effective_seat, time, Point::from((dx, dy)));
+            }
+
+            zwlr_virtual_pointer_v1::Request::MotionAbsolute {
+                time,
+                x,
+                y,
+                x_extent,
+                y_extent,
+            } => {
+                debug!("virtual_pointer: motion_absolute x={x} y={y} x_extent={x_extent} y_extent={y_extent} time={time}");
+                state.virtual_pointer_motion_absolute(effective_seat, time, x, y, x_extent, y_extent);
+            }
+
+            zwlr_virtual_pointer_v1::Request::Button {
+                time,
+                button,
+                state: button_state,
+            } => {
+                let btn_state = match button_state {
+                    WEnum::Value(wl_pointer::ButtonState::Pressed) => ButtonState::Pressed,
+                    WEnum::Value(wl_pointer::ButtonState::Released) => ButtonState::Released,
+                    WEnum::Value(_) | WEnum::Unknown(_) => return,
+                };
+                debug!("virtual_pointer: button button={button:#010x} state={btn_state:?} time={time}");
+                if let Some(seat) = effective_seat {
+                    if let Some(ptr) = seat.get_pointer() {
+                        ptr.button(
+                            state,
+                            &ButtonEvent {
+                                serial: SERIAL_COUNTER.next_serial(),
+                                time,
+                                button,
+                                state: btn_state,
+                            },
+                        );
+                    }
+                } else {
+                    warn!("virtual_pointer: button event dropped — no seat associated with virtual pointer and no default seat provided");
+                }
+            }
+
+            zwlr_virtual_pointer_v1::Request::Axis { time, axis, value } => {
+                let axis = match to_axis(axis) {
+                    Some(a) => a,
+                    None => {
+                        resource.post_error(VirtualPointerError::InvalidAxis, "invalid axis value");
+                        return;
+                    }
+                };
+                let mut pending = self.pending_axis.lock().unwrap();
+                let frame = pending.get_or_insert_with(|| AxisFrame::new(time));
+                frame.time = time;
+                let updated = (*frame).value(axis, value);
+                *frame = updated;
+            }
+
+            zwlr_virtual_pointer_v1::Request::Frame => {
+                trace!("virtual_pointer: frame");
+                let frame = self.pending_axis.lock().unwrap().take();
+                if let Some(seat) = effective_seat {
+                    if let Some(ptr) = seat.get_pointer() {
+                        if let Some(frame) = frame {
+                            debug!("virtual_pointer: dispatching axis frame {frame:?}");
+                            ptr.axis(state, frame);
+                        }
+                        ptr.frame(state);
+                    }
+                } else if frame.is_some() {
+                    warn!("virtual_pointer: axis frame dropped — no seat associated with virtual pointer and no default seat provided");
+                }
+            }
+
+            zwlr_virtual_pointer_v1::Request::AxisSource { axis_source } => {
+                let source = match to_axis_source(axis_source) {
+                    Some(s) => s,
+                    None => {
+                        resource.post_error(
+                            VirtualPointerError::InvalidAxisSource,
+                            "invalid axis source value",
+                        );
+                        return;
+                    }
+                };
+                let mut pending = self.pending_axis.lock().unwrap();
+                let frame = pending.get_or_insert_with(|| AxisFrame::new(0));
+                let updated = (*frame).source(source);
+                *frame = updated;
+            }
+
+            zwlr_virtual_pointer_v1::Request::AxisStop { time, axis } => {
+                let axis = match to_axis(axis) {
+                    Some(a) => a,
+                    None => {
+                        resource.post_error(VirtualPointerError::InvalidAxis, "invalid axis value");
+                        return;
+                    }
+                };
+                let mut pending = self.pending_axis.lock().unwrap();
+                let frame = pending.get_or_insert_with(|| AxisFrame::new(time));
+                frame.time = time;
+                let updated = (*frame).stop(axis);
+                *frame = updated;
+            }
+
+            zwlr_virtual_pointer_v1::Request::AxisDiscrete {
+                time,
+                axis,
+                value,
+                discrete,
+            } => {
+                let axis = match to_axis(axis) {
+                    Some(a) => a,
+                    None => {
+                        resource.post_error(VirtualPointerError::InvalidAxis, "invalid axis value");
+                        return;
+                    }
+                };
+                let mut pending = self.pending_axis.lock().unwrap();
+                let frame = pending.get_or_insert_with(|| AxisFrame::new(time));
+                frame.time = time;
+                // axis_discrete sends a legacy discrete step count (1 per detent).
+                // v120 uses 120 units per detent, so multiply accordingly.
+                let updated = (*frame).value(axis, value).v120(axis, discrete * 120);
+                *frame = updated;
+            }
+
+            zwlr_virtual_pointer_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn to_axis(axis: WEnum<wl_pointer::Axis>) -> Option<Axis> {
+    match axis {
+        WEnum::Value(wl_pointer::Axis::VerticalScroll) => Some(Axis::Vertical),
+        WEnum::Value(wl_pointer::Axis::HorizontalScroll) => Some(Axis::Horizontal),
+        _ => None,
+    }
+}
+
+fn to_axis_source(source: WEnum<wl_pointer::AxisSource>) -> Option<AxisSource> {
+    match source {
+        WEnum::Value(wl_pointer::AxisSource::Wheel) => Some(AxisSource::Wheel),
+        WEnum::Value(wl_pointer::AxisSource::Finger) => Some(AxisSource::Finger),
+        WEnum::Value(wl_pointer::AxisSource::Continuous) => Some(AxisSource::Continuous),
+        WEnum::Value(wl_pointer::AxisSource::WheelTilt) => Some(AxisSource::WheelTilt),
+        _ => None,
+    }
+}

--- a/test_clients/src/bin/test_virtual_pointer.rs
+++ b/test_clients/src/bin/test_virtual_pointer.rs
@@ -180,7 +180,7 @@ impl App {
 
         match self.step {
             TestStep::WaitForMap => {
-                info!("Window mapped — jumping cursor to top-left corner");
+                info!("Window mapped - jumping cursor to top-left corner");
                 self.step = TestStep::AbsoluteMotion;
                 self.step_due = Instant::now();
                 self.advance(qh);
@@ -192,7 +192,7 @@ impl App {
                 vp.motion_absolute(time, 0, 0, 1, 1);
                 vp.frame();
                 self.window.wl_surface().commit();
-                info!("Cursor at top-left — sweeping diagonally for ~2 seconds");
+                info!("Cursor at top-left - sweeping diagonally for ~2 seconds");
                 self.step = TestStep::Sweep;
                 // ~120 frames × 4px right + 3px down ≈ 480×360 px diagonal sweep
                 self.sweep_remaining = 120;
@@ -205,7 +205,7 @@ impl App {
                 self.window.wl_surface().commit();
                 self.sweep_remaining -= 1;
                 if self.sweep_remaining == 0 {
-                    info!("Sweep done — pausing 1 second so cursor is visible");
+                    info!("Sweep done - pausing 1 second so cursor is visible");
                     self.step = TestStep::Pause;
                     self.step_due = Instant::now() + Duration::from_secs(1);
                 }
@@ -226,7 +226,7 @@ impl App {
                 vp.button(time, BTN_LEFT, wl_pointer::ButtonState::Released);
                 vp.frame();
                 self.window.wl_surface().commit();
-                info!("Click sent — waiting 2 seconds then scrolling");
+                info!("Click sent - waiting 2 seconds then scrolling");
                 self.step = TestStep::Scroll;
                 self.step_due = Instant::now() + Duration::from_secs(2);
             }
@@ -237,13 +237,13 @@ impl App {
                 vp.axis_discrete(time, wl_pointer::Axis::VerticalScroll, 30.0, 3);
                 vp.frame();
                 self.window.wl_surface().commit();
-                info!("Scroll sent — done in 2 seconds");
+                info!("Scroll sent - done in 2 seconds");
                 self.step = TestStep::Done;
                 self.step_due = Instant::now() + Duration::from_secs(2);
             }
 
             TestStep::Done => {
-                info!("All virtual pointer events sent — stopping");
+                info!("All virtual pointer events sent - stopping");
                 if let Some(vp) = self.virtual_pointer.take() {
                     vp.destroy();
                 }

--- a/test_clients/src/bin/test_virtual_pointer.rs
+++ b/test_clients/src/bin/test_virtual_pointer.rs
@@ -1,0 +1,426 @@
+//! Test client for the wlr-virtual-pointer protocol.
+//!
+//! Creates a window and a virtual pointer, then runs a slow sequence of
+//! events so cursor movement is plainly visible on screen:
+//!
+//!  1. Moves the pointer to the top-left corner of the output (absolute)
+//!  2. Sweeps diagonally across the output over ~2 seconds (many small relative moves)
+//!  3. Pauses for 1 second so the cursor is clearly visible
+//!  4. Clicks the left mouse button
+//!  5. Scrolls vertically three notches
+//!
+//! Run against a compositor that implements the protocol and watch the cursor
+//! move on screen. Pointer events received by the window are logged.
+
+use std::time::{Duration, Instant};
+
+use smithay_client_toolkit::{
+    compositor::{CompositorHandler, CompositorState},
+    delegate_compositor, delegate_output, delegate_pointer, delegate_registry, delegate_seat,
+    delegate_shm, delegate_xdg_shell, delegate_xdg_window,
+    output::{OutputHandler, OutputState},
+    reexports::{
+        calloop,
+        client as wayland_client,
+        protocols_wlr::virtual_pointer::v1::client::{
+            zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1,
+            zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1,
+        },
+    },
+    registry::{ProvidesRegistryState, RegistryState},
+    registry_handlers,
+    seat::{
+        Capability, SeatHandler, SeatState,
+        pointer::{PointerEvent, PointerEventKind, PointerHandler},
+    },
+    shell::{
+        WaylandSurface,
+        xdg::{
+            XdgShell,
+            window::{Window, WindowConfigure, WindowDecorations, WindowHandler},
+        },
+    },
+    shm::{
+        Shm, ShmHandler,
+        slot::{Buffer, SlotPool},
+    },
+};
+
+use wayland_client::{
+    Connection, QueueHandle,
+    delegate_noop,
+    protocol::{
+        wl_output::WlOutput,
+        wl_pointer::{self, WlPointer},
+        wl_seat::WlSeat,
+        wl_surface::WlSurface,
+    },
+};
+
+use tracing::info;
+
+fn main() {
+    test_clients::init_logging();
+
+    let (mut event_loop, globals, qh) = test_clients::init_connection::<App>();
+
+    let compositor_state = CompositorState::bind(&globals, &qh).unwrap();
+    let xdg_shell = XdgShell::bind(&globals, &qh).unwrap();
+    let shm = Shm::bind(&globals, &qh).unwrap();
+    let pool = SlotPool::new(256 * 256 * 4, &shm).unwrap();
+
+    // Bind the seat before committing the surface so wl_seat.capabilities
+    // arrives before xdg_surface.configure.
+    let seat_state = SeatState::new(&globals, &qh);
+
+    let virtual_pointer_manager = globals
+        .bind::<ZwlrVirtualPointerManagerV1, _, _>(&qh, 1..=2, ())
+        .expect("compositor does not support zwlr_virtual_pointer_manager_v1");
+
+    let surface = compositor_state.create_surface(&qh);
+    let window = xdg_shell.create_window(surface, WindowDecorations::RequestServer, &qh);
+    window.set_title("test-virtual-pointer");
+    window.set_min_size(Some((256, 256)));
+    window.commit();
+
+    let mut app = App {
+        registry_state: RegistryState::new(&globals),
+        output_state: OutputState::new(&globals, &qh),
+        compositor_state,
+        seat_state,
+        shm,
+        virtual_pointer_manager,
+        virtual_pointer: None,
+        seat: None,
+        pointer: None,
+        window,
+        pool,
+        buffer: None,
+        width: 256,
+        height: 256,
+        shift: 0,
+        first_configure: true,
+        step: TestStep::WaitForMap,
+        step_due: Instant::now(),
+        sweep_remaining: 0,
+        loop_signal: event_loop.get_signal(),
+    };
+
+    event_loop.run(None, &mut app, |_| {}).unwrap();
+}
+
+/// Ordered sequence of actions the test performs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TestStep {
+    WaitForMap,
+    /// Jump the cursor to the output top-left corner.
+    AbsoluteMotion,
+    /// Glide diagonally across the output with many small relative moves.
+    Sweep,
+    /// Sit still for a moment so the cursor position is plainly visible.
+    Pause,
+    /// Press and release left mouse button.
+    ButtonClick,
+    /// Send a wheel scroll event.
+    Scroll,
+    Done,
+}
+
+struct App {
+    registry_state: RegistryState,
+    output_state: OutputState,
+    #[allow(dead_code)]
+    compositor_state: CompositorState,
+    seat_state: SeatState,
+    shm: Shm,
+    virtual_pointer_manager: ZwlrVirtualPointerManagerV1,
+    virtual_pointer: Option<ZwlrVirtualPointerV1>,
+    seat: Option<WlSeat>,
+    pointer: Option<WlPointer>,
+    window: Window,
+    pool: SlotPool,
+    buffer: Option<Buffer>,
+    width: u32,
+    height: u32,
+    shift: u32,
+    first_configure: bool,
+    step: TestStep,
+    /// When the next timed step should fire.
+    step_due: Instant,
+    /// Frames remaining in the Sweep step.
+    sweep_remaining: u32,
+    loop_signal: calloop::LoopSignal,
+}
+
+impl App {
+    fn draw(&mut self, qh: &QueueHandle<Self>) {
+        test_clients::draw(
+            qh,
+            self.window.wl_surface(),
+            &mut self.pool,
+            &mut self.buffer,
+            self.width,
+            self.height,
+            &mut self.shift,
+        );
+    }
+
+    fn vp(&mut self, qh: &QueueHandle<Self>) -> ZwlrVirtualPointerV1 {
+        if self.virtual_pointer.is_none() {
+            let vp = self
+                .virtual_pointer_manager
+                .create_virtual_pointer(None, qh, ());
+            self.virtual_pointer = Some(vp);
+        }
+        self.virtual_pointer.clone().unwrap()
+    }
+
+    fn advance(&mut self, qh: &QueueHandle<Self>) {
+        let time: u32 = 0;
+
+        match self.step {
+            TestStep::WaitForMap => {
+                info!("Window mapped — jumping cursor to top-left corner");
+                self.step = TestStep::AbsoluteMotion;
+                self.step_due = Instant::now();
+                self.advance(qh);
+            }
+
+            TestStep::AbsoluteMotion => {
+                // (0, 0, 1, 1) maps to the top-left corner of the output.
+                let vp = self.vp(qh);
+                vp.motion_absolute(time, 0, 0, 1, 1);
+                vp.frame();
+                self.window.wl_surface().commit();
+                info!("Cursor at top-left — sweeping diagonally for ~2 seconds");
+                self.step = TestStep::Sweep;
+                // ~120 frames × 4px right + 3px down ≈ 480×360 px diagonal sweep
+                self.sweep_remaining = 120;
+            }
+
+            TestStep::Sweep => {
+                let vp = self.vp(qh);
+                vp.motion(time, 4.0, 3.0);
+                vp.frame();
+                self.window.wl_surface().commit();
+                self.sweep_remaining -= 1;
+                if self.sweep_remaining == 0 {
+                    info!("Sweep done — pausing 1 second so cursor is visible");
+                    self.step = TestStep::Pause;
+                    self.step_due = Instant::now() + Duration::from_secs(1);
+                }
+            }
+
+            TestStep::Pause => {
+                info!("Sending left button click");
+                self.step = TestStep::ButtonClick;
+                self.step_due = Instant::now() + Duration::from_secs(2);
+                self.advance(qh);
+            }
+
+            TestStep::ButtonClick => {
+                let vp = self.vp(qh);
+                const BTN_LEFT: u32 = 0x110;
+                vp.button(time, BTN_LEFT, wl_pointer::ButtonState::Pressed);
+                vp.frame();
+                vp.button(time, BTN_LEFT, wl_pointer::ButtonState::Released);
+                vp.frame();
+                self.window.wl_surface().commit();
+                info!("Click sent — waiting 2 seconds then scrolling");
+                self.step = TestStep::Scroll;
+                self.step_due = Instant::now() + Duration::from_secs(2);
+            }
+
+            TestStep::Scroll => {
+                let vp = self.vp(qh);
+                vp.axis_source(wl_pointer::AxisSource::Wheel);
+                vp.axis_discrete(time, wl_pointer::Axis::VerticalScroll, 30.0, 3);
+                vp.frame();
+                self.window.wl_surface().commit();
+                info!("Scroll sent — done in 2 seconds");
+                self.step = TestStep::Done;
+                self.step_due = Instant::now() + Duration::from_secs(2);
+            }
+
+            TestStep::Done => {
+                info!("All virtual pointer events sent — stopping");
+                if let Some(vp) = self.virtual_pointer.take() {
+                    vp.destroy();
+                }
+                self.loop_signal.stop();
+            }
+        }
+    }
+}
+
+// ─── Protocol implementations ────────────────────────────────────────────────
+
+impl CompositorHandler for App {
+    fn scale_factor_changed(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlSurface,
+        _: i32,
+    ) {
+    }
+    fn transform_changed(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlSurface,
+        _: wayland_client::protocol::wl_output::Transform,
+    ) {
+    }
+    fn frame(&mut self, _: &Connection, qh: &QueueHandle<Self>, _: &WlSurface, _: u32) {
+        match self.step {
+            TestStep::WaitForMap => {}
+            // Sweep fires every frame to produce smooth motion.
+            TestStep::Sweep => self.advance(qh),
+            // All other steps wait for their scheduled time.
+            _ if Instant::now() >= self.step_due => self.advance(qh),
+            _ => {}
+        }
+        self.draw(qh);
+    }
+    fn surface_enter(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlSurface,
+        _: &WlOutput,
+    ) {
+    }
+    fn surface_leave(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlSurface,
+        _: &WlOutput,
+    ) {
+    }
+}
+
+impl WindowHandler for App {
+    fn request_close(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &Window) {
+        self.loop_signal.stop();
+    }
+
+    fn configure(
+        &mut self,
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+        _window: &Window,
+        configure: WindowConfigure,
+        _serial: u32,
+    ) {
+        self.buffer = None;
+        self.width = configure.new_size.0.map(|v| v.get()).unwrap_or(256);
+        self.height = configure.new_size.1.map(|v| v.get()).unwrap_or(256);
+
+        if self.first_configure {
+            self.first_configure = false;
+            self.draw(qh);
+            self.step = TestStep::WaitForMap;
+            self.advance(qh);
+        }
+    }
+}
+
+impl SeatHandler for App {
+    fn seat_state(&mut self) -> &mut SeatState {
+        &mut self.seat_state
+    }
+    fn new_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, seat: WlSeat) {
+        if self.seat.is_none() {
+            self.seat = Some(seat);
+        }
+    }
+    fn new_capability(
+        &mut self,
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+        seat: WlSeat,
+        cap: Capability,
+    ) {
+        if cap == Capability::Pointer && self.pointer.is_none() {
+            self.pointer = Some(self.seat_state.get_pointer(qh, &seat).unwrap());
+        }
+    }
+    fn remove_capability(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: WlSeat,
+        cap: Capability,
+    ) {
+        if cap == Capability::Pointer {
+            if let Some(ptr) = self.pointer.take() {
+                ptr.release();
+            }
+        }
+    }
+    fn remove_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, _: WlSeat) {}
+}
+
+impl PointerHandler for App {
+    fn pointer_frame(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlPointer,
+        events: &[PointerEvent],
+    ) {
+        for event in events {
+            match &event.kind {
+                PointerEventKind::Enter { .. } => {
+                    info!("Pointer entered surface @{:?}", event.position)
+                }
+                PointerEventKind::Leave { .. } => info!("Pointer left surface"),
+                PointerEventKind::Motion { .. } => info!("Pointer motion: {:?}", event.position),
+                PointerEventKind::Press { button, .. } => info!("Button pressed: {button:#010x}"),
+                PointerEventKind::Release { button, .. } => {
+                    info!("Button released: {button:#010x}")
+                }
+                PointerEventKind::Axis { horizontal, vertical, .. } => {
+                    info!("Axis: horizontal={:?} vertical={:?}", horizontal, vertical)
+                }
+            }
+        }
+    }
+}
+
+impl OutputHandler for App {
+    fn output_state(&mut self) -> &mut OutputState {
+        &mut self.output_state
+    }
+    fn new_output(&mut self, _: &Connection, _: &QueueHandle<Self>, _: WlOutput) {}
+    fn update_output(&mut self, _: &Connection, _: &QueueHandle<Self>, _: WlOutput) {}
+    fn output_destroyed(&mut self, _: &Connection, _: &QueueHandle<Self>, _: WlOutput) {}
+}
+
+impl ShmHandler for App {
+    fn shm_state(&mut self) -> &mut Shm {
+        &mut self.shm
+    }
+}
+
+impl ProvidesRegistryState for App {
+    fn registry(&mut self) -> &mut RegistryState {
+        &mut self.registry_state
+    }
+    registry_handlers![OutputState];
+}
+
+// The virtual pointer objects have no events going server→client, so noop impls suffice.
+delegate_noop!(App: ignore ZwlrVirtualPointerManagerV1);
+delegate_noop!(App: ignore ZwlrVirtualPointerV1);
+
+delegate_compositor!(App);
+delegate_output!(App);
+delegate_shm!(App);
+delegate_xdg_shell!(App);
+delegate_xdg_window!(App);
+delegate_registry!(App);
+delegate_seat!(App);
+delegate_pointer!(App);


### PR DESCRIPTION
## Description
Implements the wlr virtual pointer protocol:
https://wayland.app/protocols/wlr-virtual-pointer-unstable-v1

I was able to test it by running anvil:
```
RUST_LOG=smithay::wayland::virtual_pointer=debug WAYLAND_DISPLAY=wayland-1 cargo run --release --manifest-path anvil/Cargo.toml -- --winit
```
in one shell while in another running:
```
WAYLAND_DISPLAY=wayland-2 RUST_LOG=info cargo run --manifest-path test_clients/Cargo.toml --bin test_virtual_pointer
```
And I can see the events logged by anvil:

```
2026-05-20T04:12:54.472274Z DEBUG smithay::wayland::virtual_pointer: virtual_pointer: motion dx=4 dy=3 time=0
2026-05-20T04:12:55.472606Z DEBUG smithay::wayland::virtual_pointer: virtual_pointer: button button=0x00000110 state=Pressed time=0
2026-05-20T04:12:55.472654Z DEBUG smithay::wayland::virtual_pointer: virtual_pointer: button button=0x00000110 state=Released time=0
2026-05-20T04:12:57.473192Z DEBUG smithay::wayland::virtual_pointer: virtual_pointer: dispatching axis frame AxisFrame { source: Some(Wheel), relative_direction: (Identical, Identical), time: 0, axis: (0.0, 30.0), v120: Some((0, 360)), stop: (false, false) }
```
Anvil doesn't appear to draw a mouse pointer when used in this way, but the events do get logged as if they work.  I also have a branch where I wired this into cosmic-comp and was able to use it successfully with `wayland-clickdot` and `wlrctl` to move the mouse around and show clicks.  If there's some better way to have tested this within the scope of this repo I'm happy to add it.
 
AI Disclosure:
I used Claude Sonnet 4.6 to write this, but I read it and tested it myself.  It is similar to the existing virtual_keyboard protocol implementation.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
