### PR TITLE
Change WM_STATE only if the new value is different

### DIFF
--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -401,11 +401,20 @@ impl X11Surface {
 
         if let Some(conn) = self.conn.upgrade() {
             if let Some(frame) = self.state.lock().unwrap().mapped_onto {
-                if mapped {
+                let wm_state = if mapped {
                     conn.map_window(frame)?;
+                    1u32 /*NormalState*/
                 } else {
                     conn.unmap_window(frame)?;
-                }
+                    3u32 /*IconicState*/
+                };
+                conn.change_property32(
+                    PropMode::REPLACE,
+                    self.window,
+                    self.atoms.WM_STATE,
+                    self.atoms.WM_STATE,
+                    &[wm_state, 0 /*WINDOW_NONE*/],
+                )?;
                 conn.flush()?;
             }
         }
@@ -1276,6 +1285,21 @@ impl X11Surface {
         } else {
             self.change_net_state(&[], &[self.atoms._NET_WM_STATE_HIDDEN])?;
         }
+
+        if let Some(conn) = self.conn.upgrade() {
+            let wm_state = if suspended {
+                3u32 /*IconicState*/
+            } else {
+                1u32 /*NormalState*/
+            };
+            conn.change_property32(
+                PropMode::REPLACE,
+                self.window,
+                self.atoms.WM_STATE,
+                self.atoms.WM_STATE,
+                &[wm_state, 0 /*WINDOW_NONE*/],
+            )?;
+        }
         Ok(())
     }
 
@@ -1405,19 +1429,6 @@ impl X11Surface {
                 self.atoms._NET_WM_STATE,
                 AtomEnum::ATOM,
                 &new_props,
-            )?;
-
-            let wm_state = if state.net_state.contains(&self.atoms._NET_WM_STATE_HIDDEN) {
-                [3u32 /*IconicState*/, 0 /*WINDOW_NONE*/]
-            } else {
-                [1u32 /*NormalState*/, 0 /*WINDOW_NONE*/]
-            };
-            conn.change_property32(
-                PropMode::REPLACE,
-                self.window,
-                self.atoms.WM_STATE,
-                self.atoms.WM_STATE,
-                &wm_state,
             )?;
         }
 

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -400,13 +400,18 @@ impl X11Surface {
         }
 
         if let Some(conn) = self.conn.upgrade() {
-            if let Some(frame) = self.state.lock().unwrap().mapped_onto {
+            let state = self.state.lock().unwrap();
+            if let Some(frame) = state.mapped_onto {
                 let wm_state = if mapped {
                     conn.map_window(frame)?;
-                    1u32 /*NormalState*/
+                    if state.net_state.contains(&self.atoms._NET_WM_STATE_HIDDEN) {
+                        3u32 /*IconicState*/
+                    } else {
+                        1u32 /*NormalState*/
+                    }
                 } else {
                     conn.unmap_window(frame)?;
-                    3u32 /*IconicState*/
+                    0u32 /*WithdrawnState*/
                 };
                 conn.change_property32(
                     PropMode::REPLACE,
@@ -1287,18 +1292,20 @@ impl X11Surface {
         }
 
         if let Some(conn) = self.conn.upgrade() {
-            let wm_state = if suspended {
-                3u32 /*IconicState*/
-            } else {
-                1u32 /*NormalState*/
-            };
-            conn.change_property32(
-                PropMode::REPLACE,
-                self.window,
-                self.atoms.WM_STATE,
-                self.atoms.WM_STATE,
-                &[wm_state, 0 /*WINDOW_NONE*/],
-            )?;
+            if self.state.lock().unwrap().mapped_onto.is_some() {
+                let wm_state = if suspended {
+                    3u32 /*IconicState*/
+                } else {
+                    1u32 /*NormalState*/
+                };
+                conn.change_property32(
+                    PropMode::REPLACE,
+                    self.window,
+                    self.atoms.WM_STATE,
+                    self.atoms.WM_STATE,
+                    &[wm_state, 0 /*WINDOW_NONE*/],
+                )?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
This reverts commit 060e9cd9c8ae2633947bdb72cffa1748ac53922d.

## Description
This reverts the change from https://github.com/Smithay/smithay/pull/2022.

It was causing Wayland native games to not receive game controller input. The input was going to steam behind the game.

I tested Dishonored 2 (but from steam, and not GOG) and it did not minimize. My assumption is https://github.com/pop-os/cosmic-comp/commit/6e4551a20019e7790db6bd845fdbd087e41fbb9a fixed the minimizing issue.

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
