### PR TITLE
renderer/multigpu: Allow manually creating `MultiTexture`s

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1734,6 +1734,29 @@ impl MultiTexture {
         })))
     }
 
+    /// Create a `MultiTexture` from a renderer `A`-specific texture type.
+    ///
+    /// The resulting texture contains only and entry for `A` and can thus
+    /// only be successfully rendered from `MultiFrame`s where `R` equals `A`.
+    ///
+    /// Prefer using `ImportDma` or `ImportMem` for function which handle
+    /// returning and caching textures for the current renderer automatically.
+    pub fn from_native_texture<A: GraphicsApi + 'static>(
+        render_id: &ContextId<<<A::Device as ApiDevice>::Renderer as RendererSuper>::TextureId>,
+        texture: <<A::Device as ApiDevice>::Renderer as RendererSuper>::TextureId,
+    ) -> Option<MultiTexture> {
+        let mut multi = Self::new(
+            texture.size(),
+            Format {
+                code: texture.format()?,
+                modifier: Modifier::Invalid,
+            },
+        );
+        multi.0.lock().unwrap().format = texture.format();
+        multi.insert_texture::<A>(render_id, texture);
+        Some(multi)
+    }
+
     /// Attempt to get a texture of type `T: Renderer::TextureId` given the renderer type `A` for the given `DrmNode`.
     ///
     /// Will return `None` if either:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

Adds a method to the `MultiTexture` type to wrap an arbitrary texture from an underlying renderer. This is useful when doing e.g. highly renderer-specific offscreen rendering (e.g. blur), but want to use a `MultiRenderer` for compositing. You can't necessarily just get a reference to the underlying frame, as the `MultiFrame` internally tracks damaged regions.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
