### PR TITLE
wayland/alpha_modifier: add AlphaModifierSurfaceCachedState::set_multiplier

### DIFF
--- a/src/wayland/alpha_modifier/mod.rs
+++ b/src/wayland/alpha_modifier/mod.rs
@@ -92,6 +92,16 @@ impl AlphaModifierSurfaceCachedState {
         self.multiplier
     }
 
+    /// Sets the alpha multiplier for the surface.
+    ///
+    /// This allows compositors to drive the multiplier from sources other than
+    /// `wp_alpha_modifier` (e.g. bridging Chromium's `zcr_alpha_compositing_v1`).
+    /// When called on the pending state, the value takes effect on the next
+    /// `wl_surface.commit`, just like a client `set_multiplier` request.
+    pub fn set_multiplier(&mut self, multiplier: Option<u32>) {
+        self.multiplier = multiplier;
+    }
+
     /// Alpha multiplier for the surface
     pub fn multiplier_f32(&self) -> Option<f32> {
         self.multiplier


### PR DESCRIPTION

## Summary

- Add a public `set_multiplier()` accessor to `AlphaModifierSurfaceCachedState`, so compositors can drive the alpha multiplier from sources other than the `wp_alpha_modifier` protocol.

## Problem

`AlphaModifierSurfaceCachedState` exposes read accessors (`multiplier()`, `multiplier_f32()`, `multiplier_f64()`), but the `multiplier` field itself is private outside the `alpha_modifier` module. Only smithay's own `wp_alpha_modifier` dispatch code can write it.

Compositors that receive per-surface opacity through other channels cannot reuse this state — and with it the built-in rendering support in `WaylandSurfaceRenderElement` — without patching smithay. A concrete example is bridging Chromium's `zcr_alpha_compositing_v1` extension: its `set_alpha` request carries the same double-buffered per-surface opacity semantics, and mapping it onto `AlphaModifierSurfaceCachedState` lets the existing render path apply it for free.

## Solution

Add a minimal setter:

```rust
/// Sets the alpha multiplier for the surface.
///
/// This allows compositors to drive the multiplier from sources other than
/// `wp_alpha_modifier` (e.g. bridging Chromium's `zcr_alpha_compositing_v1`).
/// When called on the pending state, the value takes effect on the next
/// `wl_surface.commit`, just like a client `set_multiplier` request.
pub fn set_multiplier(&mut self, multiplier: Option<u32>) {
    self.multiplier = multiplier;
}
```

Callers are expected to write the **pending** state (`cached_state.get::<AlphaModifierSurfaceCachedState>().pending()`), mirroring what the `wp_alpha_modifier` dispatch code does; the value is then merged into the current state on `wl_surface.commit` like any other `Cacheable` state.

No behavior change for existing users; this only widens the public API surface by one method, symmetric with the existing getters.

## Test plan

- [ ] `cargo check --no-default-features --features wayland_frontend` builds.
- [ ] `cargo doc` produces no new warnings.
- [ ] Downstream usage: a compositor handler for another opacity protocol calls `set_multiplier(Some(...))` / `set_multiplier(None)` on the pending state and commits; `WaylandSurfaceRenderElement` renders the surface with the expected opacity.

## Related

- `wp_alpha_modifier` staging protocol — multiplier is double-buffered on `wl_surface.commit`.
- Chromium `zcr_alpha_compositing_v1` — downstream compositors bridge it onto `AlphaModifierSurfaceCachedState` to reuse the same rendering path.
