### PR TITLE
drm: store the current frame after committing it

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -2505,12 +2505,15 @@ where
             .frame
             .commit(&self.surface, self.supports_fencing, false, false);
 
-        if flip.is_ok() {
+        let res = self.handle_flip(&prepared_frame, flip);
+
+        if res.is_ok() {
             self.queued_frame = None;
             self.pending_frame = None;
+            self.current_frame = prepared_frame.frame;
         }
 
-        self.handle_flip(prepared_frame, None, flip)
+        res
     }
 
     /// Re-evaluates the current state of the crtc and forces calls to [`render_frame`](DrmCompositor::render_frame)
@@ -2546,13 +2549,21 @@ where
                 .page_flip(&self.surface, self.supports_fencing, allow_partial_update, true)
         };
 
-        self.handle_flip(prepared_frame, Some(user_data), flip)
+        let res = self.handle_flip(&prepared_frame, flip);
+
+        if res.is_ok() {
+            self.pending_frame = Some(PendingFrame {
+                frame: prepared_frame.frame,
+                user_data,
+            });
+        }
+
+        res
     }
 
     fn handle_flip(
         &mut self,
-        prepared_frame: PreparedFrame<A, F>,
-        user_data: Option<U>,
+        prepared_frame: &PreparedFrame<A, F>,
         flip: Result<(), crate::backend::drm::error::Error>,
     ) -> FrameResult<(), A, F> {
         match flip {
@@ -2560,11 +2571,6 @@ where
                 if prepared_frame.kind == PreparedFrameKind::Full {
                     self.reset_pending = false;
                 }
-
-                self.pending_frame = user_data.map(|user_data| PendingFrame {
-                    frame: prepared_frame.frame,
-                    user_data,
-                });
             }
             Err(crate::backend::drm::error::Error::Access(ref access))
                 if access.source.kind() == ErrorKind::InvalidInput =>


### PR DESCRIPTION
## Description

`DrmCompositor::commit_frame()` would pass `None` for the `user_data` arg to `DrmCompositor::handle_flip()`.  When `handle_flip()` sees no user-data, it dropped the prepared_frame entirely.  The swapchain would still hold a reference to the frame, but if `reset_buffers()` is called after `commit_frame()` but before the page flip actually occurs, the swapchain would drop anything in all of its slots, and frame would be fully dropped.

On the legacy DRM path, this would cause `EINVAL` to be returned on page flip, because dropping the frames would also cause all framebuffers to be deleted, and the driver would have nothing to flip to.

This modifies `handle_flip()` to no longer take the `user_data` parameter; instead, callers (there are only two of them) are expected to store the pending frame in the appropriate place.  `commit_frame()` now stores the pending frame in `self.current_frame`, which will keep it alive in the case where all data in the swapchain is dropped.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
