### PR TITLE
drm: transform plane damage to framebuffer-space for FB_DAMAGE_CLIPS

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -2299,10 +2299,16 @@ where
                                     &output_geometry.size.to_logical(1),
                                 )
                             }));
+
+                            // Here we need to apply the output_transform to the damage since we
+                            // haven't rotated our framebuffer. dst is already in the same
+                            // coordinate space src is, so no transform needed.
                             config.damage_clips = PlaneDamageClips::from_damage(
                                 self.surface.device_fd(),
                                 config.properties.src,
                                 config.properties.dst,
+                                Transform::Normal,
+                                output_transform,
                                 render_damage.iter().copied(),
                             )
                             .ok()
@@ -3967,11 +3973,17 @@ where
         let element_damage = element.damage_since(scale, previous_commit);
         let has_element_damage = !element_damage.is_empty();
 
+        // Damage were applied buffer transform to be in physical-space. We need to invert it to go
+        // back to buffer-coordinate. We'll apply the same transform to the element geometry for
+        // scale computation as it's already in physical space.
+        let transform = element.transform().invert();
         let damage_clips = if has_element_damage {
             PlaneDamageClips::from_damage(
                 self.surface.device_fd(),
                 element_config.properties.src,
                 element_config.geometry,
+                transform,
+                transform,
                 element_damage,
             )
             .ok()

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -349,9 +349,16 @@ where
         let dst = Rectangle::from_size((mode.size().0 as i32, mode.size().1 as i32).into());
 
         let damage_clips = damage.and_then(|damage| {
-            PlaneDamageClips::from_damage(self.drm.device_fd(), src, dst, damage)
-                .ok()
-                .flatten()
+            PlaneDamageClips::from_damage(
+                self.drm.device_fd(),
+                src,
+                dst,
+                Transform::Normal,
+                Transform::Normal,
+                damage,
+            )
+            .ok()
+            .flatten()
         });
 
         // Try to extract a native fence out of the supplied sync point if any

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -69,9 +69,11 @@ impl PlaneDamageClips {
         device: &DrmDeviceFd,
         src: Rectangle<f64, Buffer>,
         dst: Rectangle<i32, Physical>,
+        dst_transform: Transform,
+        damage_transform: Transform,
         damage: impl IntoIterator<Item = Rectangle<i32, Physical>>,
     ) -> io::Result<Option<Self>> {
-        let scale = src.size / dst.size.to_logical(1).to_buffer(1, Transform::Normal).to_f64();
+        let scale = src.size / dst.size.to_logical(1).to_buffer(1, dst_transform).to_f64();
 
         let mut rects = damage
             .into_iter()
@@ -81,8 +83,8 @@ impl PlaneDamageClips {
                     .to_logical(1f64)
                     .to_buffer(
                         1f64,
-                        Transform::Normal,
-                        &src.size.to_logical(1f64, Transform::Normal),
+                        damage_transform,
+                        &src.size.to_logical(scale, damage_transform),
                     )
                     .upscale(scale);
                 rect.loc += src.loc;


### PR DESCRIPTION
## Description
Right after rendering, DrmCompositor build a PlaneDamageClips object, which is used to populate the FB_DAMAGE_CLIPS plane property. This property may be used by drivers to repaint only the damaged part of the plane, and is expected to be a bunch of rectangles in framebuffer coordinate-space. Current implementation uses the render_damage directly, which are transformed following the output_transform. If the device driver respect the FB_DAMAGE_CLIPS and only repaint those areas, this breaks rendering for any transform but normal since the actual damage and the reported one are misaligned.

Fix: apply the output inverted transform on the damage rectangle before passing them to PlaneDamageClips::from_damage.

Fixes: Smithay/smithay#1651

### Note for review
There are two things I'm not 100% sure about this PR:
1. I went to the change with the least possible side-effect, so damages are transformed to framebuffer-space at the last possible moment. I'm unsure if the transform should be applied to the Vec returned to calling code. My gut feeling is that it shouldn't however.
Transforming the damage in `damage_bag.render_output` would fix winit backend in anvil for free, but also introduce a lot of side effects (I don't think I've seen any code re-transforming the damages returned by that function), but I'd like to have someone else input on this.
2. Size for the transform area is `output_geometry.size` because that's what has been used in damage computation. 
I'm unsure if it's should be changed to `config.properties.dst` which is the un-transformed output size (and would need an additional transform). As far as I can tell, the two are equal anyway, so output_geometry.size felt like a good fit.

EDIT: There's a second call to `PlaneDamageClips` for direct scanout, which might require some changes too. I haven't managed to hit that code while testing yet. I'll add a commit if I do and it's buggy.
EDIT 2: Well, still haven't hit that code, but I *think* `element_config()` does the right transformation before building the `PlaneDamageClips`.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
