### PR TITLE
xwm: handle _NET_WM_STATE_MODAL client messages

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -425,6 +425,14 @@ pub trait XwmHandler {
     fn unfullscreen_request(&mut self, xwm: XwmId, window: X11Surface) {
         let _ = (xwm, window);
     }
+    /// Window requests to be set as a modal dialog (see [`X11Surface::is_popup`]).
+    fn modal_request(&mut self, xwm: XwmId, window: X11Surface) {
+        let _ = (xwm, window);
+    }
+    /// Window requests to no longer be a modal dialog.
+    fn unmodal_request(&mut self, xwm: XwmId, window: X11Surface) {
+        let _ = (xwm, window);
+    }
     /// Window requests to be minimized.
     fn minimize_request(&mut self, xwm: XwmId, window: X11Surface) {
         let _ = (xwm, window);
@@ -2517,6 +2525,18 @@ where
                                     _ => {}
                                 }
                             }
+                            actions if actions.contains(&xwm.atoms._NET_WM_STATE_MODAL) => match data[0] {
+                                0 => state.unmodal_request(xwm_id, surface),
+                                1 => state.modal_request(xwm_id, surface),
+                                2 => {
+                                    if surface.is_popup() {
+                                        state.unmodal_request(xwm_id, surface)
+                                    } else {
+                                        state.modal_request(xwm_id, surface)
+                                    }
+                                }
+                                _ => {}
+                            },
                             actions if actions.contains(&xwm.atoms._NET_WM_STATE_ABOVE) => match data[0] {
                                 0 => state.unabove_request(xwm_id, surface),
                                 1 => state.above_request(xwm_id, surface),

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -425,7 +425,7 @@ pub trait XwmHandler {
     fn unfullscreen_request(&mut self, xwm: XwmId, window: X11Surface) {
         let _ = (xwm, window);
     }
-    /// Window requests to be set as a modal dialog (see [`X11Surface::is_popup`]).
+    /// Window requests to be set as a modal dialog (see [`X11Surface::is_modal`]).
     fn modal_request(&mut self, xwm: XwmId, window: X11Surface) {
         let _ = (xwm, window);
     }
@@ -2529,7 +2529,7 @@ where
                                 0 => state.unmodal_request(xwm_id, surface),
                                 1 => state.modal_request(xwm_id, surface),
                                 2 => {
-                                    if surface.is_popup() {
+                                    if surface.is_modal() {
                                         state.unmodal_request(xwm_id, surface)
                                     } else {
                                         state.modal_request(xwm_id, surface)

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -1102,12 +1102,20 @@ impl X11Surface {
         self.state.lock().unwrap().opacity
     }
 
+    /// Returns if the window is a modal dialog.
+    ///
+    /// Corresponds to the `_NET_WM_STATE_MODAL` state of the underlying X11 window.
+    pub fn is_modal(&self) -> bool {
+        let state = self.state.lock().unwrap();
+        state.net_state.contains(&self.atoms._NET_WM_STATE_MODAL)
+    }
+
     /// Returns if the window is considered to be a popup.
     ///
     /// Corresponds to the internal `_NET_WM_STATE_MODAL` state of the underlying X11 window.
+    #[deprecated = "use `X11Surface::is_modal` instead"]
     pub fn is_popup(&self) -> bool {
-        let state = self.state.lock().unwrap();
-        state.net_state.contains(&self.atoms._NET_WM_STATE_MODAL)
+        self.is_modal()
     }
 
     /// Returns if the underlying window is transient to another window.
@@ -1365,7 +1373,7 @@ impl X11Surface {
     /// Sets the window as a modal dialog or not.
     ///
     /// Corresponds to the `_NET_WM_STATE_MODAL` state, also reflected
-    /// by [`X11Surface::is_popup`].
+    /// by [`X11Surface::is_modal`].
     pub fn set_modal(&self, modal: bool) -> Result<(), ConnectionError> {
         if modal {
             self.change_net_state(&[self.atoms._NET_WM_STATE_MODAL], &[])?;

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -1362,6 +1362,19 @@ impl X11Surface {
         Ok(())
     }
 
+    /// Sets the window as a modal dialog or not.
+    ///
+    /// Corresponds to the `_NET_WM_STATE_MODAL` state, also reflected
+    /// by [`X11Surface::is_popup`].
+    pub fn set_modal(&self, modal: bool) -> Result<(), ConnectionError> {
+        if modal {
+            self.change_net_state(&[self.atoms._NET_WM_STATE_MODAL], &[])?;
+        } else {
+            self.change_net_state(&[], &[self.atoms._NET_WM_STATE_MODAL])?;
+        }
+        Ok(())
+    }
+
     /// Sets the window as above (always on top) or not.
     ///
     /// Allows the client to reflect this state in their UI.


### PR DESCRIPTION
## Description
Currently, the XWM tracks `_NET_WM_STATE_MODAL` only as a part of inital/updated `_NET_WM_STATE` property exposed via `X11Surface::is_popup`, but `_NET_WM_STATE` client messages toggling the modal state at runtime are silently swallowed.  A client that maps a window first and then requests modality for it never gets the state applied, so the compositor will never be notified.

This PR wires the modal state through the same path as the existing fullscreen/above/below handling:
- New `XwmHandler::modal_request` / `XwmHandler::unmodal_request` callbacks, invoked on `_NET_WM_STATE_MODAL` client messages.
- New `X11Surface::set_modal` so the compositor can acknowledge the request by updating `_NET_WM_STATE` on the window, as it does for `set_fullscreen`/`set_above`.

Both callbacks have empty default implementations, so this is not a breaking change for existing `XwmHandler` implementations.

## Small note
`is_popup` in `X11Surface` can be a misleading term for a modal window, and `is_modal` sounds more reasonable IMO.
So we might want to consider renaming it (yet it's cosmetics and a breaking change as well).

## Motivation
This PR is also part of the larger work on bringing modality to comsic-comp ([xdg-dialog-v1](https://wayland.app/protocols/xdg-dialog-v1) protocol support).

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
