### PR TITLE
xwm: Support _GTK_FRAME_EXTENTS and _KDE_NET_WM_SHADOW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,9 @@ The `delegate_*!` macros have been replaced with a single `delegate_dispatch2!` 
 of new `Dipsatch2` and `GlobalDispatch2` traits. These will replace `Dispatch` and `GlobalDispatch` in a future version of
 `wayland_server`.
 
+The `SpaceElement::geometry` impl for `X11Surface` is no longer equivalent to its bbox.  For clients that set
+`_GTK_FRAME_EXTENTS`, the shadow extents are subtracted from the bbox to give the geometry.
+
 ### Additions
 
 - ExtBackgroundEffect protocol is now available in `smithay::wayland::background_effect` module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,9 @@ of new `Dipsatch2` and `GlobalDispatch2` traits. These will replace `Dispatch` a
 The `SpaceElement::geometry` impl for `X11Surface` is no longer equivalent to its bbox.  For clients that set
 `_GTK_FRAME_EXTENTS`, the shadow extents are subtracted from the bbox to give the geometry.
 
+`X11Surface::geometry` has been renamed to `X11Surface::last_configure`. `X11Surface::geometry` now returns the bounding
+box minus the surface's frame extents.
+
 ### Additions
 
 - ExtBackgroundEffect protocol is now available in `smithay::wayland::background_effect` module.

--- a/anvil/src/shell/x11.rs
+++ b/anvil/src/shell/x11.rs
@@ -72,7 +72,7 @@ impl<BackendData: Backend> XwmHandler for AnvilState<BackendData> {
     }
 
     fn mapped_override_redirect_window(&mut self, _xwm: XwmId, window: X11Surface) {
-        let location = window.geometry().loc;
+        let location = window.last_configure().loc;
         let window = WindowElement(Window::new_x11_window(window));
         self.space.map_element(window, location, true);
     }
@@ -104,7 +104,7 @@ impl<BackendData: Backend> XwmHandler for AnvilState<BackendData> {
         _reorder: Option<Reorder>,
     ) {
         // we just set the new size, but don't let windows move themselves around freely
-        let mut geo = window.geometry();
+        let mut geo = window.last_configure();
         if let Some(w) = w {
             geo.size.w = w as i32;
         }

--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -5,11 +5,9 @@ use crate::{
             Kind,
             surface::{WaylandSurfaceRenderElement, render_elements_from_surface_tree},
         },
-        utils::RendererSurfaceStateUserData,
     },
     desktop::{WindowSurfaceType, space::SpaceElement},
     utils::{Logical, Physical, Point, Rectangle, Scale},
-    wayland::compositor,
     xwayland::X11Surface,
 };
 
@@ -17,23 +15,11 @@ use super::{WindowOutputUserData, output_update};
 
 impl SpaceElement for X11Surface {
     fn bbox(&self) -> Rectangle<i32, Logical> {
-        let size = X11Surface::wl_surface(self)
-            .and_then(|surface| {
-                compositor::with_states(&surface, |states| {
-                    states
-                        .data_map
-                        .get::<RendererSurfaceStateUserData>()
-                        .and_then(|s| s.lock().unwrap().surface_size())
-                })
-            })
-            .unwrap_or_else(|| X11Surface::geometry(self).size);
-        Rectangle::from_size(size)
+        X11Surface::bbox(self)
     }
 
     fn geometry(&self) -> Rectangle<i32, Logical> {
-        let bbox = SpaceElement::bbox(self);
-        let frame_extents = self.frame_extents();
-        bbox - frame_extents
+        X11Surface::geometry(self)
     }
 
     fn is_in_input_region(&self, point: &Point<f64, Logical>) -> bool {

--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -30,6 +30,12 @@ impl SpaceElement for X11Surface {
         Rectangle::from_size(size)
     }
 
+    fn geometry(&self) -> Rectangle<i32, Logical> {
+        let bbox = SpaceElement::bbox(self);
+        let frame_extents = self.frame_extents();
+        bbox - frame_extents
+    }
+
     fn is_in_input_region(&self, point: &Point<f64, Logical>) -> bool {
         X11Surface::surface_under(self, *point, (0, 0), WindowSurfaceType::all()).is_some()
     }

--- a/src/desktop/wayland/window.rs
+++ b/src/desktop/wayland/window.rs
@@ -227,21 +227,23 @@ impl Window {
 
     /// Returns the geometry of this window.
     pub fn geometry(&self) -> Rectangle<i32, Logical> {
-        let bbox = self.bbox();
+        match self.underlying_surface() {
+            WindowSurface::Wayland(s) => {
+                let bbox = self.bbox();
+                // It's the set geometry clamped to the bounding box with the full bounding box as the fallback.
+                with_states(s.wl_surface(), |states| {
+                    states
+                        .cached_state
+                        .get::<SurfaceCachedState>()
+                        .current()
+                        .geometry
+                        .and_then(|geo| geo.intersection(bbox))
+                })
+                .unwrap_or(bbox)
+            }
 
-        if let Some(surface) = self.wl_surface() {
-            // It's the set geometry clamped to the bounding box with the full bounding box as the fallback.
-            with_states(&surface, |states| {
-                states
-                    .cached_state
-                    .get::<SurfaceCachedState>()
-                    .current()
-                    .geometry
-                    .and_then(|geo| geo.intersection(bbox))
-            })
-            .unwrap_or(bbox)
-        } else {
-            bbox
+            #[cfg(feature = "xwayland")]
+            WindowSurface::X11(s) => SpaceElement::geometry(s),
         }
     }
 

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -1708,6 +1708,161 @@ impl<N: Default, Kind> Default for Rectangle<N, Kind> {
     }
 }
 
+/// Extra pixels around a window/surface, such as for a decorations frame or drop shadow
+#[repr(C)]
+pub struct FrameExtents<N, Kind> {
+    /// Frame pixels on the left
+    pub left: N,
+    /// Frame pixels on the right
+    pub right: N,
+    /// Frame pixels on top
+    pub top: N,
+    /// Frame pixels on the bottom
+    pub bottom: N,
+    _kind: std::marker::PhantomData<Kind>,
+}
+
+impl<N, Kind> FrameExtents<N, Kind> {
+    /// Create a new FrameExtents
+    pub const fn new(left: N, right: N, top: N, bottom: N) -> Self {
+        Self {
+            left,
+            right,
+            top,
+            bottom,
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<N: Coordinate, Kind> FrameExtents<N, Kind> {
+    /// Convert the underlying numerical type to f64 for floating point manipulations
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn to_f64(self) -> FrameExtents<f64, Kind> {
+        FrameExtents {
+            left: self.left.to_f64(),
+            right: self.right.to_f64(),
+            top: self.top.to_f64(),
+            bottom: self.bottom.to_f64(),
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<N: Coordinate> FrameExtents<N, Physical> {
+    /// Convert this physical rectangle to logical coordinate space according to given scale factor
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn to_logical(&self, scale: impl Into<Scale<N>>) -> FrameExtents<N, Logical> {
+        let scale = scale.into();
+        FrameExtents {
+            left: self.left.downscale(scale.x),
+            right: self.right.downscale(scale.x),
+            top: self.top.downscale(scale.y),
+            bottom: self.bottom.downscale(scale.y),
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<Kind> FrameExtents<f64, Kind> {
+    /// Convert to i32 for integer-space manipulations by rounding float values
+    #[inline]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn to_i32_round<N: Coordinate>(self) -> FrameExtents<N, Kind> {
+        FrameExtents {
+            left: N::from_f64(self.left.round()),
+            right: N::from_f64(self.right.round()),
+            top: N::from_f64(self.top.round()),
+            bottom: N::from_f64(self.bottom.round()),
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<N: Default, Kind> Default for FrameExtents<N, Kind> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            left: N::default(),
+            right: N::default(),
+            top: N::default(),
+            bottom: N::default(),
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<N: fmt::Debug, S> fmt::Debug for FrameExtents<N, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("FrameExtents<{}>", std::any::type_name::<S>()))?;
+        f.debug_struct("")
+            .field("left", &self.left)
+            .field("right", &self.right)
+            .field("top", &self.top)
+            .field("bottom", &self.bottom)
+            .finish()
+    }
+}
+
+impl<N: Clone, Kind> Clone for FrameExtents<N, Kind> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            left: self.left.clone(),
+            right: self.right.clone(),
+            top: self.top.clone(),
+            bottom: self.bottom.clone(),
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<N: Copy, Kind> Copy for FrameExtents<N, Kind> {}
+
+impl<N: PartialEq, Kind> PartialEq for FrameExtents<N, Kind> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.left == other.left
+            && self.right == other.right
+            && self.top == other.top
+            && self.bottom == other.bottom
+    }
+}
+
+impl<N: Eq, Kind> Eq for FrameExtents<N, Kind> {}
+
+impl<N: Coordinate, Kind> Add<FrameExtents<N, Kind>> for Rectangle<N, Kind> {
+    type Output = Rectangle<N, Kind>;
+
+    fn add(self, rhs: FrameExtents<N, Kind>) -> Self::Output {
+        Rectangle::new(
+            (self.loc.x - rhs.left, self.loc.y - rhs.top).into(),
+            (
+                (self.size.w + rhs.left + rhs.right).max(N::ZERO),
+                (self.size.h + rhs.top + rhs.bottom).max(N::ZERO),
+            )
+                .into(),
+        )
+    }
+}
+
+impl<N: Coordinate, Kind> Sub<FrameExtents<N, Kind>> for Rectangle<N, Kind> {
+    type Output = Rectangle<N, Kind>;
+
+    fn sub(self, rhs: FrameExtents<N, Kind>) -> Self::Output {
+        Rectangle::new(
+            (self.loc.x + rhs.left, self.loc.y + rhs.top).into(),
+            (
+                (self.size.w - rhs.left - rhs.right).max(N::ZERO),
+                (self.size.h - rhs.top - rhs.bottom).max(N::ZERO),
+            )
+                .into(),
+        )
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 /// Possible transformations to two-dimensional planes
 #[derive(Default)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -24,7 +24,7 @@ pub use sealed_file::SealedFile;
 #[cfg(feature = "wayland_frontend")]
 pub(crate) use self::geometry::Client;
 pub use self::geometry::{
-    Buffer, Coordinate, Logical, Physical, Point, Raw, Rectangle, Scale, Size, Transform,
+    Buffer, Coordinate, FrameExtents, Logical, Physical, Point, Raw, Rectangle, Scale, Size, Transform,
 };
 
 mod serial;

--- a/src/xwayland/xwm/dnd.rs
+++ b/src/xwayland/xwm/dnd.rs
@@ -339,7 +339,7 @@ impl XWmDnd {
                     .take()
                     .or(pos_update.then_some(offer_state.last_pos))
                 {
-                    let location = (window.geometry().loc + pos.to_i32_round())
+                    let location = (window.last_configure().loc + pos.to_i32_round())
                         .to_client_precise_round::<_, i32>(client_scale.load(Ordering::Acquire));
 
                     let data = [
@@ -1098,7 +1098,7 @@ impl<D: XwmHandler + SeatHandler> DndFocus<D> for X11Surface {
 
         let Some(xwm_id) = self.xwm_id() else { return };
         let xwm = data.xwm_state(xwm_id);
-        let location = (self.geometry().loc + location.to_i32_round())
+        let location = (self.last_configure().loc + location.to_i32_round())
             .to_client_precise_round::<_, i32>(xwm.client_scale.load(Ordering::Acquire));
 
         let data = [

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1790,7 +1790,7 @@ where
                 );
             } else if let Some(surface) = xwm.windows.iter().find(|x| x.window_id() == n.window).cloned() {
                 if surface.is_override_redirect() {
-                    surface.state.lock().unwrap().geometry = geometry;
+                    surface.state.lock().unwrap().last_configure = geometry;
                     drop(_guard);
                     state.configure_notify(
                         xwm_id,
@@ -1833,8 +1833,8 @@ where
                         conn.reparent_window(
                             n.window,
                             xwm.screen.root,
-                            state.geometry.loc.x as i16,
-                            state.geometry.loc.y as i16,
+                            state.last_configure.loc.x as i16,
+                            state.last_configure.loc.y as i16,
                         )?;
                         if let Some(frame) = state.mapped_onto.take() {
                             conn.destroy_window(frame)?;

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -235,6 +235,7 @@ mod atoms {
             _NET_WM_OPAQUE_REGION,
             _MOTIF_WM_HINTS,
             _NET_STARTUP_ID,
+            _GTK_FRAME_EXTENTS,
 
             // server -> client
             WM_S0,
@@ -900,6 +901,7 @@ impl X11Wm {
             atoms._NET_SHOWING_DESKTOP,
             atoms._NET_WM_OPAQUE_REGION,
             atoms._NET_WM_PING,
+            atoms._GTK_FRAME_EXTENTS,
         ];
         let net_supported = if sync_supported {
             net_supported_base

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -10,7 +10,10 @@ use crate::{
         },
         touch::TouchTarget,
     },
-    utils::{Client, HookId, IsAlive, Logical, Physical, Rectangle, Serial, Size, user_data::UserDataMap},
+    utils::{
+        Client, FrameExtents, HookId, IsAlive, Logical, Physical, Rectangle, Serial, Size,
+        user_data::UserDataMap,
+    },
     wayland::{
         compositor::{self, RectangleKind, RegionAttributes, SurfaceAttributes},
         seat::{WaylandFocus, keyboard::enter_internal},
@@ -127,6 +130,7 @@ pub(crate) struct SharedSurfaceState {
     pub(super) wl_surface_serial: Option<u64>,
     pub(super) mapped_onto: Option<X11Window>,
     pub(super) geometry: Rectangle<i32, Logical>,
+    frame_extents: FrameExtents<i32, Physical>,
     pub(super) override_redirect: bool,
 
     // The associated wl_surface.
@@ -351,6 +355,7 @@ impl X11Surface {
                 buffered_geometry: None,
                 mapped_onto: None,
                 geometry,
+                frame_extents: Default::default(),
                 override_redirect,
                 title: String::from(""),
                 class: String::from(""),
@@ -1463,6 +1468,7 @@ impl X11Surface {
             )?;
             state.opaque_region_dirty = false;
         }
+        self.update_toolkit_frame_extents()?;
         Ok(())
     }
 
@@ -1516,6 +1522,10 @@ impl X11Surface {
                 let mut state = self.state.lock().unwrap();
                 state.opaque_region = None;
                 state.opaque_region_dirty = true;
+                Ok(None)
+            }
+            atom if atom == self.atoms._GTK_FRAME_EXTENTS => {
+                self.update_toolkit_frame_extents()?;
                 Ok(None)
             }
 
@@ -1614,6 +1624,55 @@ impl X11Surface {
             state.opacity = Some(opacity);
         }
         Ok(())
+    }
+
+    fn fetch_gtk_frame_extents(&self) -> Result<Option<FrameExtents<i32, Physical>>, ConnectionError> {
+        let conn = self.conn.upgrade().ok_or(ConnectionError::UnknownError)?;
+        conn.get_property(
+            false,
+            self.window,
+            self.atoms._GTK_FRAME_EXTENTS,
+            AtomEnum::CARDINAL,
+            0,
+            4,
+        )?
+        .reply_unchecked()
+        .map(|reply| {
+            reply.and_then(|reply| {
+                reply.value32().and_then(|mut values| {
+                    Some(FrameExtents::new(
+                        (values.next()? as i32).max(0),
+                        (values.next()? as i32).max(0),
+                        (values.next()? as i32).max(0),
+                        (values.next()? as i32).max(0),
+                    ))
+                })
+            })
+        })
+    }
+
+    fn update_toolkit_frame_extents(&self) -> Result<(), ConnectionError> {
+        let frame_extents = self.fetch_gtk_frame_extents()?.unwrap_or_default();
+        self.state.lock().unwrap().frame_extents = frame_extents;
+        Ok(())
+    }
+
+    /// Returns the logical pixel widths of the surface's frame
+    ///
+    /// This is usually the width of the drop shadows at the edges of the surface.
+    pub fn frame_extents(&self) -> FrameExtents<i32, Logical> {
+        let scale = self
+            .client_scale
+            .as_ref()
+            .map(|scale| scale.load(Ordering::Acquire))
+            .unwrap_or(1.);
+        self.state
+            .lock()
+            .unwrap()
+            .frame_extents
+            .to_f64()
+            .to_logical(scale)
+            .to_i32_round()
     }
 
     fn update_protocols(&self) -> Result<(), ConnectionError> {

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::input::KeyState,
+    backend::{input::KeyState, renderer::utils::RendererSurfaceStateUserData},
     input::{
         Seat, SeatHandler,
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
@@ -129,8 +129,7 @@ pub(crate) struct SharedSurfaceState {
     pub(super) wl_surface_id: Option<u32>,
     pub(super) wl_surface_serial: Option<u64>,
     pub(super) mapped_onto: Option<X11Window>,
-    pub(super) geometry: Rectangle<i32, Logical>,
-    frame_extents: FrameExtents<i32, Physical>,
+    pub(super) last_configure: Rectangle<i32, Logical>,
     pub(super) override_redirect: bool,
 
     // The associated wl_surface.
@@ -148,10 +147,10 @@ pub(crate) struct SharedSurfaceState {
     next_counter_value: Int64,
     pending_sync_wait_value: Option<Int64>,
 
-    // Geometry to set after we receive an ACK for the in-flight sync request.
-    pending_geometry: Option<Rectangle<i32, Logical>>,
-    // Geometry update deferred while a sync request is in progress.
-    buffered_geometry: Option<Rectangle<i32, Logical>>,
+    // Configure to set after we receive an ACK for the in-flight sync request.
+    pending_configure: Option<Rectangle<i32, Logical>>,
+    // Configure update deferred while a sync request is in progress.
+    buffered_configure: Option<Rectangle<i32, Logical>>,
 
     title: String,
     class: String,
@@ -168,6 +167,7 @@ pub(crate) struct SharedSurfaceState {
     pub(crate) opacity: Option<u32>,
     opaque_region: Option<RegionAttributes>,
     opaque_region_dirty: bool,
+    frame_extents: FrameExtents<i32, Physical>,
     pending_enter: Option<(
         Box<dyn std::any::Any + Send + 'static>,
         Vec<Keycode>,
@@ -352,11 +352,10 @@ impl X11Surface {
                 counter_value: Default::default(),
                 next_counter_value: Default::default(),
                 pending_sync_wait_value: None,
-                pending_geometry: None,
-                buffered_geometry: None,
+                pending_configure: None,
+                buffered_configure: None,
                 mapped_onto: None,
-                geometry,
-                frame_extents: Default::default(),
+                last_configure: geometry,
                 override_redirect,
                 title: String::from(""),
                 class: String::from(""),
@@ -373,6 +372,7 @@ impl X11Surface {
                 opacity: None,
                 opaque_region: None,
                 opaque_region_dirty: true,
+                frame_extents: Default::default(),
                 pending_enter: None,
                 pending_ping_timestamp: None,
             })),
@@ -449,7 +449,7 @@ impl X11Surface {
                 .as_ref()
                 .map(|s| s.load(Ordering::Acquire))
                 .unwrap_or(1.);
-            let logical_rect = rect.unwrap_or(state.geometry);
+            let logical_rect = rect.unwrap_or(state.last_configure);
             let rect = logical_rect.to_client_precise_round(client_scale);
             let aux = ConfigureWindowAux::default()
                 .x(rect.loc.x)
@@ -489,15 +489,15 @@ impl X11Surface {
             Err(X11SurfaceError::UnsupportedForOverrideRedirect)
         } else {
             let mut state = self.state.lock().unwrap();
-            let rect = rect.or(state.pending_geometry);
+            let rect = rect.or(state.pending_configure);
 
             if state.pending_sync_wait_value.is_some() {
                 self.finish_pending_sync(&mut state);
             }
-            state.buffered_geometry = None;
+            state.buffered_configure = None;
 
             let new_geometry = self.send_configure(&mut state, rect)?;
-            state.geometry = new_geometry;
+            state.last_configure = new_geometry;
 
             Ok(())
         }
@@ -513,7 +513,7 @@ impl X11Surface {
     /// (with a new sync request) after the in-progress sync is finished and the client has
     /// committed a new buffer.
     ///
-    /// Until the client ACKs the sync request, the surface's geometry remains frozen at the
+    /// Until the client ACKs the sync request, the surface's last configure remains frozen at the
     /// previous value.  When the ACK is received,
     /// [`XwmHandler::sync_request_acked`](super::XwmHandler::sync_request_acked) is called.
     ///
@@ -522,7 +522,7 @@ impl X11Surface {
     /// [`XwmHandler::sync_request_timeout`](super::XwmHandler::sync_request_timeout) is called.
     ///
     /// If the client does not support the `_NET_WM_SYNC_REQUEST` protocol, or if `rect` has the
-    /// same size as the current geometry and there is no sync in progress, a regular configure
+    /// same size as the current configure and there is no sync in progress, a regular configure
     /// sequence is initiated (as if [`X11Surface::configure`] was called).
     ///
     /// This configure method is most useful during interactive window resizes, as it avoids
@@ -541,7 +541,7 @@ impl X11Surface {
             let rect = rect.into();
             let mut state = self.state.lock().unwrap();
 
-            if rect.size == state.geometry.size && state.pending_geometry.is_none() {
+            if rect.size == state.last_configure.size && state.pending_configure.is_none() {
                 // If the passed size is the same as our stored geometry's size, and there's no
                 // in-flight sync request, we send a normal configure without a sync request.  Some
                 // clients, when they get a configure-notify with the same size as their current
@@ -557,7 +557,7 @@ impl X11Surface {
                         self.configure(rect)
                     }
                     Err(SyncRequestError::RequestPending) => {
-                        state.buffered_geometry = Some(rect);
+                        state.buffered_configure = Some(rect);
                         Ok(())
                     }
                     Ok(_) => match self.send_configure(&mut state, rect) {
@@ -565,9 +565,9 @@ impl X11Surface {
                             self.finish_pending_sync(&mut state);
                             Err(err)
                         }
-                        Ok(pending_geometry) => {
-                            state.pending_geometry = Some(pending_geometry);
-                            state.buffered_geometry = None;
+                        Ok(pending_configure) => {
+                            state.pending_configure = Some(pending_configure);
+                            state.buffered_configure = None;
                             Ok(())
                         }
                     },
@@ -731,7 +731,7 @@ impl X11Surface {
     /// Handles a sync alarm for the sync counter for this surface.
     ///
     /// If `new_value` is a valid ACK for the currently in-flight sync request, the pending
-    /// geometry is applied.
+    /// configure is applied.
     ///
     /// The caller is responsible for notifying the compositor that the sync was ACKed, and of the
     /// new in-flight request, if any.
@@ -835,12 +835,12 @@ impl X11Surface {
 
     /// Finishes an in-flight sync request.
     ///
-    /// Promotes the pending geometry to the active geometry, unregisters the sync timeout, and
+    /// Promotes the pending configure to the active configure, unregisters the sync timeout, and
     /// tells the XWayland server to start committing buffers again.
     fn finish_pending_sync(&self, state: &mut SharedSurfaceState) {
         state.pending_sync_wait_value = None;
-        if let Some(pending_geometry) = state.pending_geometry.take() {
-            state.geometry = pending_geometry;
+        if let Some(pending_configure) = state.pending_configure.take() {
+            state.last_configure = pending_configure;
         }
         self.destroy_sync_timeout(state);
         self.set_allow_commits(state, true);
@@ -965,23 +965,25 @@ impl X11Surface {
             let surface = self.clone();
 
             compositor::add_pre_commit_hook::<D, _>(wl_surface, move |_, _, _| {
-                let (buffered_geometry, timeout) = {
+                let (buffered_configure, timeout) = {
                     let mut state = surface.state.lock().unwrap();
-                    let buffered_geometry = if state.pending_sync_wait_value.is_none()
-                        && state.buffered_geometry.is_some_and(|geom| geom != state.geometry)
+                    let buffered_configure = if state.pending_sync_wait_value.is_none()
+                        && state
+                            .buffered_configure
+                            .is_some_and(|geom| geom != state.last_configure)
                     {
                         // We only send a new configure if:
                         //   1) there is no sync currently in progress, and
-                        //   2) if the buffered geometry is not the current geometry.
-                        state.buffered_geometry.take()
+                        //   2) if the buffered configure is not the current configure.
+                        state.buffered_configure.take()
                     } else {
                         None
                     };
-                    (buffered_geometry, state.last_set_sync_timeout)
+                    (buffered_configure, state.last_set_sync_timeout)
                 };
 
-                if let Some(buffered_geometry) = buffered_geometry {
-                    if let Err(err) = surface.configure_with_sync(buffered_geometry, Some(timeout)) {
+                if let Some(buffered_configure) = buffered_configure {
+                    if let Err(err) = surface.configure_with_sync(buffered_configure, Some(timeout)) {
                         tracing::info!(
                             "Failed to send buffered surface configure/sync for window 0x{:08x}: {err}",
                             surface.window
@@ -993,35 +995,67 @@ impl X11Surface {
         state.deferred_sync_hook_id = Some(hook_id);
     }
 
-    /// Returns the current geometry of the underlying X11 window
-    pub fn geometry(&self) -> Rectangle<i32, Logical> {
-        self.state.lock().unwrap().geometry
+    /// Returns the last configure set on the underlying X11 window
+    pub fn last_configure(&self) -> Rectangle<i32, Logical> {
+        self.state.lock().unwrap().last_configure
     }
 
-    /// Returns the pending geometry, if any
+    /// Returns the pending configure, if any
     ///
-    /// The pending geometry has already been sent to the X server and client as a part of
+    /// The pending configure has already been sent to the X server and client as a part of
     /// [`configure_with_sync`](X11Surface::configure_with_sync), but the client has not yet
     /// acknowledged the corresponding sync request.
     ///
-    /// The pending geometry is promoted to [`geometry`](X11Surface::geometry) after the sync
-    /// request has been acknowledged.
-    pub fn pending_geometry(&self) -> Option<Rectangle<i32, Logical>> {
-        self.state.lock().unwrap().pending_geometry
+    /// The pending configure is promoted to [`last_configure`](X11Surface::last_configure) after
+    /// the sync request has been acknowledged.
+    pub fn pending_configure(&self) -> Option<Rectangle<i32, Logical>> {
+        self.state.lock().unwrap().pending_configure
     }
 
-    /// Returns the buffered geometry, if any
+    /// Returns the buffered configure, if any
     ///
-    /// The buffered geometry is the most recent rect passed to
+    /// The buffered configure is the most recent rect passed to
     /// [`configure_with_sync`](X11Surface::configure_with_sync).  It has not yet been sent to the
     /// X server or client because an older sync request is still in progress.  Once the client
-    /// acknowledges the in-progress sync request and commits a buffer, the buffered geometry will
+    /// acknowledges the in-progress sync request and commits a buffer, the buffered configure will
     /// be sent to the client as part of a new sync request.
     ///
-    /// The buffered geometry is promoted to [`pending_geometry`](X11Surface::pending_geometry)
+    /// The buffered configure is promoted to [`pending_configure`](X11Surface::pending_configure)
     /// once it has been sent to the client.
-    pub fn buffered_geometry(&self) -> Option<Rectangle<i32, Logical>> {
-        self.state.lock().unwrap().buffered_geometry
+    pub fn buffered_configure(&self) -> Option<Rectangle<i32, Logical>> {
+        self.state.lock().unwrap().buffered_configure
+    }
+
+    /// Returns the bounding box of this surface
+    ///
+    /// This corresponds to the last committed buffer size from the XWayland server.
+    ///
+    /// If no buffer has been committed, returns [`last_configure`](X11Surface::last_configure).
+    pub fn bbox(&self) -> Rectangle<i32, Logical> {
+        let state = self.state.lock().unwrap();
+
+        let size = state
+            .wl_surface
+            .as_ref()
+            .and_then(|surface| {
+                compositor::with_states(surface, |states| {
+                    states
+                        .data_map
+                        .get::<RendererSurfaceStateUserData>()
+                        .and_then(|s| s.lock().unwrap().surface_size())
+                })
+            })
+            .unwrap_or_else(|| state.last_configure.size);
+        Rectangle::from_size(size)
+    }
+
+    /// Returns the user-visible area of the surface
+    ///
+    /// This corresponds to the surface's bounding box, minus any frame elements like drop shadows.
+    /// Note that not all clients will advertise the sizes of frame elements, even if they are
+    /// present on the window.
+    pub fn geometry(&self) -> Rectangle<i32, Logical> {
+        self.bbox() - self.frame_extents()
     }
 
     /// Returns the current title of the underlying X11 window

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -290,6 +290,7 @@ pub enum WmWindowProperty {
     StartupId,
     Pid,
     Opacity,
+    FrameExtents,
 }
 
 /// https://x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#input_focus
@@ -1526,7 +1527,7 @@ impl X11Surface {
             }
             atom if atom == self.atoms._GTK_FRAME_EXTENTS => {
                 self.update_toolkit_frame_extents()?;
-                Ok(None)
+                Ok(Some(WmWindowProperty::FrameExtents))
             }
 
             _ => Ok(None), // unknown


### PR DESCRIPTION
## Description

This implements the first part of the discussion in #2031.  Changes:

* `X11Surface` tracks `_GTK_FRAME_EXTENTS`/`_KDE_NET_WM_SHADOW` internally.
* `X11Surface`'s `SpaceElement::geometry` impl returns the surface bbox minus the values in the frame extents (if any).
* Added `X11Surface::frame_extents` to return the extents.
* Added a new `FrameExtents` type along with the other geometry types (`Point`, `Rectangle`, etc.).  The name of the struct is perhaps too specific for something that just has left/right/top/bottom members, but I'm not sure of a better name.
* `XwmHandler::property_notify` notifies on frame extents changes.
* `Window`'s `SpaceElement::geometry` impl delegates to `X11Surface`'s impl for xwayland windows.

I've tested this in xfwl4, and it seems to work well.  I was able to delete a lot of code...

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
