### PR TITLE
 Drive DisplayID-tiled (5K) monitors as one output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ of new `Dipsatch2` and `GlobalDispatch2` traits. These will replace `Dispatch` a
 
 - ExtBackgroundEffect protocol is now available in `smithay::wayland::background_effect` module.
 
+- `DrmDevice::tile_info` exposes the parsed DRM `TILE` connector property as a new `backend::drm::TileInfo` struct, allowing compositors to identify connectors that belong to the same DisplayID-tiled monitor.
+
 `crate::input::dnd` was introduced to enable implementation of Drag&Drop operations on custom types.
 Internally the same types and traits are used to implement `wayland::data_device` dnd-operations and XDND
 operations (see below).

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1055,6 +1055,12 @@ where
     <F as ExportFramebuffer<A::Buffer>>::Framebuffer: std::fmt::Debug + Send + Sync + 'static,
     G: AsFd + 'static,
 {
+    /// Sub-rect of the logical output this tile scans out, in the output's
+    /// untransformed (mode) coordinate space. The whole output for a
+    /// single-tile compositor; one slice of the grid for a tiled one.
+    // Read by the multi-tile render path (added in a following commit).
+    #[allow(dead_code)]
+    region: Rectangle<i32, Physical>,
     surface: Arc<DrmSurface>,
     planes: Planes,
     overlay_plane_element_ids: OverlayPlaneElementIds,
@@ -1160,14 +1166,16 @@ pub enum TileConfigError {
     /// do not cover a single rectangular logical output.
     #[error("tile regions do not cover the logical output without gaps")]
     NotContiguous,
+    /// The tile surfaces span multiple DRM devices. A tiled compositor requires
+    /// a single device so all its CRTCs can share one atomic commit.
+    #[error("tile surfaces span multiple drm devices")]
+    MultipleDevices,
 }
 
 /// Validate that `regions` exactly tile a rectangle anchored at `(0, 0)` with no
 /// gaps or overlaps, returning that rectangle's size.
 ///
 /// Pure geometry, independent of any DRM state, so it is unit-testable.
-// First non-test caller is `new_tiled`, added in a following commit.
-#[allow(dead_code)]
 fn validate_tile_regions(
     regions: impl IntoIterator<Item = Rectangle<i32, Physical>>,
 ) -> Result<Size<i32, Physical>, TileConfigError> {
@@ -1245,6 +1253,16 @@ fn tile_render_offset(
 ) -> Point<i32, Physical> {
     let loc = tile_logical_region(region, size, transform).loc;
     Point::from((-loc.x, -loc.y))
+}
+
+/// The [`region`](TileState::region) for a single-tile compositor: the whole
+/// logical output. Resolved from `output_mode_source`'s current mode, falling
+/// back to a zero rect when no mode is set yet (the single-tile render path
+/// does not slice, so the value is unused until a mode exists).
+fn single_tile_region(output_mode_source: &OutputModeSource) -> Rectangle<i32, Physical> {
+    <&OutputModeSource as TryInto<(Size<i32, Physical>, Scale<f64>, Transform)>>::try_into(output_mode_source)
+        .map(|(size, _, _)| Rectangle::from_size(size))
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -1439,13 +1457,158 @@ where
         output_mode_source: impl Into<OutputModeSource> + Debug,
         surface: DrmSurface,
         planes: Option<Planes>,
-        mut allocator: A,
+        allocator: A,
         framebuffer_exporter: F,
         color_formats: impl IntoIterator<Item = DrmFourcc>,
         renderer_formats: impl IntoIterator<Item = DrmFormat>,
         cursor_size: Size<u32, BufferCoords>,
         gbm: Option<GbmDevice<G>>,
     ) -> FrameResult<Self, A, F> {
+        let output_mode_source = output_mode_source.into();
+        let renderer_formats = renderer_formats.into_iter().collect::<Vec<_>>();
+        let cursor_size = Size::from((cursor_size.w as i32, cursor_size.h as i32));
+
+        // Single-tile compositor: the one tile covers the whole logical output.
+        let region = single_tile_region(&output_mode_source);
+        let span = info_span!(
+            parent: None,
+            "drm_compositor",
+            device = ?surface.dev_path(),
+            crtc = ?surface.crtc(),
+        );
+
+        let tile = Self::build_tile(
+            surface,
+            region,
+            output_mode_source.clone(),
+            planes,
+            allocator,
+            &framebuffer_exporter,
+            color_formats,
+            renderer_formats,
+            gbm,
+        )?;
+
+        Ok(DrmCompositor {
+            output_mode_source,
+            framebuffer_exporter,
+            cursor_size,
+            debug_flags: DebugFlags::empty(),
+            span,
+            tiles: SmallVec::from_buf([tile]),
+        })
+    }
+
+    /// Initialize a [`DrmCompositor`] that drives several CRTCs as one logical,
+    /// frame-locked output — e.g. a DisplayID-tiled 5K monitor carried over two
+    /// DisplayPort streams, or a single-GPU video wall.
+    ///
+    /// `placements` provides one [`TilePlacement`] per CRTC; the surfaces must all
+    /// belong to the **same DRM device** (so their page-flips can share a single
+    /// atomic commit) and their regions must tile a gap-free rectangle anchored
+    /// at the origin, matching the logical output's mode.
+    ///
+    /// List the primary tile first. `tiles[0]`'s CRTC carries the atomic commit
+    /// and its page-flip event signals the group's completed frame. The other
+    /// tiles flip in that same commit, so the whole group stays frame-locked.
+    ///
+    /// The remaining arguments are device-wide and shared across all tiles,
+    /// exactly as in [`new`](Self::new) — of which this is the multi-CRTC
+    /// generalization.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    pub fn new_tiled(
+        output_mode_source: impl Into<OutputModeSource> + Debug,
+        placements: impl IntoIterator<Item = TilePlacement>,
+        allocator: A,
+        framebuffer_exporter: F,
+        color_formats: impl IntoIterator<Item = DrmFourcc> + Clone,
+        renderer_formats: impl IntoIterator<Item = DrmFormat>,
+        cursor_size: Size<u32, BufferCoords>,
+        gbm: Option<GbmDevice<G>>,
+    ) -> FrameResult<Self, A, F>
+    where
+        A: Clone,
+    {
+        let tiles_in: SmallVec<[TilePlacement; 4]> = placements.into_iter().collect();
+        // Geometry: the regions must tile a gap-free rectangle at the origin.
+        validate_tile_regions(tiles_in.iter().map(|p| p.region))?;
+
+        // All tiles must live on one DRM device, otherwise they cannot share a
+        // single atomic commit (and would not stay frame-locked).
+        let dev = tiles_in[0].surface.dev_path();
+        if tiles_in.iter().any(|p| p.surface.dev_path() != dev) {
+            return Err(TileConfigError::MultipleDevices.into());
+        }
+
+        let output_mode_source = output_mode_source.into();
+        let renderer_formats = renderer_formats.into_iter().collect::<Vec<_>>();
+        let cursor_size = Size::from((cursor_size.w as i32, cursor_size.h as i32));
+
+        // Each tile renders with the logical output's scale/transform into its
+        // own tile-sized framebuffer; refreshed each frame from the source.
+        let (scale, transform) =
+            match <&OutputModeSource as TryInto<(Size<i32, Physical>, Scale<f64>, Transform)>>::try_into(
+                &output_mode_source,
+            ) {
+                Ok((_, scale, transform)) => (scale, transform),
+                Err(_) => (1.0f64.into(), Transform::Normal),
+            };
+
+        let span = info_span!(
+            parent: None,
+            "drm_compositor",
+            device = ?tiles_in[0].surface.dev_path(),
+            crtc = ?tiles_in[0].surface.crtc(),
+        );
+
+        let mut tiles = SmallVec::with_capacity(tiles_in.len());
+        for placement in tiles_in {
+            let tile_mode = OutputModeSource::Static {
+                size: placement.region.size,
+                scale,
+                transform,
+            };
+            let tile = Self::build_tile(
+                placement.surface,
+                placement.region,
+                tile_mode,
+                placement.planes,
+                allocator.clone(),
+                &framebuffer_exporter,
+                color_formats.clone(),
+                renderer_formats.clone(),
+                gbm.clone(),
+            )?;
+            tiles.push(tile);
+        }
+
+        Ok(DrmCompositor {
+            output_mode_source,
+            framebuffer_exporter,
+            cursor_size,
+            debug_flags: DebugFlags::empty(),
+            span,
+            tiles,
+        })
+    }
+
+    /// Build the per-CRTC [`TileState`] for one surface, selecting a working
+    /// format from `color_formats`. Shared by [`new`](Self::new) and
+    /// [`new_tiled`](Self::new_tiled); `mode_source` is the whole output for the
+    /// former and the tile's slice for the latter.
+    #[allow(clippy::too_many_arguments)]
+    fn build_tile(
+        surface: DrmSurface,
+        region: Rectangle<i32, Physical>,
+        mode_source: OutputModeSource,
+        planes: Option<Planes>,
+        mut allocator: A,
+        framebuffer_exporter: &F,
+        color_formats: impl IntoIterator<Item = DrmFourcc>,
+        renderer_formats: Vec<DrmFormat>,
+        gbm: Option<GbmDevice<G>>,
+    ) -> FrameResult<TileState<A, F, U, G>, A, F> {
         let signaled_fence = match surface.create_syncobj(true) {
             Ok(signaled_syncobj) => match surface.syncobj_to_fd(signaled_syncobj, true) {
                 Ok(signaled_fence) => {
@@ -1464,30 +1627,17 @@ where
             }
         };
 
-        let span = info_span!(
-            parent: None,
-            "drm_compositor",
-            device = ?surface.dev_path(),
-            crtc = ?surface.crtc(),
-        );
-
-        let output_mode_source = output_mode_source.into();
-        let renderer_formats = renderer_formats.into_iter().collect::<Vec<_>>();
-
-        let mut error = None;
         let surface = Arc::new(surface);
         let mut planes = match planes {
             Some(planes) => planes,
             None => surface.planes().clone(),
         };
-
         // We do not support direct scan-out on legacy
         if surface.is_legacy() {
             planes.cursor.clear();
             planes.overlay.clear();
         }
-
-        // The selection algorithm expects the planes to be ordered form front to back
+        // The selection algorithm expects the planes to be ordered from front to back
         planes
             .overlay
             .sort_by_key(|p| std::cmp::Reverse(p.zpos.unwrap_or_default()));
@@ -1508,8 +1658,7 @@ where
                 .to_lowercase()
                 .contains("nvidia");
 
-        let cursor_size = Size::from((cursor_size.w as i32, cursor_size.h as i32));
-        let damage_tracker = OutputDamageTracker::from_mode_source(output_mode_source.clone());
+        let damage_tracker = OutputDamageTracker::from_mode_source(mode_source);
         let supports_fencing = !surface.is_legacy()
             && surface
                 .get_driver_capability(DriverCapability::SyncObj)
@@ -1524,6 +1673,7 @@ where
             && plane_has_property(&*surface, surface.plane(), "IN_FENCE_FD")?
             && !(is_nvidia && nvidia_drm_version().unwrap_or((0, 0, 0)) < (560, 35, 3));
 
+        let mut error = None;
         for format in color_formats {
             debug!("Testing color format: {}", format);
             match Self::find_supported_format(
@@ -1531,7 +1681,7 @@ where
                 supports_fencing,
                 &planes,
                 allocator,
-                &framebuffer_exporter,
+                framebuffer_exporter,
                 renderer_formats.clone(),
                 format,
             ) {
@@ -1562,37 +1712,29 @@ where
                     let overlay_plane_element_ids = OverlayPlaneElementIds::from_planes(&planes);
                     let current_frame = FrameState::from_planes(surface.plane(), &planes);
 
-                    let drm_renderer = DrmCompositor {
-                        framebuffer_exporter,
-                        cursor_size,
-                        output_mode_source,
-                        debug_flags: DebugFlags::empty(),
-                        span,
-                        tiles: SmallVec::from_buf([TileState {
-                            primary_plane_element_id: Id::new(),
-                            primary_plane_damage_bag: DamageBag::new(4),
-                            primary_is_opaque: is_opaque,
-                            reset_pending: true,
-                            signaled_fence,
-                            current_frame,
-                            pending_frame: None,
-                            queued_frame: None,
-                            next_frame: None,
-                            swapchain,
-                            cursor_state,
-                            surface,
-                            damage_tracker,
-                            planes,
-                            overlay_plane_element_ids,
-                            element_states: IndexMap::new(),
-                            previous_element_states: IndexMap::new(),
-                            opaque_regions: Vec::new(),
-                            element_opaque_regions_workhouse: Vec::new(),
-                            supports_fencing,
-                        }]),
-                    };
-
-                    return Ok(drm_renderer);
+                    return Ok(TileState {
+                        region,
+                        primary_plane_element_id: Id::new(),
+                        primary_plane_damage_bag: DamageBag::new(4),
+                        primary_is_opaque: is_opaque,
+                        reset_pending: true,
+                        signaled_fence,
+                        current_frame,
+                        pending_frame: None,
+                        queued_frame: None,
+                        next_frame: None,
+                        swapchain,
+                        cursor_state,
+                        surface,
+                        damage_tracker,
+                        planes,
+                        overlay_plane_element_ids,
+                        element_states: IndexMap::new(),
+                        previous_element_states: IndexMap::new(),
+                        opaque_regions: Vec::new(),
+                        element_opaque_regions_workhouse: Vec::new(),
+                        supports_fencing,
+                    });
                 }
                 Err((alloc, err)) => {
                     warn!("Preferred format {} not available: {:?}", format, err);
@@ -1745,6 +1887,7 @@ where
 
         let overlay_plane_element_ids = OverlayPlaneElementIds::from_planes(&planes);
         let current_frame = FrameState::from_planes(surface.plane(), &planes);
+        let primary_region = single_tile_region(&output_mode_source);
 
         let drm_renderer = DrmCompositor {
             framebuffer_exporter,
@@ -1753,6 +1896,7 @@ where
             debug_flags: DebugFlags::empty(),
             span,
             tiles: SmallVec::from_buf([TileState {
+                region: primary_region,
                 primary_plane_element_id: Id::new(),
                 primary_plane_damage_bag: DamageBag::new(4),
                 primary_is_opaque: is_opaque,
@@ -4672,6 +4816,9 @@ pub enum FrameError<
     /// `queue_frame` or trying to queue a frame without changes.
     #[error("No frame has been prepared or it does not contain any changes")]
     EmptyFrame,
+    /// The tile configuration passed to [`DrmCompositor::new_tiled`] is invalid
+    #[error("Invalid tile configuration: {0}")]
+    InvalidTileConfig(#[from] TileConfigError),
 }
 
 /// Error returned from [`DrmCompositor::render_frame`]
@@ -4717,6 +4864,7 @@ impl<
             x @ FrameError::NoSupportedPlaneFormat
             | x @ FrameError::NoSupportedRendererFormat
             | x @ FrameError::PrimaryPlaneClaimFailed
+            | x @ FrameError::InvalidTileConfig(_)
             | x @ FrameError::NoFramebuffer => SwapBuffersError::ContextLost(Box::new(x)),
             x @ FrameError::NoFreeSlotsError | x @ FrameError::EmptyFrame => {
                 SwapBuffersError::TemporaryFailure(Box::new(x))

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1085,6 +1085,177 @@ where
     span: tracing::Span,
 }
 
+/// One CRTC's contribution to a tiled [`DrmCompositor`].
+///
+/// A tiled compositor drives several CRTCs as a single logical output, each
+/// scanning out a sub-rect of that output. A `TilePlacement` pairs one
+/// [`DrmSurface`] (one CRTC) with the planes it may use and the sub-rect it
+/// covers. See [`DrmCompositor::new_tiled`].
+#[derive(Debug)]
+pub struct TilePlacement {
+    /// The surface (exactly one CRTC) backing this tile.
+    pub surface: DrmSurface,
+    /// Planes this tile may use for direct scan-out, with the same meaning as
+    /// the `planes` argument of [`DrmCompositor::new`]: `None` uses all planes
+    /// reported by [`DrmSurface::planes`]. Planes belong to a CRTC, so they are
+    /// configured per tile.
+    pub planes: Option<Planes>,
+    /// The sub-rect of the logical output this tile scans out, in the output's
+    /// untransformed (mode) coordinate space. The offset positions the tile
+    /// within the logical framebuffer; the size is expected to match
+    /// `surface`'s scan-out mode.
+    pub region: Rectangle<i32, Physical>,
+}
+
+/// Reason a set of tile regions does not form a valid logical output.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum TileConfigError {
+    /// There must be at least one tile.
+    #[error("a tiled output must contain at least one tile")]
+    Empty,
+    /// A tile region has a non-positive width or height.
+    #[error("tile region {0:?} has a non-positive size")]
+    NonPositiveRegion(Rectangle<i32, Physical>),
+    /// Two tile regions overlap.
+    #[error("tile regions {0:?} and {1:?} overlap")]
+    OverlappingRegions(Rectangle<i32, Physical>, Rectangle<i32, Physical>),
+    /// The tile regions leave a gap or are not anchored at the origin, so they
+    /// do not cover a single rectangular logical output.
+    #[error("tile regions do not cover the logical output without gaps")]
+    NotContiguous,
+}
+
+/// Validate that `regions` exactly tile a rectangle anchored at `(0, 0)` with no
+/// gaps or overlaps, returning that rectangle's size.
+///
+/// Pure geometry, independent of any DRM state, so it is unit-testable.
+// First non-test caller is `new_tiled`, added in a following commit.
+#[allow(dead_code)]
+fn validate_tile_regions(
+    regions: impl IntoIterator<Item = Rectangle<i32, Physical>>,
+) -> Result<Size<i32, Physical>, TileConfigError> {
+    let regions: SmallVec<[_; 4]> = regions.into_iter().collect();
+    let Some(first) = regions.first() else {
+        return Err(TileConfigError::Empty);
+    };
+
+    // Bounding box of all regions, rejecting any non-positive tile on the way.
+    let mut bbox = *first;
+    let mut covered: i64 = 0;
+    for region in &regions {
+        if region.size.w <= 0 || region.size.h <= 0 {
+            return Err(TileConfigError::NonPositiveRegion(*region));
+        }
+        bbox = bbox.merge(*region);
+        covered += i64::from(region.size.w) * i64::from(region.size.h);
+    }
+
+    // The logical output starts at the origin.
+    if bbox.loc != Point::from((0, 0)) {
+        return Err(TileConfigError::NotContiguous);
+    }
+
+    // No two tiles may overlap (O(n²); tile counts are tiny). `overlaps` is
+    // exclusive, so tiles sharing an edge are adjacent, not overlapping.
+    for (i, a) in regions.iter().enumerate() {
+        for b in &regions[i + 1..] {
+            if a.overlaps(*b) {
+                return Err(TileConfigError::OverlappingRegions(*a, *b));
+            }
+        }
+    }
+
+    // With overlaps ruled out, the tiles cover the bounding box exactly iff
+    // their areas sum to the box area — otherwise there is a gap.
+    let bbox_area = i64::from(bbox.size.w) * i64::from(bbox.size.h);
+    if covered != bbox_area {
+        return Err(TileConfigError::NotContiguous);
+    }
+
+    Ok(bbox.size)
+}
+
+#[cfg(test)]
+mod tiled_tests {
+    use super::{TileConfigError, validate_tile_regions};
+    use crate::utils::{Physical, Point, Rectangle, Size};
+
+    fn rect(x: i32, y: i32, w: i32, h: i32) -> Rectangle<i32, Physical> {
+        Rectangle::new(Point::from((x, y)), Size::from((w, h)))
+    }
+
+    #[test]
+    fn single_tile_is_the_whole_output() {
+        assert_eq!(
+            validate_tile_regions([rect(0, 0, 5120, 2880)]),
+            Ok(Size::from((5120, 2880)))
+        );
+    }
+
+    #[test]
+    fn two_tiles_side_by_side() {
+        // LG UltraFine 5K: two 2560×2880 halves.
+        assert_eq!(
+            validate_tile_regions([rect(0, 0, 2560, 2880), rect(2560, 0, 2560, 2880)]),
+            Ok(Size::from((5120, 2880)))
+        );
+    }
+
+    #[test]
+    fn two_by_two_grid() {
+        assert_eq!(
+            validate_tile_regions([
+                rect(0, 0, 1920, 1080),
+                rect(1920, 0, 1920, 1080),
+                rect(0, 1080, 1920, 1080),
+                rect(1920, 1080, 1920, 1080),
+            ]),
+            Ok(Size::from((3840, 2160)))
+        );
+    }
+
+    #[test]
+    fn empty_is_rejected() {
+        assert_eq!(validate_tile_regions([]), Err(TileConfigError::Empty));
+    }
+
+    #[test]
+    fn overlapping_tiles_are_rejected() {
+        let a = rect(0, 0, 2600, 2880);
+        let b = rect(2560, 0, 2560, 2880);
+        assert_eq!(
+            validate_tile_regions([a, b]),
+            Err(TileConfigError::OverlappingRegions(a, b))
+        );
+    }
+
+    #[test]
+    fn gap_between_tiles_is_rejected() {
+        // 40px gap between the two halves.
+        assert_eq!(
+            validate_tile_regions([rect(0, 0, 2560, 2880), rect(2600, 0, 2560, 2880)]),
+            Err(TileConfigError::NotContiguous)
+        );
+    }
+
+    #[test]
+    fn not_anchored_at_origin_is_rejected() {
+        assert_eq!(
+            validate_tile_regions([rect(10, 0, 2560, 2880), rect(2570, 0, 2560, 2880)]),
+            Err(TileConfigError::NotContiguous)
+        );
+    }
+
+    #[test]
+    fn non_positive_region_is_rejected() {
+        let bad = rect(0, 0, 0, 2880);
+        assert_eq!(
+            validate_tile_regions([bad]),
+            Err(TileConfigError::NonPositiveRegion(bad))
+        );
+    }
+}
+
 impl<A, F, U, G> DrmCompositor<A, F, U, G>
 where
     A: Allocator,

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1041,18 +1041,20 @@ bitflags::bitflags! {
     }
 }
 
-/// Composite an output using a combination of planes and rendering
+/// Per-CRTC state of a [`DrmCompositor`].
 ///
-/// see the [`module docs`](crate::backend::drm::compositor) for more information
-#[derive(Debug)]
-pub struct DrmCompositor<A, F, U, G>
+/// A `DrmCompositor` holds one `TileState` per CRTC it drives — exactly one in
+/// the common case, several when compositing a tiled output (see
+/// [`DrmCompositor::new_tiled`]). Everything that belongs to a single scan-out
+/// pipeline (the surface, its planes, swapchain and frame-state machine) lives
+/// here; the logical output state stays on `DrmCompositor`.
+struct TileState<A, F, U, G>
 where
     A: Allocator,
     F: ExportFramebuffer<A::Buffer>,
     <F as ExportFramebuffer<A::Buffer>>::Framebuffer: std::fmt::Debug + Send + Sync + 'static,
     G: AsFd + 'static,
 {
-    output_mode_source: OutputModeSource,
     surface: Arc<DrmSurface>,
     planes: Planes,
     overlay_plane_element_ids: OverlayPlaneElementIds,
@@ -1063,26 +1065,61 @@ where
     supports_fencing: bool,
     reset_pending: bool,
     signaled_fence: Option<Arc<OwnedFd>>,
-
-    framebuffer_exporter: F,
-
     current_frame: CompositorFrameState<A, F>,
     pending_frame: Option<PendingFrame<A, F, U>>,
     queued_frame: Option<QueuedFrame<A, F, U>>,
     next_frame: Option<PreparedFrame<A, F>>,
-
     swapchain: Swapchain<A>,
-
-    cursor_size: Size<i32, Physical>,
     cursor_state: Option<CursorState<G>>,
-
     element_states: IndexMap<Id, ElementState<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>,
     previous_element_states: IndexMap<Id, ElementState<<F as ExportFramebuffer<A::Buffer>>::Framebuffer>>,
     opaque_regions: Vec<Rectangle<i32, Physical>>,
     element_opaque_regions_workhouse: Vec<Rectangle<i32, Physical>>,
+}
 
+/// Composite an output using a combination of planes and rendering
+///
+/// see the [`module docs`](crate::backend::drm::compositor) for more information
+pub struct DrmCompositor<A, F, U, G>
+where
+    A: Allocator,
+    F: ExportFramebuffer<A::Buffer>,
+    <F as ExportFramebuffer<A::Buffer>>::Framebuffer: std::fmt::Debug + Send + Sync + 'static,
+    G: AsFd + 'static,
+{
+    output_mode_source: OutputModeSource,
+    framebuffer_exporter: F,
+    cursor_size: Size<i32, Physical>,
+    // `tiles[0]` is the primary: its CRTC's vblank drives the group's
+    // presentation, its surface carries the atomic commit, and it seeds the
+    // aggregated frame result. The rest are secondary. (Positional, by
+    // convention; the constructor takes the primary placement first.)
+    //
+    // Inline capacity 1: a single-CRTC output is the common case and stays
+    // heap-free. A tiled output (several CRTCs) spills to one heap allocation.
+    // Kept at 1 because TileState is large, so extra inline slots would bloat
+    // every (mostly single-tile) compositor just for the rare tiled case.
+    tiles: SmallVec<[TileState<A, F, U, G>; 1]>,
     debug_flags: DebugFlags,
     span: tracing::Span,
+}
+
+impl<A, F, U, G> std::fmt::Debug for DrmCompositor<A, F, U, G>
+where
+    A: Allocator,
+    F: ExportFramebuffer<A::Buffer>,
+    <F as ExportFramebuffer<A::Buffer>>::Framebuffer: std::fmt::Debug + Send + Sync + 'static,
+    G: AsFd + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DrmCompositor")
+            .field("output_mode_source", &self.output_mode_source)
+            .field("cursor_size", &self.cursor_size)
+            .field("tiles", &self.tiles.len())
+            .field("debug_flags", &self.debug_flags)
+            .field("span", &self.span)
+            .finish_non_exhaustive()
+    }
 }
 
 /// One CRTC's contribution to a tiled [`DrmCompositor`].
@@ -1526,31 +1563,33 @@ where
                     let current_frame = FrameState::from_planes(surface.plane(), &planes);
 
                     let drm_renderer = DrmCompositor {
-                        primary_plane_element_id: Id::new(),
-                        primary_plane_damage_bag: DamageBag::new(4),
-                        primary_is_opaque: is_opaque,
-                        reset_pending: true,
-                        signaled_fence,
-                        current_frame,
-                        pending_frame: None,
-                        queued_frame: None,
-                        next_frame: None,
-                        swapchain,
                         framebuffer_exporter,
                         cursor_size,
-                        cursor_state,
-                        surface,
-                        damage_tracker,
                         output_mode_source,
-                        planes,
-                        overlay_plane_element_ids,
-                        element_states: IndexMap::new(),
-                        previous_element_states: IndexMap::new(),
-                        opaque_regions: Vec::new(),
-                        element_opaque_regions_workhouse: Vec::new(),
-                        supports_fencing,
                         debug_flags: DebugFlags::empty(),
                         span,
+                        tiles: SmallVec::from_buf([TileState {
+                            primary_plane_element_id: Id::new(),
+                            primary_plane_damage_bag: DamageBag::new(4),
+                            primary_is_opaque: is_opaque,
+                            reset_pending: true,
+                            signaled_fence,
+                            current_frame,
+                            pending_frame: None,
+                            queued_frame: None,
+                            next_frame: None,
+                            swapchain,
+                            cursor_state,
+                            surface,
+                            damage_tracker,
+                            planes,
+                            overlay_plane_element_ids,
+                            element_states: IndexMap::new(),
+                            previous_element_states: IndexMap::new(),
+                            opaque_regions: Vec::new(),
+                            element_opaque_regions_workhouse: Vec::new(),
+                            supports_fencing,
+                        }]),
                     };
 
                     return Ok(drm_renderer);
@@ -1708,31 +1747,33 @@ where
         let current_frame = FrameState::from_planes(surface.plane(), &planes);
 
         let drm_renderer = DrmCompositor {
-            primary_plane_element_id: Id::new(),
-            primary_plane_damage_bag: DamageBag::new(4),
-            primary_is_opaque: is_opaque,
-            reset_pending: true,
-            signaled_fence,
-            current_frame,
-            pending_frame: None,
-            queued_frame: None,
-            next_frame: None,
-            swapchain,
             framebuffer_exporter,
             cursor_size,
-            cursor_state,
-            surface,
-            damage_tracker,
             output_mode_source,
-            planes,
-            overlay_plane_element_ids,
-            element_states: IndexMap::new(),
-            previous_element_states: IndexMap::new(),
-            opaque_regions: Vec::new(),
-            element_opaque_regions_workhouse: Vec::new(),
-            supports_fencing,
             debug_flags: DebugFlags::empty(),
             span,
+            tiles: SmallVec::from_buf([TileState {
+                primary_plane_element_id: Id::new(),
+                primary_plane_damage_bag: DamageBag::new(4),
+                primary_is_opaque: is_opaque,
+                reset_pending: true,
+                signaled_fence,
+                current_frame,
+                pending_frame: None,
+                queued_frame: None,
+                next_frame: None,
+                swapchain,
+                cursor_state,
+                surface,
+                damage_tracker,
+                planes,
+                overlay_plane_element_ids,
+                element_states: IndexMap::new(),
+                previous_element_states: IndexMap::new(),
+                opaque_regions: Vec::new(),
+                element_opaque_regions_workhouse: Vec::new(),
+                supports_fencing,
+            }]),
         };
 
         Ok(drm_renderer)
@@ -1979,7 +2020,7 @@ where
     {
         let mut clear_color = clear_color.into();
 
-        if !self.surface.is_active() {
+        if !self.tiles[0].surface.is_active() {
             return Err(RenderFrameErrorType::<A, F, R>::PrepareFrame(
                 FrameError::DrmError(DrmError::DeviceInactive),
             ));
@@ -1987,12 +2028,12 @@ where
 
         // Just reset any next state, this will put
         // any already acquired slot back to the swapchain
-        std::mem::drop(self.next_frame.take());
+        std::mem::drop(self.tiles[0].next_frame.take());
 
         // If a commit is pending we may still be able to just use a previous
         // state, but we want to queue a frame so we just fake the damage to
         // make sure queue_frame won't be skipped because of no damage
-        let allow_partial_update = !self.reset_pending && !self.surface.commit_pending();
+        let allow_partial_update = !self.tiles[0].reset_pending && !self.tiles[0].surface.commit_pending();
 
         let (current_size, output_scale, output_transform) = (&self.output_mode_source)
             .try_into()
@@ -2013,7 +2054,7 @@ where
         // if we could end up doing direct scan-out on the primary plane.
         // The reason is that we can't know upfront and we need a framebuffer
         // on the primary plane to test overlay/cursor planes
-        let primary_plane_buffer = self
+        let primary_plane_buffer = self.tiles[0]
             .swapchain
             .acquire()
             .map_err(FrameError::Allocator)?
@@ -2031,9 +2072,9 @@ where
             let fb_buffer = self
                 .framebuffer_exporter
                 .add_framebuffer(
-                    self.surface.device_fd(),
+                    self.tiles[0].surface.device_fd(),
                     ExportBuffer::Allocator(&primary_plane_buffer),
-                    self.primary_is_opaque,
+                    self.tiles[0].primary_is_opaque,
                 )
                 .map_err(FrameError::FramebufferExport)?
                 .ok_or(FrameError::NoFramebuffer)?;
@@ -2049,10 +2090,11 @@ where
             .unwrap()
             .clone();
 
-        let mut opaque_regions: Vec<Rectangle<i32, Physical>> = std::mem::take(&mut self.opaque_regions);
-        std::mem::swap(&mut self.previous_element_states, &mut self.element_states);
-        let mut element_states = std::mem::take(&mut self.element_states);
-        element_states.reserve(std::cmp::min(elements.len(), self.planes.overlay.len()));
+        let tile = &mut self.tiles[0];
+        let mut opaque_regions: Vec<Rectangle<i32, Physical>> = std::mem::take(&mut tile.opaque_regions);
+        std::mem::swap(&mut tile.previous_element_states, &mut tile.element_states);
+        let mut element_states = std::mem::take(&mut tile.element_states);
+        element_states.reserve(std::cmp::min(elements.len(), tile.planes.overlay.len()));
         let mut render_element_states = RenderElementStates {
             states: HashMap::with_capacity(elements.len()),
         };
@@ -2063,14 +2105,14 @@ where
             <A as Allocator>::Buffer,
             <F as ExportFramebuffer<<A as Allocator>::Buffer>>::Framebuffer,
         > = {
-            let previous_state = self
+            let previous_state = self.tiles[0]
                 .pending_frame
                 .as_ref()
                 .map(|pending| &pending.frame)
-                .unwrap_or(&self.current_frame);
+                .unwrap_or(&self.tiles[0].current_frame);
 
             // This will create an empty frame state, all planes are skipped by default
-            let mut next_frame_state = FrameState::from_planes(self.surface.plane(), &self.planes);
+            let mut next_frame_state = FrameState::from_planes(self.tiles[0].surface.plane(), &self.tiles[0].planes);
 
             // We want to set skip to false on all planes that previously had something assigned so that
             // they get cleared when they are not longer used
@@ -2090,7 +2132,7 @@ where
 
         // We want to make sure we can actually scan-out the primary plane, so
         // explicitly set skip to false
-        let plane_claim = self.surface.claim_plane(self.surface.plane()).ok_or_else(|| {
+        let plane_claim = self.tiles[0].surface.claim_plane(self.tiles[0].surface.plane()).ok_or_else(|| {
             error!("failed to claim primary plane");
             FrameError::PrimaryPlaneClaimFailed
         })?;
@@ -2122,7 +2164,7 @@ where
 
         // unconditionally set the primary plane state
         // if this would fail the test we are screwed anyway
-        next_frame_state.set_state(self.surface.plane(), primary_plane_state.clone());
+        next_frame_state.set_state(self.tiles[0].surface.plane(), primary_plane_state.clone());
 
         // This holds all elements that are visible on the output
         // A element is considered visible if it intersects with the output geometry
@@ -2130,7 +2172,7 @@ where
         let mut output_elements: Vec<(&'a E, Rectangle<i32, Physical>, usize, bool)> =
             Vec::with_capacity(elements.len());
 
-        let mut element_opaque_regions_workhouse = std::mem::take(&mut self.element_opaque_regions_workhouse);
+        let mut element_opaque_regions_workhouse = std::mem::take(&mut self.tiles[0].element_opaque_regions_workhouse);
         for (index, element) in elements.iter().enumerate() {
             let element_id = element.id();
             let element_geometry = element.geometry(output_scale);
@@ -2244,7 +2286,7 @@ where
 
             output_elements.push((element, element_geometry, element_visible_area, element_is_opaque));
         }
-        self.element_opaque_regions_workhouse = element_opaque_regions_workhouse;
+        self.tiles[0].element_opaque_regions_workhouse = element_opaque_regions_workhouse;
 
         // This will hold the element that has been selected for direct scan-out on
         // the primary plane if any
@@ -2255,7 +2297,7 @@ where
         // This will hold the element per plane that has been assigned to a overlay/underlay
         // plane for direct scan-out
         let mut overlay_plane_elements: IndexMap<plane::Handle, &'a E> =
-            IndexMap::with_capacity(self.planes.overlay.len());
+            IndexMap::with_capacity(self.tiles[0].planes.overlay.len());
         // This will hold the element assigned on the cursor plane if any
         let mut cursor_plane_element: Option<&'a E> = None;
 
@@ -2279,12 +2321,12 @@ where
                     (clear_color.r() == 0f32 && clear_color.g() == 0f32 && clear_color.b() == 0f32)
                         || clear_color.a() == 0f32;
                 let element_spans_complete_output = element_geometry.contains_rect(output_geometry);
-                let overlaps_with_underlay = self
+                let overlaps_with_underlay = self.tiles[0]
                     .planes
                     .overlay
                     .iter()
                     .filter(|p| {
-                        p.zpos.unwrap_or_default() < self.surface.plane_info().zpos.unwrap_or_default()
+                        p.zpos.unwrap_or_default() < self.tiles[0].surface.plane_info().zpos.unwrap_or_default()
                     })
                     .any(|p| next_frame_state.overlaps(p.handle, element_geometry));
                 !overlaps_with_underlay
@@ -2347,16 +2389,17 @@ where
         for element_state in element_states.values_mut() {
             element_state.fb_cache.cleanup();
         }
-        self.element_states = element_states;
-        self.previous_element_states.clear();
+        self.tiles[0].element_states = element_states;
+        self.tiles[0].previous_element_states.clear();
         opaque_regions.clear();
-        self.opaque_regions = opaque_regions;
+        self.tiles[0].opaque_regions = opaque_regions;
 
-        let previous_state = self
+        let tile = &mut self.tiles[0];
+        let previous_state = tile
             .pending_frame
             .as_ref()
             .map(|pending| &pending.frame)
-            .unwrap_or(&self.current_frame);
+            .unwrap_or(&tile.current_frame);
 
         // Check if the next frame state is fully compatible with the previous frame state.
         // If not do a single atomic commit test and when that fails render everything that failed
@@ -2365,8 +2408,8 @@ where
         if next_frame_state
             .test_state_complete(
                 previous_state,
-                &self.surface,
-                self.supports_fencing,
+                &tile.surface,
+                tile.supports_fencing,
                 false,
                 allow_partial_update,
             )
@@ -2389,9 +2432,9 @@ where
 
                 // Check if the element we are potentially going to remove is
                 // on the primary plane, cursor plane or an overlay plane
-                let element = if *plane == self.surface.plane() {
+                let element = if *plane == tile.surface.plane() {
                     primary_plane_scanout_element.take()
-                } else if self.planes.cursor.iter().any(|p| *plane == p.handle) {
+                } else if tile.planes.cursor.iter().any(|p| *plane == p.handle) {
                     cursor_plane_element.take()
                 } else {
                     overlay_plane_elements.shift_remove(plane)
@@ -2419,7 +2462,7 @@ where
             // to make sure we actually have a slot on the primary
             // plane we can render into
             if !removed_overlay_elements.is_empty() {
-                next_frame_state.set_state(self.surface.plane(), primary_plane_state);
+                next_frame_state.set_state(tile.surface.plane(), primary_plane_state);
             }
 
             removed_overlay_elements.sort_by_key(|(z_index, _)| *z_index);
@@ -2440,12 +2483,12 @@ where
                     .and_then(|state| state.config.as_ref())
                     .is_none()
             {
-                self.overlay_plane_element_ids.remove_plane(handle);
+                tile.overlay_plane_element_ids.remove_plane(handle);
             }
         }
 
         let render = next_frame_state
-            .plane_buffer(self.surface.plane())
+            .plane_buffer(tile.surface.plane())
             .map(|config| matches!(config.buffer, ScanoutBuffer::Swapchain(_)))
             .unwrap_or(false);
 
@@ -2453,10 +2496,10 @@ where
             trace!(
                 "rendering {} elements on the primary {:?}",
                 primary_plane_elements.len(),
-                self.surface.plane(),
+                tile.surface.plane(),
             );
             let (mut dmabuf, age) = {
-                let primary_plane_state = next_frame_state.plane_state(self.surface.plane()).unwrap();
+                let primary_plane_state = next_frame_state.plane_state(tile.surface.plane()).unwrap();
                 let config = primary_plane_state.config.as_ref().unwrap();
                 let slot = match &config.buffer.buffer {
                     ScanoutBuffer::Swapchain(slot) => slot,
@@ -2487,11 +2530,11 @@ where
             // So we use an Id per plane for as long as we have the same element
             // on that plane.
             let overlay_plane_elements = overlay_plane_elements.iter().filter_map(|(p, element)| {
-                let id = self
+                let id = tile
                     .overlay_plane_element_ids
                     .plane_id_for_element_id(p, element.id());
 
-                let plane_z_pos = self
+                let plane_z_pos = tile
                     .planes
                     .overlay
                     .iter()
@@ -2503,7 +2546,7 @@ where
                         }
                     })
                     .unwrap_or_default();
-                let is_underlay = plane_z_pos < self.surface.plane_info().zpos.unwrap_or_default();
+                let is_underlay = plane_z_pos < tile.surface.plane_info().zpos.unwrap_or_default();
                 if is_underlay {
                     Some(HolepunchRenderElement::from_render_element(id, element, output_scale).into())
                 } else {
@@ -2524,7 +2567,7 @@ where
                 .bind(&mut dmabuf)
                 .map_err(|err| RenderFrameError::RenderFrame(OutputDamageTrackerError::Rendering(err)))?;
             let render_res =
-                self.damage_tracker
+                tile.damage_tracker
                     .render_output(renderer, &mut framebuffer, age, &elements, clear_color);
 
             // restore the renderer debug flags
@@ -2541,7 +2584,7 @@ where
 
                     for (id, state) in render_output_result.states.states.into_iter() {
                         // Skip the state for our fake elements
-                        if self.overlay_plane_element_ids.contains_plane_id(&id) {
+                        if tile.overlay_plane_element_ids.contains_plane_id(&id) {
                             continue;
                         }
 
@@ -2563,18 +2606,18 @@ where
                     // but now use it for rendering we do not replace the damage which is
                     // the whole plane initially.
                     let had_direct_scan_out = previous_state
-                        .plane_state(self.surface.plane())
+                        .plane_state(tile.surface.plane())
                         .map(|state| state.element_state.is_some())
                         .unwrap_or(true);
 
-                    let primary_plane_state = next_frame_state.plane_state_mut(self.surface.plane()).unwrap();
+                    let primary_plane_state = next_frame_state.plane_state_mut(tile.surface.plane()).unwrap();
                     let config = primary_plane_state.config.as_mut().unwrap();
 
                     if !had_direct_scan_out {
                         if let Some(render_damage) = render_output_result.damage {
                             trace!("rendering damage: {:?}", render_damage);
 
-                            self.primary_plane_damage_bag.add(render_damage.iter().map(|d| {
+                            tile.primary_plane_damage_bag.add(render_damage.iter().map(|d| {
                                 d.to_logical(1).to_buffer(
                                     1,
                                     Transform::Normal,
@@ -2582,7 +2625,7 @@ where
                                 )
                             }));
                             config.damage_clips = PlaneDamageClips::from_damage(
-                                self.surface.device_fd(),
+                                tile.surface.device_fd(),
                                 config.properties.src,
                                 config.properties.dst,
                                 render_damage.iter().copied(),
@@ -2595,7 +2638,7 @@ where
 
                             primary_plane_state.skip = true;
                             *config = previous_state
-                                .plane_state(self.surface.plane())
+                                .plane_state(tile.surface.plane())
                                 .and_then(|state| state.config.as_ref().cloned())
                                 .unwrap_or_else(|| config.clone());
                         }
@@ -2603,7 +2646,7 @@ where
                         trace!(
                             "clearing previous direct scan-out on primary plane, damaging complete output"
                         );
-                        self.primary_plane_damage_bag
+                        tile.primary_plane_damage_bag
                             .add([output_geometry.to_logical(1).to_buffer(
                                 1,
                                 Transform::Normal,
@@ -2616,7 +2659,7 @@ where
                 Err(err) => {
                     // Rendering failed at some point, reset the buffers
                     // as we probably now have some half drawn buffer
-                    self.swapchain.reset_buffers();
+                    tile.swapchain.reset_buffers();
                     return Err(RenderFrameError::from(err));
                 }
             }
@@ -2629,7 +2672,7 @@ where
 
         let primary_plane_element = if render {
             let (slot, sync) = {
-                let primary_plane_state = next_frame_state.plane_state(self.surface.plane()).unwrap();
+                let primary_plane_state = next_frame_state.plane_state(tile.surface.plane()).unwrap();
                 let config = primary_plane_state.config.as_ref().unwrap();
                 (
                     config.buffer.clone(),
@@ -2644,7 +2687,7 @@ where
             PrimaryPlaneElement::Swapchain(PrimarySwapchainElement {
                 slot,
                 transform: output_transform,
-                damage: self.primary_plane_damage_bag.snapshot(),
+                damage: tile.primary_plane_damage_bag.snapshot(),
                 sync,
             })
         } else {
@@ -2656,12 +2699,12 @@ where
             && allow_partial_update
             && next_frame_state.planes.iter().all(|(plane, state)| {
                 state.skip
-                    || (self.planes.cursor.iter().any(|p| *plane == p.handle)
+                    || (tile.planes.cursor.iter().any(|p| *plane == p.handle)
                         && state.buffer().map(|b| &b.fb)
                             == previous_state.plane_buffer(*plane).map(|b| &b.fb))
             })
         {
-            for plane in self.planes.cursor.iter() {
+            for plane in tile.planes.cursor.iter() {
                 let Some(state) = next_frame_state.plane_state_mut(plane.handle) else {
                     continue;
                 };
@@ -2683,15 +2726,15 @@ where
             overlay_elements: overlay_plane_elements.into_values().collect(),
             cursor_element: cursor_plane_element,
             states: render_element_states,
-            primary_plane_element_id: self.primary_plane_element_id.clone(),
-            supports_fencing: self.supports_fencing,
+            primary_plane_element_id: tile.primary_plane_element_id.clone(),
+            supports_fencing: tile.supports_fencing,
         };
 
         // We only store the next frame if it actually contains any changes or if a commit is pending
         // Storing the (empty) frame could keep a reference to wayland buffers which
         // could otherwise be potentially released on `frame_submitted`
         if !next_frame.is_empty() {
-            self.next_frame = Some(next_frame);
+            tile.next_frame = Some(next_frame);
         }
 
         Ok(frame_reference)
@@ -2715,16 +2758,16 @@ where
     /// `user_data` can be used to attach some data to a specific buffer and later retrieved with [`DrmCompositor::frame_submitted`]
     #[profiling::function]
     pub fn queue_frame(&mut self, user_data: U) -> FrameResult<(), A, F> {
-        if !self.surface.is_active() {
+        if !self.tiles[0].surface.is_active() {
             return Err(FrameErrorType::<A, F>::DrmError(DrmError::DeviceInactive));
         }
 
-        let prepared_frame = self.next_frame.take().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
+        let prepared_frame = self.tiles[0].next_frame.take().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
         if prepared_frame.is_empty() {
             return Err(FrameErrorType::<A, F>::EmptyFrame);
         }
 
-        if let Some(plane_state) = prepared_frame.frame.plane_state(self.surface.plane()) {
+        if let Some(plane_state) = prepared_frame.frame.plane_state(self.tiles[0].surface.plane()) {
             if !plane_state.skip {
                 let slot = plane_state.buffer().and_then(|config| match &config.buffer {
                     ScanoutBuffer::Swapchain(slot) => Some(slot),
@@ -2732,16 +2775,16 @@ where
                 });
 
                 if let Some(slot) = slot {
-                    self.swapchain.submitted(slot);
+                    self.tiles[0].swapchain.submitted(slot);
                 }
             }
         }
 
-        self.queued_frame = Some(QueuedFrame {
+        self.tiles[0].queued_frame = Some(QueuedFrame {
             prepared_frame,
             user_data,
         });
-        if self.pending_frame.is_none() {
+        if self.tiles[0].pending_frame.is_none() {
             self.submit()?;
         }
         Ok(())
@@ -2761,16 +2804,16 @@ where
     /// *Note*: This function should not be followed up with [`DrmCompositor::frame_submitted`]
     /// and will not generate a vblank event on the underlying device.
     pub fn commit_frame(&mut self) -> FrameResult<(), A, F> {
-        if !self.surface.is_active() {
+        if !self.tiles[0].surface.is_active() {
             return Err(FrameErrorType::<A, F>::DrmError(DrmError::DeviceInactive));
         }
 
-        let mut prepared_frame = self.next_frame.take().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
+        let mut prepared_frame = self.tiles[0].next_frame.take().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
         if prepared_frame.is_empty() {
             return Err(FrameErrorType::<A, F>::EmptyFrame);
         }
 
-        if let Some(plane_state) = prepared_frame.frame.plane_state(self.surface.plane()) {
+        if let Some(plane_state) = prepared_frame.frame.plane_state(self.tiles[0].surface.plane()) {
             if !plane_state.skip {
                 let slot = plane_state.buffer().and_then(|config| match &config.buffer {
                     ScanoutBuffer::Swapchain(slot) => Some(slot),
@@ -2778,18 +2821,18 @@ where
                 });
 
                 if let Some(slot) = slot {
-                    self.swapchain.submitted(slot);
+                    self.tiles[0].swapchain.submitted(slot);
                 }
             }
         }
 
         let flip = prepared_frame
             .frame
-            .commit(&self.surface, self.supports_fencing, false, false);
+            .commit(&self.tiles[0].surface, self.tiles[0].supports_fencing, false, false);
 
         if flip.is_ok() {
-            self.queued_frame = None;
-            self.pending_frame = None;
+            self.tiles[0].queued_frame = None;
+            self.tiles[0].pending_frame = None;
         }
 
         self.handle_flip(prepared_frame, None, flip)
@@ -2805,8 +2848,8 @@ where
     /// the state of the crtc is modified elsewhere, you may call this function
     /// to reset it's internal state.
     pub fn reset_state(&mut self) -> Result<(), DrmError> {
-        self.surface.reset_state()?;
-        self.reset_pending = true;
+        self.tiles[0].surface.reset_state()?;
+        self.tiles[0].reset_pending = true;
         Ok(())
     }
 
@@ -2815,17 +2858,17 @@ where
         let QueuedFrame {
             mut prepared_frame,
             user_data,
-        } = self.queued_frame.take().unwrap();
+        } = self.tiles[0].queued_frame.take().unwrap();
 
         let allow_partial_update = prepared_frame.kind == PreparedFrameKind::Partial;
-        let flip = if self.surface.commit_pending() {
+        let flip = if self.tiles[0].surface.commit_pending() {
             prepared_frame
                 .frame
-                .commit(&self.surface, self.supports_fencing, allow_partial_update, true)
+                .commit(&self.tiles[0].surface, self.tiles[0].supports_fencing, allow_partial_update, true)
         } else {
             prepared_frame
                 .frame
-                .page_flip(&self.surface, self.supports_fencing, allow_partial_update, true)
+                .page_flip(&self.tiles[0].surface, self.tiles[0].supports_fencing, allow_partial_update, true)
         };
 
         self.handle_flip(prepared_frame, Some(user_data), flip)
@@ -2840,10 +2883,10 @@ where
         match flip {
             Ok(_) => {
                 if prepared_frame.kind == PreparedFrameKind::Full {
-                    self.reset_pending = false;
+                    self.tiles[0].reset_pending = false;
                 }
 
-                self.pending_frame = user_data.map(|user_data| PendingFrame {
+                self.tiles[0].pending_frame = user_data.map(|user_data| PendingFrame {
                     frame: prepared_frame.frame,
                     user_data,
                 });
@@ -2856,7 +2899,7 @@ where
                 // the next call to render_frame
                 let primary_plane_element_state = prepared_frame
                     .frame
-                    .plane_state(self.surface.plane())
+                    .plane_state(self.tiles[0].surface.plane())
                     .and_then(|plane_state| {
                         plane_state
                             .element_state
@@ -2864,7 +2907,7 @@ where
                             .map(|element_state| &element_state.id)
                     })
                     .and_then(|primary_plane_element_id| {
-                        self.element_states.get_mut(primary_plane_element_id)
+                        self.tiles[0].element_states.get_mut(primary_plane_element_id)
                     });
 
                 if let Some(primary_plane_element_state) = primary_plane_element_state {
@@ -2886,9 +2929,9 @@ where
     /// Otherwise the underlying swapchain will run out of buffers eventually.
     #[profiling::function]
     pub fn frame_submitted(&mut self) -> FrameResult<Option<U>, A, F> {
-        if let Some(PendingFrame { mut frame, user_data }) = self.pending_frame.take() {
-            std::mem::swap(&mut frame, &mut self.current_frame);
-            if self.queued_frame.is_some() {
+        if let Some(PendingFrame { mut frame, user_data }) = self.tiles[0].pending_frame.take() {
+            std::mem::swap(&mut frame, &mut self.tiles[0].current_frame);
+            if self.tiles[0].queued_frame.is_some() {
                 self.submit()?;
             }
             Ok(Some(user_data))
@@ -2899,7 +2942,7 @@ where
 
     /// Reset the underlying buffers
     pub fn reset_buffers(&mut self) {
-        self.swapchain.reset_buffers();
+        self.tiles[0].swapchain.reset_buffers();
     }
 
     /// Reset the age for all buffers.
@@ -2907,28 +2950,28 @@ where
     /// This can be used to efficiently clear the damage history without having to
     /// modify the damage for each surface.
     pub fn reset_buffer_ages(&mut self) {
-        self.swapchain.reset_buffer_ages();
+        self.tiles[0].swapchain.reset_buffer_ages();
     }
 
     /// Returns the underlying [`crtc`] of this surface
     pub fn crtc(&self) -> crtc::Handle {
-        self.surface.crtc()
+        self.tiles[0].surface.crtc()
     }
 
     /// Returns the underlying [`plane`] of this surface
     pub fn plane(&self) -> plane::Handle {
-        self.surface.plane()
+        self.tiles[0].surface.plane()
     }
 
     /// Currently used [`connector`]s of this `Surface`
     pub fn current_connectors(&self) -> impl IntoIterator<Item = connector::Handle> {
-        self.surface.current_connectors()
+        self.tiles[0].surface.current_connectors()
     }
 
     /// Returns the pending [`connector`]s
     /// used for the next frame queued via [`queue_frame`](DrmCompositor::queue_frame).
     pub fn pending_connectors(&self) -> impl IntoIterator<Item = connector::Handle> {
-        self.surface.pending_connectors()
+        self.tiles[0].surface.pending_connectors()
     }
 
     /// Tries to add a new [`connector`]
@@ -2944,7 +2987,7 @@ where
     /// or is not compatible with the currently pending
     /// [`Mode`].
     pub fn add_connector(&self, connector: connector::Handle) -> FrameResult<(), A, F> {
-        self.surface
+        self.tiles[0].surface
             .add_connector(connector)
             .map_err(FrameError::DrmError)
     }
@@ -2952,7 +2995,7 @@ where
     /// Tries to mark a [`connector`]
     /// for removal on the next commit.
     pub fn remove_connector(&self, connector: connector::Handle) -> FrameResult<(), A, F> {
-        self.surface
+        self.tiles[0].surface
             .remove_connector(connector)
             .map_err(FrameError::DrmError)
     }
@@ -2964,7 +3007,7 @@ where
     /// or is not compatible with the currently pending
     /// [`Mode`].
     pub fn set_connectors(&self, connectors: &[connector::Handle]) -> FrameResult<(), A, F> {
-        self.surface
+        self.tiles[0].surface
             .set_connectors(connectors)
             .map_err(FrameError::DrmError)
     }
@@ -2972,13 +3015,13 @@ where
     /// Returns the currently active [`Mode`]
     /// of the underlying [`crtc`]
     pub fn current_mode(&self) -> Mode {
-        self.surface.current_mode()
+        self.tiles[0].surface.current_mode()
     }
 
     /// Returns the currently pending [`Mode`]
     /// to be used after the next commit.
     pub fn pending_mode(&self) -> Mode {
-        self.surface.pending_mode()
+        self.tiles[0].surface.pending_mode()
     }
 
     /// Tries to set a new [`Mode`]
@@ -2988,9 +3031,9 @@ where
     /// [`crtc`] or any of the
     /// pending [`connector`]s.
     pub fn use_mode(&mut self, mode: Mode) -> FrameResult<(), A, F> {
-        self.surface.use_mode(mode).map_err(FrameError::DrmError)?;
+        self.tiles[0].surface.use_mode(mode).map_err(FrameError::DrmError)?;
         let (w, h) = mode.size();
-        self.swapchain.resize(w as _, h as _);
+        self.tiles[0].swapchain.resize(w as _, h as _);
         Ok(())
     }
 
@@ -2998,12 +3041,12 @@ where
     ///
     /// See [`DrmSurface::vrr_supported`] for more details.
     pub fn vrr_supported(&self, conn: connector::Handle) -> FrameResult<VrrSupport, A, F> {
-        self.surface.vrr_supported(conn).map_err(FrameError::DrmError)
+        self.tiles[0].surface.vrr_supported(conn).map_err(FrameError::DrmError)
     }
 
     /// Returns if Variable Refresh Rate is currently enabled for frames composed by this [`DrmCompositor`].
     pub fn vrr_enabled(&self) -> bool {
-        self.surface.vrr_enabled()
+        self.tiles[0].surface.vrr_enabled()
     }
 
     /// Tries to set variable refresh rate (VRR) for the next frame.
@@ -3012,7 +3055,7 @@ where
     /// Check [`DrmCompositor::vrr_supported`], which indicates if VRR can be
     /// used without a modeset on the attached connectors.
     pub fn use_vrr(&mut self, vrr: bool) -> FrameResult<(), A, F> {
-        self.surface.use_vrr(vrr).map_err(FrameError::DrmError)
+        self.tiles[0].surface.use_vrr(vrr).map_err(FrameError::DrmError)
     }
 
     /// Set the [`DebugFlags`] to use
@@ -3022,7 +3065,7 @@ where
     pub fn set_debug_flags(&mut self, flags: DebugFlags) {
         if self.debug_flags != flags {
             self.debug_flags = flags;
-            self.swapchain.reset_buffers();
+            self.tiles[0].swapchain.reset_buffers();
         }
     }
 
@@ -3033,17 +3076,17 @@ where
 
     /// Returns a reference to the underlying drm surface
     pub fn surface(&self) -> &DrmSurface {
-        &self.surface
+        &self.tiles[0].surface
     }
 
     /// Get the format of the underlying swapchain
     pub fn format(&self) -> DrmFourcc {
-        self.swapchain.format()
+        self.tiles[0].swapchain.format()
     }
 
     /// Get the allowed modifiers of the underlying swapchain
     pub fn modifiers(&self) -> &[DrmModifier] {
-        self.swapchain.modifiers()
+        self.tiles[0].swapchain.modifiers()
     }
 
     /// Reset the underlying swapchain and assign a new color format.
@@ -3054,9 +3097,9 @@ where
         modifiers: impl IntoIterator<Item = DrmModifier>,
     ) -> Result<(), FrameErrorType<A, F>> {
         let (swapchain, is_oapque) = Self::test_format(
-            &self.surface,
-            self.supports_fencing,
-            &self.planes,
+            &self.tiles[0].surface,
+            self.tiles[0].supports_fencing,
+            &self.tiles[0].planes,
             allocator,
             &self.framebuffer_exporter,
             code,
@@ -3064,8 +3107,8 @@ where
         )
         .map_err(|(_, err)| err)?;
 
-        self.swapchain = swapchain;
-        self.primary_is_opaque = is_oapque;
+        self.tiles[0].swapchain = swapchain;
+        self.tiles[0].primary_is_opaque = is_oapque;
 
         Ok(())
     }
@@ -3077,7 +3120,7 @@ where
             return;
         }
 
-        self.damage_tracker = OutputDamageTracker::from_mode_source(output_mode_source.clone());
+        self.tiles[0].damage_tracker = OutputDamageTracker::from_mode_source(output_mode_source.clone());
         self.output_mode_source = output_mode_source;
     }
 
@@ -3135,7 +3178,7 @@ where
                     trace!(
                         "assigned element {:?} to primary {:?}",
                         element.id(),
-                        self.surface.plane()
+                        self.tiles[0].surface.plane()
                     );
                     return Ok(plane);
                 }
@@ -3213,7 +3256,7 @@ where
         }
 
         if frame_state
-            .plane_state(self.surface.plane())
+            .plane_state(self.tiles[0].surface.plane())
             .map(|state| state.element_state.is_some())
             .unwrap_or(true)
         {
@@ -3233,7 +3276,7 @@ where
         )?;
 
         if let ScanoutBuffer::Swapchain(slot) = &frame_state
-            .plane_buffer(self.surface.plane())
+            .plane_buffer(self.tiles[0].surface.plane())
             .expect("We have a buffer for the primary plane")
             .buffer
         {
@@ -3243,18 +3286,18 @@ where
                 trace!(
                     "failed to assign element {:?} to primary {:?}, format doesn't match",
                     element.id(),
-                    self.surface.plane()
+                    self.tiles[0].surface.plane()
                 );
                 return Err(None);
             }
         }
 
-        let has_underlay = self
+        let has_underlay = self.tiles[0]
             .planes
             .overlay
             .iter()
             .filter(|plane| {
-                self.surface.plane_info().zpos.unwrap_or_default() > plane.zpos.unwrap_or_default()
+                self.tiles[0].surface.plane_info().zpos.unwrap_or_default() > plane.zpos.unwrap_or_default()
             })
             .any(|plane| frame_state.is_assigned(plane.handle));
 
@@ -3262,7 +3305,7 @@ where
             trace!(
                 "failed to assign element {:?} to primary {:?}, already has underlay",
                 element.id(),
-                self.surface.plane()
+                self.tiles[0].surface.plane()
             );
             return Err(None);
         }
@@ -3274,7 +3317,7 @@ where
         let res = self.try_assign_plane(
             element,
             &element_config,
-            self.surface.plane_info(),
+            self.tiles[0].surface.plane_info(),
             scale,
             frame_state,
         );
@@ -3309,7 +3352,8 @@ where
             return None;
         }
 
-        let Some(cursor_state) = self.cursor_state.as_mut() else {
+        let tile = &mut self.tiles[0];
+        let Some(cursor_state) = tile.cursor_state.as_mut() else {
             trace!("no cursor state, skipping cursor rendering");
             return None;
         };
@@ -3334,7 +3378,7 @@ where
 
         // For now we only support a single cursor plane, so first test if we already
         // assigned something to any cursor plane
-        if let Some(plane_info) = self
+        if let Some(plane_info) = tile
             .planes
             .cursor
             .iter()
@@ -3348,23 +3392,23 @@ where
             return None;
         }
 
-        let previous_state = self
+        let previous_state = tile
             .pending_frame
             .as_ref()
             .map(|pending| &pending.frame)
-            .unwrap_or(&self.current_frame);
+            .unwrap_or(&tile.current_frame);
 
         // In case we have multiple cursor planes we will try to keep using
         // the same cursor plane for as long as possible.
         // So first we test the previous state for an assigned cursor plane and
         // if that fails we will try to pick the first unclaimed cursor plane.
-        let Some((plane_info, plane_claim)) = self
+        let Some((plane_info, plane_claim)) = tile
             .planes
             .cursor
             .iter()
             .find_map(|plane_info: &PlaneInfo| {
                 if previous_state.is_assigned(plane_info.handle) {
-                    self.surface
+                    tile.surface
                         .claim_plane(plane_info.handle)
                         .map(|claim| (plane_info, claim))
                 } else {
@@ -3372,8 +3416,8 @@ where
                 }
             })
             .or_else(|| {
-                self.planes.cursor.iter().find_map(|plane_info| {
-                    self.surface
+                tile.planes.cursor.iter().find_map(|plane_info| {
+                    tile.surface
                         .claim_plane(plane_info.handle)
                         .map(|claim| (plane_info, claim))
                 })
@@ -3407,11 +3451,11 @@ where
             .transform_point_in(element.location(scale), &output_geometry.size)
             - output_transform.transform_point_in(Point::default(), &cursor_plane_size);
 
-        let previous_state = self
+        let previous_state = tile
             .pending_frame
             .as_ref()
             .map(|pending| &pending.frame)
-            .unwrap_or(&self.current_frame);
+            .unwrap_or(&tile.current_frame);
 
         let previous_element_state = previous_state
             .plane_state(plane_info.handle)
@@ -3505,7 +3549,7 @@ where
 
         // if we fail to export a framebuffer for our buffer we can skip the rest
         let framebuffer = match cursor_state.framebuffer_exporter.add_framebuffer(
-            self.surface.device_fd(),
+            tile.surface.device_fd(),
             ExportBuffer::Allocator(&cursor_buffer),
             false,
         ) {
@@ -3701,8 +3745,8 @@ where
         } else {
             frame_state
                 .test_state(
-                    &self.surface,
-                    self.supports_fencing,
+                    &tile.surface,
+                    tile.supports_fencing,
                     plane_info.handle,
                     plane_state,
                     false,
@@ -3764,7 +3808,7 @@ where
         // we got the same id multiple times. If we can't find it we use the previous
         // state if available
         if !element_states.contains_key(element_id) {
-            let previous_fb_cache = self
+            let previous_fb_cache = self.tiles[0]
                 .previous_element_states
                 .get_mut(element_id)
                 // Note: We can mem::take the old fb_cache here here as we guarantee that
@@ -3799,7 +3843,7 @@ where
 
             let fb = self
                 .framebuffer_exporter
-                .add_framebuffer(self.surface.device_fd(), export_buffer, allow_opaque_fallback)
+                .add_framebuffer(self.tiles[0].surface.device_fd(), export_buffer, allow_opaque_fallback)
                 .map_err(|err| {
                     trace!("failed to add framebuffer: {:?}", err);
                     ExportBufferError::ExportFailed
@@ -3862,7 +3906,7 @@ where
             .any(|i| i.properties == properties)
         {
             let overlay_bitmask =
-                self.planes
+                self.tiles[0].planes
                     .overlay
                     .iter()
                     .enumerate()
@@ -3873,7 +3917,7 @@ where
                         acc
                     });
             let cursor_bitmask =
-                self.planes
+                self.tiles[0].planes
                     .cursor
                     .iter()
                     .enumerate()
@@ -3884,7 +3928,7 @@ where
                         acc
                     });
             let current_plane_snapshot = PlanesSnapshot {
-                primary: frame_state.is_assigned(self.surface.plane()),
+                primary: frame_state.is_assigned(self.tiles[0].surface.plane()),
                 cursor_bitmask,
                 overlay_bitmask,
             };
@@ -3896,7 +3940,7 @@ where
                 failed_planes: Default::default(),
             });
 
-            if let Some(previous_state) = self.previous_element_states.get(element_id) {
+            if let Some(previous_state) = self.tiles[0].previous_element_states.get(element_id) {
                 // lets look if we find a previous instance with exactly the same properties.
                 // if we find one we can test if nothing changed and re-use the failed tests
                 let matching_instance = previous_state
@@ -3906,11 +3950,11 @@ where
 
                 if let Some(matching_instance) = matching_instance {
                     if current_plane_snapshot == matching_instance.active_planes {
-                        let previous_frame_state = self
+                        let previous_frame_state = self.tiles[0]
                             .pending_frame
                             .as_ref()
                             .map(|pending| &pending.frame)
-                            .unwrap_or(&self.current_frame);
+                            .unwrap_or(&self.tiles[0].current_frame);
 
                         // Note: we ignore the cursor plane here as this would result
                         // in constant re-tests of cursor moves and we do not expect
@@ -3918,14 +3962,14 @@ where
                         // Adding or removing cursor can influence the other planes, but
                         // is already covered in the active planes check.
                         let primary_plane_changed = if current_plane_snapshot.primary {
-                            frame_state.plane_properties(self.surface.plane())
-                                != previous_frame_state.plane_properties(self.surface.plane())
+                            frame_state.plane_properties(self.tiles[0].surface.plane())
+                                != previous_frame_state.plane_properties(self.tiles[0].surface.plane())
                         } else {
                             false
                         };
 
                         let overlay_plane_changed =
-                            self.planes.overlay.iter().enumerate().any(|(index, plane)| {
+                            self.tiles[0].planes.overlay.iter().enumerate().any(|(index, plane)| {
                                 // we only want to test planes that are currently in use
                                 if current_plane_snapshot.overlay_bitmask & (1 << index) == 0 {
                                     return false;
@@ -4011,7 +4055,7 @@ where
         let element_id = element.id();
 
         // Check if we have a free plane, otherwise we can exit early
-        if self
+        if self.tiles[0]
             .planes
             .overlay
             .iter()
@@ -4042,15 +4086,15 @@ where
         });
 
         let primary_plane_has_alpha = frame_state
-            .plane_buffer(self.surface.plane())
+            .plane_buffer(self.tiles[0].surface.plane())
             .map(|state| has_alpha(state.format().code))
             .unwrap_or(false);
 
-        let previous_frame_state = self
+        let previous_frame_state = self.tiles[0]
             .pending_frame
             .as_ref()
             .map(|pending| &pending.frame)
-            .unwrap_or(&self.current_frame);
+            .unwrap_or(&self.tiles[0].current_frame);
 
         // We consider a plane compatible if the z-index of the previous assigned
         // element is or equal to our z-index and the properties (src/dst/format/...)
@@ -4093,7 +4137,7 @@ where
 
             // test if the plane represents an underlay
             let is_underlay =
-                self.surface.plane_info().zpos.unwrap_or_default() > plane.zpos.unwrap_or_default();
+                self.tiles[0].surface.plane_info().zpos.unwrap_or_default() > plane.zpos.unwrap_or_default();
 
             if is_underlay && !(element_is_opaque && primary_plane_has_alpha) {
                 trace!(
@@ -4114,7 +4158,7 @@ where
                 return Err(None);
             }
 
-            let overlaps_with_plane_underneath = self
+            let overlaps_with_plane_underneath = self.tiles[0]
                 .planes
                 .overlay
                 .iter()
@@ -4142,7 +4186,7 @@ where
 
         // First try to assign the element to a compatible plane, this can save us
         // from some atomic testing
-        for plane in self.planes.overlay.iter().filter(is_plane_compatible) {
+        for plane in self.tiles[0].planes.overlay.iter().filter(is_plane_compatible) {
             if let Ok(plane_assignment) = test_overlay_plane(plane, &element_config) {
                 trace!(
                     "assigned element {:?} geometry {:?} to compatible {:?} with zpos {:?}",
@@ -4154,7 +4198,7 @@ where
 
         // If we found no compatible plane fall back to walk all available planes
         let mut rendering_reason: Option<RenderingReason> = None;
-        for (index, plane) in self.planes.overlay.iter().enumerate() {
+        for (index, plane) in self.tiles[0].planes.overlay.iter().enumerate() {
             // if the tested element state already tells us that this failed skip the test
             if element_config.failed_planes.overlay_bitmask & (1 << index) != 0 {
                 trace!(
@@ -4202,7 +4246,7 @@ where
     {
         let element_id = element.id();
 
-        let plane_claim = match self.surface.claim_plane(plane.handle) {
+        let plane_claim = match self.tiles[0].surface.claim_plane(plane.handle) {
             Some(claim) => claim,
             None => {
                 trace!("failed to claim {:?} for element {:?}", plane.handle, element_id);
@@ -4224,11 +4268,11 @@ where
             return Err(Some(RenderingReason::FormatUnsupported));
         }
 
-        let previous_state = self
+        let previous_state = self.tiles[0]
             .pending_frame
             .as_ref()
             .map(|pending| &pending.frame)
-            .unwrap_or(&self.current_frame);
+            .unwrap_or(&self.tiles[0].current_frame);
 
         let previous_commit = previous_state.plane_state(plane.handle).and_then(|state| {
             state.element_state.as_ref().and_then(|state| {
@@ -4245,7 +4289,7 @@ where
 
         let damage_clips = if has_element_damage {
             PlaneDamageClips::from_damage(
-                self.surface.device_fd(),
+                self.tiles[0].surface.device_fd(),
                 element_config.properties.src,
                 element_config.geometry,
                 element_damage,
@@ -4264,7 +4308,7 @@ where
             sync: element_config
                 .buffer
                 .buffer
-                .acquire_point(self.signaled_fence.as_ref()),
+                .acquire_point(self.tiles[0].signaled_fence.as_ref()),
         };
 
         let is_compatible = previous_state
@@ -4316,8 +4360,8 @@ where
         } else {
             frame_state
                 .test_state(
-                    &self.surface,
-                    self.supports_fencing,
+                    &self.tiles[0].surface,
+                    self.tiles[0].supports_fencing,
                     plane.handle,
                     plane_state,
                     false,
@@ -4347,15 +4391,15 @@ where
     ///
     /// Calling [`queue_frame`][Self::queue_frame] will re-enable.
     pub fn clear(&mut self) -> Result<(), DrmError> {
-        self.surface.clear()?;
+        self.tiles[0].surface.clear()?;
 
-        self.current_frame
+        self.tiles[0].current_frame
             .planes
             .iter_mut()
             .for_each(|(_, state)| *state = Default::default());
-        self.pending_frame = None;
-        self.queued_frame = None;
-        self.next_frame = None;
+        self.tiles[0].pending_frame = None;
+        self.tiles[0].queued_frame = None;
+        self.tiles[0].next_frame = None;
 
         Ok(())
     }

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -135,7 +135,7 @@ use std::{
 
 use drm::{
     Device, DriverCapability,
-    control::{Device as _, Mode, PlaneType, atomic::AtomicModeReq, connector, crtc, framebuffer, plane},
+    control::{Device as _, Mode, PlaneType, connector, crtc, framebuffer, plane},
 };
 use drm_fourcc::{DrmFormat, DrmFourcc, DrmModifier};
 use indexmap::{IndexMap, IndexSet};
@@ -3393,10 +3393,28 @@ where
         // modeset path; the shared atomic commit is all-or-nothing.
         let modeset = self.tiles.iter().any(|tile| tile.surface.commit_pending());
 
+        let [primary, rest @ ..] = &mut self.tiles[..] else {
+            unreachable!("DrmCompositor always has at least one tile");
+        };
+        let prepared = &mut primary
+            .queued_frame
+            .as_mut()
+            .expect("all tiles queued together")
+            .prepared_frame;
+        let allow_partial = !modeset && prepared.kind == PreparedFrameKind::Partial;
+        let planes = prepared
+            .frame
+            .build_planes(&primary.surface, primary.supports_fencing, allow_partial)
+            .into_iter()
+            .collect::<SmallVec<[_; 8]>>();
+        let mut commit = primary
+            .surface
+            .begin_atomic_commit(planes, true, modeset)
+            .map_err(FrameError::DrmError)?;
+
         // Keep each queued `FrameState` in place until the commit consumes the
         // request, so its fences remain alive.
-        let mut req = AtomicModeReq::new();
-        for tile in self.tiles.iter_mut() {
+        for tile in rest {
             let prepared = &mut tile
                 .queued_frame
                 .as_mut()
@@ -3408,17 +3426,16 @@ where
                 .build_planes(&tile.surface, tile.supports_fencing, allow_partial)
                 .into_iter()
                 .collect::<SmallVec<[_; 8]>>();
-            tile.surface
-                .append_to_request(&mut req, planes, modeset)
+            commit
+                .add_surface(&tile.surface, planes)
                 .map_err(FrameError::DrmError)?;
         }
 
-        let flip = self.tiles[0].surface.commit_request(req, true, modeset);
+        let flip = commit.commit();
 
         let has_user_data = user_data.is_some();
         if flip.is_ok() {
             for tile in self.tiles.iter_mut() {
-                tile.surface.mark_request_submitted(modeset);
                 let prepared = tile.queued_frame.take().expect("queued before submit").prepared_frame;
                 if prepared.kind == PreparedFrameKind::Full {
                     tile.reset_pending = false;
@@ -3444,8 +3461,33 @@ where
 
         let modeset = self.tiles.iter().any(|tile| tile.surface.commit_pending());
 
-        let mut req = AtomicModeReq::new();
-        for tile in self.tiles.iter_mut() {
+        let [primary, rest @ ..] = &mut self.tiles[..] else {
+            unreachable!("DrmCompositor always has at least one tile");
+        };
+        let prepared = primary.next_frame.as_mut().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
+        if let Some(plane_state) = prepared.frame.plane_state(primary.surface.plane()) {
+            if !plane_state.skip {
+                let slot = plane_state.buffer().and_then(|config| match &config.buffer {
+                    ScanoutBuffer::Swapchain(slot) => Some(slot),
+                    _ => None,
+                });
+                if let Some(slot) = slot {
+                    primary.swapchain.submitted(slot);
+                }
+            }
+        }
+        let allow_partial = !modeset && prepared.kind == PreparedFrameKind::Partial;
+        let planes = prepared
+            .frame
+            .build_planes(&primary.surface, primary.supports_fencing, allow_partial)
+            .into_iter()
+            .collect::<SmallVec<[_; 8]>>();
+        let mut commit = primary
+            .surface
+            .begin_atomic_commit(planes, false, modeset)
+            .map_err(FrameError::DrmError)?;
+
+        for tile in rest {
             let prepared = tile.next_frame.as_mut().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
             if let Some(plane_state) = prepared.frame.plane_state(tile.surface.plane()) {
                 if !plane_state.skip {
@@ -3464,17 +3506,16 @@ where
                 .build_planes(&tile.surface, tile.supports_fencing, allow_partial)
                 .into_iter()
                 .collect::<SmallVec<[_; 8]>>();
-            tile.surface
-                .append_to_request(&mut req, planes, modeset)
+            commit
+                .add_surface(&tile.surface, planes)
                 .map_err(FrameError::DrmError)?;
         }
 
         // Blocking commit, no page-flip event (mirrors single-tile `commit_frame`).
-        let flip = self.tiles[0].surface.commit_request(req, false, modeset);
+        let flip = commit.commit();
 
         if flip.is_ok() {
             for tile in self.tiles.iter_mut() {
-                tile.surface.mark_request_submitted(modeset);
                 tile.next_frame = None;
                 tile.queued_frame = None;
                 tile.pending_frame = None;

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1175,10 +1175,49 @@ fn validate_tile_regions(
     Ok(bbox.size)
 }
 
+/// Map a tile's framebuffer-space `region` into the logical (post-transform)
+/// coordinate space that render elements live in, given the output's full
+/// framebuffer `size` and `transform`.
+///
+/// Tile regions are fixed in framebuffer space and do not rotate. The render
+/// transform is applied to the whole logical scene *before* tiles are sliced, so
+/// to place a tile we map its fixed region *through* the transform. This is what
+/// keeps tiling correct under rotation/flip.
+// First used by `render_frame`, added in a following commit.
+#[allow(dead_code)]
+fn tile_logical_region(
+    region: Rectangle<i32, Physical>,
+    size: Size<i32, Physical>,
+    transform: Transform,
+) -> Rectangle<i32, Physical> {
+    transform.transform_rect_in(region, &size)
+}
+
+/// Offset to relocate render elements by (in logical space) so that a tile's
+/// `region` slice of the logical output lands at the tile framebuffer's origin.
+///
+/// Equal to `−tile_logical_region(..).loc`. Because it is derived through
+/// `transform`, the per-CRTC render stays correct at every orientation — unlike
+/// a raw framebuffer-space offset, which is only correct at [`Transform::Normal`].
+// First used by `render_frame`, added in a following commit.
+#[allow(dead_code)]
+fn tile_render_offset(
+    region: Rectangle<i32, Physical>,
+    size: Size<i32, Physical>,
+    transform: Transform,
+) -> Point<i32, Physical> {
+    let loc = tile_logical_region(region, size, transform).loc;
+    Point::from((-loc.x, -loc.y))
+}
+
 #[cfg(test)]
 mod tiled_tests {
-    use super::{TileConfigError, validate_tile_regions};
-    use crate::utils::{Physical, Point, Rectangle, Size};
+    use super::{TileConfigError, tile_logical_region, tile_render_offset, validate_tile_regions};
+    use crate::utils::{Physical, Point, Rectangle, Size, Transform};
+
+    fn full() -> Size<i32, Physical> {
+        Size::from((5120, 2880))
+    }
 
     fn rect(x: i32, y: i32, w: i32, h: i32) -> Rectangle<i32, Physical> {
         Rectangle::new(Point::from((x, y)), Size::from((w, h)))
@@ -1253,6 +1292,78 @@ mod tiled_tests {
             validate_tile_regions([bad]),
             Err(TileConfigError::NonPositiveRegion(bad))
         );
+    }
+
+    #[test]
+    fn render_offset_normal_is_negative_region_loc() {
+        // At Normal the relocate is just −region.loc.
+        assert_eq!(
+            tile_render_offset(rect(0, 0, 2560, 2880), full(), Transform::Normal),
+            Point::from((0, 0))
+        );
+        assert_eq!(
+            tile_render_offset(rect(2560, 0, 2560, 2880), full(), Transform::Normal),
+            Point::from((-2560, 0))
+        );
+    }
+
+    #[test]
+    fn render_offset_180_swaps_halves() {
+        // 180° puts the right half at the logical origin and the left half at +2560.
+        assert_eq!(
+            tile_render_offset(rect(2560, 0, 2560, 2880), full(), Transform::_180),
+            Point::from((0, 0))
+        );
+        assert_eq!(
+            tile_render_offset(rect(0, 0, 2560, 2880), full(), Transform::_180),
+            Point::from((-2560, 0))
+        );
+    }
+
+    #[test]
+    fn render_offset_90_stacks_halves_vertically() {
+        // 90° turns the side-by-side halves into a vertical stack in the
+        // 2880×5120 logical space — proof the offset is *not* the raw physical
+        // offset (which would still be on the X axis).
+        assert_eq!(
+            tile_render_offset(rect(0, 0, 2560, 2880), full(), Transform::_90),
+            Point::from((0, 0))
+        );
+        assert_eq!(
+            tile_render_offset(rect(2560, 0, 2560, 2880), full(), Transform::_90),
+            Point::from((0, -2560))
+        );
+    }
+
+    #[test]
+    fn tiles_partition_logical_output_under_every_transform() {
+        // The core rotation-correctness property: for *every* orientation, the
+        // two fixed framebuffer-space halves still tile the (rotated) logical
+        // output with no gaps or overlaps, anchored at the origin. A raw
+        // framebuffer-space offset would break this for non-Normal transforms —
+        // that was the bug class in the earlier prototype.
+        let left = rect(0, 0, 2560, 2880);
+        let right = rect(2560, 0, 2560, 2880);
+        for transform in [
+            Transform::Normal,
+            Transform::_90,
+            Transform::_180,
+            Transform::_270,
+            Transform::Flipped,
+            Transform::Flipped90,
+            Transform::Flipped180,
+            Transform::Flipped270,
+        ] {
+            let logical = [
+                tile_logical_region(left, full(), transform),
+                tile_logical_region(right, full(), transform),
+            ];
+            assert_eq!(
+                validate_tile_regions(logical),
+                Ok(transform.transform_size(full())),
+                "tiles must partition the logical output under {transform:?}",
+            );
+        }
     }
 }
 

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -2481,6 +2481,7 @@ where
             };
 
             match self.try_assign_element(
+                0,
                 renderer,
                 *element,
                 index,
@@ -3273,6 +3274,7 @@ where
     #[profiling::function]
     fn try_assign_element<'a, R, E>(
         &mut self,
+        tile: usize,
         renderer: &mut R,
         element: &'a E,
         element_zindex: usize,
@@ -3307,6 +3309,7 @@ where
 
         if try_assign_primary_plane {
             match self.try_assign_primary_plane(
+                tile,
                 renderer,
                 element,
                 element_zindex,
@@ -3322,7 +3325,7 @@ where
                     trace!(
                         "assigned element {:?} to primary {:?}",
                         element.id(),
-                        self.tiles[0].surface.plane()
+                        self.tiles[tile].surface.plane()
                     );
                     return Ok(plane);
                 }
@@ -3331,6 +3334,7 @@ where
         }
 
         if let Some(plane) = self.try_assign_cursor_plane(
+            tile,
             renderer,
             element,
             element_zindex,
@@ -3346,6 +3350,7 @@ where
         }
 
         match self.try_assign_overlay_plane(
+            tile,
             renderer,
             element,
             element_zindex,
@@ -3378,6 +3383,7 @@ where
     #[profiling::function]
     fn try_assign_primary_plane<'a, R, E>(
         &mut self,
+        tile: usize,
         renderer: &mut R,
         element: &'a E,
         element_zindex: usize,
@@ -3400,7 +3406,7 @@ where
         }
 
         if frame_state
-            .plane_state(self.tiles[0].surface.plane())
+            .plane_state(self.tiles[tile].surface.plane())
             .map(|state| state.element_state.is_some())
             .unwrap_or(true)
         {
@@ -3408,6 +3414,7 @@ where
         }
 
         let element_config = self.element_config(
+            tile,
             renderer,
             element,
             element_zindex,
@@ -3420,7 +3427,7 @@ where
         )?;
 
         if let ScanoutBuffer::Swapchain(slot) = &frame_state
-            .plane_buffer(self.tiles[0].surface.plane())
+            .plane_buffer(self.tiles[tile].surface.plane())
             .expect("We have a buffer for the primary plane")
             .buffer
         {
@@ -3430,18 +3437,18 @@ where
                 trace!(
                     "failed to assign element {:?} to primary {:?}, format doesn't match",
                     element.id(),
-                    self.tiles[0].surface.plane()
+                    self.tiles[tile].surface.plane()
                 );
                 return Err(None);
             }
         }
 
-        let has_underlay = self.tiles[0]
+        let has_underlay = self.tiles[tile]
             .planes
             .overlay
             .iter()
             .filter(|plane| {
-                self.tiles[0].surface.plane_info().zpos.unwrap_or_default() > plane.zpos.unwrap_or_default()
+                self.tiles[tile].surface.plane_info().zpos.unwrap_or_default() > plane.zpos.unwrap_or_default()
             })
             .any(|plane| frame_state.is_assigned(plane.handle));
 
@@ -3449,7 +3456,7 @@ where
             trace!(
                 "failed to assign element {:?} to primary {:?}, already has underlay",
                 element.id(),
-                self.tiles[0].surface.plane()
+                self.tiles[tile].surface.plane()
             );
             return Err(None);
         }
@@ -3459,9 +3466,10 @@ where
         }
 
         let res = self.try_assign_plane(
+            tile,
             element,
             &element_config,
-            self.tiles[0].surface.plane_info(),
+            self.tiles[tile].surface.plane_info(),
             scale,
             frame_state,
         );
@@ -3478,6 +3486,7 @@ where
     #[profiling::function]
     fn try_assign_cursor_plane<R, E>(
         &mut self,
+        tile: usize,
         renderer: &mut R,
         element: &E,
         element_zindex: usize,
@@ -3496,7 +3505,7 @@ where
             return None;
         }
 
-        let tile = &mut self.tiles[0];
+        let tile = &mut self.tiles[tile];
         let Some(cursor_state) = tile.cursor_state.as_mut() else {
             trace!("no cursor state, skipping cursor rendering");
             return None;
@@ -3913,6 +3922,7 @@ where
     #[profiling::function]
     fn element_config<'a, R, E>(
         &mut self,
+        tile: usize,
         renderer: &mut R,
         element: &E,
         element_zindex: usize,
@@ -3952,7 +3962,7 @@ where
         // we got the same id multiple times. If we can't find it we use the previous
         // state if available
         if !element_states.contains_key(element_id) {
-            let previous_fb_cache = self.tiles[0]
+            let previous_fb_cache = self.tiles[tile]
                 .previous_element_states
                 .get_mut(element_id)
                 // Note: We can mem::take the old fb_cache here here as we guarantee that
@@ -3987,7 +3997,7 @@ where
 
             let fb = self
                 .framebuffer_exporter
-                .add_framebuffer(self.tiles[0].surface.device_fd(), export_buffer, allow_opaque_fallback)
+                .add_framebuffer(self.tiles[tile].surface.device_fd(), export_buffer, allow_opaque_fallback)
                 .map_err(|err| {
                     trace!("failed to add framebuffer: {:?}", err);
                     ExportBufferError::ExportFailed
@@ -4050,7 +4060,7 @@ where
             .any(|i| i.properties == properties)
         {
             let overlay_bitmask =
-                self.tiles[0].planes
+                self.tiles[tile].planes
                     .overlay
                     .iter()
                     .enumerate()
@@ -4061,7 +4071,7 @@ where
                         acc
                     });
             let cursor_bitmask =
-                self.tiles[0].planes
+                self.tiles[tile].planes
                     .cursor
                     .iter()
                     .enumerate()
@@ -4072,7 +4082,7 @@ where
                         acc
                     });
             let current_plane_snapshot = PlanesSnapshot {
-                primary: frame_state.is_assigned(self.tiles[0].surface.plane()),
+                primary: frame_state.is_assigned(self.tiles[tile].surface.plane()),
                 cursor_bitmask,
                 overlay_bitmask,
             };
@@ -4084,7 +4094,7 @@ where
                 failed_planes: Default::default(),
             });
 
-            if let Some(previous_state) = self.tiles[0].previous_element_states.get(element_id) {
+            if let Some(previous_state) = self.tiles[tile].previous_element_states.get(element_id) {
                 // lets look if we find a previous instance with exactly the same properties.
                 // if we find one we can test if nothing changed and re-use the failed tests
                 let matching_instance = previous_state
@@ -4094,11 +4104,11 @@ where
 
                 if let Some(matching_instance) = matching_instance {
                     if current_plane_snapshot == matching_instance.active_planes {
-                        let previous_frame_state = self.tiles[0]
+                        let previous_frame_state = self.tiles[tile]
                             .pending_frame
                             .as_ref()
                             .map(|pending| &pending.frame)
-                            .unwrap_or(&self.tiles[0].current_frame);
+                            .unwrap_or(&self.tiles[tile].current_frame);
 
                         // Note: we ignore the cursor plane here as this would result
                         // in constant re-tests of cursor moves and we do not expect
@@ -4106,14 +4116,14 @@ where
                         // Adding or removing cursor can influence the other planes, but
                         // is already covered in the active planes check.
                         let primary_plane_changed = if current_plane_snapshot.primary {
-                            frame_state.plane_properties(self.tiles[0].surface.plane())
-                                != previous_frame_state.plane_properties(self.tiles[0].surface.plane())
+                            frame_state.plane_properties(self.tiles[tile].surface.plane())
+                                != previous_frame_state.plane_properties(self.tiles[tile].surface.plane())
                         } else {
                             false
                         };
 
                         let overlay_plane_changed =
-                            self.tiles[0].planes.overlay.iter().enumerate().any(|(index, plane)| {
+                            self.tiles[tile].planes.overlay.iter().enumerate().any(|(index, plane)| {
                                 // we only want to test planes that are currently in use
                                 if current_plane_snapshot.overlay_bitmask & (1 << index) == 0 {
                                     return false;
@@ -4166,6 +4176,7 @@ where
     #[profiling::function]
     fn try_assign_overlay_plane<'a, R, E>(
         &mut self,
+        tile: usize,
         renderer: &mut R,
         element: &'a E,
         element_zindex: usize,
@@ -4199,7 +4210,7 @@ where
         let element_id = element.id();
 
         // Check if we have a free plane, otherwise we can exit early
-        if self.tiles[0]
+        if self.tiles[tile]
             .planes
             .overlay
             .iter()
@@ -4213,6 +4224,7 @@ where
         }
 
         let element_config = self.element_config(
+            tile,
             renderer,
             element,
             element_zindex,
@@ -4230,15 +4242,15 @@ where
         });
 
         let primary_plane_has_alpha = frame_state
-            .plane_buffer(self.tiles[0].surface.plane())
+            .plane_buffer(self.tiles[tile].surface.plane())
             .map(|state| has_alpha(state.format().code))
             .unwrap_or(false);
 
-        let previous_frame_state = self.tiles[0]
+        let previous_frame_state = self.tiles[tile]
             .pending_frame
             .as_ref()
             .map(|pending| &pending.frame)
-            .unwrap_or(&self.tiles[0].current_frame);
+            .unwrap_or(&self.tiles[tile].current_frame);
 
         // We consider a plane compatible if the z-index of the previous assigned
         // element is or equal to our z-index and the properties (src/dst/format/...)
@@ -4281,7 +4293,7 @@ where
 
             // test if the plane represents an underlay
             let is_underlay =
-                self.tiles[0].surface.plane_info().zpos.unwrap_or_default() > plane.zpos.unwrap_or_default();
+                self.tiles[tile].surface.plane_info().zpos.unwrap_or_default() > plane.zpos.unwrap_or_default();
 
             if is_underlay && !(element_is_opaque && primary_plane_has_alpha) {
                 trace!(
@@ -4302,7 +4314,7 @@ where
                 return Err(None);
             }
 
-            let overlaps_with_plane_underneath = self.tiles[0]
+            let overlaps_with_plane_underneath = self.tiles[tile]
                 .planes
                 .overlay
                 .iter()
@@ -4325,12 +4337,12 @@ where
                 return Err(None);
             }
 
-            self.try_assign_plane(element, element_config, plane, scale, frame_state)
+            self.try_assign_plane(tile, element, element_config, plane, scale, frame_state)
         };
 
         // First try to assign the element to a compatible plane, this can save us
         // from some atomic testing
-        for plane in self.tiles[0].planes.overlay.iter().filter(is_plane_compatible) {
+        for plane in self.tiles[tile].planes.overlay.iter().filter(is_plane_compatible) {
             if let Ok(plane_assignment) = test_overlay_plane(plane, &element_config) {
                 trace!(
                     "assigned element {:?} geometry {:?} to compatible {:?} with zpos {:?}",
@@ -4342,7 +4354,7 @@ where
 
         // If we found no compatible plane fall back to walk all available planes
         let mut rendering_reason: Option<RenderingReason> = None;
-        for (index, plane) in self.tiles[0].planes.overlay.iter().enumerate() {
+        for (index, plane) in self.tiles[tile].planes.overlay.iter().enumerate() {
             // if the tested element state already tells us that this failed skip the test
             if element_config.failed_planes.overlay_bitmask & (1 << index) != 0 {
                 trace!(
@@ -4374,6 +4386,7 @@ where
     #[profiling::function]
     fn try_assign_plane<R, E>(
         &self,
+        tile: usize,
         element: &E,
         element_config: &ElementPlaneConfig<
             '_,
@@ -4390,7 +4403,7 @@ where
     {
         let element_id = element.id();
 
-        let plane_claim = match self.tiles[0].surface.claim_plane(plane.handle) {
+        let plane_claim = match self.tiles[tile].surface.claim_plane(plane.handle) {
             Some(claim) => claim,
             None => {
                 trace!("failed to claim {:?} for element {:?}", plane.handle, element_id);
@@ -4412,11 +4425,11 @@ where
             return Err(Some(RenderingReason::FormatUnsupported));
         }
 
-        let previous_state = self.tiles[0]
+        let previous_state = self.tiles[tile]
             .pending_frame
             .as_ref()
             .map(|pending| &pending.frame)
-            .unwrap_or(&self.tiles[0].current_frame);
+            .unwrap_or(&self.tiles[tile].current_frame);
 
         let previous_commit = previous_state.plane_state(plane.handle).and_then(|state| {
             state.element_state.as_ref().and_then(|state| {
@@ -4433,7 +4446,7 @@ where
 
         let damage_clips = if has_element_damage {
             PlaneDamageClips::from_damage(
-                self.tiles[0].surface.device_fd(),
+                self.tiles[tile].surface.device_fd(),
                 element_config.properties.src,
                 element_config.geometry,
                 element_damage,
@@ -4452,7 +4465,7 @@ where
             sync: element_config
                 .buffer
                 .buffer
-                .acquire_point(self.tiles[0].signaled_fence.as_ref()),
+                .acquire_point(self.tiles[tile].signaled_fence.as_ref()),
         };
 
         let is_compatible = previous_state
@@ -4504,8 +4517,8 @@ where
         } else {
             frame_state
                 .test_state(
-                    &self.tiles[0].surface,
-                    self.tiles[0].supports_fencing,
+                    &self.tiles[tile].surface,
+                    self.tiles[tile].supports_fencing,
                     plane.handle,
                     plane_state,
                     false,

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1192,7 +1192,7 @@ fn validate_tile_regions(
     }
 
     // The logical output starts at the origin.
-    if bbox.loc != Point::from((0, 0)) {
+    if bbox.loc != Point::new(0, 0) {
         return Err(TileConfigError::NotContiguous);
     }
 

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -942,10 +942,9 @@ impl From<&PlaneInfo> for PlaneAssignment {
     }
 }
 
-// The frame lifecycle (`queued`/`pending`) tracks the per-tile scan-out
-// `FrameState` here, but the caller's `user_data` is one token per *frame* — a
-// tiled output flips all its tiles in a single atomic commit — so it lives on
-// the `DrmCompositor`, not in these per-tile wrappers.
+// The frame lifecycle (`queued`/`pending`) tracks per-CRTC scan-out state here,
+// but the caller's `user_data` is one token per logical frame. Keep it on the
+// `DrmCompositor` so a tiled output submits presentation feedback once.
 struct PendingFrame<A: Allocator, F: ExportFramebuffer<<A as Allocator>::Buffer>> {
     frame: CompositorFrameState<A, F>,
 }
@@ -1040,11 +1039,8 @@ bitflags::bitflags! {
 
 /// Per-CRTC state of a [`DrmCompositor`].
 ///
-/// A `DrmCompositor` holds one `TileState` per CRTC it drives — exactly one in
-/// the common case, several when compositing a tiled output (see
-/// [`DrmCompositor::new_tiled`]). Everything that belongs to a single scan-out
-/// pipeline (the surface, its planes, swapchain and frame-state machine) lives
-/// here; the logical output state stays on `DrmCompositor`.
+/// A `DrmCompositor` holds one `TileState` per CRTC it drives. Per-CRTC scan-out
+/// state lives here; logical output state stays on `DrmCompositor`.
 struct TileState<A, F, G>
 where
     A: Allocator,
@@ -1052,9 +1048,8 @@ where
     <F as ExportFramebuffer<A::Buffer>>::Framebuffer: std::fmt::Debug + Send + Sync + 'static,
     G: AsFd + 'static,
 {
-    /// Sub-rect of the logical output this tile scans out, in the output's
-    /// untransformed (mode) coordinate space. The whole output for a
-    /// single-tile compositor; one slice of the grid for a tiled one.
+    /// Sub-rect of the logical output this CRTC scans out, in untransformed
+    /// output coordinates.
     region: Rectangle<i32, Physical>,
     surface: Arc<DrmSurface>,
     planes: Planes,
@@ -1091,20 +1086,18 @@ where
     output_mode_source: OutputModeSource,
     framebuffer_exporter: F,
     cursor_size: Size<i32, Physical>,
-    // `tiles[0]` is the primary: its CRTC's vblank drives the group's
-    // presentation, its surface carries the atomic commit, and it seeds the
-    // aggregated frame result. The rest are secondary. (Positional, by
-    // convention; the constructor takes the primary placement first.)
+    // `tiles[0]` is the primary: its CRTC's vblank drives presentation for the
+    // logical output, its surface carries the atomic commit, and it seeds the
+    // aggregated frame result. The constructor takes the primary placement first.
     //
     // Inline capacity 1: a single-CRTC output is the common case and stays
     // heap-free. A tiled output (several CRTCs) spills to one heap allocation.
     // Kept at 1 because TileState is large, so extra inline slots would bloat
     // every (mostly single-tile) compositor just for the rare tiled case.
     tiles: SmallVec<[TileState<A, F, G>; 1]>,
-    /// `user_data` for the frame queued via [`queue_frame`](DrmCompositor::queue_frame)
-    /// but not yet submitted, and for the in-flight frame awaiting its vblank,
-    /// respectively. These are per-frame (one atomic commit across all tiles),
-    /// hence held here rather than per-tile.
+    /// `user_data` for the queued and in-flight logical frames, respectively.
+    /// Held here, rather than per tile, because one atomic commit presents one
+    /// logical frame.
     queued_user_data: Option<U>,
     pending_user_data: Option<U>,
     debug_flags: DebugFlags,
@@ -1129,25 +1122,22 @@ where
     }
 }
 
-/// One CRTC's contribution to a tiled [`DrmCompositor`].
+/// One CRTC's placement in a tiled [`DrmCompositor`].
 ///
-/// A tiled compositor drives several CRTCs as a single logical output, each
-/// scanning out a sub-rect of that output. A `TilePlacement` pairs one
-/// [`DrmSurface`] (one CRTC) with the planes it may use and the sub-rect it
-/// covers. See [`DrmCompositor::new_tiled`].
+/// A `TilePlacement` pairs a [`DrmSurface`] with the planes it may use and the
+/// sub-rect of the logical output it scans out.
 #[derive(Debug)]
 pub struct TilePlacement {
-    /// The surface (exactly one CRTC) backing this tile.
+    /// The surface backing this CRTC.
     pub surface: DrmSurface,
     /// Planes this tile may use for direct scan-out, with the same meaning as
     /// the `planes` argument of [`DrmCompositor::new`]: `None` uses all planes
     /// reported by [`DrmSurface::planes`]. Planes belong to a CRTC, so they are
     /// configured per tile.
     pub planes: Option<Planes>,
-    /// The sub-rect of the logical output this tile scans out, in the output's
-    /// untransformed (mode) coordinate space. The offset positions the tile
-    /// within the logical framebuffer; the size is expected to match
-    /// `surface`'s scan-out mode.
+    /// The sub-rect of the logical output this CRTC scans out, in untransformed
+    /// output coordinates. The size is expected to match `surface`'s scan-out
+    /// mode.
     pub region: Rectangle<i32, Physical>,
 }
 
@@ -1599,22 +1589,23 @@ where
         })
     }
 
-    /// Initialize a [`DrmCompositor`] that drives several CRTCs as one logical,
-    /// frame-locked output — e.g. a DisplayID-tiled 5K monitor carried over two
-    /// DisplayPort streams, or a single-GPU video wall.
+    /// Initialize a [`DrmCompositor`] that drives several CRTCs as one logical
+    /// output.
     ///
-    /// `placements` provides one [`TilePlacement`] per CRTC; the surfaces must all
-    /// belong to the **same DRM device** (so their page-flips can share a single
-    /// atomic commit) and their regions must tile a gap-free rectangle anchored
-    /// at the origin, matching the logical output's mode.
+    /// This is the multi-CRTC generalization of [`new`](Self::new). It is not
+    /// tied to the DRM `TILE` property: callers may use it for DisplayID-tiled
+    /// monitors, a same-device video wall, or any other layout where several
+    /// CRTCs scan out rectangular parts of one logical output.
     ///
-    /// List the primary tile first. `tiles[0]`'s CRTC carries the atomic commit
-    /// and its page-flip event signals the group's completed frame. The other
-    /// tiles flip in that same commit, so the whole group stays frame-locked.
+    /// `placements` provides one [`TilePlacement`] per CRTC. The surfaces must
+    /// all belong to the same DRM device, and their regions must tile a gap-free
+    /// rectangle anchored at the origin, matching the logical output's mode.
     ///
-    /// The remaining arguments are device-wide and shared across all tiles,
-    /// exactly as in [`new`](Self::new) — of which this is the multi-CRTC
-    /// generalization.
+    /// List the primary tile first. `tiles[0]`'s CRTC carries the atomic commit,
+    /// and its page-flip event signals the group's completed frame.
+    ///
+    /// The remaining arguments are device-wide and shared across all tiles, as
+    /// in [`new`](Self::new).
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     pub fn new_tiled(
@@ -1635,14 +1626,13 @@ where
         validate_tile_regions(tiles_in.iter().map(|p| p.region))?;
 
         // All tiles must live on one DRM device, otherwise they cannot share a
-        // single atomic commit (and would not stay frame-locked).
+        // single atomic commit.
         let dev = tiles_in[0].surface.dev_path();
         if tiles_in.iter().any(|p| p.surface.dev_path() != dev) {
             return Err(TileConfigError::MultipleDevices.into());
         }
 
-        // The frame-locked commit relies on the atomic API; legacy surfaces have
-        // no way to flip several CRTCs together.
+        // Legacy surfaces have no way to flip several CRTCs together.
         if tiles_in.iter().any(|p| p.surface.is_legacy()) {
             return Err(FrameError::DrmError(DrmError::AtomicUnsupported));
         }
@@ -1651,8 +1641,6 @@ where
         let renderer_formats = renderer_formats.into_iter().collect::<Vec<_>>();
         let cursor_size = Size::from((cursor_size.w as i32, cursor_size.h as i32));
 
-        // Each tile renders with the logical output's scale/transform into its
-        // own tile-sized framebuffer; refreshed each frame from the source.
         let (scale, transform) =
             match <&OutputModeSource as TryInto<(Size<i32, Physical>, Scale<f64>, Transform)>>::try_into(
                 &output_mode_source,
@@ -3364,21 +3352,18 @@ where
 
     // Tiled (multi-CRTC) frame lifecycle.
     //
-    // A tiled `DrmCompositor` drives several CRTCs as one logical output, flipped
-    // together in a single atomic commit (see `DrmSurface::append_to_request` /
-    // `commit_request`) so they stay frame-locked. Because the flip is atomic,
-    // the primary tile's vblank stands in for the whole group: when it arrives,
-    // every tile has flipped, so the caller — which routes that one CRTC's vblank
-    // to `frame_submitted` — advances the entire group exactly once. The other
-    // CRTCs' redundant vblanks belong to no logical output and are ignored.
+    // A tiled `DrmCompositor` flips several CRTCs together in one atomic commit.
+    // The primary CRTC's page-flip event is the logical output's completion
+    // signal; the other CRTCs are advanced from the same `frame_submitted_tiled`
+    // call.
 
     fn queue_frame_tiled(&mut self, user_data: U) -> FrameResult<(), A, F> {
         if !self.tiles[0].surface.is_active() {
             return Err(FrameErrorType::<A, F>::DrmError(DrmError::DeviceInactive));
         }
 
-        // Every tile rendered a frame (`render_frame` stores even unchanged tiles
-        // for a tiled output), so they queue and flip together.
+        // `render_frame` stores a frame for every tile, even unchanged ones, so
+        // the group always queues and flips together.
         for tile in self.tiles.iter_mut() {
             let prepared = tile.next_frame.take().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
             if let Some(plane_state) = prepared.frame.plane_state(tile.surface.plane()) {
@@ -3405,12 +3390,11 @@ where
     fn submit_tiled(&mut self) -> FrameResult<(), A, F> {
         let user_data = self.queued_user_data.take();
         // A pending modeset on any tile forces the whole commit through the
-        // modeset path (the single atomic commit is all-or-nothing).
+        // modeset path; the shared atomic commit is all-or-nothing.
         let modeset = self.tiles.iter().any(|tile| tile.surface.commit_pending());
 
-        // Assemble every tile's planes into one request. Each tile's queued
-        // `FrameState` stays in place (and keeps its fences alive) until the
-        // commit below has consumed the request.
+        // Keep each queued `FrameState` in place until the commit consumes the
+        // request, so its fences remain alive.
         let mut req = AtomicModeReq::new();
         for tile in self.tiles.iter_mut() {
             let prepared = &mut tile
@@ -3429,8 +3413,6 @@ where
                 .map_err(FrameError::DrmError)?;
         }
 
-        // One atomic commit flips every tile together; the page-flip event on the
-        // primary CRTC is the group's frame-completion signal.
         let flip = self.tiles[0].surface.commit_request(req, true, modeset);
 
         let has_user_data = user_data.is_some();
@@ -3446,7 +3428,7 @@ where
             self.pending_user_data = user_data;
         } else {
             // Drop the queued frames so the next `render_frame` produces a fresh
-            // set rather than retrying this (failed) one.
+            // set rather than retrying this failed one.
             for tile in self.tiles.iter_mut() {
                 tile.queued_frame = None;
             }
@@ -3509,7 +3491,6 @@ where
             return Ok(None);
         }
 
-        // The whole group flipped in one atomic commit, so advance every tile.
         for tile in self.tiles.iter_mut() {
             if let Some(PendingFrame { mut frame }) = tile.pending_frame.take() {
                 std::mem::swap(&mut frame, &mut tile.current_frame);

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -135,7 +135,7 @@ use std::{
 
 use drm::{
     Device, DriverCapability,
-    control::{Device as _, Mode, PlaneType, connector, crtc, framebuffer, plane},
+    control::{Device as _, Mode, PlaneType, atomic::AtomicModeReq, connector, crtc, framebuffer, plane},
 };
 use drm_fourcc::{DrmFormat, DrmFourcc, DrmModifier};
 use indexmap::{IndexMap, IndexSet};
@@ -1171,6 +1171,11 @@ pub enum TileConfigError {
     /// a single device so all its CRTCs can share one atomic commit.
     #[error("tile surfaces span multiple drm devices")]
     MultipleDevices,
+    /// A runtime mode change was requested on a tiled output. Its logical size is
+    /// fixed by the tile geometry passed to [`DrmCompositor::new_tiled`], so
+    /// changing it through [`DrmCompositor::use_mode`] is not supported.
+    #[error("changing the mode of a tiled output is not supported")]
+    ModeChangeUnsupported,
 }
 
 /// Validate that `regions` exactly tile a rectangle anchored at `(0, 0)` with no
@@ -1634,6 +1639,12 @@ where
         let dev = tiles_in[0].surface.dev_path();
         if tiles_in.iter().any(|p| p.surface.dev_path() != dev) {
             return Err(TileConfigError::MultipleDevices.into());
+        }
+
+        // The frame-locked commit relies on the atomic API; legacy surfaces have
+        // no way to flip several CRTCs together.
+        if tiles_in.iter().any(|p| p.surface.is_legacy()) {
+            return Err(FrameError::DrmError(DrmError::AtomicUnsupported));
         }
 
         let output_mode_source = output_mode_source.into();
@@ -2273,7 +2284,7 @@ where
 
         // Common case: a single CRTC drives the whole output, no relocation.
         if self.tiles.len() == 1 {
-            return self.render_tile(0, renderer, elements, clear_color, frame_flags);
+            return self.render_tile(0, renderer, elements, clear_color, frame_flags, false);
         }
 
         // Tiled output. Relocate the elements into each tile's framebuffer space
@@ -2319,7 +2330,7 @@ where
                     .iter()
                     .map(|element| RelocateRenderElement::from_element(element, offset, Relocate::Relative)),
             );
-            let result = self.render_tile(0, renderer, &scratch, clear_color, frame_flags)?;
+            let result = self.render_tile(0, renderer, &scratch, clear_color, frame_flags, true)?;
             (
                 match result.primary_element {
                     PrimaryPlaneElement::Swapchain(element) => PrimaryPlaneElement::Swapchain(element),
@@ -2345,7 +2356,7 @@ where
                     .iter()
                     .map(|element| RelocateRenderElement::from_element(element, offset, Relocate::Relative)),
             );
-            let result = self.render_tile(index, renderer, &scratch, clear_color, frame_flags)?;
+            let result = self.render_tile(index, renderer, &scratch, clear_color, frame_flags, true)?;
             all_empty &= result.is_empty;
             merge_render_element_states(&mut states, result.states);
         }
@@ -2379,6 +2390,7 @@ where
         elements: &'a [E],
         clear_color: Color32F,
         frame_flags: FrameFlags,
+        store_empty: bool,
     ) -> Result<RenderFrameResult<'a, A::Buffer, F::Framebuffer, E>, RenderFrameErrorType<A, F, R>>
     where
         E: RenderElement<R>,
@@ -3106,8 +3118,13 @@ where
 
         // We only store the next frame if it actually contains any changes or if a commit is pending
         // Storing the (empty) frame could keep a reference to wayland buffers which
-        // could otherwise be potentially released on `frame_submitted`
-        if !next_frame.is_empty() {
+        // could otherwise be potentially released on `frame_submitted`.
+        //
+        // A tiled compositor (`store_empty`) always stores it: the tiles flip
+        // together in one atomic commit, so even an unchanged tile must re-state
+        // its planes in that commit (in particular the primary tile, whose vblank
+        // is the group's frame-completion signal).
+        if store_empty || !next_frame.is_empty() {
             tile.next_frame = Some(next_frame);
         }
 
@@ -3132,6 +3149,10 @@ where
     /// `user_data` can be used to attach some data to a specific buffer and later retrieved with [`DrmCompositor::frame_submitted`]
     #[profiling::function]
     pub fn queue_frame(&mut self, user_data: U) -> FrameResult<(), A, F> {
+        if self.tiles.len() > 1 {
+            return self.queue_frame_tiled(user_data);
+        }
+
         if !self.tiles[0].surface.is_active() {
             return Err(FrameErrorType::<A, F>::DrmError(DrmError::DeviceInactive));
         }
@@ -3176,6 +3197,10 @@ where
     /// *Note*: This function should not be followed up with [`DrmCompositor::frame_submitted`]
     /// and will not generate a vblank event on the underlying device.
     pub fn commit_frame(&mut self) -> FrameResult<(), A, F> {
+        if self.tiles.len() > 1 {
+            return self.commit_frame_tiled();
+        }
+
         if !self.tiles[0].surface.is_active() {
             return Err(FrameErrorType::<A, F>::DrmError(DrmError::DeviceInactive));
         }
@@ -3222,13 +3247,21 @@ where
     /// the state of the crtc is modified elsewhere, you may call this function
     /// to reset it's internal state.
     pub fn reset_state(&mut self) -> Result<(), DrmError> {
-        self.tiles[0].surface.reset_state()?;
-        self.tiles[0].reset_pending = true;
+        // Every tile's CRTC is part of the group's atomic commit, so all of them
+        // must have their state re-read after a VT switch, not just the primary.
+        for tile in &mut self.tiles {
+            tile.surface.reset_state()?;
+            tile.reset_pending = true;
+        }
         Ok(())
     }
 
     #[profiling::function]
     fn submit(&mut self) -> FrameResult<(), A, F> {
+        if self.tiles.len() > 1 {
+            return self.submit_tiled();
+        }
+
         let QueuedFrame { mut prepared_frame } = self.tiles[0].queued_frame.take().unwrap();
         let user_data = self.queued_user_data.take();
 
@@ -3311,6 +3344,10 @@ where
     /// Otherwise the underlying swapchain will run out of buffers eventually.
     #[profiling::function]
     pub fn frame_submitted(&mut self) -> FrameResult<Option<U>, A, F> {
+        if self.tiles.len() > 1 {
+            return self.frame_submitted_tiled();
+        }
+
         if let Some(PendingFrame { mut frame }) = self.tiles[0].pending_frame.take() {
             std::mem::swap(&mut frame, &mut self.tiles[0].current_frame);
             // Take the in-flight `user_data` before `submit` repopulates it from
@@ -3325,9 +3362,172 @@ where
         }
     }
 
+    // Tiled (multi-CRTC) frame lifecycle.
+    //
+    // A tiled `DrmCompositor` drives several CRTCs as one logical output, flipped
+    // together in a single atomic commit (see `DrmSurface::append_to_request` /
+    // `commit_request`) so they stay frame-locked. Because the flip is atomic,
+    // the primary tile's vblank stands in for the whole group: when it arrives,
+    // every tile has flipped, so the caller — which routes that one CRTC's vblank
+    // to `frame_submitted` — advances the entire group exactly once. The other
+    // CRTCs' redundant vblanks belong to no logical output and are ignored.
+
+    fn queue_frame_tiled(&mut self, user_data: U) -> FrameResult<(), A, F> {
+        if !self.tiles[0].surface.is_active() {
+            return Err(FrameErrorType::<A, F>::DrmError(DrmError::DeviceInactive));
+        }
+
+        // Every tile rendered a frame (`render_frame` stores even unchanged tiles
+        // for a tiled output), so they queue and flip together.
+        for tile in self.tiles.iter_mut() {
+            let prepared = tile.next_frame.take().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
+            if let Some(plane_state) = prepared.frame.plane_state(tile.surface.plane()) {
+                if !plane_state.skip {
+                    let slot = plane_state.buffer().and_then(|config| match &config.buffer {
+                        ScanoutBuffer::Swapchain(slot) => Some(slot),
+                        _ => None,
+                    });
+                    if let Some(slot) = slot {
+                        tile.swapchain.submitted(slot);
+                    }
+                }
+            }
+            tile.queued_frame = Some(QueuedFrame { prepared_frame: prepared });
+        }
+
+        self.queued_user_data = Some(user_data);
+        if self.tiles[0].pending_frame.is_none() {
+            self.submit_tiled()?;
+        }
+        Ok(())
+    }
+
+    fn submit_tiled(&mut self) -> FrameResult<(), A, F> {
+        let user_data = self.queued_user_data.take();
+        // A pending modeset on any tile forces the whole commit through the
+        // modeset path (the single atomic commit is all-or-nothing).
+        let modeset = self.tiles.iter().any(|tile| tile.surface.commit_pending());
+
+        // Assemble every tile's planes into one request. Each tile's queued
+        // `FrameState` stays in place (and keeps its fences alive) until the
+        // commit below has consumed the request.
+        let mut req = AtomicModeReq::new();
+        for tile in self.tiles.iter_mut() {
+            let prepared = &mut tile
+                .queued_frame
+                .as_mut()
+                .expect("all tiles queued together")
+                .prepared_frame;
+            let allow_partial = !modeset && prepared.kind == PreparedFrameKind::Partial;
+            let planes = prepared
+                .frame
+                .build_planes(&tile.surface, tile.supports_fencing, allow_partial)
+                .into_iter()
+                .collect::<SmallVec<[_; 8]>>();
+            tile.surface
+                .append_to_request(&mut req, planes, modeset)
+                .map_err(FrameError::DrmError)?;
+        }
+
+        // One atomic commit flips every tile together; the page-flip event on the
+        // primary CRTC is the group's frame-completion signal.
+        let flip = self.tiles[0].surface.commit_request(req, true, modeset);
+
+        let has_user_data = user_data.is_some();
+        if flip.is_ok() {
+            for tile in self.tiles.iter_mut() {
+                tile.surface.mark_request_submitted(modeset);
+                let prepared = tile.queued_frame.take().expect("queued before submit").prepared_frame;
+                if prepared.kind == PreparedFrameKind::Full {
+                    tile.reset_pending = false;
+                }
+                tile.pending_frame = has_user_data.then_some(PendingFrame { frame: prepared.frame });
+            }
+            self.pending_user_data = user_data;
+        } else {
+            // Drop the queued frames so the next `render_frame` produces a fresh
+            // set rather than retrying this (failed) one.
+            for tile in self.tiles.iter_mut() {
+                tile.queued_frame = None;
+            }
+        }
+
+        flip.map_err(FrameError::DrmError)
+    }
+
+    fn commit_frame_tiled(&mut self) -> FrameResult<(), A, F> {
+        if !self.tiles[0].surface.is_active() {
+            return Err(FrameErrorType::<A, F>::DrmError(DrmError::DeviceInactive));
+        }
+
+        let modeset = self.tiles.iter().any(|tile| tile.surface.commit_pending());
+
+        let mut req = AtomicModeReq::new();
+        for tile in self.tiles.iter_mut() {
+            let prepared = tile.next_frame.as_mut().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
+            if let Some(plane_state) = prepared.frame.plane_state(tile.surface.plane()) {
+                if !plane_state.skip {
+                    let slot = plane_state.buffer().and_then(|config| match &config.buffer {
+                        ScanoutBuffer::Swapchain(slot) => Some(slot),
+                        _ => None,
+                    });
+                    if let Some(slot) = slot {
+                        tile.swapchain.submitted(slot);
+                    }
+                }
+            }
+            let allow_partial = !modeset && prepared.kind == PreparedFrameKind::Partial;
+            let planes = prepared
+                .frame
+                .build_planes(&tile.surface, tile.supports_fencing, allow_partial)
+                .into_iter()
+                .collect::<SmallVec<[_; 8]>>();
+            tile.surface
+                .append_to_request(&mut req, planes, modeset)
+                .map_err(FrameError::DrmError)?;
+        }
+
+        // Blocking commit, no page-flip event (mirrors single-tile `commit_frame`).
+        let flip = self.tiles[0].surface.commit_request(req, false, modeset);
+
+        if flip.is_ok() {
+            for tile in self.tiles.iter_mut() {
+                tile.surface.mark_request_submitted(modeset);
+                tile.next_frame = None;
+                tile.queued_frame = None;
+                tile.pending_frame = None;
+            }
+            self.queued_user_data = None;
+            self.pending_user_data = None;
+        }
+
+        flip.map_err(FrameError::DrmError)
+    }
+
+    fn frame_submitted_tiled(&mut self) -> FrameResult<Option<U>, A, F> {
+        if self.tiles[0].pending_frame.is_none() {
+            return Ok(None);
+        }
+
+        // The whole group flipped in one atomic commit, so advance every tile.
+        for tile in self.tiles.iter_mut() {
+            if let Some(PendingFrame { mut frame }) = tile.pending_frame.take() {
+                std::mem::swap(&mut frame, &mut tile.current_frame);
+            }
+        }
+
+        let user_data = self.pending_user_data.take();
+        if self.tiles[0].queued_frame.is_some() {
+            self.submit_tiled()?;
+        }
+        Ok(user_data)
+    }
+
     /// Reset the underlying buffers
     pub fn reset_buffers(&mut self) {
-        self.tiles[0].swapchain.reset_buffers();
+        for tile in &mut self.tiles {
+            tile.swapchain.reset_buffers();
+        }
     }
 
     /// Reset the age for all buffers.
@@ -3335,7 +3535,9 @@ where
     /// This can be used to efficiently clear the damage history without having to
     /// modify the damage for each surface.
     pub fn reset_buffer_ages(&mut self) {
-        self.tiles[0].swapchain.reset_buffer_ages();
+        for tile in &mut self.tiles {
+            tile.swapchain.reset_buffer_ages();
+        }
     }
 
     /// Returns the underlying [`crtc`] of this surface
@@ -3415,7 +3617,14 @@ where
     /// Fails if the mode is not compatible with the underlying
     /// [`crtc`] or any of the
     /// pending [`connector`]s.
+    ///
+    /// Errors with [`TileConfigError::ModeChangeUnsupported`] on a tiled output:
+    /// its mode is fixed by the tile geometry, and a coordinated per-tile mode
+    /// change is not supported.
     pub fn use_mode(&mut self, mode: Mode) -> FrameResult<(), A, F> {
+        if self.tiles.len() > 1 {
+            return Err(FrameError::InvalidTileConfig(TileConfigError::ModeChangeUnsupported));
+        }
         self.tiles[0].surface.use_mode(mode).map_err(FrameError::DrmError)?;
         let (w, h) = mode.size();
         self.tiles[0].swapchain.resize(w as _, h as _);
@@ -3440,7 +3649,22 @@ where
     /// Check [`DrmCompositor::vrr_supported`], which indicates if VRR can be
     /// used without a modeset on the attached connectors.
     pub fn use_vrr(&mut self, vrr: bool) -> FrameResult<(), A, F> {
-        self.tiles[0].surface.use_vrr(vrr).map_err(FrameError::DrmError)
+        // VRR is a per-CRTC property carried in the group's combined commit, so
+        // every tile must agree. `use_vrr` mutates each surface's pending state on
+        // success, so a failure partway through would leave earlier tiles changed
+        // and let the next commit carry a half-applied VRR state. Roll those tiles
+        // back to the previous value (all tiles share it — they commit together)
+        // before returning the error.
+        let previous = self.tiles[0].surface.vrr_enabled();
+        for i in 0..self.tiles.len() {
+            if let Err(err) = self.tiles[i].surface.use_vrr(vrr) {
+                for j in 0..i {
+                    let _ = self.tiles[j].surface.use_vrr(previous);
+                }
+                return Err(FrameError::DrmError(err));
+            }
+        }
+        Ok(())
     }
 
     /// Set the [`DebugFlags`] to use
@@ -3450,7 +3674,9 @@ where
     pub fn set_debug_flags(&mut self, flags: DebugFlags) {
         if self.debug_flags != flags {
             self.debug_flags = flags;
-            self.tiles[0].swapchain.reset_buffers();
+            for tile in &mut self.tiles {
+                tile.swapchain.reset_buffers();
+            }
         }
     }
 
@@ -4788,15 +5014,19 @@ where
     ///
     /// Calling [`queue_frame`][Self::queue_frame] will re-enable.
     pub fn clear(&mut self) -> Result<(), DrmError> {
-        self.tiles[0].surface.clear()?;
+        // Disable and clear every tile's CRTC, not just the primary, or the rest
+        // of a tiled monitor stays lit after a DPMS-off / clear.
+        for tile in &mut self.tiles {
+            tile.surface.clear()?;
 
-        self.tiles[0].current_frame
-            .planes
-            .iter_mut()
-            .for_each(|(_, state)| *state = Default::default());
-        self.tiles[0].pending_frame = None;
-        self.tiles[0].queued_frame = None;
-        self.tiles[0].next_frame = None;
+            tile.current_frame
+                .planes
+                .iter_mut()
+                .for_each(|(_, state)| *state = Default::default());
+            tile.pending_frame = None;
+            tile.queued_frame = None;
+            tile.next_frame = None;
+        }
         self.queued_user_data = None;
         self.pending_user_data = None;
 

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -164,6 +164,7 @@ use crate::{
             element::{
                 Element, Id, Kind, RenderElement, RenderElementPresentationState, RenderElementState,
                 RenderElementStates, RenderingReason, UnderlyingStorage,
+                utils::{Relocate, RelocateRenderElement},
             },
             sync::SyncPoint,
             utils::{CommitCounter, DamageBag},
@@ -1058,8 +1059,6 @@ where
     /// Sub-rect of the logical output this tile scans out, in the output's
     /// untransformed (mode) coordinate space. The whole output for a
     /// single-tile compositor; one slice of the grid for a tiled one.
-    // Read by the multi-tile render path (added in a following commit).
-    #[allow(dead_code)]
     region: Rectangle<i32, Physical>,
     surface: Arc<DrmSurface>,
     planes: Planes,
@@ -1228,8 +1227,6 @@ fn validate_tile_regions(
 /// transform is applied to the whole logical scene *before* tiles are sliced, so
 /// to place a tile we map its fixed region *through* the transform. This is what
 /// keeps tiling correct under rotation/flip.
-// First used by `render_frame`, added in a following commit.
-#[allow(dead_code)]
 fn tile_logical_region(
     region: Rectangle<i32, Physical>,
     size: Size<i32, Physical>,
@@ -1244,8 +1241,6 @@ fn tile_logical_region(
 /// Equal to `−tile_logical_region(..).loc`. Because it is derived through
 /// `transform`, the per-CRTC render stays correct at every orientation — unlike
 /// a raw framebuffer-space offset, which is only correct at [`Transform::Normal`].
-// First used by `render_frame`, added in a following commit.
-#[allow(dead_code)]
 fn tile_render_offset(
     region: Rectangle<i32, Physical>,
     size: Size<i32, Physical>,
@@ -1263,6 +1258,27 @@ fn single_tile_region(output_mode_source: &OutputModeSource) -> Rectangle<i32, P
     <&OutputModeSource as TryInto<(Size<i32, Physical>, Scale<f64>, Transform)>>::try_into(output_mode_source)
         .map(|(size, _, _)| Rectangle::from_size(size))
         .unwrap_or_default()
+}
+
+/// Merge the per-element render states of one tile (`from`) into the running
+/// total (`acc`) for a tiled frame.
+///
+/// An element can be visible on several tiles. This mirrors how a single render
+/// already folds an element seen on several planes: a non-skipped state wins
+/// over a skipped one, otherwise the visible areas add up.
+#[allow(clippy::mutable_key_type)]
+fn merge_render_element_states(acc: &mut RenderElementStates, from: RenderElementStates) {
+    for (id, state) in from.states {
+        match acc.states.get_mut(&id) {
+            Some(existing) if existing.presentation_state != RenderElementPresentationState::Skipped => {
+                existing.visible_area += state.visible_area;
+            }
+            Some(existing) => *existing = state,
+            None => {
+                acc.states.insert(id, state);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1418,6 +1434,81 @@ mod tiled_tests {
                 Ok(transform.transform_size(full())),
                 "tiles must partition the logical output under {transform:?}",
             );
+        }
+    }
+
+    mod merge_states {
+        use super::super::merge_render_element_states;
+        use crate::backend::renderer::element::{
+            Id, RenderElementPresentationState, RenderElementState, RenderElementStates,
+        };
+
+        fn rendered(visible_area: usize) -> RenderElementState {
+            RenderElementState {
+                visible_area,
+                presentation_state: RenderElementPresentationState::Rendering { reason: None },
+                needs_capture: false,
+            }
+        }
+
+        fn skipped() -> RenderElementState {
+            RenderElementState {
+                visible_area: 0,
+                presentation_state: RenderElementPresentationState::Skipped,
+                needs_capture: false,
+            }
+        }
+
+        fn states(entries: impl IntoIterator<Item = (Id, RenderElementState)>) -> RenderElementStates {
+            RenderElementStates {
+                states: entries.into_iter().collect(),
+            }
+        }
+
+        #[test]
+        fn disjoint_elements_are_unioned() {
+            let a = Id::new();
+            let b = Id::new();
+            let mut acc = states([(a.clone(), rendered(10))]);
+            merge_render_element_states(&mut acc, states([(b.clone(), rendered(20))]));
+            assert_eq!(acc.states[&a].visible_area, 10);
+            assert_eq!(acc.states[&b].visible_area, 20);
+        }
+
+        #[test]
+        fn visible_on_two_tiles_sums_area() {
+            // The same element rendered on both tiles: its visible areas add up.
+            let id = Id::new();
+            let mut acc = states([(id.clone(), rendered(10))]);
+            merge_render_element_states(&mut acc, states([(id.clone(), rendered(20))]));
+            assert_eq!(acc.states[&id].visible_area, 30);
+        }
+
+        #[test]
+        fn rendered_replaces_skipped() {
+            // Skipped on the first tile, rendered on the second: rendered wins.
+            let id = Id::new();
+            let mut acc = states([(id.clone(), skipped())]);
+            merge_render_element_states(&mut acc, states([(id.clone(), rendered(15))]));
+            assert_eq!(
+                acc.states[&id].presentation_state,
+                RenderElementPresentationState::Rendering { reason: None }
+            );
+            assert_eq!(acc.states[&id].visible_area, 15);
+        }
+
+        #[test]
+        fn skipped_does_not_override_rendered() {
+            // Rendered on the first tile, skipped on the second: stays rendered,
+            // area unchanged (a skipped state contributes zero).
+            let id = Id::new();
+            let mut acc = states([(id.clone(), rendered(15))]);
+            merge_render_element_states(&mut acc, states([(id.clone(), skipped())]));
+            assert_eq!(
+                acc.states[&id].presentation_state,
+                RenderElementPresentationState::Rendering { reason: None }
+            );
+            assert_eq!(acc.states[&id].visible_area, 15);
         }
     }
 }
@@ -2148,6 +2239,14 @@ where
     ///
     /// - `elements` for this frame in front-to-back order
     /// - `frame_flags` specifies techniques allowed to realize the frame
+    ///
+    /// For a tiled compositor (see [`new_tiled`](Self::new_tiled)) every tile is
+    /// rendered into its own framebuffer from the same `elements`, each relocated
+    /// so the tile draws its slice of the logical output. The returned
+    /// [`RenderFrameResult`] is frame-locked across the tiles: it reports
+    /// `is_empty` only when *no* tile changed — so a change confined to one tile
+    /// still queues the whole group — and merges every tile's
+    /// [`RenderElementStates`]. Its plane elements describe the primary tile.
     #[instrument(level = "trace", parent = &self.span, skip_all)]
     #[profiling::function]
     pub fn render_frame<'a, R, E>(
@@ -2162,9 +2261,125 @@ where
         R: Renderer + Bind<Dmabuf>,
         R::TextureId: Texture + 'static,
     {
-        let mut clear_color = clear_color.into();
+        let clear_color = clear_color.into();
 
-        if !self.tiles[0].surface.is_active() {
+        // Common case: a single CRTC drives the whole output, no relocation.
+        if self.tiles.len() == 1 {
+            return self.render_tile(0, renderer, elements, clear_color, frame_flags);
+        }
+
+        // Tiled output. Relocate the elements into each tile's framebuffer space
+        // and render every tile. The offset is derived through the output
+        // transform (`tile_render_offset`) so it stays correct under rotation.
+        let (output_size, output_scale, output_transform): (Size<i32, Physical>, Scale<f64>, Transform) =
+            (&self.output_mode_source)
+                .try_into()
+                .map_err(OutputDamageTrackerError::OutputNoMode)?;
+
+        // Keep each tile's per-CRTC mode source in step with the output's live
+        // scale/transform. A tile renders with this source's transform, while the
+        // relocation offset below uses the output transform directly; if the
+        // output is rotated/rescaled after construction the two must stay in
+        // agreement or the tiles render upright into a rotated layout. The tile's
+        // framebuffer-space region is fixed, so only scale/transform track.
+        for tile in self.tiles.iter_mut() {
+            let mode = OutputModeSource::Static {
+                size: tile.region.size,
+                scale: output_scale,
+                transform: output_transform,
+            };
+            if *tile.damage_tracker.mode() != mode {
+                tile.damage_tracker = OutputDamageTracker::from_mode_source(mode);
+            }
+        }
+
+        // One reusable scratch buffer holds the elements relocated into the
+        // current tile's framebuffer space; it is refilled per tile rather than
+        // allocating a vec per tile. The offset is derived through the output
+        // transform (`tile_render_offset`) so it stays correct under rotation.
+        let mut scratch: Vec<RelocateRenderElement<&E>> = Vec::with_capacity(elements.len());
+
+        // The primary tile (index 0) seeds the frame result. Its plane elements
+        // are recovered as references into the original `elements` via
+        // `RelocateRenderElement::element`, so they do not borrow `scratch` and
+        // it can be refilled for the next tile.
+        let (primary_element, overlay_elements, cursor_element, mut all_empty, mut states) = {
+            let offset = tile_render_offset(self.tiles[0].region, output_size, output_transform);
+            scratch.clear();
+            scratch.extend(
+                elements
+                    .iter()
+                    .map(|element| RelocateRenderElement::from_element(element, offset, Relocate::Relative)),
+            );
+            let result = self.render_tile(0, renderer, &scratch, clear_color, frame_flags)?;
+            (
+                match result.primary_element {
+                    PrimaryPlaneElement::Swapchain(element) => PrimaryPlaneElement::Swapchain(element),
+                    PrimaryPlaneElement::Element(wrapped) => PrimaryPlaneElement::Element(*wrapped.inner()),
+                },
+                result
+                    .overlay_elements
+                    .into_iter()
+                    .map(|wrapped| *wrapped.inner())
+                    .collect::<Vec<_>>(),
+                result.cursor_element.map(|wrapped| *wrapped.inner()),
+                result.is_empty,
+                result.states,
+            )
+        };
+
+        // The remaining tiles only contribute to frame-locking and element states.
+        for index in 1..self.tiles.len() {
+            let offset = tile_render_offset(self.tiles[index].region, output_size, output_transform);
+            scratch.clear();
+            scratch.extend(
+                elements
+                    .iter()
+                    .map(|element| RelocateRenderElement::from_element(element, offset, Relocate::Relative)),
+            );
+            let result = self.render_tile(index, renderer, &scratch, clear_color, frame_flags)?;
+            all_empty &= result.is_empty;
+            merge_render_element_states(&mut states, result.states);
+        }
+
+        Ok(RenderFrameResult {
+            is_empty: all_empty,
+            states,
+            primary_element,
+            overlay_elements,
+            cursor_element,
+            primary_plane_element_id: self.tiles[0].primary_plane_element_id.clone(),
+            supports_fencing: self.tiles[0].supports_fencing,
+        })
+    }
+
+    /// Render `tile`'s slice of the logical output into its own swapchain
+    /// buffer using that tile's [`OutputDamageTracker`], stashing the prepared
+    /// frame in `self.tiles[tile].next_frame`.
+    ///
+    /// `elements` are expected to already live in the tile's framebuffer space:
+    /// for a single-tile compositor that is just the output's elements, for a
+    /// tiled one they are relocated by [`render_frame`](Self::render_frame) so
+    /// the tile's slice sits at the framebuffer origin. The returned
+    /// [`RenderFrameResult`] describes this tile alone.
+    #[instrument(level = "trace", parent = &self.span, skip_all)]
+    #[profiling::function]
+    fn render_tile<'a, R, E>(
+        &mut self,
+        tile: usize,
+        renderer: &mut R,
+        elements: &'a [E],
+        clear_color: Color32F,
+        frame_flags: FrameFlags,
+    ) -> Result<RenderFrameResult<'a, A::Buffer, F::Framebuffer, E>, RenderFrameErrorType<A, F, R>>
+    where
+        E: RenderElement<R>,
+        R: Renderer + Bind<Dmabuf>,
+        R::TextureId: Texture + 'static,
+    {
+        let mut clear_color = clear_color;
+
+        if !self.tiles[tile].surface.is_active() {
             return Err(RenderFrameErrorType::<A, F, R>::PrepareFrame(
                 FrameError::DrmError(DrmError::DeviceInactive),
             ));
@@ -2172,14 +2387,20 @@ where
 
         // Just reset any next state, this will put
         // any already acquired slot back to the swapchain
-        std::mem::drop(self.tiles[0].next_frame.take());
+        std::mem::drop(self.tiles[tile].next_frame.take());
 
         // If a commit is pending we may still be able to just use a previous
         // state, but we want to queue a frame so we just fake the damage to
         // make sure queue_frame won't be skipped because of no damage
-        let allow_partial_update = !self.tiles[0].reset_pending && !self.tiles[0].surface.commit_pending();
+        let allow_partial_update = !self.tiles[tile].reset_pending && !self.tiles[tile].surface.commit_pending();
 
-        let (current_size, output_scale, output_transform) = (&self.output_mode_source)
+        // Derive the mode from this tile's own damage tracker: for a single-tile
+        // compositor it mirrors `output_mode_source`; for a tiled one it is the
+        // tile's `Static` slice (its framebuffer size with the output's
+        // scale/transform), which is what the render below targets.
+        let (current_size, output_scale, output_transform) = self.tiles[tile]
+            .damage_tracker
+            .mode()
             .try_into()
             .map_err(OutputDamageTrackerError::OutputNoMode)?;
 
@@ -2198,7 +2419,7 @@ where
         // if we could end up doing direct scan-out on the primary plane.
         // The reason is that we can't know upfront and we need a framebuffer
         // on the primary plane to test overlay/cursor planes
-        let primary_plane_buffer = self.tiles[0]
+        let primary_plane_buffer = self.tiles[tile]
             .swapchain
             .acquire()
             .map_err(FrameError::Allocator)?
@@ -2216,9 +2437,9 @@ where
             let fb_buffer = self
                 .framebuffer_exporter
                 .add_framebuffer(
-                    self.tiles[0].surface.device_fd(),
+                    self.tiles[tile].surface.device_fd(),
                     ExportBuffer::Allocator(&primary_plane_buffer),
-                    self.tiles[0].primary_is_opaque,
+                    self.tiles[tile].primary_is_opaque,
                 )
                 .map_err(FrameError::FramebufferExport)?
                 .ok_or(FrameError::NoFramebuffer)?;
@@ -2234,11 +2455,11 @@ where
             .unwrap()
             .clone();
 
-        let tile = &mut self.tiles[0];
-        let mut opaque_regions: Vec<Rectangle<i32, Physical>> = std::mem::take(&mut tile.opaque_regions);
-        std::mem::swap(&mut tile.previous_element_states, &mut tile.element_states);
-        let mut element_states = std::mem::take(&mut tile.element_states);
-        element_states.reserve(std::cmp::min(elements.len(), tile.planes.overlay.len()));
+        let tile_state = &mut self.tiles[tile];
+        let mut opaque_regions: Vec<Rectangle<i32, Physical>> = std::mem::take(&mut tile_state.opaque_regions);
+        std::mem::swap(&mut tile_state.previous_element_states, &mut tile_state.element_states);
+        let mut element_states = std::mem::take(&mut tile_state.element_states);
+        element_states.reserve(std::cmp::min(elements.len(), tile_state.planes.overlay.len()));
         let mut render_element_states = RenderElementStates {
             states: HashMap::with_capacity(elements.len()),
         };
@@ -2249,14 +2470,14 @@ where
             <A as Allocator>::Buffer,
             <F as ExportFramebuffer<<A as Allocator>::Buffer>>::Framebuffer,
         > = {
-            let previous_state = self.tiles[0]
+            let previous_state = self.tiles[tile]
                 .pending_frame
                 .as_ref()
                 .map(|pending| &pending.frame)
-                .unwrap_or(&self.tiles[0].current_frame);
+                .unwrap_or(&self.tiles[tile].current_frame);
 
             // This will create an empty frame state, all planes are skipped by default
-            let mut next_frame_state = FrameState::from_planes(self.tiles[0].surface.plane(), &self.tiles[0].planes);
+            let mut next_frame_state = FrameState::from_planes(self.tiles[tile].surface.plane(), &self.tiles[tile].planes);
 
             // We want to set skip to false on all planes that previously had something assigned so that
             // they get cleared when they are not longer used
@@ -2276,7 +2497,7 @@ where
 
         // We want to make sure we can actually scan-out the primary plane, so
         // explicitly set skip to false
-        let plane_claim = self.tiles[0].surface.claim_plane(self.tiles[0].surface.plane()).ok_or_else(|| {
+        let plane_claim = self.tiles[tile].surface.claim_plane(self.tiles[tile].surface.plane()).ok_or_else(|| {
             error!("failed to claim primary plane");
             FrameError::PrimaryPlaneClaimFailed
         })?;
@@ -2308,7 +2529,7 @@ where
 
         // unconditionally set the primary plane state
         // if this would fail the test we are screwed anyway
-        next_frame_state.set_state(self.tiles[0].surface.plane(), primary_plane_state.clone());
+        next_frame_state.set_state(self.tiles[tile].surface.plane(), primary_plane_state.clone());
 
         // This holds all elements that are visible on the output
         // A element is considered visible if it intersects with the output geometry
@@ -2316,7 +2537,7 @@ where
         let mut output_elements: Vec<(&'a E, Rectangle<i32, Physical>, usize, bool)> =
             Vec::with_capacity(elements.len());
 
-        let mut element_opaque_regions_workhouse = std::mem::take(&mut self.tiles[0].element_opaque_regions_workhouse);
+        let mut element_opaque_regions_workhouse = std::mem::take(&mut self.tiles[tile].element_opaque_regions_workhouse);
         for (index, element) in elements.iter().enumerate() {
             let element_id = element.id();
             let element_geometry = element.geometry(output_scale);
@@ -2430,7 +2651,7 @@ where
 
             output_elements.push((element, element_geometry, element_visible_area, element_is_opaque));
         }
-        self.tiles[0].element_opaque_regions_workhouse = element_opaque_regions_workhouse;
+        self.tiles[tile].element_opaque_regions_workhouse = element_opaque_regions_workhouse;
 
         // This will hold the element that has been selected for direct scan-out on
         // the primary plane if any
@@ -2441,7 +2662,7 @@ where
         // This will hold the element per plane that has been assigned to a overlay/underlay
         // plane for direct scan-out
         let mut overlay_plane_elements: IndexMap<plane::Handle, &'a E> =
-            IndexMap::with_capacity(self.tiles[0].planes.overlay.len());
+            IndexMap::with_capacity(self.tiles[tile].planes.overlay.len());
         // This will hold the element assigned on the cursor plane if any
         let mut cursor_plane_element: Option<&'a E> = None;
 
@@ -2465,12 +2686,12 @@ where
                     (clear_color.r() == 0f32 && clear_color.g() == 0f32 && clear_color.b() == 0f32)
                         || clear_color.a() == 0f32;
                 let element_spans_complete_output = element_geometry.contains_rect(output_geometry);
-                let overlaps_with_underlay = self.tiles[0]
+                let overlaps_with_underlay = self.tiles[tile]
                     .planes
                     .overlay
                     .iter()
                     .filter(|p| {
-                        p.zpos.unwrap_or_default() < self.tiles[0].surface.plane_info().zpos.unwrap_or_default()
+                        p.zpos.unwrap_or_default() < self.tiles[tile].surface.plane_info().zpos.unwrap_or_default()
                     })
                     .any(|p| next_frame_state.overlaps(p.handle, element_geometry));
                 !overlaps_with_underlay
@@ -2481,7 +2702,7 @@ where
             };
 
             match self.try_assign_element(
-                0,
+                tile,
                 renderer,
                 *element,
                 index,
@@ -2534,12 +2755,12 @@ where
         for element_state in element_states.values_mut() {
             element_state.fb_cache.cleanup();
         }
-        self.tiles[0].element_states = element_states;
-        self.tiles[0].previous_element_states.clear();
+        self.tiles[tile].element_states = element_states;
+        self.tiles[tile].previous_element_states.clear();
         opaque_regions.clear();
-        self.tiles[0].opaque_regions = opaque_regions;
+        self.tiles[tile].opaque_regions = opaque_regions;
 
-        let tile = &mut self.tiles[0];
+        let tile = &mut self.tiles[tile];
         let previous_state = tile
             .pending_frame
             .as_ref()

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -957,7 +957,9 @@ where
     <F as ExportFramebuffer<<A as Allocator>::Buffer>>::Framebuffer: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PendingFrame").field("frame", &self.frame).finish()
+        f.debug_struct("PendingFrame")
+            .field("frame", &self.frame)
+            .finish()
     }
 }
 
@@ -2400,7 +2402,8 @@ where
         // If a commit is pending we may still be able to just use a previous
         // state, but we want to queue a frame so we just fake the damage to
         // make sure queue_frame won't be skipped because of no damage
-        let allow_partial_update = !self.tiles[tile].reset_pending && !self.tiles[tile].surface.commit_pending();
+        let allow_partial_update =
+            !self.tiles[tile].reset_pending && !self.tiles[tile].surface.commit_pending();
 
         // Derive the mode from this tile's own damage tracker: for a single-tile
         // compositor it mirrors `output_mode_source`; for a tiled one it is the
@@ -2464,8 +2467,12 @@ where
             .clone();
 
         let tile_state = &mut self.tiles[tile];
-        let mut opaque_regions: Vec<Rectangle<i32, Physical>> = std::mem::take(&mut tile_state.opaque_regions);
-        std::mem::swap(&mut tile_state.previous_element_states, &mut tile_state.element_states);
+        let mut opaque_regions: Vec<Rectangle<i32, Physical>> =
+            std::mem::take(&mut tile_state.opaque_regions);
+        std::mem::swap(
+            &mut tile_state.previous_element_states,
+            &mut tile_state.element_states,
+        );
         let mut element_states = std::mem::take(&mut tile_state.element_states);
         element_states.reserve(std::cmp::min(elements.len(), tile_state.planes.overlay.len()));
         let mut render_element_states = RenderElementStates {
@@ -2485,7 +2492,8 @@ where
                 .unwrap_or(&self.tiles[tile].current_frame);
 
             // This will create an empty frame state, all planes are skipped by default
-            let mut next_frame_state = FrameState::from_planes(self.tiles[tile].surface.plane(), &self.tiles[tile].planes);
+            let mut next_frame_state =
+                FrameState::from_planes(self.tiles[tile].surface.plane(), &self.tiles[tile].planes);
 
             // We want to set skip to false on all planes that previously had something assigned so that
             // they get cleared when they are not longer used
@@ -2505,10 +2513,13 @@ where
 
         // We want to make sure we can actually scan-out the primary plane, so
         // explicitly set skip to false
-        let plane_claim = self.tiles[tile].surface.claim_plane(self.tiles[tile].surface.plane()).ok_or_else(|| {
-            error!("failed to claim primary plane");
-            FrameError::PrimaryPlaneClaimFailed
-        })?;
+        let plane_claim = self.tiles[tile]
+            .surface
+            .claim_plane(self.tiles[tile].surface.plane())
+            .ok_or_else(|| {
+                error!("failed to claim primary plane");
+                FrameError::PrimaryPlaneClaimFailed
+            })?;
         let primary_plane_state: PlaneState<
             <A as Allocator>::Buffer,
             <F as ExportFramebuffer<<A as Allocator>::Buffer>>::Framebuffer,
@@ -2545,7 +2556,8 @@ where
         let mut output_elements: Vec<(&'a E, Rectangle<i32, Physical>, usize, bool)> =
             Vec::with_capacity(elements.len());
 
-        let mut element_opaque_regions_workhouse = std::mem::take(&mut self.tiles[tile].element_opaque_regions_workhouse);
+        let mut element_opaque_regions_workhouse =
+            std::mem::take(&mut self.tiles[tile].element_opaque_regions_workhouse);
         for (index, element) in elements.iter().enumerate() {
             let element_id = element.id();
             let element_geometry = element.geometry(output_scale);
@@ -2699,7 +2711,8 @@ where
                     .overlay
                     .iter()
                     .filter(|p| {
-                        p.zpos.unwrap_or_default() < self.tiles[tile].surface.plane_info().zpos.unwrap_or_default()
+                        p.zpos.unwrap_or_default()
+                            < self.tiles[tile].surface.plane_info().zpos.unwrap_or_default()
                     })
                     .any(|p| next_frame_state.overlaps(p.handle, element_geometry));
                 !overlaps_with_underlay
@@ -3145,7 +3158,10 @@ where
             return Err(FrameErrorType::<A, F>::DrmError(DrmError::DeviceInactive));
         }
 
-        let prepared_frame = self.tiles[0].next_frame.take().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
+        let prepared_frame = self.tiles[0]
+            .next_frame
+            .take()
+            .ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
         if prepared_frame.is_empty() {
             return Err(FrameErrorType::<A, F>::EmptyFrame);
         }
@@ -3193,7 +3209,10 @@ where
             return Err(FrameErrorType::<A, F>::DrmError(DrmError::DeviceInactive));
         }
 
-        let mut prepared_frame = self.tiles[0].next_frame.take().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
+        let mut prepared_frame = self.tiles[0]
+            .next_frame
+            .take()
+            .ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
         if prepared_frame.is_empty() {
             return Err(FrameErrorType::<A, F>::EmptyFrame);
         }
@@ -3211,9 +3230,12 @@ where
             }
         }
 
-        let flip = prepared_frame
-            .frame
-            .commit(&self.tiles[0].surface, self.tiles[0].supports_fencing, false, false);
+        let flip = prepared_frame.frame.commit(
+            &self.tiles[0].surface,
+            self.tiles[0].supports_fencing,
+            false,
+            false,
+        );
 
         if flip.is_ok() {
             self.tiles[0].queued_frame = None;
@@ -3255,13 +3277,19 @@ where
 
         let allow_partial_update = prepared_frame.kind == PreparedFrameKind::Partial;
         let flip = if self.tiles[0].surface.commit_pending() {
-            prepared_frame
-                .frame
-                .commit(&self.tiles[0].surface, self.tiles[0].supports_fencing, allow_partial_update, true)
+            prepared_frame.frame.commit(
+                &self.tiles[0].surface,
+                self.tiles[0].supports_fencing,
+                allow_partial_update,
+                true,
+            )
         } else {
-            prepared_frame
-                .frame
-                .page_flip(&self.tiles[0].surface, self.tiles[0].supports_fencing, allow_partial_update, true)
+            prepared_frame.frame.page_flip(
+                &self.tiles[0].surface,
+                self.tiles[0].supports_fencing,
+                allow_partial_update,
+                true,
+            )
         };
 
         self.handle_flip(prepared_frame, user_data, flip)
@@ -3377,7 +3405,9 @@ where
                     }
                 }
             }
-            tile.queued_frame = Some(QueuedFrame { prepared_frame: prepared });
+            tile.queued_frame = Some(QueuedFrame {
+                prepared_frame: prepared,
+            });
         }
 
         self.queued_user_data = Some(user_data);
@@ -3436,11 +3466,17 @@ where
         let has_user_data = user_data.is_some();
         if flip.is_ok() {
             for tile in self.tiles.iter_mut() {
-                let prepared = tile.queued_frame.take().expect("queued before submit").prepared_frame;
+                let prepared = tile
+                    .queued_frame
+                    .take()
+                    .expect("queued before submit")
+                    .prepared_frame;
                 if prepared.kind == PreparedFrameKind::Full {
                     tile.reset_pending = false;
                 }
-                tile.pending_frame = has_user_data.then_some(PendingFrame { frame: prepared.frame });
+                tile.pending_frame = has_user_data.then_some(PendingFrame {
+                    frame: prepared.frame,
+                });
             }
             self.pending_user_data = user_data;
         } else {
@@ -3464,7 +3500,10 @@ where
         let [primary, rest @ ..] = &mut self.tiles[..] else {
             unreachable!("DrmCompositor always has at least one tile");
         };
-        let prepared = primary.next_frame.as_mut().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
+        let prepared = primary
+            .next_frame
+            .as_mut()
+            .ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
         if let Some(plane_state) = prepared.frame.plane_state(primary.surface.plane()) {
             if !plane_state.skip {
                 let slot = plane_state.buffer().and_then(|config| match &config.buffer {
@@ -3488,7 +3527,10 @@ where
             .map_err(FrameError::DrmError)?;
 
         for tile in rest {
-            let prepared = tile.next_frame.as_mut().ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
+            let prepared = tile
+                .next_frame
+                .as_mut()
+                .ok_or(FrameErrorType::<A, F>::EmptyFrame)?;
             if let Some(plane_state) = prepared.frame.plane_state(tile.surface.plane()) {
                 if !plane_state.skip {
                     let slot = plane_state.buffer().and_then(|config| match &config.buffer {
@@ -3596,7 +3638,8 @@ where
     /// or is not compatible with the currently pending
     /// [`Mode`].
     pub fn add_connector(&self, connector: connector::Handle) -> FrameResult<(), A, F> {
-        self.tiles[0].surface
+        self.tiles[0]
+            .surface
             .add_connector(connector)
             .map_err(FrameError::DrmError)
     }
@@ -3604,7 +3647,8 @@ where
     /// Tries to mark a [`connector`]
     /// for removal on the next commit.
     pub fn remove_connector(&self, connector: connector::Handle) -> FrameResult<(), A, F> {
-        self.tiles[0].surface
+        self.tiles[0]
+            .surface
             .remove_connector(connector)
             .map_err(FrameError::DrmError)
     }
@@ -3616,7 +3660,8 @@ where
     /// or is not compatible with the currently pending
     /// [`Mode`].
     pub fn set_connectors(&self, connectors: &[connector::Handle]) -> FrameResult<(), A, F> {
-        self.tiles[0].surface
+        self.tiles[0]
+            .surface
             .set_connectors(connectors)
             .map_err(FrameError::DrmError)
     }
@@ -3645,9 +3690,14 @@ where
     /// change is not supported.
     pub fn use_mode(&mut self, mode: Mode) -> FrameResult<(), A, F> {
         if self.tiles.len() > 1 {
-            return Err(FrameError::InvalidTileConfig(TileConfigError::ModeChangeUnsupported));
+            return Err(FrameError::InvalidTileConfig(
+                TileConfigError::ModeChangeUnsupported,
+            ));
         }
-        self.tiles[0].surface.use_mode(mode).map_err(FrameError::DrmError)?;
+        self.tiles[0]
+            .surface
+            .use_mode(mode)
+            .map_err(FrameError::DrmError)?;
         let (w, h) = mode.size();
         self.tiles[0].swapchain.resize(w as _, h as _);
         Ok(())
@@ -3657,7 +3707,10 @@ where
     ///
     /// See [`DrmSurface::vrr_supported`] for more details.
     pub fn vrr_supported(&self, conn: connector::Handle) -> FrameResult<VrrSupport, A, F> {
-        self.tiles[0].surface.vrr_supported(conn).map_err(FrameError::DrmError)
+        self.tiles[0]
+            .surface
+            .vrr_supported(conn)
+            .map_err(FrameError::DrmError)
     }
 
     /// Returns if Variable Refresh Rate is currently enabled for frames composed by this [`DrmCompositor`].
@@ -3936,7 +3989,8 @@ where
             .overlay
             .iter()
             .filter(|plane| {
-                self.tiles[tile].surface.plane_info().zpos.unwrap_or_default() > plane.zpos.unwrap_or_default()
+                self.tiles[tile].surface.plane_info().zpos.unwrap_or_default()
+                    > plane.zpos.unwrap_or_default()
             })
             .any(|plane| frame_state.is_assigned(plane.handle));
 
@@ -4485,7 +4539,11 @@ where
 
             let fb = self
                 .framebuffer_exporter
-                .add_framebuffer(self.tiles[tile].surface.device_fd(), export_buffer, allow_opaque_fallback)
+                .add_framebuffer(
+                    self.tiles[tile].surface.device_fd(),
+                    export_buffer,
+                    allow_opaque_fallback,
+                )
                 .map_err(|err| {
                     trace!("failed to add framebuffer: {:?}", err);
                     ExportBufferError::ExportFailed
@@ -4548,7 +4606,8 @@ where
             .any(|i| i.properties == properties)
         {
             let overlay_bitmask =
-                self.tiles[tile].planes
+                self.tiles[tile]
+                    .planes
                     .overlay
                     .iter()
                     .enumerate()
@@ -4559,7 +4618,8 @@ where
                         acc
                     });
             let cursor_bitmask =
-                self.tiles[tile].planes
+                self.tiles[tile]
+                    .planes
                     .cursor
                     .iter()
                     .enumerate()
@@ -4611,15 +4671,20 @@ where
                         };
 
                         let overlay_plane_changed =
-                            self.tiles[tile].planes.overlay.iter().enumerate().any(|(index, plane)| {
-                                // we only want to test planes that are currently in use
-                                if current_plane_snapshot.overlay_bitmask & (1 << index) == 0 {
-                                    return false;
-                                }
+                            self.tiles[tile]
+                                .planes
+                                .overlay
+                                .iter()
+                                .enumerate()
+                                .any(|(index, plane)| {
+                                    // we only want to test planes that are currently in use
+                                    if current_plane_snapshot.overlay_bitmask & (1 << index) == 0 {
+                                        return false;
+                                    }
 
-                                frame_state.plane_properties(plane.handle)
-                                    != previous_frame_state.plane_properties(plane.handle)
-                            });
+                                    frame_state.plane_properties(plane.handle)
+                                        != previous_frame_state.plane_properties(plane.handle)
+                                });
 
                         if !(primary_plane_changed || overlay_plane_changed) {
                             // we now know that nothing changed and we can assume any previously failed
@@ -4780,8 +4845,8 @@ where
             }
 
             // test if the plane represents an underlay
-            let is_underlay =
-                self.tiles[tile].surface.plane_info().zpos.unwrap_or_default() > plane.zpos.unwrap_or_default();
+            let is_underlay = self.tiles[tile].surface.plane_info().zpos.unwrap_or_default()
+                > plane.zpos.unwrap_or_default();
 
             if is_underlay && !(element_is_opaque && primary_plane_has_alpha) {
                 trace!(

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -942,44 +942,40 @@ impl From<&PlaneInfo> for PlaneAssignment {
     }
 }
 
-struct PendingFrame<A: Allocator, F: ExportFramebuffer<<A as Allocator>::Buffer>, U> {
+// The frame lifecycle (`queued`/`pending`) tracks the per-tile scan-out
+// `FrameState` here, but the caller's `user_data` is one token per *frame* — a
+// tiled output flips all its tiles in a single atomic commit — so it lives on
+// the `DrmCompositor`, not in these per-tile wrappers.
+struct PendingFrame<A: Allocator, F: ExportFramebuffer<<A as Allocator>::Buffer>> {
     frame: CompositorFrameState<A, F>,
-    user_data: U,
 }
 
-impl<A, F, U> std::fmt::Debug for PendingFrame<A, F, U>
+impl<A, F> std::fmt::Debug for PendingFrame<A, F>
 where
     A: Allocator,
     <A as Allocator>::Buffer: std::fmt::Debug,
     F: ExportFramebuffer<<A as Allocator>::Buffer>,
     <F as ExportFramebuffer<<A as Allocator>::Buffer>>::Framebuffer: std::fmt::Debug,
-    U: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PendingFrame")
-            .field("frame", &self.frame)
-            .field("user_data", &self.user_data)
-            .finish()
+        f.debug_struct("PendingFrame").field("frame", &self.frame).finish()
     }
 }
 
-struct QueuedFrame<A: Allocator, F: ExportFramebuffer<<A as Allocator>::Buffer>, U> {
+struct QueuedFrame<A: Allocator, F: ExportFramebuffer<<A as Allocator>::Buffer>> {
     prepared_frame: PreparedFrame<A, F>,
-    user_data: U,
 }
 
-impl<A, F, U> std::fmt::Debug for QueuedFrame<A, F, U>
+impl<A, F> std::fmt::Debug for QueuedFrame<A, F>
 where
     A: Allocator,
     <A as Allocator>::Buffer: std::fmt::Debug,
     F: ExportFramebuffer<<A as Allocator>::Buffer>,
     <F as ExportFramebuffer<<A as Allocator>::Buffer>>::Framebuffer: std::fmt::Debug,
-    U: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QueuedFrame")
             .field("prepared_frame", &self.prepared_frame)
-            .field("user_data", &self.user_data)
             .finish()
     }
 }
@@ -1049,7 +1045,7 @@ bitflags::bitflags! {
 /// [`DrmCompositor::new_tiled`]). Everything that belongs to a single scan-out
 /// pipeline (the surface, its planes, swapchain and frame-state machine) lives
 /// here; the logical output state stays on `DrmCompositor`.
-struct TileState<A, F, U, G>
+struct TileState<A, F, G>
 where
     A: Allocator,
     F: ExportFramebuffer<A::Buffer>,
@@ -1071,8 +1067,8 @@ where
     reset_pending: bool,
     signaled_fence: Option<Arc<OwnedFd>>,
     current_frame: CompositorFrameState<A, F>,
-    pending_frame: Option<PendingFrame<A, F, U>>,
-    queued_frame: Option<QueuedFrame<A, F, U>>,
+    pending_frame: Option<PendingFrame<A, F>>,
+    queued_frame: Option<QueuedFrame<A, F>>,
     next_frame: Option<PreparedFrame<A, F>>,
     swapchain: Swapchain<A>,
     cursor_state: Option<CursorState<G>>,
@@ -1104,7 +1100,13 @@ where
     // heap-free. A tiled output (several CRTCs) spills to one heap allocation.
     // Kept at 1 because TileState is large, so extra inline slots would bloat
     // every (mostly single-tile) compositor just for the rare tiled case.
-    tiles: SmallVec<[TileState<A, F, U, G>; 1]>,
+    tiles: SmallVec<[TileState<A, F, G>; 1]>,
+    /// `user_data` for the frame queued via [`queue_frame`](DrmCompositor::queue_frame)
+    /// but not yet submitted, and for the in-flight frame awaiting its vblank,
+    /// respectively. These are per-frame (one atomic commit across all tiles),
+    /// hence held here rather than per-tile.
+    queued_user_data: Option<U>,
+    pending_user_data: Option<U>,
     debug_flags: DebugFlags,
     span: tracing::Span,
 }
@@ -1584,6 +1586,8 @@ where
             output_mode_source,
             framebuffer_exporter,
             cursor_size,
+            queued_user_data: None,
+            pending_user_data: None,
             debug_flags: DebugFlags::empty(),
             span,
             tiles: SmallVec::from_buf([tile]),
@@ -1678,6 +1682,8 @@ where
             output_mode_source,
             framebuffer_exporter,
             cursor_size,
+            queued_user_data: None,
+            pending_user_data: None,
             debug_flags: DebugFlags::empty(),
             span,
             tiles,
@@ -1699,7 +1705,7 @@ where
         color_formats: impl IntoIterator<Item = DrmFourcc>,
         renderer_formats: Vec<DrmFormat>,
         gbm: Option<GbmDevice<G>>,
-    ) -> FrameResult<TileState<A, F, U, G>, A, F> {
+    ) -> FrameResult<TileState<A, F, G>, A, F> {
         let signaled_fence = match surface.create_syncobj(true) {
             Ok(signaled_syncobj) => match surface.syncobj_to_fd(signaled_syncobj, true) {
                 Ok(signaled_fence) => {
@@ -1984,6 +1990,8 @@ where
             framebuffer_exporter,
             cursor_size,
             output_mode_source,
+            queued_user_data: None,
+            pending_user_data: None,
             debug_flags: DebugFlags::empty(),
             span,
             tiles: SmallVec::from_buf([TileState {
@@ -3146,10 +3154,8 @@ where
             }
         }
 
-        self.tiles[0].queued_frame = Some(QueuedFrame {
-            prepared_frame,
-            user_data,
-        });
+        self.tiles[0].queued_frame = Some(QueuedFrame { prepared_frame });
+        self.queued_user_data = Some(user_data);
         if self.tiles[0].pending_frame.is_none() {
             self.submit()?;
         }
@@ -3199,6 +3205,8 @@ where
         if flip.is_ok() {
             self.tiles[0].queued_frame = None;
             self.tiles[0].pending_frame = None;
+            self.queued_user_data = None;
+            self.pending_user_data = None;
         }
 
         self.handle_flip(prepared_frame, None, flip)
@@ -3221,10 +3229,8 @@ where
 
     #[profiling::function]
     fn submit(&mut self) -> FrameResult<(), A, F> {
-        let QueuedFrame {
-            mut prepared_frame,
-            user_data,
-        } = self.tiles[0].queued_frame.take().unwrap();
+        let QueuedFrame { mut prepared_frame } = self.tiles[0].queued_frame.take().unwrap();
+        let user_data = self.queued_user_data.take();
 
         let allow_partial_update = prepared_frame.kind == PreparedFrameKind::Partial;
         let flip = if self.tiles[0].surface.commit_pending() {
@@ -3237,7 +3243,7 @@ where
                 .page_flip(&self.tiles[0].surface, self.tiles[0].supports_fencing, allow_partial_update, true)
         };
 
-        self.handle_flip(prepared_frame, Some(user_data), flip)
+        self.handle_flip(prepared_frame, user_data, flip)
     }
 
     fn handle_flip(
@@ -3252,10 +3258,20 @@ where
                     self.tiles[0].reset_pending = false;
                 }
 
-                self.tiles[0].pending_frame = user_data.map(|user_data| PendingFrame {
-                    frame: prepared_frame.frame,
-                    user_data,
-                });
+                // A pending frame is only tracked when there is `user_data` to
+                // return on its vblank (i.e. for `queue_frame`, not `commit_frame`).
+                match user_data {
+                    Some(user_data) => {
+                        self.tiles[0].pending_frame = Some(PendingFrame {
+                            frame: prepared_frame.frame,
+                        });
+                        self.pending_user_data = Some(user_data);
+                    }
+                    None => {
+                        self.tiles[0].pending_frame = None;
+                        self.pending_user_data = None;
+                    }
+                }
             }
             Err(crate::backend::drm::error::Error::Access(ref access))
                 if access.source.kind() == ErrorKind::InvalidInput =>
@@ -3295,12 +3311,15 @@ where
     /// Otherwise the underlying swapchain will run out of buffers eventually.
     #[profiling::function]
     pub fn frame_submitted(&mut self) -> FrameResult<Option<U>, A, F> {
-        if let Some(PendingFrame { mut frame, user_data }) = self.tiles[0].pending_frame.take() {
+        if let Some(PendingFrame { mut frame }) = self.tiles[0].pending_frame.take() {
             std::mem::swap(&mut frame, &mut self.tiles[0].current_frame);
+            // Take the in-flight `user_data` before `submit` repopulates it from
+            // the next queued frame.
+            let user_data = self.pending_user_data.take();
             if self.tiles[0].queued_frame.is_some() {
                 self.submit()?;
             }
-            Ok(Some(user_data))
+            Ok(user_data)
         } else {
             Ok(None)
         }
@@ -4778,6 +4797,8 @@ where
         self.tiles[0].pending_frame = None;
         self.tiles[0].queued_frame = None;
         self.tiles[0].next_frame = None;
+        self.queued_user_data = None;
+        self.pending_user_data = None;
 
         Ok(())
     }

--- a/src/backend/drm/device/mod.rs
+++ b/src/backend/drm/device/mod.rs
@@ -18,7 +18,7 @@ use crate::utils::{Buffer, DevPath, Size};
 
 use super::error::AccessError;
 use super::surface::{DrmSurface, DrmSurfaceInternal, atomic::AtomicDrmSurface, legacy::LegacyDrmSurface};
-use super::{Planes, error::Error, planes};
+use super::{Planes, TileInfo, error::Error, planes, tile_info};
 use atomic::AtomicDrmDevice;
 use legacy::LegacyDrmDevice;
 
@@ -274,6 +274,14 @@ impl DrmDevice {
     /// Returns a set of available planes for a given crtc
     pub fn planes(&self, crtc: &crtc::Handle) -> Result<Planes, Error> {
         planes(self, crtc, self.has_universal_planes)
+    }
+
+    /// Returns the parsed `TILE` property of a connector, if set.
+    ///
+    /// Tiled monitors (DisplayID Tile Topology) expose multiple connectors
+    /// that share a [`TileInfo::group_id`].
+    pub fn tile_info(&self, conn: connector::Handle) -> Result<Option<TileInfo>, Error> {
+        tile_info(self, conn)
     }
 
     /// Claim a plane so that it won't be used by a different crtc

--- a/src/backend/drm/error.rs
+++ b/src/backend/drm/error.rs
@@ -90,6 +90,9 @@ pub enum Error {
     /// legacy device, which has no atomic modesetting API.
     #[error("Atomic commits spanning multiple crtcs are not supported on legacy devices")]
     AtomicUnsupported,
+    /// A shared atomic commit was requested for surfaces on different DRM devices.
+    #[error("Atomic commits spanning multiple drm devices are not supported")]
+    AtomicDeviceMismatch,
 }
 
 impl From<Error> for SwapBuffersError {

--- a/src/backend/drm/error.rs
+++ b/src/backend/drm/error.rs
@@ -86,6 +86,10 @@ pub enum Error {
     /// Atomic Test failed for new properties
     #[error("Atomic Test failed for new properties on crtc ({0:?})")]
     TestFailed(crtc::Handle),
+    /// A multi-CRTC atomic commit (e.g. a tiled output) was requested on a
+    /// legacy device, which has no atomic modesetting API.
+    #[error("Atomic commits spanning multiple crtcs are not supported on legacy devices")]
+    AtomicUnsupported,
 }
 
 impl From<Error> for SwapBuffersError {

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -102,7 +102,7 @@ pub use surface::{DrmSurface, PlaneConfig, PlaneDamageClips, PlaneState, VrrSupp
 
 use drm::{
     DriverCapability,
-    control::{Device as ControlDevice, PlaneType, crtc, framebuffer, plane},
+    control::{Device as ControlDevice, PlaneType, connector, crtc, framebuffer, plane},
 };
 use tracing::trace;
 
@@ -514,4 +514,163 @@ fn plane_size_hints(
         }
     }
     Ok(None)
+}
+
+/// Information from a connector's DRM `TILE` property
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TileInfo {
+    /// Tile-group identifier shared by all connectors of the same monitor
+    pub group_id: u32,
+    /// Total horizontal tile count in the group
+    pub num_h_tiles: u8,
+    /// Total vertical tile count in the group
+    pub num_v_tiles: u8,
+    /// Horizontal location of this tile, `0..num_h_tiles`
+    pub loc_h: u8,
+    /// Vertical location of this tile, `0..num_v_tiles`
+    pub loc_v: u8,
+    /// Native horizontal pixel size of this tile
+    pub tile_w: u16,
+    /// Native vertical pixel size of this tile
+    pub tile_h: u16,
+}
+
+fn tile_info(
+    dev: &(impl ControlDevice + DevPath),
+    conn: connector::Handle,
+) -> Result<Option<TileInfo>, DrmError> {
+    let props = dev.get_properties(conn).map_err(|source| {
+        DrmError::Access(AccessError {
+            errmsg: "Failed to get properties of connector",
+            dev: dev.dev_path(),
+            source,
+        })
+    })?;
+    let (ids, vals) = props.as_props_and_values();
+    for (&id, &val) in ids.iter().zip(vals.iter()) {
+        let info = dev.get_property(id).map_err(|source| {
+            DrmError::Access(AccessError {
+                errmsg: "Failed to get property info",
+                dev: dev.dev_path(),
+                source,
+            })
+        })?;
+        if info.name().to_str().map(|x| x == "TILE").unwrap_or(false) {
+            let tile_info =
+                if let drm::control::property::Value::Blob(blob_id) = info.value_type().convert_value(val) {
+                    // Value 0 means "no blob set" — the kernel uses this for
+                    // non-tiled connectors that nonetheless expose the property.
+                    if blob_id == 0 {
+                        return Ok(None);
+                    }
+                    let data = dev.get_property_blob(blob_id).map_err(|source| {
+                        DrmError::Access(AccessError {
+                            errmsg: "Failed to read TILE property blob",
+                            dev: dev.dev_path(),
+                            source,
+                        })
+                    })?;
+                    parse_tile_blob(&data)
+                } else {
+                    tracing::debug!(?conn, "TILE property has wrong value type");
+                    None
+                };
+            return Ok(tile_info);
+        }
+    }
+    Ok(None)
+}
+
+// Format written by the kernel in drm_connector_set_tile_property: eight
+// unsigned decimal fields separated by ':', in the order
+// group_id:flags:num_h_tiles:num_v_tiles:loc_h:loc_v:tile_w:tile_h.
+fn parse_tile_blob(data: &[u8]) -> Option<TileInfo> {
+    // The blob is a NUL-terminated C string; trim trailing NULs before parsing.
+    let s = std::str::from_utf8(data).ok()?.trim_end_matches('\0').trim();
+
+    let mut parts = s.split(':');
+    let group_id: u32 = parts.next()?.parse().ok()?;
+    // Field 2 is the kernel ABI "flags" placeholder; currently always 0 and unused.
+    let _flags: u32 = parts.next()?.parse().ok()?;
+    let num_h_tiles: u8 = parts.next()?.parse().ok()?;
+    let num_v_tiles: u8 = parts.next()?.parse().ok()?;
+    let loc_h: u8 = parts.next()?.parse().ok()?;
+    let loc_v: u8 = parts.next()?.parse().ok()?;
+    let tile_w: u16 = parts.next()?.parse().ok()?;
+    let tile_h: u16 = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+
+    // group_id == 0 is the kernel sentinel for "no tile info".
+    if group_id == 0 || num_h_tiles == 0 || num_v_tiles == 0 {
+        return None;
+    }
+    if loc_h >= num_h_tiles || loc_v >= num_v_tiles {
+        return None;
+    }
+
+    Some(TileInfo {
+        group_id,
+        num_h_tiles,
+        num_v_tiles,
+        loc_h,
+        loc_v,
+        tile_w,
+        tile_h,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::{TileInfo, parse_tile_blob};
+
+    #[test]
+    fn parse_tile_blob_kernel_format() {
+        let blob = b"305419896:0:2:1:1:0:2560:2880";
+        assert_eq!(
+            parse_tile_blob(blob),
+            Some(TileInfo {
+                group_id: 0x12345678,
+                num_h_tiles: 2,
+                num_v_tiles: 1,
+                loc_h: 1,
+                loc_v: 0,
+                tile_w: 2560,
+                tile_h: 2880,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_tile_blob_tolerates_nul_padding() {
+        let info = parse_tile_blob(b"42:0:2:1:0:0:2560:2880\0\0\0").unwrap();
+        assert_eq!(info.group_id, 42);
+    }
+
+    #[test]
+    fn parse_tile_blob_rejects_zero_group_id() {
+        assert_eq!(parse_tile_blob(b"0:0:2:1:0:0:2560:2880"), None);
+    }
+
+    #[test]
+    fn parse_tile_blob_rejects_zero_tile_count() {
+        assert_eq!(parse_tile_blob(b"1:0:0:1:0:0:2560:2880"), None);
+        assert_eq!(parse_tile_blob(b"1:0:2:0:0:0:2560:2880"), None);
+    }
+
+    #[test]
+    fn parse_tile_blob_rejects_out_of_range_location() {
+        assert_eq!(parse_tile_blob(b"1:0:2:1:2:0:2560:2880"), None);
+        assert_eq!(parse_tile_blob(b"1:0:2:1:0:1:2560:2880"), None);
+    }
+
+    #[test]
+    fn parse_tile_blob_rejects_malformed() {
+        assert_eq!(parse_tile_blob(b""), None);
+        assert_eq!(parse_tile_blob(b"not:a:tile:blob"), None);
+        assert_eq!(parse_tile_blob(b"1:0:2:1:0:0:2560"), None);
+        assert_eq!(parse_tile_blob(b"1:0:2:1:0:0:2560:2880:99"), None);
+        assert_eq!(parse_tile_blob(b"1,0,2,1,0,0,2560,2880"), None);
+    }
 }

--- a/src/backend/drm/mod.rs
+++ b/src/backend/drm/mod.rs
@@ -98,7 +98,7 @@ pub use error::Error as DrmError;
 use indexmap::IndexSet;
 #[cfg(feature = "backend_gbm")]
 pub use surface::gbm::{Error as GbmBufferedSurfaceError, GbmBufferedSurface};
-pub use surface::{DrmSurface, PlaneConfig, PlaneDamageClips, PlaneState, VrrSupport};
+pub use surface::{DrmAtomicCommit, DrmSurface, PlaneConfig, PlaneDamageClips, PlaneState, VrrSupport};
 
 use drm::{
     DriverCapability,

--- a/src/backend/drm/output.rs
+++ b/src/backend/drm/output.rs
@@ -1,7 +1,7 @@
 //! Device-wide synchronization helpers
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt,
     marker::PhantomData,
     os::fd::AsFd,
@@ -21,18 +21,25 @@ use crate::{
         renderer::{Bind, Color32F, DebugFlags, Renderer, RendererSuper, Texture, element::RenderElement},
     },
     output::OutputModeSource,
+    utils::{Physical, Rectangle},
 };
 
 use super::{
     DrmDevice, DrmError, Planes,
     compositor::{
         DrmCompositor, FrameError, FrameFlags, FrameResult, PrimaryPlaneElement, RenderFrameError,
-        RenderFrameErrorType, RenderFrameResult,
+        RenderFrameErrorType, RenderFrameResult, TileConfigError, TilePlacement,
     },
     exporter::ExportFramebuffer,
 };
+use smallvec::SmallVec;
 
 type CompositorList<A, F, U, G> = Arc<RwLock<HashMap<crtc::Handle, Mutex<DrmCompositor<A, F, U, G>>>>>;
+/// CRTCs claimed by tiled outputs that have no entry of their own in the
+/// [`CompositorList`] (only the primary tile's CRTC keys that map). Lets a later
+/// `initialize_output`/`initialize_tiled_output` reject a CRTC a tiled
+/// `DrmCompositor` already drives.
+type ReservedCrtcs = Arc<RwLock<HashSet<crtc::Handle>>>;
 
 /// Provides synchronization between a [`DrmDevice`] and derived [`DrmOutput`]s.
 ///
@@ -55,6 +62,7 @@ where
     exporter: F,
     gbm: Option<GbmDevice<G>>,
     compositor: CompositorList<A, F, U, G>,
+    reserved_crtcs: ReservedCrtcs,
     color_formats: Vec<DrmFourcc>,
     renderer_formats: Vec<DrmFormat>,
 }
@@ -73,6 +81,7 @@ where
     gbm: &'a mut Option<GbmDevice<G>>,
     compositor: RwLockWriteGuard<'a, HashMap<crtc::Handle, Mutex<DrmCompositor<A, F, U, G>>>>,
     compositor_arc: CompositorList<A, F, U, G>,
+    reserved_crtcs: ReservedCrtcs,
     color_formats: &'a [DrmFourcc],
     renderer_formats: &'a [DrmFormat],
 }
@@ -93,6 +102,7 @@ where
             .field("exporter", &self.exporter)
             .field("gbm", &self.gbm)
             .field("compositor", &self.compositor)
+            .field("reserved_crtcs", &self.reserved_crtcs)
             .field("color_formats", &self.color_formats)
             .field("renderer_formats", &self.renderer_formats)
             .finish()
@@ -253,6 +263,7 @@ where
             exporter,
             gbm,
             compositor: Default::default(),
+            reserved_crtcs: Default::default(),
             color_formats: color_formats.into_iter().collect(),
             renderer_formats: renderer_formats.into_iter().collect(),
         }
@@ -271,6 +282,7 @@ where
             gbm: &mut self.gbm,
             compositor: self.compositor.write().unwrap(),
             compositor_arc: self.compositor.clone(),
+            reserved_crtcs: self.reserved_crtcs.clone(),
             color_formats: &self.color_formats,
             renderer_formats: &self.renderer_formats,
         }
@@ -328,7 +340,7 @@ where
     {
         let output_mode_source = output_mode_source.into();
 
-        if self.compositor.contains_key(&crtc) {
+        if self.compositor.contains_key(&crtc) || self.reserved_crtcs.read().unwrap().contains(&crtc) {
             return Err(DrmOutputManagerError::DuplicateCrtc(crtc));
         }
 
@@ -488,7 +500,118 @@ where
 
         Ok(DrmOutput {
             compositor: self.compositor_arc.clone(),
+            reserved_crtcs: self.reserved_crtcs.clone(),
+            secondary_crtcs: SmallVec::new(),
             crtc,
+            allocator: self.allocator.clone(),
+            renderer_formats: Vec::from(self.renderer_formats),
+        })
+    }
+
+    /// Create a tiled [`DrmOutput`]: several CRTCs of this device driven as one
+    /// logical, frame-locked output (e.g. a DisplayID-tiled monitor carried over
+    /// several DisplayPort streams). The CRTCs flip together in a single atomic
+    /// commit — see [`DrmCompositor::new_tiled`], the multi-CRTC generalization
+    /// of [`initialize_output`](Self::initialize_output).
+    ///
+    /// `tiles` lists one [`DrmTilePlacement`] per CRTC; `tiles[0]` is the primary
+    /// tile, whose CRTC keys the resulting output (and whose vblank the caller
+    /// should treat as the group's frame-completion signal). The placements'
+    /// regions must tile a gap-free rectangle anchored at the origin matching
+    /// `output_mode_source`'s size, and all CRTCs must belong to this device and
+    /// be unused.
+    #[allow(clippy::too_many_arguments)]
+    pub fn initialize_tiled_output<R, E>(
+        &mut self,
+        tiles: impl IntoIterator<Item = DrmTilePlacement>,
+        output_mode_source: impl Into<OutputModeSource> + std::fmt::Debug,
+        renderer: &mut R,
+        render_elements: &DrmOutputRenderElements<R, E>,
+    ) -> DrmOutputManagerResult<DrmOutput<A, F, U, G>, A, F, R>
+    where
+        E: RenderElement<R>,
+        R: Renderer + Bind<Dmabuf>,
+        R::TextureId: Texture + 'static,
+        R::Error: Send + Sync + 'static,
+    {
+        let output_mode_source = output_mode_source.into();
+        let tiles: SmallVec<[DrmTilePlacement; 4]> = tiles.into_iter().collect();
+
+        let Some(primary_crtc) = tiles.first().map(|tile| tile.crtc) else {
+            return Err(DrmOutputManagerError::Frame(FrameError::InvalidTileConfig(
+                TileConfigError::Empty,
+            )));
+        };
+
+        let mut seen = HashSet::new();
+        for tile in &tiles {
+            // Reject a CRTC repeated within this list, or one already driven by
+            // another compositor / reserved by another tiled output — each would
+            // otherwise create a second surface for a CRTC already in use.
+            if !seen.insert(tile.crtc)
+                || self.compositor.contains_key(&tile.crtc)
+                || self.reserved_crtcs.read().unwrap().contains(&tile.crtc)
+            {
+                return Err(DrmOutputManagerError::DuplicateCrtc(tile.crtc));
+            }
+        }
+
+        // Create a surface per tile and pair it with its sub-rect of the output.
+        let mut placements = Vec::with_capacity(tiles.len());
+        for tile in &tiles {
+            let surface = self
+                .device
+                .create_surface(tile.crtc, tile.mode, &tile.connectors)
+                .map_err(|err| DrmOutputManagerError::Frame(FrameError::DrmError(err)))?;
+            placements.push(TilePlacement {
+                surface,
+                planes: tile.planes.clone(),
+                region: tile.region,
+            });
+        }
+
+        // NOTE: unlike `initialize_output`, this does not yet retry under
+        // bandwidth pressure (disabling overlay planes / implicit modifiers). A
+        // tiled output is a single dedicated monitor, so the simple path is used
+        // for now.
+        let compositor = DrmCompositor::<A, F, U, G>::new_tiled(
+            output_mode_source,
+            placements,
+            self.allocator.clone(),
+            self.exporter.clone(),
+            self.color_formats.iter().copied(),
+            self.renderer_formats.iter().copied(),
+            self.device.cursor_size(),
+            self.gbm.clone(),
+        )
+        .map_err(DrmOutputManagerError::Frame)?;
+
+        self.compositor.insert(primary_crtc, Mutex::new(compositor));
+
+        // Render once to lock in the primary plane with the chosen format (see
+        // `initialize_output`).
+        let compositor = self.compositor.get_mut(&primary_crtc).unwrap().get_mut().unwrap();
+        if let Err(err) = render_elements.submit_composited_frame(&mut *compositor, renderer) {
+            self.compositor.remove(&primary_crtc);
+            return Err(err);
+        }
+
+        // Reserve the non-primary CRTCs: only `primary_crtc` keys `self.compositor`,
+        // so without this a later `initialize_output`/`initialize_tiled_output`
+        // would consider the others free and hand out a second surface for a CRTC
+        // this compositor already drives. Released on `DrmOutput::drop`.
+        let secondary_crtcs: SmallVec<[crtc::Handle; 3]> =
+            tiles.iter().skip(1).map(|tile| tile.crtc).collect();
+        self.reserved_crtcs
+            .write()
+            .unwrap()
+            .extend(secondary_crtcs.iter().copied());
+
+        Ok(DrmOutput {
+            compositor: self.compositor_arc.clone(),
+            reserved_crtcs: self.reserved_crtcs.clone(),
+            secondary_crtcs,
+            crtc: primary_crtc,
             allocator: self.allocator.clone(),
             renderer_formats: Vec::from(self.renderer_formats),
         })
@@ -611,6 +734,30 @@ where
     }
 }
 
+/// Placement of one CRTC within a tiled [`DrmOutput`].
+///
+/// One per CRTC, passed to [`LockedDrmOutputManager::initialize_tiled_output`].
+/// The manager creates the surface for `crtc` (so, unlike the compositor's
+/// `TilePlacement`, this carries the CRTC setup rather than a ready surface).
+#[derive(Debug, Clone)]
+pub struct DrmTilePlacement {
+    /// The CRTC driving this tile.
+    pub crtc: crtc::Handle,
+    /// The mode this tile's CRTC scans out — its native per-tile resolution, not
+    /// the aggregated logical-output size.
+    pub mode: Mode,
+    /// Connectors to drive from this tile's CRTC.
+    pub connectors: Vec<connector::Handle>,
+    /// Planes this tile may use for direct scan-out (`None` = all available).
+    pub planes: Option<Planes>,
+    /// Sub-rect of the logical output this tile scans out, in the output's
+    /// untransformed (mode) coordinate space.
+    ///
+    /// Derive it from the connector's [`TileInfo`](super::TileInfo) (read via
+    /// [`DrmDevice::tile_info`]): `((loc_h * tile_w, loc_v * tile_h), (tile_w, tile_h))`.
+    pub region: Rectangle<i32, Physical>,
+}
+
 /// A handle to an underlying [`DrmCompositor`] handled by an [`DrmOutputManager`].
 pub struct DrmOutput<A, F, U, G>
 where
@@ -620,6 +767,13 @@ where
     G: AsFd + 'static,
 {
     compositor: CompositorList<A, F, U, G>,
+    /// Shared reserved-CRTC set (see [`DrmOutputManager`]); the `secondary_crtcs`
+    /// entries are removed from it on drop.
+    reserved_crtcs: ReservedCrtcs,
+    /// Non-primary CRTCs this output drives — empty for a single-CRTC output,
+    /// populated for a tiled one. Reserved in `reserved_crtcs` for the output's
+    /// lifetime so nothing else hands them out.
+    secondary_crtcs: SmallVec<[crtc::Handle; 3]>,
     crtc: crtc::Handle,
     allocator: A,
     renderer_formats: Vec<DrmFormat>,
@@ -808,8 +962,13 @@ where
     G: AsFd + 'static,
 {
     fn drop(&mut self) {
-        let mut write_guard = self.compositor.write().unwrap();
-        write_guard.remove(&self.crtc);
+        self.compositor.write().unwrap().remove(&self.crtc);
+        if !self.secondary_crtcs.is_empty() {
+            let mut reserved = self.reserved_crtcs.write().unwrap();
+            for crtc in &self.secondary_crtcs {
+                reserved.remove(crtc);
+            }
+        }
     }
 }
 

--- a/src/backend/drm/output.rs
+++ b/src/backend/drm/output.rs
@@ -508,18 +508,18 @@ where
         })
     }
 
-    /// Create a tiled [`DrmOutput`]: several CRTCs of this device driven as one
-    /// logical, frame-locked output (e.g. a DisplayID-tiled monitor carried over
-    /// several DisplayPort streams). The CRTCs flip together in a single atomic
-    /// commit — see [`DrmCompositor::new_tiled`], the multi-CRTC generalization
-    /// of [`initialize_output`](Self::initialize_output).
+    /// Create a [`DrmOutput`] that drives several CRTCs on this device as one
+    /// logical output.
     ///
-    /// `tiles` lists one [`DrmTilePlacement`] per CRTC; `tiles[0]` is the primary
-    /// tile, whose CRTC keys the resulting output (and whose vblank the caller
-    /// should treat as the group's frame-completion signal). The placements'
-    /// regions must tile a gap-free rectangle anchored at the origin matching
-    /// `output_mode_source`'s size, and all CRTCs must belong to this device and
-    /// be unused.
+    /// This wraps [`DrmCompositor::new_tiled`] for callers that want one logical
+    /// output backed by multiple same-device CRTCs, whether that layout comes
+    /// from a DisplayID-tiled monitor or from compositor policy.
+    ///
+    /// `tiles` lists one [`DrmTilePlacement`] per CRTC. `tiles[0]` is the
+    /// primary tile; its CRTC keys the resulting output and provides the
+    /// page-flip event for the logical frame. The regions must tile a gap-free
+    /// rectangle anchored at the origin matching `output_mode_source`'s size, and
+    /// all CRTCs must be unused.
     #[allow(clippy::too_many_arguments)]
     pub fn initialize_tiled_output<R, E>(
         &mut self,
@@ -545,9 +545,6 @@ where
 
         let mut seen = HashSet::new();
         for tile in &tiles {
-            // Reject a CRTC repeated within this list, or one already driven by
-            // another compositor / reserved by another tiled output — each would
-            // otherwise create a second surface for a CRTC already in use.
             if !seen.insert(tile.crtc)
                 || self.compositor.contains_key(&tile.crtc)
                 || self.reserved_crtcs.read().unwrap().contains(&tile.crtc)
@@ -556,7 +553,6 @@ where
             }
         }
 
-        // Create a surface per tile and pair it with its sub-rect of the output.
         let mut placements = Vec::with_capacity(tiles.len());
         for tile in &tiles {
             let surface = self

--- a/src/backend/drm/output.rs
+++ b/src/backend/drm/output.rs
@@ -553,36 +553,126 @@ where
             }
         }
 
-        let mut placements = Vec::with_capacity(tiles.len());
-        for tile in &tiles {
-            let surface = self
-                .device
-                .create_surface(tile.crtc, tile.mode, &tile.connectors)
-                .map_err(|err| DrmOutputManagerError::Frame(FrameError::DrmError(err)))?;
-            placements.push(TilePlacement {
-                surface,
-                planes: tile.planes.clone(),
-                region: tile.region,
-            });
-        }
+        let mut create_compositor =
+            |implicit_modifiers: bool| -> FrameResult<DrmCompositor<A, F, U, G>, A, F> {
+                let mut placements = Vec::with_capacity(tiles.len());
+                for tile in &tiles {
+                    let surface = self
+                        .device
+                        .create_surface(tile.crtc, tile.mode, &tile.connectors)?;
+                    placements.push(TilePlacement {
+                        surface,
+                        planes: tile.planes.clone(),
+                        region: tile.region,
+                    });
+                }
 
-        // NOTE: unlike `initialize_output`, this does not yet retry under
-        // bandwidth pressure (disabling overlay planes / implicit modifiers). A
-        // tiled output is a single dedicated monitor, so the simple path is used
-        // for now.
-        let compositor = DrmCompositor::<A, F, U, G>::new_tiled(
-            output_mode_source,
-            placements,
-            self.allocator.clone(),
-            self.exporter.clone(),
-            self.color_formats.iter().copied(),
-            self.renderer_formats.iter().copied(),
-            self.device.cursor_size(),
-            self.gbm.clone(),
-        )
-        .map_err(DrmOutputManagerError::Frame)?;
+                if implicit_modifiers {
+                    DrmCompositor::<A, F, U, G>::new_tiled(
+                        output_mode_source.clone(),
+                        placements,
+                        self.allocator.clone(),
+                        self.exporter.clone(),
+                        self.color_formats.iter().copied(),
+                        self.renderer_formats
+                            .iter()
+                            .filter(|f| f.modifier == DrmModifier::Invalid)
+                            .copied(),
+                        self.device.cursor_size(),
+                        self.gbm.clone(),
+                    )
+                } else {
+                    DrmCompositor::<A, F, U, G>::new_tiled(
+                        output_mode_source.clone(),
+                        placements,
+                        self.allocator.clone(),
+                        self.exporter.clone(),
+                        self.color_formats.iter().copied(),
+                        self.renderer_formats.iter().copied(),
+                        self.device.cursor_size(),
+                        self.gbm.clone(),
+                    )
+                }
+            };
 
-        self.compositor.insert(primary_crtc, Mutex::new(compositor));
+        match create_compositor(false) {
+            Ok(compositor) => {
+                self.compositor.insert(primary_crtc, Mutex::new(compositor));
+            }
+            Err(err) => {
+                tracing::warn!(
+                    ?primary_crtc,
+                    ?err,
+                    "failed to initialize tiled output, trying to lower bandwidth"
+                );
+
+                for compositor in self.compositor.values_mut() {
+                    let compositor = compositor.get_mut().unwrap();
+                    if let Err(err) = render_elements.submit_composited_frame(&mut *compositor, renderer) {
+                        if !matches!(err, DrmOutputManagerError::Frame(FrameError::EmptyFrame)) {
+                            return Err(err);
+                        }
+                    }
+                }
+
+                match create_compositor(false) {
+                    Ok(compositor) => {
+                        self.compositor.insert(primary_crtc, Mutex::new(compositor));
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            ?primary_crtc,
+                            ?err,
+                            "failed to initialize tiled output, trying implicit modifiers"
+                        );
+
+                        for compositor in self.compositor.values_mut() {
+                            let compositor = compositor.get_mut().unwrap();
+
+                            let current_format = compositor.format();
+                            if let Err(err) = compositor.set_format(
+                                self.allocator.clone(),
+                                current_format,
+                                [DrmModifier::Invalid],
+                            ) {
+                                tracing::warn!(?err, "failed to set new format");
+                                continue;
+                            }
+
+                            render_elements.submit_composited_frame(&mut *compositor, renderer)?;
+                        }
+
+                        match create_compositor(true) {
+                            Ok(compositor) => {
+                                self.compositor.insert(primary_crtc, Mutex::new(compositor));
+                            }
+                            Err(err) => {
+                                for compositor in self.compositor.values_mut() {
+                                    let compositor = compositor.get_mut().unwrap();
+
+                                    let current_format = compositor.format();
+                                    if let Err(err) = compositor.set_format(
+                                        self.allocator.clone(),
+                                        current_format,
+                                        self.renderer_formats
+                                            .iter()
+                                            .filter(|f| f.code == current_format)
+                                            .map(|f| f.modifier),
+                                    ) {
+                                        tracing::warn!(?err, "failed to reset format");
+                                        continue;
+                                    }
+
+                                    render_elements.submit_composited_frame(&mut *compositor, renderer)?;
+                                }
+
+                                return Err(DrmOutputManagerError::Frame(err));
+                            }
+                        }
+                    }
+                }
+            }
+        };
 
         // Render once to lock in the primary plane with the chosen format (see
         // `initialize_output`).

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -924,6 +924,129 @@ impl AtomicDrmSurface {
         res
     }
 
+    /// Append this surface's scan-out state for the next frame into a shared
+    /// atomic request, without committing.
+    ///
+    /// Several surfaces driving CRTCs on the *same* device can append into one
+    /// request and then be committed together by [`commit_request`](Self::commit_request),
+    /// so they flip in a single atomic commit and stay frame-locked (used for
+    /// tiled outputs). `allow_modeset` selects a full modeset (mode blob +
+    /// connectors, like [`commit`](Self::commit)) over a page-flip (like
+    /// [`page_flip`](Self::page_flip)).
+    pub(in crate::backend::drm) fn append_to_request<'b>(
+        &self,
+        req: &mut AtomicModeReq,
+        planes: impl IntoIterator<Item = PlaneState<'b>>,
+        allow_modeset: bool,
+    ) -> Result<(), Error> {
+        if !self.active.load(Ordering::SeqCst) {
+            return Err(Error::DeviceInactive);
+        }
+
+        let mapping = self.prop_mapping.read().unwrap();
+
+        if allow_modeset {
+            let current = self.state.read().unwrap();
+            let pending = self.pending.read().unwrap();
+            for conn in &pending.connectors {
+                req_set_connector(&mapping, req, *conn, self.crtc)?;
+            }
+            for conn in current.connectors.difference(&pending.connectors) {
+                req_reset_connector(&mapping, req, *conn)?;
+            }
+            req_set_crtc(&mapping, req, self.crtc, Some(pending.blob), pending.vrr)?;
+        } else {
+            let vrr = self.state.read().unwrap().vrr;
+            req_set_crtc(&mapping, req, self.crtc, None, vrr)?;
+        }
+
+        let planes = planes.into_iter().collect::<Vec<_>>();
+        for plane in &planes {
+            req_set_plane(&mapping, req, self.crtc, plane)?;
+        }
+
+        // Track plane usage so a later `clear`/`reset_state` resets these planes.
+        // Done optimistically (before the shared commit): the set is only
+        // consulted when clearing, where an over-inclusive entry is harmless.
+        let mut used_planes = self.used_planes.lock().unwrap();
+        for plane in &planes {
+            if plane.config.is_some() {
+                used_planes.insert(plane.handle);
+            } else {
+                used_planes.remove(&plane.handle);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Commit a request previously assembled with [`append_to_request`](Self::append_to_request)
+    /// (from this and possibly other surfaces on the same device) as one atomic
+    /// commit. For a modeset it is validated with a `TEST_ONLY` commit first, as
+    /// a multi-CRTC commit can be rejected even when each CRTC passes alone.
+    pub(in crate::backend::drm) fn commit_request(
+        &self,
+        req: AtomicModeReq,
+        event: bool,
+        allow_modeset: bool,
+    ) -> Result<(), Error> {
+        if !self.active.load(Ordering::SeqCst) {
+            return Err(Error::DeviceInactive);
+        }
+
+        if allow_modeset {
+            if let Err(err) = self.fd.atomic_commit(
+                AtomicCommitFlags::ALLOW_MODESET | AtomicCommitFlags::TEST_ONLY,
+                req.clone(),
+            ) {
+                warn!("Tiled screen configuration invalid: {}", err);
+                return Err(Error::TestFailed(self.crtc));
+            }
+        }
+
+        // Commit synchronously (no NONBLOCK). A NONBLOCK commit spanning several
+        // CRTCs is rejected with EBUSY whenever they are not vblank-co-timed: the
+        // next combined flip is queued (on the primary CRTC's event) while
+        // another CRTC's previous flip is still pending. On a DisplayID-tiled
+        // output whose DP streams are not phase-locked at the source this happens
+        // on essentially every frame, so the async path is unusable here. A
+        // blocking commit lets the kernel apply all CRTCs together and serializes
+        // frames at vblank. (A non-blocking path would need per-CRTC flip-done
+        // tracking across the whole group.)
+        let mut flags = AtomicCommitFlags::empty();
+        if event {
+            flags |= AtomicCommitFlags::PAGE_FLIP_EVENT;
+        }
+        if allow_modeset {
+            flags |= AtomicCommitFlags::ALLOW_MODESET;
+        }
+
+        self.fd.atomic_commit(flags, req).map_err(|source| {
+            Error::Access(AccessError {
+                errmsg: "Failed to commit tiled atomic request",
+                dev: self.fd.dev_path(),
+                source,
+            })
+        })
+    }
+
+    /// Advance this surface's state after a successful tiled commit that
+    /// included it. A modeset makes `pending` current (so later frames page-flip
+    /// instead of re-running the modeset) and frees the previous mode blob.
+    pub(in crate::backend::drm) fn mark_request_submitted(&self, did_modeset: bool) {
+        if !did_modeset {
+            return;
+        }
+        let mut current = self.state.write().unwrap();
+        let pending = self.pending.read().unwrap();
+        if current.mode != pending.mode {
+            if let Err(err) = self.fd.destroy_property_blob(current.blob.into()) {
+                warn!("Failed to destroy old mode property blob: {}", err);
+            }
+        }
+        *current = pending.clone();
+    }
+
     // this helper function disconnects the plane.
     // this is mostly used to remove the contents quickly, e.g. on tty switch,
     // as other compositors might not make use of other planes,
@@ -1354,21 +1477,11 @@ impl<'a> AtomicRequest<'a> {
     }
 
     fn set_connector(&mut self, conn: connector::Handle, crtc: crtc::Handle) -> Result<(), Error> {
-        self.request.add_property(
-            conn,
-            self.mapping.conn_prop_handle(conn, "CRTC_ID")?,
-            property::Value::CRTC(Some(crtc)),
-        );
-        Ok(())
+        req_set_connector(self.mapping, &mut self.request, conn, crtc)
     }
 
     fn reset_connector(&mut self, conn: connector::Handle) -> Result<(), Error> {
-        self.request.add_property(
-            conn,
-            self.mapping.conn_prop_handle(conn, "CRTC_ID")?,
-            property::Value::CRTC(None),
-        );
-        Ok(())
+        req_reset_connector(self.mapping, &mut self.request, conn)
     }
 
     fn set_crtc(
@@ -1377,28 +1490,7 @@ impl<'a> AtomicRequest<'a> {
         mode: Option<property::Value<'static>>,
         vrr: bool,
     ) -> Result<(), Error> {
-        if let Some(blob) = mode {
-            self.request
-                .add_property(crtc, self.mapping.crtc_prop_handle(crtc, "MODE_ID")?, blob);
-        }
-
-        self.request.add_property(
-            crtc,
-            self.mapping.crtc_prop_handle(crtc, "ACTIVE")?,
-            property::Value::Boolean(true),
-        );
-
-        if let Ok(vrr_prop) = self.mapping.crtc_prop_handle(crtc, "VRR_ENABLED") {
-            self.request
-                .add_property(crtc, vrr_prop, property::Value::Boolean(vrr));
-        } else if vrr {
-            return Err(Error::UnknownProperty {
-                handle: crtc.into(),
-                name: "VRR_ENABLED",
-            });
-        }
-
-        Ok(())
+        req_set_crtc(self.mapping, &mut self.request, crtc, mode, vrr)
     }
 
     fn reset_crtc(&mut self, crtc: crtc::Handle) -> Result<(), Error> {
@@ -1420,202 +1512,11 @@ impl<'a> AtomicRequest<'a> {
     }
 
     fn set_plane(&mut self, crtc: crtc::Handle, plane_state: &PlaneState<'_>) -> Result<(), Error> {
-        let handle = plane_state.handle;
-        if let Some(config) = plane_state.config.as_ref() {
-            // connect the plane to the CRTC
-            self.request.add_property(
-                handle,
-                self.mapping.plane_prop_handle(handle, "CRTC_ID")?,
-                property::Value::CRTC(Some(crtc)),
-            );
-
-            // Set the fb for the plane
-            self.request.add_property(
-                handle,
-                self.mapping.plane_prop_handle(handle, "FB_ID")?,
-                property::Value::Framebuffer(Some(config.fb)),
-            );
-
-            self.request.add_property(
-                handle,
-                self.mapping.plane_prop_handle(handle, "SRC_X")?,
-                // these are 16.16. fixed point
-                property::Value::UnsignedRange(to_fixed(config.src.loc.x) as u64),
-            );
-            self.request.add_property(
-                handle,
-                self.mapping.plane_prop_handle(handle, "SRC_Y")?,
-                // these are 16.16. fixed point
-                property::Value::UnsignedRange(to_fixed(config.src.loc.y) as u64),
-            );
-            self.request.add_property(
-                handle,
-                self.mapping.plane_prop_handle(handle, "SRC_W")?,
-                // these are 16.16. fixed point
-                property::Value::UnsignedRange(to_fixed(config.src.size.w) as u64),
-            );
-            self.request.add_property(
-                handle,
-                self.mapping.plane_prop_handle(handle, "SRC_H")?,
-                // these are 16.16. fixed point
-                property::Value::UnsignedRange(to_fixed(config.src.size.h) as u64),
-            );
-
-            self.request.add_property(
-                handle,
-                self.mapping.plane_prop_handle(handle, "CRTC_X")?,
-                property::Value::SignedRange(config.dst.loc.x as i64),
-            );
-            self.request.add_property(
-                handle,
-                self.mapping.plane_prop_handle(handle, "CRTC_Y")?,
-                property::Value::SignedRange(config.dst.loc.y as i64),
-            );
-            self.request.add_property(
-                handle,
-                self.mapping.plane_prop_handle(handle, "CRTC_W")?,
-                property::Value::UnsignedRange(config.dst.size.w as u64),
-            );
-            self.request.add_property(
-                handle,
-                self.mapping.plane_prop_handle(handle, "CRTC_H")?,
-                property::Value::UnsignedRange(config.dst.size.h as u64),
-            );
-            if let Ok(prop) = self.mapping.plane_prop_handle(handle, "rotation") {
-                self.request.add_property(
-                    handle,
-                    prop,
-                    property::Value::Bitmask(DrmRotation::from(config.transform).bits() as u64),
-                );
-            } else if config.transform != Transform::Normal {
-                // if we are missing the rotation property we can no rely on
-                // the driver to report a non working configuration and can
-                // only guarantee that Transform::Normal (no rotation) will
-                // work
-                return Err(Error::UnknownProperty {
-                    handle: handle.into(),
-                    name: "rotation",
-                });
-            }
-            if let Ok(prop) = self.mapping.plane_prop_handle(handle, "alpha") {
-                self.request.add_property(
-                    handle,
-                    prop,
-                    property::Value::UnsignedRange((config.alpha * u16::MAX as f32).round() as u64),
-                );
-            } else if config.alpha != 1.0 {
-                // if we are missing the alpha property we can not display any transparent alpha values
-                return Err(Error::UnknownProperty {
-                    handle: handle.into(),
-                    name: "alpha",
-                });
-            }
-            if let Ok(prop) = self.mapping.plane_prop_handle(handle, "FB_DAMAGE_CLIPS") {
-                if let Some(damage) = config.damage_clips.as_ref() {
-                    self.request.add_property(handle, prop, *damage);
-                } else {
-                    self.request.add_property(handle, prop, property::Value::Blob(0));
-                }
-            }
-            if let Ok(prop) = self.mapping.plane_prop_handle(handle, "IN_FENCE_FD") {
-                if let Some(fence) = config.fence.as_ref().map(|f| f.as_raw_fd()) {
-                    self.request
-                        .add_property(handle, prop, property::Value::SignedRange(fence as i64));
-                } else {
-                    self.request
-                        .add_property(handle, prop, property::Value::SignedRange(-1));
-                }
-            } else if config.fence.is_some() {
-                return Err(Error::UnknownProperty {
-                    handle: handle.into(),
-                    name: "IN_FENCE_FD",
-                });
-            }
-        } else {
-            self.reset_plane(handle)?;
-        }
-
-        Ok(())
+        req_set_plane(self.mapping, &mut self.request, crtc, plane_state)
     }
 
     fn reset_plane(&mut self, plane: plane::Handle) -> Result<(), Error> {
-        self.request.add_property(
-            plane,
-            self.mapping.plane_prop_handle(plane, "CRTC_ID")?,
-            property::Value::CRTC(None),
-        );
-
-        self.request.add_property(
-            plane,
-            self.mapping.plane_prop_handle(plane, "FB_ID")?,
-            property::Value::Framebuffer(None),
-        );
-
-        // reset the plane properties
-        self.request.add_property(
-            plane,
-            self.mapping.plane_prop_handle(plane, "SRC_X")?,
-            // these are 16.16. fixed point
-            property::Value::UnsignedRange(0u64),
-        );
-        self.request.add_property(
-            plane,
-            self.mapping.plane_prop_handle(plane, "SRC_Y")?,
-            // these are 16.16. fixed point
-            property::Value::UnsignedRange(0u64),
-        );
-        self.request.add_property(
-            plane,
-            self.mapping.plane_prop_handle(plane, "SRC_W")?,
-            // these are 16.16. fixed point
-            property::Value::UnsignedRange(0u64),
-        );
-        self.request.add_property(
-            plane,
-            self.mapping.plane_prop_handle(plane, "SRC_H")?,
-            // these are 16.16. fixed point
-            property::Value::UnsignedRange(0u64),
-        );
-
-        self.request.add_property(
-            plane,
-            self.mapping.plane_prop_handle(plane, "CRTC_X")?,
-            property::Value::SignedRange(0i64),
-        );
-        self.request.add_property(
-            plane,
-            self.mapping.plane_prop_handle(plane, "CRTC_Y")?,
-            property::Value::SignedRange(0i64),
-        );
-        self.request.add_property(
-            plane,
-            self.mapping.plane_prop_handle(plane, "CRTC_W")?,
-            property::Value::UnsignedRange(0u64),
-        );
-        self.request.add_property(
-            plane,
-            self.mapping.plane_prop_handle(plane, "CRTC_H")?,
-            property::Value::UnsignedRange(0u64),
-        );
-        if let Ok(prop) = self.mapping.plane_prop_handle(plane, "rotation") {
-            self.request.add_property(
-                plane,
-                prop,
-                property::Value::Bitmask(DrmRotation::from(Transform::Normal).bits() as u64),
-            );
-        }
-        if let Ok(prop) = self.mapping.plane_prop_handle(plane, "alpha") {
-            self.request
-                .add_property(plane, prop, property::Value::UnsignedRange(0xffff));
-        }
-        if let Ok(prop) = self.mapping.plane_prop_handle(plane, "FB_DAMAGE_CLIPS") {
-            self.request.add_property(plane, prop, property::Value::Blob(0));
-        }
-        if let Ok(prop) = self.mapping.plane_prop_handle(plane, "IN_FENCE_FD") {
-            self.request
-                .add_property(plane, prop, property::Value::SignedRange(-1));
-        }
-        Ok(())
+        req_reset_plane(self.mapping, &mut self.request, plane)
     }
 
     fn build(&self) -> Result<AtomicModeReq, Error> {
@@ -1660,4 +1561,255 @@ impl<'a> AtomicRequest<'a> {
 
         Ok(req)
     }
+}
+
+// The property-emitting logic below is shared between the per-surface
+// `AtomicRequest` (release builds delegate to it) and the multi-surface tiled
+// commit, which appends several CRTCs' state into one `AtomicModeReq`. It
+// resolves property handles through `mapping` — which, on a single device, is
+// the same `Arc<RwLock<PropMapping>>` for every surface and covers all objects,
+// so one request can carry every tile's properties.
+
+fn req_set_connector(
+    mapping: &PropMapping,
+    req: &mut AtomicModeReq,
+    conn: connector::Handle,
+    crtc: crtc::Handle,
+) -> Result<(), Error> {
+    req.add_property(
+        conn,
+        mapping.conn_prop_handle(conn, "CRTC_ID")?,
+        property::Value::CRTC(Some(crtc)),
+    );
+    Ok(())
+}
+
+fn req_reset_connector(
+    mapping: &PropMapping,
+    req: &mut AtomicModeReq,
+    conn: connector::Handle,
+) -> Result<(), Error> {
+    req.add_property(
+        conn,
+        mapping.conn_prop_handle(conn, "CRTC_ID")?,
+        property::Value::CRTC(None),
+    );
+    Ok(())
+}
+
+fn req_set_crtc(
+    mapping: &PropMapping,
+    req: &mut AtomicModeReq,
+    crtc: crtc::Handle,
+    mode: Option<property::Value<'static>>,
+    vrr: bool,
+) -> Result<(), Error> {
+    if let Some(blob) = mode {
+        req.add_property(crtc, mapping.crtc_prop_handle(crtc, "MODE_ID")?, blob);
+    }
+
+    req.add_property(
+        crtc,
+        mapping.crtc_prop_handle(crtc, "ACTIVE")?,
+        property::Value::Boolean(true),
+    );
+
+    if let Ok(vrr_prop) = mapping.crtc_prop_handle(crtc, "VRR_ENABLED") {
+        req.add_property(crtc, vrr_prop, property::Value::Boolean(vrr));
+    } else if vrr {
+        return Err(Error::UnknownProperty {
+            handle: crtc.into(),
+            name: "VRR_ENABLED",
+        });
+    }
+
+    Ok(())
+}
+
+fn req_set_plane(
+    mapping: &PropMapping,
+    req: &mut AtomicModeReq,
+    crtc: crtc::Handle,
+    plane_state: &PlaneState<'_>,
+) -> Result<(), Error> {
+    let handle = plane_state.handle;
+    if let Some(config) = plane_state.config.as_ref() {
+        // connect the plane to the CRTC
+        req.add_property(
+            handle,
+            mapping.plane_prop_handle(handle, "CRTC_ID")?,
+            property::Value::CRTC(Some(crtc)),
+        );
+        // Set the fb for the plane
+        req.add_property(
+            handle,
+            mapping.plane_prop_handle(handle, "FB_ID")?,
+            property::Value::Framebuffer(Some(config.fb)),
+        );
+        // these are 16.16. fixed point
+        req.add_property(
+            handle,
+            mapping.plane_prop_handle(handle, "SRC_X")?,
+            property::Value::UnsignedRange(to_fixed(config.src.loc.x) as u64),
+        );
+        req.add_property(
+            handle,
+            mapping.plane_prop_handle(handle, "SRC_Y")?,
+            property::Value::UnsignedRange(to_fixed(config.src.loc.y) as u64),
+        );
+        req.add_property(
+            handle,
+            mapping.plane_prop_handle(handle, "SRC_W")?,
+            property::Value::UnsignedRange(to_fixed(config.src.size.w) as u64),
+        );
+        req.add_property(
+            handle,
+            mapping.plane_prop_handle(handle, "SRC_H")?,
+            property::Value::UnsignedRange(to_fixed(config.src.size.h) as u64),
+        );
+
+        req.add_property(
+            handle,
+            mapping.plane_prop_handle(handle, "CRTC_X")?,
+            property::Value::SignedRange(config.dst.loc.x as i64),
+        );
+        req.add_property(
+            handle,
+            mapping.plane_prop_handle(handle, "CRTC_Y")?,
+            property::Value::SignedRange(config.dst.loc.y as i64),
+        );
+        req.add_property(
+            handle,
+            mapping.plane_prop_handle(handle, "CRTC_W")?,
+            property::Value::UnsignedRange(config.dst.size.w as u64),
+        );
+        req.add_property(
+            handle,
+            mapping.plane_prop_handle(handle, "CRTC_H")?,
+            property::Value::UnsignedRange(config.dst.size.h as u64),
+        );
+        if let Ok(prop) = mapping.plane_prop_handle(handle, "rotation") {
+            req.add_property(
+                handle,
+                prop,
+                property::Value::Bitmask(DrmRotation::from(config.transform).bits() as u64),
+            );
+        } else if config.transform != Transform::Normal {
+            // if we are missing the rotation property we can no rely on
+            // the driver to report a non working configuration and can
+            // only guarantee that Transform::Normal (no rotation) will
+            // work
+            return Err(Error::UnknownProperty {
+                handle: handle.into(),
+                name: "rotation",
+            });
+        }
+        if let Ok(prop) = mapping.plane_prop_handle(handle, "alpha") {
+            req.add_property(
+                handle,
+                prop,
+                property::Value::UnsignedRange((config.alpha * u16::MAX as f32).round() as u64),
+            );
+        } else if config.alpha != 1.0 {
+            // if we are missing the alpha property we can not display any transparent alpha values
+            return Err(Error::UnknownProperty {
+                handle: handle.into(),
+                name: "alpha",
+            });
+        }
+        if let Ok(prop) = mapping.plane_prop_handle(handle, "FB_DAMAGE_CLIPS") {
+            if let Some(damage) = config.damage_clips.as_ref() {
+                req.add_property(handle, prop, *damage);
+            } else {
+                req.add_property(handle, prop, property::Value::Blob(0));
+            }
+        }
+        if let Ok(prop) = mapping.plane_prop_handle(handle, "IN_FENCE_FD") {
+            if let Some(fence) = config.fence.as_ref().map(|f| f.as_raw_fd()) {
+                req.add_property(handle, prop, property::Value::SignedRange(fence as i64));
+            } else {
+                req.add_property(handle, prop, property::Value::SignedRange(-1));
+            }
+        } else if config.fence.is_some() {
+            return Err(Error::UnknownProperty {
+                handle: handle.into(),
+                name: "IN_FENCE_FD",
+            });
+        }
+    } else {
+        req_reset_plane(mapping, req, handle)?;
+    }
+
+    Ok(())
+}
+
+fn req_reset_plane(mapping: &PropMapping, req: &mut AtomicModeReq, plane: plane::Handle) -> Result<(), Error> {
+    req.add_property(
+        plane,
+        mapping.plane_prop_handle(plane, "CRTC_ID")?,
+        property::Value::CRTC(None),
+    );
+    req.add_property(
+        plane,
+        mapping.plane_prop_handle(plane, "FB_ID")?,
+        property::Value::Framebuffer(None),
+    );
+    // these are 16.16. fixed point
+    req.add_property(
+        plane,
+        mapping.plane_prop_handle(plane, "SRC_X")?,
+        property::Value::UnsignedRange(0u64),
+    );
+    req.add_property(
+        plane,
+        mapping.plane_prop_handle(plane, "SRC_Y")?,
+        property::Value::UnsignedRange(0u64),
+    );
+    req.add_property(
+        plane,
+        mapping.plane_prop_handle(plane, "SRC_W")?,
+        property::Value::UnsignedRange(0u64),
+    );
+    req.add_property(
+        plane,
+        mapping.plane_prop_handle(plane, "SRC_H")?,
+        property::Value::UnsignedRange(0u64),
+    );
+    req.add_property(
+        plane,
+        mapping.plane_prop_handle(plane, "CRTC_X")?,
+        property::Value::SignedRange(0i64),
+    );
+    req.add_property(
+        plane,
+        mapping.plane_prop_handle(plane, "CRTC_Y")?,
+        property::Value::SignedRange(0i64),
+    );
+    req.add_property(
+        plane,
+        mapping.plane_prop_handle(plane, "CRTC_W")?,
+        property::Value::UnsignedRange(0u64),
+    );
+    req.add_property(
+        plane,
+        mapping.plane_prop_handle(plane, "CRTC_H")?,
+        property::Value::UnsignedRange(0u64),
+    );
+    if let Ok(prop) = mapping.plane_prop_handle(plane, "rotation") {
+        req.add_property(
+            plane,
+            prop,
+            property::Value::Bitmask(DrmRotation::from(Transform::Normal).bits() as u64),
+        );
+    }
+    if let Ok(prop) = mapping.plane_prop_handle(plane, "alpha") {
+        req.add_property(plane, prop, property::Value::UnsignedRange(0xffff));
+    }
+    if let Ok(prop) = mapping.plane_prop_handle(plane, "FB_DAMAGE_CLIPS") {
+        req.add_property(plane, prop, property::Value::Blob(0));
+    }
+    if let Ok(prop) = mapping.plane_prop_handle(plane, "IN_FENCE_FD") {
+        req.add_property(plane, prop, property::Value::SignedRange(-1));
+    }
+    Ok(())
 }

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -1743,7 +1743,11 @@ fn req_set_plane(
     Ok(())
 }
 
-fn req_reset_plane(mapping: &PropMapping, req: &mut AtomicModeReq, plane: plane::Handle) -> Result<(), Error> {
+fn req_reset_plane(
+    mapping: &PropMapping,
+    req: &mut AtomicModeReq,
+    plane: plane::Handle,
+) -> Result<(), Error> {
     req.add_property(
         plane,
         mapping.plane_prop_handle(plane, "CRTC_ID")?,

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use drm::Device as BasicDevice;
+use drm::control::atomic::AtomicModeReq;
 use drm::control::{Device as ControlDevice, Mode, connector, crtc, framebuffer, plane};
 
 use libc::dev_t;
@@ -436,6 +437,56 @@ impl DrmSurface {
                 let fb = ensure_legacy_planes(self, planes)?;
                 surf.page_flip(fb, event)
             }
+        }
+    }
+
+    /// Append this surface's scan-out state for the next frame into a shared
+    /// atomic request, without committing it.
+    ///
+    /// Several surfaces driving CRTCs on the **same** device can append into one
+    /// request and be committed together by [`commit_request`](DrmSurface::commit_request),
+    /// so they flip in a single atomic commit and stay frame-locked — this is how
+    /// a tiled output ([`DrmCompositor::new_tiled`](crate::backend::drm::compositor::DrmCompositor::new_tiled))
+    /// drives its CRTCs. `allow_modeset` selects a full modeset over a page-flip.
+    ///
+    /// Only supported on the atomic API; returns [`Error::AtomicUnsupported`] for
+    /// legacy devices.
+    pub(crate) fn append_to_request<'b>(
+        &self,
+        req: &mut AtomicModeReq,
+        planes: impl IntoIterator<Item = PlaneState<'b>>,
+        allow_modeset: bool,
+    ) -> Result<(), Error> {
+        match &*self.internal {
+            DrmSurfaceInternal::Atomic(surf) => surf.append_to_request(req, planes, allow_modeset),
+            DrmSurfaceInternal::Legacy(_) => Err(Error::AtomicUnsupported),
+        }
+    }
+
+    /// Commit a request assembled with [`append_to_request`](DrmSurface::append_to_request)
+    /// (possibly from several surfaces on this device) as one atomic commit.
+    ///
+    /// `event` requests a page-flip event; `allow_modeset` permits (and, for a
+    /// multi-CRTC request, first test-commits) a modeset. Only supported on the
+    /// atomic API.
+    pub(crate) fn commit_request(
+        &self,
+        req: AtomicModeReq,
+        event: bool,
+        allow_modeset: bool,
+    ) -> Result<(), Error> {
+        match &*self.internal {
+            DrmSurfaceInternal::Atomic(surf) => surf.commit_request(req, event, allow_modeset),
+            DrmSurfaceInternal::Legacy(_) => Err(Error::AtomicUnsupported),
+        }
+    }
+
+    /// Advance this surface's state after a successful commit that included a
+    /// request it contributed to via [`append_to_request`](DrmSurface::append_to_request).
+    /// A no-op on legacy devices and for non-modeset commits.
+    pub(crate) fn mark_request_submitted(&self, did_modeset: bool) {
+        if let DrmSurfaceInternal::Atomic(surf) = &*self.internal {
+            surf.mark_request_submitted(did_modeset);
         }
     }
 

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -8,6 +8,7 @@ use drm::control::atomic::AtomicModeReq;
 use drm::control::{Device as ControlDevice, Mode, connector, crtc, framebuffer, plane};
 
 use libc::dev_t;
+use smallvec::SmallVec;
 
 pub(super) mod atomic;
 #[cfg(feature = "backend_gbm")]
@@ -188,6 +189,62 @@ impl BasicDevice for DrmSurface {}
 impl ControlDevice for DrmSurface {}
 
 impl DrmSurface {
+    /// Start assembling one atomic commit that includes this surface.
+    ///
+    /// The returned [`DrmAtomicCommit`] owns the atomic request and records this
+    /// surface as the primary one used to submit it. Additional surfaces can be
+    /// appended with [`DrmAtomicCommit::add_surface`]; all appended surfaces are
+    /// marked as submitted only if [`DrmAtomicCommit::commit`] succeeds.
+    ///
+    /// Callers must serialize commits, page-flips, and pending-state changes for
+    /// all participating surfaces while the [`DrmAtomicCommit`] is alive.
+    ///
+    /// Only supported on the atomic API; returns [`Error::AtomicUnsupported`] for
+    /// legacy surfaces.
+    ///
+    /// ```no_run
+    /// # use smithay::backend::drm::{DrmSurface, PlaneState};
+    /// # fn queue_atomic_commit<'a>(
+    /// #     surface_a: &'a DrmSurface,
+    /// #     planes_a: Vec<PlaneState<'a>>,
+    /// #     surface_b: &'a DrmSurface,
+    /// #     planes_b: Vec<PlaneState<'a>>,
+    /// # ) -> Result<(), smithay::backend::drm::DrmError> {
+    /// let mut commit = surface_a.begin_atomic_commit(planes_a, true, false)?;
+    /// commit.add_surface(surface_b, planes_b)?;
+    /// commit.commit()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```no_run
+    /// # use smithay::backend::drm::{DrmSurface, PlaneState};
+    /// # fn rollback_atomic_commit<'a>(
+    /// #     surface_a: &'a DrmSurface,
+    /// #     planes_a: Vec<PlaneState<'a>>,
+    /// # ) -> Result<(), smithay::backend::drm::DrmError> {
+    /// let commit = surface_a.begin_atomic_commit(planes_a, false, true)?;
+    /// commit.rollback();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn begin_atomic_commit<'a, 'b>(
+        &'a self,
+        planes: impl IntoIterator<Item = PlaneState<'b>>,
+        event: bool,
+        allow_modeset: bool,
+    ) -> Result<DrmAtomicCommit<'a>, Error> {
+        let mut commit = DrmAtomicCommit {
+            primary: self,
+            contributors: SmallVec::new(),
+            req: AtomicModeReq::new(),
+            event,
+            allow_modeset,
+        };
+        commit.add_surface(self, planes)?;
+        Ok(commit)
+    }
+
     /// Returns the underlying [`DrmDeviceFd`]
     pub fn device_fd(&self) -> &DrmDeviceFd {
         match &*self.internal {
@@ -551,6 +608,63 @@ impl DrmSurface {
             DrmSurfaceInternal::Legacy(surf) => surf.clear(),
         }
     }
+}
+
+/// A shared atomic commit assembled from one or more [`DrmSurface`]s.
+///
+/// A `DrmAtomicCommit` starts from a primary surface via
+/// [`DrmSurface::begin_atomic_commit`]. The primary surface is included in the
+/// request immediately and is later used to submit the request. Additional
+/// same-device surfaces can be appended with [`add_surface`](Self::add_surface).
+///
+/// This type encodes the request lifecycle: callers can append surfaces, then
+/// either [`commit`](Self::commit) the request or [`rollback`](Self::rollback)
+/// it. Successful commits advance the submitted state of all participating
+/// surfaces; dropped or rolled-back commits do not.
+///
+/// Callers must serialize commits, page-flips, and pending-state changes for all
+/// participating surfaces while the `DrmAtomicCommit` is alive.
+#[derive(Debug)]
+pub struct DrmAtomicCommit<'a> {
+    primary: &'a DrmSurface,
+    contributors: SmallVec<[&'a DrmSurface; 4]>,
+    req: AtomicModeReq,
+    event: bool,
+    allow_modeset: bool,
+}
+
+impl<'a> DrmAtomicCommit<'a> {
+    /// Append another surface's scan-out state to this atomic commit.
+    ///
+    /// The surface must belong to the same DRM device as the primary surface.
+    /// It is recorded as a contributor only after its state has been appended
+    /// successfully.
+    pub fn add_surface<'b>(
+        &mut self,
+        surface: &'a DrmSurface,
+        planes: impl IntoIterator<Item = PlaneState<'b>>,
+    ) -> Result<(), Error> {
+        if surface.device_fd().dev_path() != self.primary.device_fd().dev_path() {
+            return Err(Error::AtomicDeviceMismatch);
+        }
+
+        surface.append_to_request(&mut self.req, planes, self.allow_modeset)?;
+        self.contributors.push(surface);
+        Ok(())
+    }
+
+    /// Commit the assembled request through the primary surface.
+    pub fn commit(self) -> Result<(), Error> {
+        self.primary
+            .commit_request(self.req, self.event, self.allow_modeset)?;
+        for surface in self.contributors {
+            surface.mark_request_submitted(self.allow_modeset);
+        }
+        Ok(())
+    }
+
+    /// Abandon the assembled request without committing it.
+    pub fn rollback(self) {}
 }
 
 fn ensure_legacy_planes<'a>(

--- a/src/backend/renderer/element/utils/elements.rs
+++ b/src/backend/renderer/element/utils/elements.rs
@@ -349,6 +349,11 @@ impl<E: Element> RelocateRenderElement<E> {
             relocate,
         }
     }
+
+    /// The wrapped element, without this wrapper's relocation applied.
+    pub(crate) fn inner(&self) -> &E {
+        &self.element
+    }
 }
 
 impl<E: Element> Element for RelocateRenderElement<E> {


### PR DESCRIPTION
Some high-res monitors can't fit their full resolution down a single cable, so they present as several DRM connectors, one per tile, each carrying a slice of the image. The connectors share a DisplayID Tile Topology block describing how the tiles fit together (the LG UltraFine 5K and Dell UP2715K are the common ones).

This drives such a monitor as a single logical output. The tiles sit on separate CRTCs but page-flip together in one atomic commit, so they stay frame-locked. The primary tile's vblank stands in for the whole group.

The pieces:

- `DrmDevice::tile_info` reads a connector's `TILE` property into a `TileInfo`. Connectors sharing a `group_id` belong to the same monitor.
- `DrmCompositor::new_tiled` drives N CRTCs as one logical output. It's a general primitive (a single-GPU video wall qualifies too), so it takes geometry as a `TilePlacement` per CRTC rather than `TileInfo` directly. All surfaces must live on one device so they can share the atomic commit.
- `DrmOutputManager::initialize_tiled_output` wraps that as one `DrmOutput`, keyed by the primary tile's CRTC.

Each tile renders its slice of the logical scene into its own framebuffer. The relocation offset is derived through the output transform, so it stays correct under rotation and flip. That part is pure geometry and unit-tested across all eight transforms.

Exercised on a real LG UltraFine 5K over its two DisplayPort streams (via cosmic-comp): display, live rotation, and screencopy all work.

Making use of this requires changes to `cosmic-comp` to read the `TileInfo` and using `new_tiled`. This is deliberate, since `cosmic-comp` needs to present this correctly to the user in settings.

I have prepared the `cosmic-comp` changes, but will keep that PR away until we settled the smithay side. It needs tidying up before PR, but for reference, here it is: https://github.com/pop-os/cosmic-comp/compare/master...algesten:cosmic-comp:tiled-output

Close #2034

* [x] I have used AI in working out this solution. I have carefully reviewed the code presented.
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
