### PR TITLE
gles: Fix blitting from dmabufs

### DIFF
--- a/src/backend/drm/dumb.rs
+++ b/src/backend/drm/dumb.rs
@@ -177,7 +177,7 @@ pub fn framebuffer_from_dumb_buffer(
 
             let fourcc = format.code;
             let (depth, bpp) = get_depth(fourcc)
-                .and_then(|d| get_bpp(fourcc).map(|b| (d, b)))
+                .zip(get_bpp(fourcc))
                 .ok_or_else(|| AccessError {
                     errmsg: "Unknown format for legacy framebuffer",
                     dev: drm.dev_path(),

--- a/src/backend/drm/gbm.rs
+++ b/src/backend/drm/gbm.rs
@@ -354,7 +354,7 @@ where
 
             let fourcc = bo.format();
             let (depth, bpp) = get_depth(fourcc)
-                .and_then(|d| get_bpp(fourcc).map(|b| (d, b)))
+                .zip(get_bpp(fourcc))
                 .ok_or_else(|| AccessError {
                     errmsg: "Unknown format for legacy framebuffer",
                     dev: drm.dev_path(),

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1620,12 +1620,12 @@ impl<'buffer> BlitFrame<GlesTarget<'buffer>> for GlesFrame<'_, '_> {
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<SyncPoint, Self::Error> {
         let res = self.renderer.blit(self.target, to, src, dst, filter);
         self.target
             .0
             .make_current(&self.renderer.gl, &self.renderer.egl)?;
-        res.map(|_| ())
+        res
     }
 
     fn blit_from(
@@ -1634,12 +1634,12 @@ impl<'buffer> BlitFrame<GlesTarget<'buffer>> for GlesFrame<'_, '_> {
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<SyncPoint, Self::Error> {
         let res = self.renderer.blit(from, self.target, src, dst, filter);
         self.target
             .0
             .make_current(&self.renderer.gl, &self.renderer.egl)?;
-        res.map(|_| ())
+        res
     }
 }
 

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -13,7 +13,6 @@ use std::{
     mem,
     os::raw::c_char,
     ptr,
-    rc::Rc,
     sync::{
         Arc, Mutex, RwLock, RwLockWriteGuard, TryLockError,
         atomic::{AtomicBool, AtomicPtr, Ordering},
@@ -49,7 +48,7 @@ use super::{
 use crate::{
     backend::{
         allocator::{
-            Buffer, Format, Fourcc,
+            Format, Fourcc,
             dmabuf::{Dmabuf, WeakDmabuf},
             format::{FormatSet, get_bpp, get_opaque, has_alpha},
         },
@@ -88,32 +87,6 @@ enum CleanupResource {
     Sync(ffi::types::GLsync),
 }
 unsafe impl Send for CleanupResource {}
-
-#[derive(Debug)]
-struct GlesBufferInner {
-    dmabuf: WeakDmabuf,
-    image: EGLImage,
-    rbo: ffi::types::GLuint,
-    fbo: ffi::types::GLuint,
-    destruction_callback_sender: Sender<CleanupResource>,
-}
-
-impl Drop for GlesBufferInner {
-    fn drop(&mut self) {
-        let _ = self
-            .destruction_callback_sender
-            .send(CleanupResource::FramebufferObject(self.fbo));
-        let _ = self
-            .destruction_callback_sender
-            .send(CleanupResource::RenderbufferObject(self.rbo));
-        let _ = self
-            .destruction_callback_sender
-            .send(CleanupResource::EGLImage(self.image));
-    }
-}
-
-#[derive(Debug, Clone)]
-struct GlesBuffer(Rc<GlesBufferInner>);
 
 /// Offscreen render surface
 ///
@@ -164,12 +137,6 @@ pub struct GlesTarget<'a>(GlesTargetInternal<'a>);
 
 #[derive(Debug)]
 enum GlesTargetInternal<'a> {
-    Image {
-        // TODO: Ideally we would be able to share the texture between renderers with shared EGLContexts though.
-        // But we definitely don't want to add user data to a dmabuf to facilitate this. Maybe use the EGLContexts userdata for storing the buffers?
-        buf: GlesBuffer,
-        dmabuf: &'a mut Dmabuf,
-    },
     Surface {
         surface: &'a mut EGLSurface,
     },
@@ -196,7 +163,6 @@ impl Texture for GlesTarget<'_> {
 
     fn size(&self) -> Size<i32, BufferCoord> {
         match &self.0 {
-            GlesTargetInternal::Image { dmabuf, .. } => dmabuf.size(),
             GlesTargetInternal::Surface { surface } => surface
                 .get_size()
                 .expect("a bound EGLSurface needs to have a size")
@@ -216,13 +182,6 @@ impl Texture for GlesTarget<'_> {
 impl GlesTargetInternal<'_> {
     fn format(&self) -> Option<(ffi::types::GLenum, bool)> {
         match self {
-            GlesTargetInternal::Image { dmabuf, .. } => {
-                let format = crate::backend::allocator::Buffer::format(*dmabuf).code;
-                let has_alpha = has_alpha(format);
-                let (format, _, _) = fourcc_to_gl_formats(format)?;
-
-                Some((format, has_alpha))
-            }
             GlesTargetInternal::Surface { surface, .. } => {
                 let format = surface.pixel_format();
                 let format = match (format.color_bits, format.alpha_bits) {
@@ -248,7 +207,6 @@ impl GlesTargetInternal<'_> {
             } else {
                 egl.make_current()?;
                 match self {
-                    GlesTargetInternal::Image { buf, .. } => gl.BindFramebuffer(ffi::FRAMEBUFFER, buf.0.fbo),
                     GlesTargetInternal::Texture { fbo, .. } => gl.BindFramebuffer(ffi::FRAMEBUFFER, *fbo),
                     GlesTargetInternal::Renderbuffer { fbo, .. } => {
                         gl.BindFramebuffer(ffi::FRAMEBUFFER, *fbo)
@@ -393,7 +351,6 @@ pub struct GlesRenderer {
     solid_program: GlesSolidProgram,
 
     // caches
-    buffers: Vec<GlesBuffer>,
     dmabuf_cache: HashMap<WeakDmabuf, GlesTexture>,
     vbos: [ffi::types::GLuint; 2],
     vertices: Vec<f32>,
@@ -449,7 +406,6 @@ impl fmt::Debug for GlesFrame<'_, '_> {
 impl fmt::Debug for GlesRenderer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GlesRenderer")
-            .field("buffers", &self.buffers)
             .field("extensions", &self.extensions)
             .field("capabilities", &self.capabilities)
             .field("tex_program", &self.tex_program)
@@ -734,7 +690,6 @@ impl GlesRenderer {
             min_filter: TextureFilter::Linear,
             max_filter: TextureFilter::Linear,
 
-            buffers: Vec::new(),
             dmabuf_cache: std::collections::HashMap::new(),
             vertices: Vec::with_capacity(6 * 16),
             non_opaque_damage: Vec::with_capacity(16),
@@ -812,7 +767,6 @@ impl GlesRenderer {
     #[profiling::function]
     fn cleanup(&mut self) {
         self.dmabuf_cache.retain(|entry, _tex| !entry.is_gone());
-        self.buffers.retain(|buffer| !buffer.0.dmabuf.is_gone());
         self.gles_cleanup().cleanup(&self.egl, &self.gl);
     }
 
@@ -1512,70 +1466,11 @@ impl Bind<EGLSurface> for GlesRenderer {
 impl Bind<Dmabuf> for GlesRenderer {
     fn bind<'a>(&mut self, dmabuf: &'a mut Dmabuf) -> Result<GlesTarget<'a>, GlesError> {
         let mut bind = |dmabuf: &'a mut Dmabuf| {
-            let buf = self
-                .buffers
-                .iter_mut()
-                .find(|buffer| {
-                    if let Some(dma) = buffer.0.dmabuf.upgrade() {
-                        dma == *dmabuf
-                    } else {
-                        false
-                    }
-                })
-                .map(|buf| Ok(buf.clone()))
-                .unwrap_or_else(|| {
-                    unsafe {
-                        self.egl.make_current()?;
-                    }
-
-                    trace!("Creating EGLImage for Dmabuf: {:?}", dmabuf);
-                    let image = self
-                        .egl
-                        .display()
-                        .create_image_from_dmabuf(dmabuf)
-                        .map_err(GlesError::BindBufferEGLError)?;
-
-                    unsafe {
-                        let mut rbo = 0;
-                        self.gl.GenRenderbuffers(1, &mut rbo as *mut _);
-                        self.gl.BindRenderbuffer(ffi::RENDERBUFFER, rbo);
-                        self.gl
-                            .EGLImageTargetRenderbufferStorageOES(ffi::RENDERBUFFER, image);
-                        self.gl.BindRenderbuffer(ffi::RENDERBUFFER, 0);
-
-                        let mut fbo = 0;
-                        self.gl.GenFramebuffers(1, &mut fbo as *mut _);
-                        self.gl.BindFramebuffer(ffi::FRAMEBUFFER, fbo);
-                        self.gl.FramebufferRenderbuffer(
-                            ffi::FRAMEBUFFER,
-                            ffi::COLOR_ATTACHMENT0,
-                            ffi::RENDERBUFFER,
-                            rbo,
-                        );
-                        let status = self.gl.CheckFramebufferStatus(ffi::FRAMEBUFFER);
-                        self.gl.BindFramebuffer(ffi::FRAMEBUFFER, 0);
-
-                        if status != ffi::FRAMEBUFFER_COMPLETE {
-                            self.gl.DeleteFramebuffers(1, &mut fbo as *mut _);
-                            self.gl.DeleteRenderbuffers(1, &mut rbo as *mut _);
-                            ffi_egl::DestroyImageKHR(**self.egl.display().get_display_handle(), image);
-                            return Err(GlesError::FramebufferBindingError);
-                        }
-                        let buf = GlesBuffer(Rc::new(GlesBufferInner {
-                            dmabuf: dmabuf.weak(),
-                            image,
-                            rbo,
-                            fbo,
-                            destruction_callback_sender: self.gles_cleanup().sender.clone(),
-                        }));
-
-                        self.buffers.push(buf.clone());
-
-                        Ok(buf)
-                    }
-                })?;
-
-            Ok(GlesTarget(GlesTargetInternal::Image { buf, dmabuf }))
+            let texture = self.import_dmabuf(dmabuf, None)?;
+            self.bind_texture(&texture)
+                // SAFETY: The lifetime of the target only depends on the dmabuf,
+                // as the GlesTexture is cloned internally.
+                .map(|tex| unsafe { std::mem::transmute::<GlesTarget<'_>, GlesTarget<'a>>(tex) })
         };
 
         bind(dmabuf).inspect_err(|_| {
@@ -1786,9 +1681,6 @@ impl Blit for GlesRenderer {
         let scope = self.profiler.scope(gpu_span_location!("blit"), &self.gl);
 
         match &src_target.0 {
-            GlesTargetInternal::Image { buf, .. } => unsafe {
-                self.gl.BindFramebuffer(ffi::READ_FRAMEBUFFER, buf.0.fbo)
-            },
             GlesTargetInternal::Texture { fbo, .. } => unsafe {
                 self.gl.BindFramebuffer(ffi::READ_FRAMEBUFFER, *fbo)
             },
@@ -1798,9 +1690,6 @@ impl Blit for GlesRenderer {
             _ => {} // Note: The only target missing is `Surface` and handled above
         }
         match &dst_target.0 {
-            GlesTargetInternal::Image { buf, .. } => unsafe {
-                self.gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, buf.0.fbo)
-            },
             GlesTargetInternal::Texture { fbo, .. } => unsafe {
                 self.gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, *fbo)
             },

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -597,7 +597,7 @@ impl<'buffer> BlitFrame<GlesTarget<'buffer>> for GlowFrame<'_, 'buffer> {
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<sync::SyncPoint, Self::Error> {
         self.frame.as_mut().unwrap().blit_to(to, src, dst, filter)
     }
 
@@ -607,7 +607,7 @@ impl<'buffer> BlitFrame<GlesTarget<'buffer>> for GlowFrame<'_, 'buffer> {
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<sync::SyncPoint, Self::Error> {
         self.frame.as_mut().unwrap().blit_from(from, src, dst, filter)
     }
 }

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -843,7 +843,7 @@ where
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<SyncPoint, Self::Error>;
 
     /// Copies the contents of the provided framebuffer to `dst` in the bound framebuffer,
     /// applying `filter` if necessary.
@@ -864,7 +864,7 @@ where
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<SyncPoint, Self::Error>;
 }
 
 #[cfg(feature = "wayland_frontend")]

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -3052,7 +3052,7 @@ where
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<SyncPoint, Self::Error> {
         self.flush_frame()?;
         if let Some(target) = self.target.as_mut() {
             let MultiFramebufferInternal::Target(to_fb) = &mut to.0 else {
@@ -3063,8 +3063,7 @@ where
                 .renderer_mut()
                 .blit(target.framebuffer, to_fb, src, dst, filter)
                 .map_err(Error::Target)?;
-            target.device.renderer_mut().wait(&sync).map_err(Error::Target)?;
-            Ok(())
+            Ok(sync)
         } else {
             let MultiFramebufferInternal::Render(to_fb) = &mut to.0 else {
                 unreachable!()
@@ -3092,7 +3091,7 @@ where
         src: Rectangle<i32, Physical>,
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<SyncPoint, Self::Error> {
         self.flush_frame()?;
         if let Some(target) = self.target.as_mut() {
             let MultiFramebufferInternal::Target(from_fb) = &from.0 else {
@@ -3103,8 +3102,7 @@ where
                 .renderer_mut()
                 .blit(from_fb, target.framebuffer, src, dst, filter)
                 .map_err(Error::Target)?;
-            target.device.renderer_mut().wait(&sync).map_err(Error::Target)?;
-            Ok(())
+            Ok(sync)
         } else {
             let MultiFramebufferInternal::Render(from_fb) = &from.0 else {
                 unreachable!()


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

This PR does two things which seems to be necessary to use blitting for blur successfully in certain setups:

1. Return `SyncPoint`s from `BlitFrame` as well. These are necessary to wait upon for the results of the blit to be visible, when sampling from the same framebuffer in e.g. a sub-renderer/frame. (Observed with the multi-gpu renderer and an intel-device being the render gpu)
2. Use the bind-texture path to import dmabufs for binding instead of `EGLImageTargetRenderbufferStorageOES`. This fixes blits to dmabufs being visible at all on nvidia gpus. (Which definitely sounds like a driver bug, but oh well.) In limited profiling I have not observed any performance differences, binding dmabufs imported as `external` will still fail, but in `GlesRenderer::bind_texture` instead.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
