### PR TITLE
Fix broken drm pending state

### DIFF
--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -994,7 +994,6 @@ impl AtomicDrmSurface {
         if res.is_ok() {
             self.used_planes.lock().unwrap().clear();
             self.state.write().unwrap().clear();
-            self.pending.write().unwrap().clear();
         }
 
         res
@@ -1009,7 +1008,6 @@ impl AtomicDrmSurface {
         } else {
             State::current_state(&*self.fd, self.crtc, &mut self.prop_mapping.write().unwrap())?
         };
-        *self.pending.write().unwrap() = self.state.read().unwrap().clone();
         Ok(())
     }
 

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -1008,6 +1008,20 @@ impl AtomicDrmSurface {
         } else {
             State::current_state(&*self.fd, self.crtc, &mut self.prop_mapping.write().unwrap())?
         };
+
+        // Re-initialize the mode blob which might got lost after suspend/resume
+        let mut pending = self.pending.write().unwrap();
+        let blob = self.fd.create_property_blob(&pending.mode).map_err(|source| {
+            Error::Access(AccessError {
+                errmsg: "Failed to create Property Blob for mode",
+                dev: self.fd.dev_path(),
+                source,
+            })
+        })?;
+
+        let old_blob = std::mem::replace(&mut pending.blob, blob);
+        let _ = self.fd.destroy_property_blob(old_blob.into());
+
         Ok(())
     }
 

--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -462,7 +462,6 @@ impl LegacyDrmSurface {
         } else {
             State::current_state(&*self.fd, self.crtc)?
         };
-        *self.pending.write().unwrap() = self.state.read().unwrap().clone();
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Reverts 13f07dd1f1f20ef0b3a0daa1f860d87f27a816d7 and tries to re-initialize the mode blob.

@Drakulix Not sure about the connectors, but just using the current state might also not match the user expectation.
An alternative to this might be to not revert the commit, but document the expectations and require all callers to
re-issue the mode and connectors (not sure this is actually stored anywhere else as in the surface itself).

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [X] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
