### PR TITLE
xwayland: ignore InputOnly windows in XWM

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1531,6 +1531,11 @@ where
                 return Ok(());
             }
 
+            let attrs = conn.get_window_attributes(n.window)?.reply()?;
+            if attrs.class != WindowClass::INPUT_OUTPUT {
+                return Ok(());
+            }
+
             xwm.conn.change_window_attributes(
                 n.window,
                 &ChangeWindowAttributesAux::new()


### PR DESCRIPTION
## Summary

- Ignore X11 CreateNotify events for InputOnly windows in the XWM before creating an X11Surface.

- Prevent invisible helper/grab windows from being treated as managed Xwayland surfaces.


## Why

Some X11 clients, including Chromium/Electron drag-and-drop helpers, create InputOnly windows. Those windows cannot be rendered or managed as normal InputOutput windows. The XWM already only reparents/maps InputOutput windows on MapRequest; this applies the same guard earlier on CreateNotify.


## Validation

- cargo fmt --check
- cargo check -p smithay --no-default-features --features wayland_frontend,backend_drm,xwayland




