### PR TITLE
anvil: update primary scan-out output in nested sessions

### DIFF
--- a/anvil/src/winit.rs
+++ b/anvil/src/winit.rs
@@ -46,7 +46,7 @@ use smithay::{
 };
 use tracing::{error, info, warn};
 
-use crate::state::{AnvilState, Backend, take_presentation_feedback};
+use crate::state::{AnvilState, Backend, take_presentation_feedback, update_primary_scanout_output};
 use crate::{drawing::*, render::*};
 
 pub const OUTPUT_NAME: &str = "winit";
@@ -392,6 +392,15 @@ pub fn run_winit() {
                     backend.window().set_cursor_visible(cursor_visible);
 
                     let states = render_output_result.states;
+
+                    update_primary_scanout_output(
+                        &state.space,
+                        &output,
+                        &state.dnd_icon,
+                        &state.cursor_status,
+                        &states,
+                    );
+
                     if has_rendered {
                         let mut output_presentation_feedback =
                             take_presentation_feedback(&output, &state.space, &states);

--- a/anvil/src/x11.rs
+++ b/anvil/src/x11.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{
     drawing::*,
     render::*,
-    state::{AnvilState, Backend, take_presentation_feedback},
+    state::{AnvilState, Backend, take_presentation_feedback, update_primary_scanout_output},
 };
 #[cfg(feature = "egl")]
 use smithay::backend::renderer::ImportEgl;
@@ -414,6 +414,15 @@ pub fn run_x11() {
                     };
 
                     let states = render_output_result.states;
+
+                    update_primary_scanout_output(
+                        &state.space,
+                        &output,
+                        &state.dnd_icon,
+                        &state.cursor_status,
+                        &states,
+                    );
+
                     #[cfg(feature = "debug")]
                     let rendered = render_output_result.damage.is_some();
                     if render_output_result.damage.is_some() {


### PR DESCRIPTION
## Description

At some point we refactored out updating the primary scan-out output from `post_repaint` but missed updating
the nested sessions like x11 and winit.

fixes #1908 

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [X] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
