### PR TITLE
anvil: change throttle duration in `post_repaint` based on monitor's refresh rate

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -910,7 +910,9 @@ impl<BackendData: Backend + 'static> AnvilState<BackendData> {
         render_element_states: &RenderElementStates,
     ) {
         let time = time.into();
-        let throttle = Some(Duration::from_secs(1));
+        let throttle = output
+            .current_mode()
+            .map(|mode| Duration::from_secs_f64(1_000f64 / mode.refresh as f64));
 
         #[allow(clippy::mutable_key_type)]
         let mut clients: HashMap<ClientId, Client> = HashMap::new();


### PR DESCRIPTION
## Description
fix #1908

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
