### PR TITLE
drm: check for EINVAL when dropping master

### DIFF
--- a/src/wayland/drm_lease/mod.rs
+++ b/src/wayland/drm_lease/mod.rs
@@ -368,12 +368,13 @@ fn get_non_master_fd<P: AsRef<Path>>(path: P) -> Result<OwnedFd, Error> {
     )
     .map_err(Error::UnableToOpenNode)?;
 
-    // check if the fd has master
-    if drm_ffi::get_client(fd.as_fd(), 0)
-        .map(|client| client.auth == 1)
-        .unwrap_or(false)
-    {
-        drm_ffi::auth::release_master(fd.as_fd()).map_err(Error::UnableToDropMaster)?;
+    // Attempt to drop master unconditionally. EINVAL means the fd never had
+    // master to begin with (common on drivers like nvidia-drm that mark all
+    // clients as authenticated regardless of master status)
+    match drm_ffi::auth::release_master(fd.as_fd()) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::InvalidInput => {}
+        Err(e) => return Err(Error::UnableToDropMaster(e)),
     }
 
     Ok(fd)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->

When using DRM leasing on the NVIDIA driver smithay may run into an error while trying to release master during `DrmLeaseState::new()->get_non_master_fd()`. The NVIDIA driver marks all clients as authenticated, so when smithay does the `get_client()` call it erroneously assumes the fd has master and tries to drop it. Dropping master fails since the fd never had it to begin with.

This change checks for EINVAL while releasing master. If we see EINVAL returned then we know that the fd, while potentially marked as authenticated, did not have master and therefore was unable to drop it. 

Open to suggestions if you do not think this is the right fix.

<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
