### PR TITLE
feat(drm_syncobj): add sync point accessors and sync-file import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ cursor-icon = "1.2.0"
 downcast-rs = "1.2.0"
 drm-fourcc = "^2.2.0"
 drm = { version = "0.14.0", optional = true }
-drm-ffi = { version = "0.9.0", optional = true }
+drm-ffi = { version = "0.9.1", optional = true }
+drm-sys = { version = "0.8.1", optional = true }
 errno = "0.3.5"
 gbm = { version = "0.18.0", optional = true, default-features = false, features = ["drm-support"] }
 glow = { version = "0.16", optional = true }
@@ -91,7 +92,7 @@ cc = { version = "1.0.79", optional = true }
 default = ["backend_drm", "backend_gbm", "backend_libinput", "backend_udev", "backend_session_libseat", "backend_x11", "backend_winit", "desktop", "renderer_gl", "renderer_pixman", "renderer_multi", "xwayland", "wayland_frontend", "backend_vulkan", "backend_libei"]
 backend_winit = ["winit", "backend_egl", "wayland-client", "wayland-cursor", "wayland-egl", "renderer_gl"]
 backend_x11 = ["x11rb", "x11rb/dri3", "x11rb/xfixes", "x11rb/xinput", "x11rb/present", "x11rb_event_source", "backend_gbm", "backend_drm", "backend_egl"]
-backend_drm = ["drm", "drm-ffi"]
+backend_drm = ["drm", "drm-ffi", "drm-sys"]
 backend_gbm = ["gbm", "cc", "pkg-config", "backend_drm"]
 backend_gbm_has_fd_for_plane = []
 backend_gbm_has_create_with_modifiers2 = []

--- a/src/wayland/drm_syncobj/sync_point.rs
+++ b/src/wayland/drm_syncobj/sync_point.rs
@@ -81,6 +81,12 @@ impl PartialEq for DrmTimeline {
     }
 }
 
+impl AsFd for DrmTimeline {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.timeline_fd.as_fd()
+    }
+}
+
 impl DrmTimeline {
     /// Import DRM timeline from file descriptor
     pub fn new(device: &DrmDeviceFd, fd: OwnedFd) -> io::Result<Self> {
@@ -113,6 +119,16 @@ pub struct DrmSyncPoint {
 }
 
 impl DrmSyncPoint {
+    /// Borrow the [`DrmTimeline`] this point lives on.
+    pub fn timeline(&self) -> &DrmTimeline {
+        &self.timeline
+    }
+
+    /// Numeric timeline value for this point.
+    pub fn point(&self) -> u64 {
+        self.point
+    }
+
     /// Create an eventfd that will be signaled by the syncpoint
     pub fn eventfd(&self) -> io::Result<Arc<OwnedFd>> {
         let fd = rustix::event::eventfd(

--- a/src/wayland/drm_syncobj/sync_point.rs
+++ b/src/wayland/drm_syncobj/sync_point.rs
@@ -81,12 +81,6 @@ impl PartialEq for DrmTimeline {
     }
 }
 
-impl AsFd for DrmTimeline {
-    fn as_fd(&self) -> BorrowedFd<'_> {
-        self.0.timeline_fd.as_fd()
-    }
-}
-
 impl DrmTimeline {
     /// Import DRM timeline from file descriptor
     pub fn new(device: &DrmDeviceFd, fd: OwnedFd) -> io::Result<Self> {
@@ -181,6 +175,29 @@ impl DrmSyncPoint {
 
         let res = device.syncobj_to_fd(syncobj, true);
         let _ = device.destroy_syncobj(syncobj);
+        res
+    }
+
+    /// Import a DRM sync file fd as the materialized fence at this
+    /// timeline point. Symmetric counterpart of
+    /// [`DrmSyncPoint::export_sync_file`].
+    ///
+    /// Internally creates a temporary binary syncobj from `fd`
+    /// (`drmSyncobjFDToHandle` with `IMPORT_SYNC_FILE`), transfers its
+    /// point 0 to this timeline at `self.point`, and destroys the
+    /// temp. Used by compositors that drive Vulkan explicit sync via
+    /// `VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT` and need to
+    /// inject the resulting sync-file fence into the client's release
+    /// point. Mirrors `wlr_drm_syncobj_timeline_import_sync_file`.
+    pub fn import_sync_file(&self, fd: BorrowedFd<'_>) -> io::Result<()> {
+        let ctx = self.timeline.0.dev_ctx.lock().unwrap();
+        let Some(device) = ctx.device.upgrade() else {
+            return Err(io::ErrorKind::InvalidInput.into());
+        };
+
+        let tmp = device.fd_to_syncobj(fd, true)?;
+        let res = device.syncobj_timeline_transfer(tmp, ctx.syncobj, 0, self.point);
+        let _ = device.destroy_syncobj(tmp);
         res
     }
 

--- a/src/wayland/drm_syncobj/sync_point.rs
+++ b/src/wayland/drm_syncobj/sync_point.rs
@@ -182,20 +182,73 @@ impl DrmSyncPoint {
     /// timeline point. Symmetric counterpart of
     /// [`DrmSyncPoint::export_sync_file`].
     ///
-    /// Internally creates a temporary binary syncobj from `fd`
-    /// (`drmSyncobjFDToHandle` with `IMPORT_SYNC_FILE`), transfers its
-    /// point 0 to this timeline at `self.point`, and destroys the
-    /// temp. Used by compositors that drive Vulkan explicit sync via
+    /// Internally creates a fresh binary syncobj, imports the sync
+    /// file fence into it via the `IMPORT_SYNC_FILE` ioctl (raw
+    /// because the `drm` crate's public wrapper hardcodes the
+    /// destination handle to `0`, which the kernel rejects with
+    /// `ENOENT` — only the two-step `drmSyncobjCreate` +
+    /// `drmSyncobjImportSyncFile(existing_handle, fd)` pattern is
+    /// supported, mirroring libdrm). Then transfers the temp's
+    /// point 0 into this timeline at `self.point` and destroys the
+    /// temp.
+    ///
+    /// Mirrors `wlr_drm_syncobj_timeline_import_sync_file`. Used by
+    /// compositors that drive Vulkan explicit sync via
     /// `VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT` and need to
-    /// inject the resulting sync-file fence into the client's release
-    /// point. Mirrors `wlr_drm_syncobj_timeline_import_sync_file`.
+    /// inject the resulting sync-file fence into the client's
+    /// release point.
     pub fn import_sync_file(&self, fd: BorrowedFd<'_>) -> io::Result<()> {
+        use std::os::fd::AsRawFd;
+
         let ctx = self.timeline.0.dev_ctx.lock().unwrap();
         let Some(device) = ctx.device.upgrade() else {
             return Err(io::ErrorKind::InvalidInput.into());
         };
 
-        let tmp = device.fd_to_syncobj(fd, true)?;
+        let tmp = device.create_syncobj(false)?;
+
+        // DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE with
+        // DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE and a
+        // non-zero existing handle. Computed ioctl number:
+        //   _IOWR('d', 0xC2, drm_syncobj_handle)
+        //     = (3<<30) | (sizeof(24)<<16) | (0x64<<8) | 0xC2
+        //     = 0xC018_64C2
+        const DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE: libc::c_ulong = 0xC018_64C2;
+        const DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE: u32 = 1;
+
+        #[repr(C)]
+        struct DrmSyncobjHandle {
+            handle: u32,
+            flags: u32,
+            fd: i32,
+            pad: u32,
+            point: u64,
+        }
+
+        let mut args = DrmSyncobjHandle {
+            handle: tmp.into(),
+            flags: DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE,
+            fd: fd.as_raw_fd(),
+            pad: 0,
+            point: 0,
+        };
+        // SAFETY: `device.as_raw_fd()` is a valid DRM device fd;
+        // `args` layout matches the kernel's `drm_syncobj_handle`;
+        // the ioctl is a standard `_IOWR` that reads+writes `args`
+        // and returns 0 on success or -1 with errno set.
+        let ret = unsafe {
+            libc::ioctl(
+                device.as_raw_fd(),
+                DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE,
+                &mut args as *mut _,
+            )
+        };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            let _ = device.destroy_syncobj(tmp);
+            return Err(err);
+        }
+
         let res = device.syncobj_timeline_transfer(tmp, ctx.syncobj, 0, self.point);
         let _ = device.destroy_syncobj(tmp);
         res

--- a/src/wayland/drm_syncobj/sync_point.rs
+++ b/src/wayland/drm_syncobj/sync_point.rs
@@ -198,6 +198,7 @@ impl DrmSyncPoint {
     /// inject the resulting sync-file fence into the client's
     /// release point.
     pub fn import_sync_file(&self, fd: BorrowedFd<'_>) -> io::Result<()> {
+        use rustix::ioctl::{Updater, ioctl, opcode::read_write};
         use std::os::fd::AsRawFd;
 
         let ctx = self.timeline.0.dev_ctx.lock().unwrap();
@@ -207,46 +208,28 @@ impl DrmSyncPoint {
 
         let tmp = device.create_syncobj(false)?;
 
-        // DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE with
-        // DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE and a
-        // non-zero existing handle. Computed ioctl number:
-        //   _IOWR('d', 0xC2, drm_syncobj_handle)
-        //     = (3<<30) | (sizeof(24)<<16) | (0x64<<8) | 0xC2
-        //     = 0xC018_64C2
-        const DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE: libc::c_ulong = 0xC018_64C2;
-        const DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE: u32 = 1;
+        const DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE: rustix::ioctl::Opcode =
+            read_write::<drm_ffi::drm_syncobj_handle>(drm_ffi::DRM_IOCTL_BASE, 0xC2);
 
-        #[repr(C)]
-        struct DrmSyncobjHandle {
-            handle: u32,
-            flags: u32,
-            fd: i32,
-            pad: u32,
-            point: u64,
-        }
-
-        let mut args = DrmSyncobjHandle {
+        let mut args = drm_ffi::drm_syncobj_handle {
             handle: tmp.into(),
-            flags: DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE,
+            flags: drm_ffi::DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE,
             fd: fd.as_raw_fd(),
             pad: 0,
             point: 0,
         };
-        // SAFETY: `device.as_raw_fd()` is a valid DRM device fd;
-        // `args` layout matches the kernel's `drm_syncobj_handle`;
-        // the ioctl is a standard `_IOWR` that reads+writes `args`
-        // and returns 0 on success or -1 with errno set.
-        let ret = unsafe {
-            libc::ioctl(
-                device.as_raw_fd(),
-                DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE,
-                &mut args as *mut _,
+        // SAFETY: `device.as_fd()` is a valid DRM device fd;
+        // `drm_ffi::drm_syncobj_handle` is the type expected by the
+        // DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE ioctl.
+        let res = unsafe {
+            ioctl(
+                device.as_fd(),
+                Updater::<DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE, _>::new(&mut args),
             )
         };
-        if ret < 0 {
-            let err = io::Error::last_os_error();
+        if let Err(err) = res {
             let _ = device.destroy_syncobj(tmp);
-            return Err(err);
+            return Err(err.into());
         }
 
         let res = device.syncobj_timeline_transfer(tmp, ctx.syncobj, 0, self.point);


### PR DESCRIPTION
## Description
This PR adds focused DRM syncobj timeline-point accessors and an explicit sync-file import path for `DrmSyncPoint`.

`DrmSyncPoint::timeline()` and `DrmSyncPoint::point()` let callers inspect the timeline and numeric point without reaching through private state. The direct `AsFd` exposure on `DrmTimeline` is replaced with `DrmSyncPoint::import_sync_file(...)`, which better represents the operation callers need: materializing an exported sync fd as the fence for a specific timeline point.

The import implementation now follows the kernel/libdrm contract directly. It creates a temporary binary syncobj, imports the sync fd into that existing handle with `DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE` and `IMPORT_SYNC_FILE`, then transfers point `0` into the target timeline point before destroying the temporary syncobj. This avoids the `drm` crate helper path that passes `handle = 0`, which the kernel rejects with `ENOENT` for sync-file import.

This is intended for compositors that drive Vulkan explicit sync with `VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT` and need to import the resulting sync fd into a client's release point.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
