### PR TITLE
drm/legacy: recover from EINVAL from a failed page flip

### DIFF
--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -1,6 +1,7 @@
 use drm::control::{Device as ControlDevice, Mode, PageFlipFlags, connector, crtc, encoder, framebuffer};
 
 use std::collections::HashSet;
+use std::io::ErrorKind;
 use std::sync::{
     Arc, Mutex, RwLock,
     atomic::{AtomicBool, Ordering},
@@ -9,7 +10,7 @@ use std::sync::{
 use crate::backend::drm::error::AccessError;
 use crate::{
     backend::drm::{
-        DrmDeviceFd, device::DrmDeviceInternal, device::legacy::set_connector_state, error::Error,
+        DrmDeviceFd, DrmSurface, device::DrmDeviceInternal, device::legacy::set_connector_state, error::Error,
     },
     utils::DevPath,
 };
@@ -333,7 +334,7 @@ impl LegacyDrmSurface {
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
     #[profiling::function]
-    pub fn page_flip(&self, framebuffer: framebuffer::Handle, event: bool) -> Result<(), Error> {
+    fn do_page_flip(&self, framebuffer: framebuffer::Handle, event: bool) -> Result<(), Error> {
         trace!("Queueing Page flip");
 
         if !self.active.load(Ordering::SeqCst) {
@@ -365,6 +366,29 @@ impl LegacyDrmSurface {
                 source,
             })
         })
+    }
+
+    #[instrument(level = "trace", parent = &self.span, skip(self))]
+    #[profiling::function]
+    pub fn page_flip(&self, framebuffer: framebuffer::Handle, event: bool) -> Result<(), Error> {
+        match self.do_page_flip(framebuffer, event) {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                let lost_mode = matches!(err, Error::Access(AccessError { ref source, .. }) if source.kind() == ErrorKind::InvalidInput);
+
+                if lost_mode {
+                    self.reset_state::<DrmSurface>(None)?;
+                    if self.commit_pending() {
+                        self.commit(framebuffer, false)?;
+                        self.do_page_flip(framebuffer, event)
+                    } else {
+                        Err(err)
+                    }
+                } else {
+                    Err(err)
+                }
+            }
+        }
     }
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]


### PR DESCRIPTION
## Description

In the legacy path, we can't be sure that the hardware is set up as it was the last time we did a commit, as a VT switch or some other DRM master operation might change things from underneath us.

There's also a case where a compositor might call reset_buffers() right before a page flip is queued, which will drop the swapchain and destroy all framebuffers, which will cause the page flip to fail, as there's nothing left to flip.

So, if we get EINVAL, try to reset state, and if that causes there to be a pending commit, do the commit and then retry the page flip.

For reference, here's a (lightly edited and annotated for clarity and to remove repetitive prefixes) excerpt from the user's kernel log with DRM debugging enabled:

```
# LVDS-1 (CRTC 44) is modeset with FB:56 as its scanout buffer:
[ 8668.920949] [drm:drm_mode_setcrtc] [CRTC:44:crtc-0]
[ 8668.920977] [drm:drm_mode_setcrtc] [CONNECTOR:48:LVDS-1]
[ 8668.921003] [drm:drm_crtc_helper_set_config] [CRTC:44:crtc-0] [FB:56] #connectors=1 (x y) (0 0)

# FB:56 is removed while still bound, so the kernel tears the whole pipe down (this corresponds to
# xfwl4 calling reset_buffers() on a scale change, which it perhaps doesn't need to do, but the
# expectation is that this would be safe):
[ 8670.156213] DRM_IOCTL_MODE_RMFB
[ 8670.156632] [drm:drm_mode_rmfb_work_fn]  Removing [FB:56] from all active usage due to RMFB ioctl
[ 8670.156654] [drm:drm_framebuffer_remove] Disabling [CRTC:44:crtc-0] because [FB:56] is removed
[ 8670.156679] [drm:drm_crtc_helper_set_config] [CRTC:44:crtc-0] [NOFB]

# Then we get to the first render: a new fb is created:
[ 8671.449317] [drm:drm_mode_addfb2] [FB:56]
# ... then a page-flip onto the now-modeless CRTC, which leads to EINVAL:
[ 8671.455982] DRM_IOCTL_MODE_PAGE_FLIP
[ 8671.456002] comm="xfwl4.orig", pid=31653, ret=-22
```

Smithay translates this into a seemingly-unrecoverable error:

```
ContextLost(
    Access(
        AccessError {
            errmsg: "Failed to page flip",
            dev: Some(
                "/dev/dri/card0",
            ),
            source: Os {
                code: 22,
                kind: InvalidInput,
                message: "Invalid argument",
            },
        },
    ),
)
```

User reports that the issue goes away with this patch.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
