### PR TITLE
2066 touch input rework

### DIFF
--- a/anvil/src/focus.rs
+++ b/anvil/src/focus.rs
@@ -24,7 +24,7 @@ use smithay::{
             GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent,
             GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent,
         },
-        touch::TouchTarget,
+        touch::{FrameMarker, TouchTarget},
     },
     reexports::wayland_server::DisplayHandle,
     utils::{Logical, Point},
@@ -286,9 +286,8 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for PointerFocus
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::DownEvent,
-        seq: Serial,
     ) {
-        self.inner_touch_target().down(seat, data, event, seq)
+        self.inner_touch_target().down(seat, data, event)
     }
 
     fn up(
@@ -296,9 +295,8 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for PointerFocus
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::UpEvent,
-        seq: Serial,
     ) {
-        self.inner_touch_target().up(seat, data, event, seq)
+        self.inner_touch_target().up(seat, data, event)
     }
 
     fn motion(
@@ -306,17 +304,26 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for PointerFocus
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::MotionEvent,
-        seq: Serial,
     ) {
-        self.inner_touch_target().motion(seat, data, event, seq)
+        self.inner_touch_target().motion(seat, data, event)
     }
 
-    fn frame(&self, seat: &Seat<AnvilState<BackendData>>, data: &mut AnvilState<BackendData>, seq: Serial) {
-        self.inner_touch_target().frame(seat, data, seq)
+    fn frame(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        marker: FrameMarker,
+    ) {
+        self.inner_touch_target().frame(seat, data, marker)
     }
 
-    fn cancel(&self, seat: &Seat<AnvilState<BackendData>>, data: &mut AnvilState<BackendData>, seq: Serial) {
-        self.inner_touch_target().cancel(seat, data, seq)
+    fn cancel(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        marker: FrameMarker,
+    ) {
+        self.inner_touch_target().cancel(seat, data, marker)
     }
 
     fn shape(
@@ -324,9 +331,8 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for PointerFocus
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::ShapeEvent,
-        seq: Serial,
     ) {
-        self.inner_touch_target().shape(seat, data, event, seq)
+        self.inner_touch_target().shape(seat, data, event)
     }
 
     fn orientation(
@@ -334,9 +340,16 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for PointerFocus
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::OrientationEvent,
-        seq: Serial,
     ) {
-        self.inner_touch_target().orientation(seat, data, event, seq)
+        self.inner_touch_target().orientation(seat, data, event)
+    }
+
+    fn last_frame(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+    ) -> Option<FrameMarker> {
+        self.inner_touch_target().last_frame(seat, data)
     }
 }
 

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -15,7 +15,7 @@ use smithay::{
             GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
             GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
         },
-        touch::TouchTarget,
+        touch::{FrameMarker, TouchTarget},
     },
     output::Output,
     reexports::{
@@ -282,7 +282,6 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for SSD {
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::DownEvent,
-        _seq: Serial,
     ) {
         let mut state = self.0.decoration_state();
         if state.is_ssd {
@@ -296,7 +295,6 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for SSD {
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::UpEvent,
-        _seq: Serial,
     ) {
         let mut state = self.0.decoration_state();
         if state.is_ssd {
@@ -309,7 +307,6 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for SSD {
         _seat: &Seat<AnvilState<BackendData>>,
         _data: &mut AnvilState<BackendData>,
         event: &smithay::input::touch::MotionEvent,
-        _seq: Serial,
     ) {
         let mut state = self.0.decoration_state();
         if state.is_ssd {
@@ -321,7 +318,7 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for SSD {
         &self,
         _seat: &Seat<AnvilState<BackendData>>,
         _data: &mut AnvilState<BackendData>,
-        _seq: Serial,
+        _marker: FrameMarker,
     ) {
     }
 
@@ -329,7 +326,7 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for SSD {
         &self,
         _seat: &Seat<AnvilState<BackendData>>,
         _data: &mut AnvilState<BackendData>,
-        _seq: Serial,
+        _marker: FrameMarker,
     ) {
     }
 
@@ -338,7 +335,6 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for SSD {
         _seat: &Seat<AnvilState<BackendData>>,
         _data: &mut AnvilState<BackendData>,
         _event: &smithay::input::touch::ShapeEvent,
-        _seq: Serial,
     ) {
     }
 
@@ -347,8 +343,17 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for SSD {
         _seat: &Seat<AnvilState<BackendData>>,
         _data: &mut AnvilState<BackendData>,
         _event: &smithay::input::touch::OrientationEvent,
-        _seq: Serial,
     ) {
+    }
+
+    fn last_frame(
+        &self,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
+    ) -> Option<FrameMarker> {
+        // It would be more correct to store the marker on frame and cancel,
+        // but since we're ignoring those anyway, no need for the added complexity.
+        None
     }
 }
 

--- a/anvil/src/shell/grabs.rs
+++ b/anvil/src/shell/grabs.rs
@@ -183,7 +183,6 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
             Point<f64, Logical>,
         )>,
         _event: &smithay::input::touch::DownEvent,
-        _seq: Serial,
     ) {
     }
 
@@ -192,13 +191,12 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
         data: &mut AnvilState<BackendData>,
         handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
         event: &smithay::input::touch::UpEvent,
-        seq: Serial,
     ) {
         if event.slot != self.start_data.slot {
             return;
         }
 
-        handle.up(data, event, seq);
+        handle.up(data, event);
         handle.unset_grab(self, data);
     }
 
@@ -211,7 +209,6 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
             Point<f64, Logical>,
         )>,
         event: &smithay::input::touch::MotionEvent,
-        _seq: Serial,
     ) {
         if event.slot != self.start_data.slot {
             return;
@@ -227,7 +224,6 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
         &mut self,
         _data: &mut AnvilState<BackendData>,
         _handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
-        _seq: Serial,
     ) {
     }
 
@@ -235,9 +231,8 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
-        seq: Serial,
     ) {
-        handle.cancel(data, seq);
+        handle.cancel(data);
         handle.unset_grab(self, data);
     }
 
@@ -246,9 +241,8 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
         data: &mut AnvilState<BackendData>,
         handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
         event: &smithay::input::touch::ShapeEvent,
-        seq: Serial,
     ) {
-        handle.shape(data, event, seq);
+        handle.shape(data, event);
     }
 
     fn orientation(
@@ -256,9 +250,8 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchMoveSurfa
         data: &mut AnvilState<BackendData>,
         handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
         event: &smithay::input::touch::OrientationEvent,
-        seq: Serial,
     ) {
-        handle.orientation(data, event, seq);
+        handle.orientation(data, event);
     }
 
     fn start_data(&self) -> &smithay::input::touch::GrabStartData<AnvilState<BackendData>> {
@@ -644,7 +637,6 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
             Point<f64, Logical>,
         )>,
         _event: &smithay::input::touch::DownEvent,
-        _seq: Serial,
     ) {
     }
 
@@ -653,7 +645,6 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
         data: &mut AnvilState<BackendData>,
         handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
         event: &smithay::input::touch::UpEvent,
-        _seq: Serial,
     ) {
         if event.slot != self.start_data.slot {
             return;
@@ -750,7 +741,6 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
             Point<f64, Logical>,
         )>,
         event: &smithay::input::touch::MotionEvent,
-        _seq: Serial,
     ) {
         if event.slot != self.start_data.slot {
             return;
@@ -827,7 +817,6 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
         &mut self,
         _data: &mut AnvilState<BackendData>,
         _handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
-        _seq: Serial,
     ) {
     }
 
@@ -835,9 +824,8 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
         &mut self,
         data: &mut AnvilState<BackendData>,
         handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
-        seq: Serial,
     ) {
-        handle.cancel(data, seq);
+        handle.cancel(data);
         handle.unset_grab(self, data);
     }
 
@@ -846,9 +834,8 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
         data: &mut AnvilState<BackendData>,
         handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
         event: &smithay::input::touch::ShapeEvent,
-        seq: Serial,
     ) {
-        handle.shape(data, event, seq);
+        handle.shape(data, event);
     }
 
     fn orientation(
@@ -856,9 +843,8 @@ impl<BackendData: Backend> TouchGrab<AnvilState<BackendData>> for TouchResizeSur
         data: &mut AnvilState<BackendData>,
         handle: &mut smithay::input::touch::TouchInnerHandle<'_, AnvilState<BackendData>>,
         event: &smithay::input::touch::OrientationEvent,
-        seq: Serial,
     ) {
-        handle.orientation(data, event, seq);
+        handle.orientation(data, event);
     }
 
     fn start_data(&self) -> &smithay::input::touch::GrabStartData<AnvilState<BackendData>> {

--- a/src/input/dnd/grab.rs
+++ b/src/input/dnd/grab.rs
@@ -483,12 +483,11 @@ where
         _handle: &mut TouchInnerHandle<'_, D>,
         _focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         _event: &DownEvent,
-        _seq: Serial,
     ) {
         // Ignore
     }
 
-    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent, _seq: Serial) {
+    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent) {
         if event.slot != self.start_data().slot {
             return;
         }
@@ -504,13 +503,12 @@ where
         handle: &mut TouchInnerHandle<'_, D>,
         focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &TouchMotionEvent,
-        seq: Serial,
     ) {
         if event.slot != self.start_data().slot {
             return;
         }
 
-        handle.motion(data, self.touch_focus(), event, seq);
+        handle.motion(data, self.touch_focus(), event);
 
         self.last_position = event.location;
 
@@ -523,11 +521,11 @@ where
         );
     }
 
-    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
-        handle.frame(data, seq);
+    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>) {
+        handle.frame(data);
     }
 
-    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, _seq: Serial) {
+    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>) {
         handle.unset_grab(self, data);
     }
 
@@ -536,7 +534,6 @@ where
         _data: &mut D,
         _handle: &mut TouchInnerHandle<'_, D>,
         _event: &crate::input::touch::ShapeEvent,
-        _seq: Serial,
     ) {
     }
 
@@ -545,7 +542,6 @@ where
         _data: &mut D,
         _handle: &mut TouchInnerHandle<'_, D>,
         _event: &crate::input::touch::OrientationEvent,
-        _seq: Serial,
     ) {
     }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -24,7 +24,7 @@
 //! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
 //! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
+//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget, FrameMarker},
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
 //!
@@ -77,13 +77,14 @@
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
 //! # impl TouchTarget<State> for Target {
-//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
-//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
-//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
-//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
-//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent) {}
+//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent) {}
+//! #   fn last_frame(&self, seat: &Seat<State>, data: &mut State) -> Option<FrameMarker> { unimplemented!() }
 //! # }
 //!
 //! // implement the required traits
@@ -371,7 +372,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
     /// #             GestureHoldBeginEvent, GestureHoldEndEvent},
     /// #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-    /// #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
+    /// #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget, FrameMarker},
     /// # };
     /// # use smithay::utils::{IsAlive, Serial};
     /// #
@@ -412,13 +413,14 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
     /// # }
     /// # impl TouchTarget<State> for Target {
-    /// #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
-    /// #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
-    /// #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
-    /// #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-    /// #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-    /// #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
-    /// #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+    /// #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent) {}
+    /// #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent) {}
+    /// #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent) {}
+    /// #   fn frame(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+    /// #   fn cancel(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+    /// #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent) {}
+    /// #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent) {}
+    /// #   fn last_frame(&self, seat: &Seat<State>, data: &mut State) -> Option<FrameMarker> { unimplemented!() }
     /// # }
     /// # struct State;
     /// # impl SeatHandler for State {
@@ -492,7 +494,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
     /// #             GestureHoldBeginEvent, GestureHoldEndEvent},
     /// #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-    /// #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
+    /// #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget, FrameMarker},
     /// # };
     /// # use smithay::utils::{IsAlive, Serial};
     /// #
@@ -533,13 +535,14 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
     /// # }
     /// # impl TouchTarget<State> for Target {
-    /// #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
-    /// #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
-    /// #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
-    /// #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-    /// #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-    /// #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
-    /// #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+    /// #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent) {}
+    /// #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent) {}
+    /// #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent) {}
+    /// #   fn frame(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+    /// #   fn cancel(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+    /// #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent) {}
+    /// #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent) {}
+    /// #   fn last_frame(&self, seat: &Seat<State>, data: &mut State) -> Option<FrameMarker> { unimplemented!() }
     /// # }
     /// #
     /// # struct State;
@@ -638,10 +641,16 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// # Examples
     ///
     /// ```no_run
+    /// # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
     /// # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
     /// # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
     /// #
     /// # struct State;
+    /// # impl CompositorHandler for State {
+    /// #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+    /// #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+    /// #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+    /// # }
     /// # impl SeatHandler for State {
     /// #     type KeyboardFocus = WlSurface;
     /// #     type PointerFocus = WlSurface;

--- a/src/input/touch/grab.rs
+++ b/src/input/touch/grab.rs
@@ -5,7 +5,7 @@ use downcast_rs::{Downcast, impl_downcast};
 use crate::{
     backend::input::TouchSlot,
     input::SeatHandler,
-    utils::{Logical, Point, Serial},
+    utils::{Logical, Point},
 };
 
 use super::{DownEvent, MotionEvent, OrientationEvent, ShapeEvent, TouchInnerHandle, UpEvent};
@@ -45,7 +45,6 @@ pub trait TouchGrab<D: SeatHandler>: Send + Downcast {
         handle: &mut TouchInnerHandle<'_, D>,
         focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
-        seq: Serial,
     );
     /// A touch point disappeared
     ///
@@ -55,7 +54,7 @@ pub trait TouchGrab<D: SeatHandler>: Send + Downcast {
     ///
     /// Some grabs (such as drag'n'drop, shell resize and motion) drop up events while they are active,
     /// but will end when the touch point that initiated the grab disappeared.
-    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent, seq: Serial);
+    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent);
 
     /// A touch point has changed coordinates.
     ///
@@ -72,7 +71,6 @@ pub trait TouchGrab<D: SeatHandler>: Send + Downcast {
         handle: &mut TouchInnerHandle<'_, D>,
         focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
-        seq: Serial,
     );
 
     /// Marks the end of a set of events that logically belong together.
@@ -82,7 +80,7 @@ pub trait TouchGrab<D: SeatHandler>: Send + Downcast {
     /// If you don't, the rest of the compositor will behave as if the frame event never occurred.
     ///
     /// This will to be called after one or more calls to down/motion events.
-    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial);
+    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>);
 
     /// A touch session has been cancelled.
     ///
@@ -91,19 +89,13 @@ pub trait TouchGrab<D: SeatHandler>: Send + Downcast {
     /// If you don't, the rest of the compositor will behave as if the cancel event never occurred.
     ///
     /// Usually called in case the compositor decides the touch stream is a global gesture.
-    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial);
+    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>);
 
     /// A touch point has changed its shape.
-    fn shape(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &ShapeEvent, seq: Serial);
+    fn shape(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &ShapeEvent);
 
     /// A touch point has changed its orientation.
-    fn orientation(
-        &mut self,
-        data: &mut D,
-        handle: &mut TouchInnerHandle<'_, D>,
-        event: &OrientationEvent,
-        seq: Serial,
-    );
+    fn orientation(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &OrientationEvent);
 
     /// The data about the event that started the grab.
     fn start_data(&self) -> &GrabStartData<D>;
@@ -157,9 +149,8 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
         handle: &mut TouchInnerHandle<'_, D>,
         focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
-        seq: Serial,
     ) {
-        handle.down(data, focus.clone(), event, seq);
+        handle.down(data, focus.clone(), event);
         handle.set_grab(
             self,
             data,
@@ -175,8 +166,8 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
         );
     }
 
-    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent, seq: Serial) {
-        handle.up(data, event, seq)
+    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent) {
+        handle.up(data, event)
     }
 
     fn motion(
@@ -185,31 +176,24 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for DefaultGrab {
         handle: &mut TouchInnerHandle<'_, D>,
         focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
-        seq: Serial,
     ) {
-        handle.motion(data, focus, event, seq)
+        handle.motion(data, focus, event)
     }
 
-    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
-        handle.frame(data, seq)
+    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>) {
+        handle.frame(data)
     }
 
-    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
-        handle.cancel(data, seq)
+    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>) {
+        handle.cancel(data)
     }
 
-    fn shape(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &ShapeEvent, seq: Serial) {
-        handle.shape(data, event, seq)
+    fn shape(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &ShapeEvent) {
+        handle.shape(data, event)
     }
 
-    fn orientation(
-        &mut self,
-        data: &mut D,
-        handle: &mut TouchInnerHandle<'_, D>,
-        event: &OrientationEvent,
-        seq: Serial,
-    ) {
-        handle.orientation(data, event, seq)
+    fn orientation(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &OrientationEvent) {
+        handle.orientation(data, event)
     }
 
     fn start_data(&self) -> &GrabStartData<D> {
@@ -247,14 +231,13 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for TouchDownGrab<D> {
         handle: &mut TouchInnerHandle<'_, D>,
         _focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
-        seq: Serial,
     ) {
-        handle.down(data, self.start_data.focus.clone(), event, seq);
+        handle.down(data, self.start_data.focus.clone(), event);
         self.touch_points += 1;
     }
 
-    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent, seq: Serial) {
-        handle.up(data, event, seq);
+    fn up(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &UpEvent) {
+        handle.up(data, event);
         self.touch_points = self.touch_points.saturating_sub(1);
         if self.touch_points == 0 {
             handle.unset_grab(self, data);
@@ -267,32 +250,25 @@ impl<D: SeatHandler + 'static> TouchGrab<D> for TouchDownGrab<D> {
         handle: &mut TouchInnerHandle<'_, D>,
         _focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
-        seq: Serial,
     ) {
-        handle.motion(data, self.start_data.focus.clone(), event, seq)
+        handle.motion(data, self.start_data.focus.clone(), event)
     }
 
-    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
-        handle.frame(data, seq)
+    fn frame(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>) {
+        handle.frame(data)
     }
 
-    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, seq: Serial) {
-        handle.cancel(data, seq);
+    fn cancel(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>) {
+        handle.cancel(data);
         handle.unset_grab(self, data);
     }
 
-    fn shape(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &ShapeEvent, seq: Serial) {
-        handle.shape(data, event, seq)
+    fn shape(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &ShapeEvent) {
+        handle.shape(data, event)
     }
 
-    fn orientation(
-        &mut self,
-        data: &mut D,
-        handle: &mut TouchInnerHandle<'_, D>,
-        event: &OrientationEvent,
-        seq: Serial,
-    ) {
-        handle.orientation(data, event, seq)
+    fn orientation(&mut self, data: &mut D, handle: &mut TouchInnerHandle<'_, D>, event: &OrientationEvent) {
+        handle.orientation(data, event)
     }
 
     fn start_data(&self) -> &GrabStartData<D> {

--- a/src/input/touch/mod.rs
+++ b/src/input/touch/mod.rs
@@ -9,13 +9,27 @@ use tracing::{info_span, instrument};
 use wayland_server::Weak;
 
 use crate::backend::input::TouchSlot;
-use crate::utils::{IsAlive, Logical, Point, Serial, SerialCounter};
+use crate::utils::{IsAlive, Logical, Point, Serial};
 
 pub use grab::{DefaultGrab, GrabStartData, TouchDownGrab, TouchGrab};
 
 use super::{GrabStatus, Seat, SeatHandler};
 
 mod grab;
+
+crate::utils::ids::id_gen!(frame_marker);
+
+/// A marker to identify a given touch frame.
+///
+/// This marker is sent to [`TouchTarget`] during `frame` and `cancel`, and can be returned via the
+/// [`TouchTarget::last_frame`] function. They are used internally by [`TouchHandle`] to avoid
+/// sending `frame` and `cancel` event more than once.
+///
+/// FrameMarker are used instead of comparing [`TouchTarget`] as different [`TouchTarget`] could
+/// refer to the same underlying object (e.g. multiple surfaces belonging to the same wayland
+/// `Client`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameMarker(usize);
 
 /// An handle to a touch handler
 ///
@@ -29,8 +43,7 @@ mod grab;
 pub struct TouchHandle<D: SeatHandler> {
     pub(crate) inner: Arc<Mutex<TouchInternal<D>>>,
     #[cfg(feature = "wayland_frontend")]
-    pub(crate) known_instances:
-        Arc<Mutex<Vec<(Weak<wayland_server::protocol::wl_touch::WlTouch>, Option<Serial>)>>>,
+    pub(crate) known_instances: Arc<Mutex<Vec<Weak<wayland_server::protocol::wl_touch::WlTouch>>>>,
     pub(crate) span: tracing::Span,
 }
 
@@ -81,16 +94,24 @@ impl<D: SeatHandler> std::cmp::Eq for TouchHandle<D> {}
 
 pub(crate) struct TouchInternal<D: SeatHandler> {
     focus: HashMap<TouchSlot, TouchSlotState<D>>,
-    seq_counter: SerialCounter,
+    pending_frame: Option<FrameMarker>,
     default_grab: Box<dyn Fn() -> Box<dyn TouchGrab<D>> + Send + 'static>,
     grab: GrabStatus<dyn TouchGrab<D>>,
+}
+
+impl<D: SeatHandler> Drop for TouchInternal<D> {
+    fn drop(&mut self) {
+        if let Some(marker) = self.pending_frame.take() {
+            frame_marker::remove(marker.0);
+        }
+    }
 }
 
 struct TouchSlotState<D: SeatHandler> {
     focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
     frame_pending: Option<<D as SeatHandler>::TouchFocus>,
-    pending: Serial,
-    current: Option<Serial>,
+    pending: FrameMarker,
+    current: Option<FrameMarker>,
 }
 
 impl<D: SeatHandler> fmt::Debug for TouchSlotState<D> {
@@ -178,26 +199,34 @@ where
     ///
     /// This touch point is assigned a unique ID. Future events from this touch point reference this ID.
     /// The ID ceases to be valid after a touch up event and may be reused in the future.
-    fn down(&self, seat: &Seat<D>, data: &mut D, event: &DownEvent, seq: Serial);
+    fn down(&self, seat: &Seat<D>, data: &mut D, event: &DownEvent);
 
     /// The touch point has disappeared.
     ///
     /// No further events will be sent for this touch point and the touch point's ID
     /// is released and may be reused in a future touch down event.
-    fn up(&self, seat: &Seat<D>, data: &mut D, event: &UpEvent, seq: Serial);
+    fn up(&self, seat: &Seat<D>, data: &mut D, event: &UpEvent);
 
     /// A touch point has changed coordinates.
-    fn motion(&self, seat: &Seat<D>, data: &mut D, event: &MotionEvent, seq: Serial);
+    fn motion(&self, seat: &Seat<D>, data: &mut D, event: &MotionEvent);
 
     /// Indicates the end of a set of events that logically belong together.
-    fn frame(&self, seat: &Seat<D>, data: &mut D, seq: Serial);
+    ///
+    /// The `marker` parameter is used to avoid re-sending the cancel event if the [`TouchTarget`]
+    /// has multiple active touch slot, or if multiple [`TouchTarget`] belong to the same underlying
+    /// target (e.g. a single client). See [`TouchTarget::last_frame`].
+    fn frame(&self, seat: &Seat<D>, data: &mut D, marker: FrameMarker);
 
     /// Touch session cancelled.
     ///
     /// Touch cancellation applies to all touch points currently active on this target.
     /// The client is responsible for finalizing the touch points, future touch points on
     /// this target may reuse the touch point ID.
-    fn cancel(&self, seat: &Seat<D>, data: &mut D, seq: Serial);
+    ///
+    /// The `marker` parameter is used to avoid re-sending the cancel event if the [`TouchTarget`]
+    /// has multiple active touch slot, or if multiple [`TouchTarget`] belong to the same underlying
+    /// target (e.g. a single client). See [`TouchTarget::last_frame`].
+    fn cancel(&self, seat: &Seat<D>, data: &mut D, marker: FrameMarker);
 
     /// Sent when a touch point has changed its shape.
     ///
@@ -206,14 +235,20 @@ where
     /// length describes the shorter diameter. Major and minor are orthogonal and both are specified
     /// in surface-local coordinates. The center of the ellipse is always at the touch point location
     /// as reported by [`TouchTarget::down`] or [`TouchTarget::motion`].
-    fn shape(&self, seat: &Seat<D>, data: &mut D, event: &ShapeEvent, seq: Serial);
+    fn shape(&self, seat: &Seat<D>, data: &mut D, event: &ShapeEvent);
 
     /// Sent when a touch point has changed its orientation.
     ///
     /// The orientation describes the clockwise angle of a touch point's major axis to the positive surface
     /// y-axis and is normalized to the -180 to +180 degree range. The granularity of orientation depends
     /// on the touch device, some devices only support binary rotation values between 0 and 90 degrees.
-    fn orientation(&self, seat: &Seat<D>, data: &mut D, event: &OrientationEvent, seq: Serial);
+    fn orientation(&self, seat: &Seat<D>, data: &mut D, event: &OrientationEvent);
+
+    /// Returns last know [`FrameMarker`].
+    ///
+    /// If this function returns `Some(marker)`, [`TouchHandle`] will use that value to avoid
+    /// sending the `frame` or `cancel` event more than once.
+    fn last_frame(&self, seat: &Seat<D>, data: &mut D) -> Option<FrameMarker>;
 }
 
 impl<D: SeatHandler + 'static> TouchHandle<D> {
@@ -295,9 +330,8 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
     ) {
         let mut inner = self.inner.lock().unwrap();
         let seat = self.get_seat(data);
-        let seq = inner.seq_counter.next_serial();
         inner.with_grab(data, &seat, |data, handle, grab| {
-            grab.down(data, handle, focus, event, seq);
+            grab.down(data, handle, focus, event);
         });
     }
 
@@ -305,9 +339,8 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
     pub fn up(&self, data: &mut D, event: &UpEvent) {
         let mut inner = self.inner.lock().unwrap();
         let seat = self.get_seat(data);
-        let seq = inner.seq_counter.next_serial();
         inner.with_grab(data, &seat, |data, handle, grab| {
-            grab.up(data, handle, event, seq);
+            grab.up(data, handle, event);
         });
     }
 
@@ -331,9 +364,8 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
     ) {
         let mut inner = self.inner.lock().unwrap();
         let seat = self.get_seat(data);
-        let seq = inner.seq_counter.next_serial();
         inner.with_grab(data, &seat, |data, handle, grab| {
-            grab.motion(data, handle, focus, event, seq);
+            grab.motion(data, handle, focus, event);
         });
     }
 
@@ -343,9 +375,8 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
     pub fn frame(&self, data: &mut D) {
         let mut inner = self.inner.lock().unwrap();
         let seat = self.get_seat(data);
-        let seq = inner.seq_counter.next_serial();
         inner.with_grab(data, &seat, |data, handle, grab| {
-            grab.frame(data, handle, seq);
+            grab.frame(data, handle);
         });
     }
 
@@ -357,9 +388,8 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
     pub fn cancel(&self, data: &mut D) {
         let mut inner = self.inner.lock().unwrap();
         let seat = self.get_seat(data);
-        let seq = inner.seq_counter.next_serial();
         inner.with_grab(data, &seat, |data, handle, grab| {
-            grab.cancel(data, handle, seq);
+            grab.cancel(data, handle);
         });
     }
 
@@ -367,9 +397,8 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
     pub fn shape(&self, data: &mut D, event: &ShapeEvent) {
         let mut inner = self.inner.lock().unwrap();
         let seat = self.get_seat(data);
-        let seq = inner.seq_counter.next_serial();
         inner.with_grab(data, &seat, |data, handle, grab| {
-            grab.shape(data, handle, event, seq);
+            grab.shape(data, handle, event);
         });
     }
 
@@ -377,9 +406,8 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
     pub fn orientation(&self, data: &mut D, event: &OrientationEvent) {
         let mut inner = self.inner.lock().unwrap();
         let seat = self.get_seat(data);
-        let seq = inner.seq_counter.next_serial();
         inner.with_grab(data, &seat, |data, handle, grab| {
-            grab.orientation(data, handle, event, seq);
+            grab.orientation(data, handle, event);
         });
     }
 
@@ -447,14 +475,13 @@ impl<D: SeatHandler + 'static> TouchInnerHandle<'_, D> {
         data: &mut D,
         focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
-        seq: Serial,
     ) {
-        self.inner.down(data, self.seat, focus, event, seq)
+        self.inner.down(data, self.seat, focus, event)
     }
 
     /// Notify that a touch point disappeared
-    pub fn up(&mut self, data: &mut D, event: &UpEvent, seq: Serial) {
-        self.inner.up(data, self.seat, event, seq)
+    pub fn up(&mut self, data: &mut D, event: &UpEvent) {
+        self.inner.up(data, self.seat, event)
     }
 
     /// Notify that a touch point has changed coordinates.
@@ -474,26 +501,25 @@ impl<D: SeatHandler + 'static> TouchInnerHandle<'_, D> {
         data: &mut D,
         focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
-        seq: Serial,
     ) {
-        self.inner.motion(data, self.seat, focus, event, seq)
+        self.inner.motion(data, self.seat, focus, event)
     }
 
     /// Notify about the end of a set of events that logically belong together.
     ///
     /// This needs to be called after one or move calls to [`TouchHandle::down`] or [`TouchHandle::motion`]
-    pub fn frame(&mut self, data: &mut D, seq: Serial) {
-        self.inner.frame(data, self.seat, seq)
+    pub fn frame(&mut self, data: &mut D) {
+        self.inner.frame(data, self.seat)
     }
 
     /// Notify that a touch point has changed its shape.
-    pub fn shape(&mut self, data: &mut D, event: &ShapeEvent, seq: Serial) {
-        self.inner.shape(data, self.seat, event, seq)
+    pub fn shape(&mut self, data: &mut D, event: &ShapeEvent) {
+        self.inner.shape(data, self.seat, event)
     }
 
     /// Notify that a touch point has changed its orientation.
-    pub fn orientation(&mut self, data: &mut D, event: &OrientationEvent, seq: Serial) {
-        self.inner.orientation(data, self.seat, event, seq)
+    pub fn orientation(&mut self, data: &mut D, event: &OrientationEvent) {
+        self.inner.orientation(data, self.seat, event)
     }
 
     /// Notify that the touch session has been cancelled.
@@ -501,8 +527,8 @@ impl<D: SeatHandler + 'static> TouchInnerHandle<'_, D> {
     /// Use in case you decide the touch stream is a global gesture.
     /// This will remove all current focus targets, and no further events will be sent
     /// until a new touch point appears.
-    pub fn cancel(&mut self, data: &mut D, seq: Serial) {
-        self.inner.cancel(data, self.seat, seq)
+    pub fn cancel(&mut self, data: &mut D) {
+        self.inner.cancel(data, self.seat)
     }
 }
 
@@ -513,7 +539,7 @@ impl<D: SeatHandler + 'static> TouchInternal<D> {
     {
         Self {
             focus: Default::default(),
-            seq_counter: SerialCounter::new(),
+            pending_frame: None,
             default_grab: Box::new(default_grab),
             grab: GrabStatus::None,
         }
@@ -545,36 +571,38 @@ impl<D: SeatHandler + 'static> TouchInternal<D> {
         seat: &Seat<D>,
         focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &DownEvent,
-        seq: Serial,
     ) {
+        let marker = self.frame_marker();
         self.focus
             .entry(event.slot)
             .and_modify(|state| {
-                state.pending = seq;
+                state.pending = marker;
                 state.frame_pending = None;
                 state.focus.clone_from(&focus);
             })
             .or_insert_with(|| TouchSlotState {
                 focus,
                 frame_pending: None,
-                pending: seq,
+                pending: marker,
                 current: None,
             });
+
         let state = self.focus.get(&event.slot).unwrap();
         if let Some((focus, loc)) = state.focus.as_ref() {
             let mut new_event = event.clone();
             new_event.location -= *loc;
-            focus.down(seat, data, &new_event, seq);
+            focus.down(seat, data, &new_event);
         }
     }
 
-    fn up(&mut self, data: &mut D, seat: &Seat<D>, event: &UpEvent, seq: Serial) {
+    fn up(&mut self, data: &mut D, seat: &Seat<D>, event: &UpEvent) {
+        let marker = self.frame_marker();
         let Some(state) = self.focus.get_mut(&event.slot) else {
             return;
         };
-        state.pending = seq;
+        state.pending = marker;
         if let Some((focus, _)) = state.focus.take() {
-            focus.up(seat, data, event, seq);
+            focus.up(seat, data, event);
 
             // Keep the focus around to be able to send a frame event after up, but move
             // it out of the current focus to prevent sending other events.
@@ -588,66 +616,93 @@ impl<D: SeatHandler + 'static> TouchInternal<D> {
         seat: &Seat<D>,
         _focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
-        seq: Serial,
     ) {
+        let marker = self.frame_marker();
         let Some(state) = self.focus.get_mut(&event.slot) else {
             return;
         };
-        state.pending = seq;
+        state.pending = marker;
         if let Some((focus, loc)) = state.focus.as_ref() {
             let mut new_event = event.clone();
             new_event.location -= *loc;
-            focus.motion(seat, data, &new_event, seq);
+            focus.motion(seat, data, &new_event);
         }
     }
 
-    fn frame(&mut self, data: &mut D, seat: &Seat<D>, seq: Serial) {
+    fn frame(&mut self, data: &mut D, seat: &Seat<D>) {
+        let Some(marker) = self.pending_frame.take() else {
+            tracing::warn!("frame called without prior events");
+            return;
+        };
+
         for state in self.focus.values_mut() {
-            if state.current.map(|c| c >= state.pending).unwrap_or(false) {
+            if state.current.map(|c| c == state.pending).unwrap_or(false) {
                 continue;
             }
-            state.current = Some(seq);
+            state.current = Some(marker);
 
             // Send the frame event for any stored focus in the up handler
             if let Some(focus) = state.frame_pending.take() {
-                focus.frame(seat, data, seq);
+                if focus.last_frame(seat, data) != Some(marker) {
+                    focus.frame(seat, data, marker);
+                }
             }
 
             if let Some((focus, _)) = state.focus.as_ref() {
-                focus.frame(seat, data, seq);
+                if focus.last_frame(seat, data) != Some(marker) {
+                    focus.frame(seat, data, marker);
+                }
             }
         }
+
+        frame_marker::remove(marker.0);
     }
 
-    fn cancel(&mut self, data: &mut D, seat: &Seat<D>, seq: Serial) {
+    fn cancel(&mut self, data: &mut D, seat: &Seat<D>) {
+        let Some(marker) = self.pending_frame.take() else {
+            tracing::warn!("cancel called without prior events");
+            return;
+        };
+
         for state in self.focus.values_mut() {
-            if state.current.map(|c| c >= state.pending).unwrap_or(false) {
+            if state.current.map(|c| c == state.pending).unwrap_or(false) {
                 continue;
             }
-            state.current = Some(seq);
+
+            state.current = Some(marker);
+
             if let Some((focus, _)) = state.focus.take() {
-                focus.cancel(seat, data, seq);
+                if focus.last_frame(seat, data) != Some(marker) {
+                    focus.cancel(seat, data, marker);
+                }
             }
         }
+
+        frame_marker::remove(marker.0);
     }
 
-    fn shape(&mut self, data: &mut D, seat: &Seat<D>, event: &ShapeEvent, seq: Serial) {
+    fn shape(&mut self, data: &mut D, seat: &Seat<D>, event: &ShapeEvent) {
+        let marker = self.frame_marker();
+
         let Some(state) = self.focus.get_mut(&event.slot) else {
             return;
         };
-        state.pending = seq;
+
+        state.pending = marker;
         if let Some((focus, _)) = state.focus.as_ref() {
-            focus.shape(seat, data, event, seq);
+            focus.shape(seat, data, event);
         }
     }
 
-    fn orientation(&mut self, data: &mut D, seat: &Seat<D>, event: &OrientationEvent, seq: Serial) {
+    fn orientation(&mut self, data: &mut D, seat: &Seat<D>, event: &OrientationEvent) {
+        let marker = self.frame_marker();
+
         let Some(state) = self.focus.get_mut(&event.slot) else {
             return;
         };
-        state.pending = seq;
+        state.pending = marker;
         if let Some((focus, _)) = state.focus.as_ref() {
-            focus.orientation(seat, data, event, seq);
+            focus.orientation(seat, data, event);
         }
     }
 
@@ -689,5 +744,13 @@ impl<D: SeatHandler + 'static> TouchInternal<D> {
             // the grab has not been ended nor replaced, put it back in place
             self.grab = grab;
         }
+    }
+
+    fn frame_marker(&mut self) -> FrameMarker {
+        if self.pending_frame.is_none() {
+            self.pending_frame = Some(FrameMarker(frame_marker::next()));
+        };
+
+        self.pending_frame.unwrap()
     }
 }

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -51,7 +51,7 @@
 //!    }
 //!
 //!    fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState {
-//!        &client.get_data::<ClientState>().unwrap().compositor_state    
+//!        &client.get_data::<ClientState>().unwrap().compositor_state
 //!    }
 //!
 //!    fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {
@@ -121,6 +121,7 @@ use self::transaction::TransactionQueue;
 pub use self::transaction::{Barrier, Blocker, BlockerState};
 pub use self::tree::{AlreadyHasRole, TraversalAction};
 use self::tree::{PrivateSurfaceData, SuggestedSurfaceState};
+use crate::input::touch::FrameMarker;
 use crate::utils::Transform;
 pub use crate::utils::hook::HookId;
 use crate::utils::{Buffer, Logical, Point, Rectangle, user_data::UserDataMap};
@@ -620,6 +621,7 @@ pub struct CompositorState {
 pub struct CompositorClientState {
     queue: Mutex<Option<TransactionQueue>>,
     scale_override: Arc<AtomicF64>,
+    last_touch_frame: Mutex<Option<FrameMarker>>,
 }
 
 impl Default for CompositorClientState {
@@ -627,6 +629,7 @@ impl Default for CompositorClientState {
         CompositorClientState {
             queue: Mutex::new(None),
             scale_override: Arc::new(AtomicF64::new(1.)),
+            last_touch_frame: Mutex::new(None),
         }
     }
 }
@@ -671,6 +674,14 @@ impl CompositorClientState {
 
     pub(crate) fn clone_client_scale(&self) -> Arc<AtomicF64> {
         self.scale_override.clone()
+    }
+
+    pub(crate) fn set_last_touch_frame(&self, frame_marker: FrameMarker) {
+        *self.last_touch_frame.lock().unwrap() = Some(frame_marker);
+    }
+
+    pub(crate) fn last_touch_frame(&self) -> Option<FrameMarker> {
+        *self.last_touch_frame.lock().unwrap()
     }
 }
 

--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -18,7 +18,7 @@
 //! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
 //! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
+//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget, FrameMarker},
 //! #   Seat, SeatHandler, SeatState,
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
@@ -69,13 +69,14 @@
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
 //! # impl TouchTarget<State> for Target {
-//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
-//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
-//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
-//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
-//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent) {}
+//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent) {}
+//! #   fn last_frame(&self, seat: &Seat<State>, data: &mut State) -> Option<FrameMarker> { unimplemented!() }
 //! # }
 //! # struct State {
 //! #     seat_state: SeatState<Self>,

--- a/src/wayland/idle_notify/mod.rs
+++ b/src/wayland/idle_notify/mod.rs
@@ -3,6 +3,7 @@
 //! ```
 //! # extern crate wayland_server;
 //! # #[macro_use] extern crate smithay;
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::wayland::idle_notify::{IdleNotifierState, IdleNotifierHandler};
 //! # use smithay::input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus};
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
@@ -19,6 +20,11 @@
 //! let state = State { idle_notifier };
 //!
 //! // Implement the necessary trait
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+//! # }
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = WlSurface;
 //! #     type PointerFocus = WlSurface;

--- a/src/wayland/keyboard_shortcuts_inhibit/mod.rs
+++ b/src/wayland/keyboard_shortcuts_inhibit/mod.rs
@@ -181,10 +181,16 @@ pub trait KeyboardShortcutsInhibitorSeat {
     /// Can be used to check if certain surface has inhibitor on it
     /// ```no_run
     /// use smithay::input::Seat;
+    /// # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
     /// use smithay::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat;
     /// # use smithay::input::{SeatHandler, SeatState, pointer::CursorImageStatus};
     /// # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
     /// # struct State;
+    /// # impl CompositorHandler for State {
+    /// #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+    /// #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+    /// #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+    /// # }
     /// # impl SeatHandler for State {
     /// #     type KeyboardFocus = WlSurface;
     /// #     type PointerFocus = WlSurface;

--- a/src/wayland/pointer_gestures.rs
+++ b/src/wayland/pointer_gestures.rs
@@ -27,7 +27,7 @@
 //! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
 //! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
+//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget, FrameMarker},
 //! #   Seat, SeatHandler, SeatState,
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
@@ -69,13 +69,14 @@
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
 //! # impl TouchTarget<State> for Target {
-//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
-//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
-//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
-//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
-//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent) {}
+//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent) {}
+//! #   fn last_frame(&self, seat: &Seat<State>, data: &mut State) -> Option<FrameMarker> { unimplemented!() }
 //! # }
 //! # struct State {
 //! #     seat_state: SeatState<Self>,

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -15,7 +15,7 @@
 //! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
 //! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
+//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget, FrameMarker},
 //! #   Seat, SeatHandler, SeatState,
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
@@ -57,13 +57,14 @@
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
 //! # impl TouchTarget<State> for Target {
-//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
-//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
-//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
-//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
-//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent) {}
+//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent) {}
+//! #   fn last_frame(&self, seat: &Seat<State>, data: &mut State) -> Option<FrameMarker> { unimplemented!() }
 //! # }
 //! # struct State {
 //! #     seat_state: SeatState<Self>,

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, atomic::Ordering};
 
 use atomic_float::AtomicF64;
 use wayland_server::{
-    DisplayHandle, Resource,
+    Client, DisplayHandle, Resource,
     backend::ClientId,
     protocol::wl_touch::{self, WlTouch},
 };
@@ -10,14 +10,16 @@ use wayland_server::{
 use super::SeatHandler;
 use crate::input::touch::TouchHandle;
 use crate::input::touch::TouchTarget;
-use crate::input::{
-    Seat,
-    touch::{MotionEvent, OrientationEvent, ShapeEvent, UpEvent},
-};
 use crate::wayland::Dispatch2;
-use crate::{input::touch::DownEvent, wayland::seat::wl_surface::WlSurface};
-#[cfg(feature = "wayland_frontend")]
-use crate::{input::touch::FrameMarker, wayland::compositor::CompositorHandler};
+use crate::wayland::compositor::CompositorHandler;
+use crate::wayland::seat::wl_surface::WlSurface;
+use crate::{
+    input::{
+        Seat,
+        touch::{DownEvent, FrameMarker, MotionEvent, OrientationEvent, ShapeEvent, UpEvent},
+    },
+    utils::iter::new_locked_obj_iter_from_vec,
+};
 
 impl<D: SeatHandler> TouchHandle<D> {
     pub(crate) fn new_touch(&self, touch: WlTouch) {
@@ -33,6 +35,12 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
     /// the touch capability.
     pub fn from_resource(seat: &WlTouch) -> Option<Self> {
         seat.data::<TouchUserData<D>>()?.handle.clone()
+    }
+
+    /// Return all raw [`WlTouch`] instances for a particular [`Client`]
+    pub fn client_touch<'a>(&'a self, client: &Client) -> impl Iterator<Item = WlTouch> + 'a {
+        let guard = self.known_instances.lock().unwrap();
+        new_locked_obj_iter_from_vec(guard, client.id())
     }
 }
 

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -8,6 +8,7 @@ use wayland_server::{
 };
 
 use super::SeatHandler;
+use crate::input::touch::TouchHandle;
 use crate::input::touch::TouchTarget;
 use crate::input::{
     Seat,
@@ -15,12 +16,13 @@ use crate::input::{
 };
 use crate::wayland::Dispatch2;
 use crate::{input::touch::DownEvent, wayland::seat::wl_surface::WlSurface};
-use crate::{input::touch::TouchHandle, utils::Serial};
+#[cfg(feature = "wayland_frontend")]
+use crate::{input::touch::FrameMarker, wayland::compositor::CompositorHandler};
 
 impl<D: SeatHandler> TouchHandle<D> {
     pub(crate) fn new_touch(&self, touch: WlTouch) {
         let mut guard = self.known_instances.lock().unwrap();
-        guard.push((touch.downgrade(), None));
+        guard.push(touch.downgrade());
     }
 }
 
@@ -37,21 +39,29 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
 fn for_each_focused_touch<D: SeatHandler + 'static>(
     seat: &Seat<D>,
     surface: &WlSurface,
-    seq: Serial,
     mut f: impl FnMut(WlTouch),
 ) {
     if let Some(touch) = seat.get_touch() {
         let mut inner = touch.known_instances.lock().unwrap();
-        for (ptr, last_seq) in &mut *inner {
+        for ptr in &mut *inner {
             let Ok(ptr) = ptr.upgrade() else {
                 continue;
             };
 
-            if ptr.id().same_client_as(&surface.id()) && last_seq.map(|last| last < seq).unwrap_or(true) {
-                *last_seq = Some(seq);
+            if ptr.id().same_client_as(&surface.id()) {
                 f(ptr.clone());
             }
         }
+    }
+}
+
+fn set_touch_frame_marker<D: CompositorHandler + 'static>(
+    data: &D,
+    surface: &WlSurface,
+    marker: FrameMarker,
+) {
+    if let Some(client) = surface.client().as_ref() {
+        data.client_compositor_state(client).set_last_touch_frame(marker);
     }
 }
 
@@ -59,11 +69,13 @@ fn for_each_focused_touch<D: SeatHandler + 'static>(
 impl<D> TouchTarget<D> for WlSurface
 where
     D: SeatHandler + 'static,
+    D: CompositorHandler,
 {
-    fn down(&self, seat: &Seat<D>, _data: &mut D, event: &DownEvent, seq: Serial) {
+    fn down(&self, seat: &Seat<D>, _data: &mut D, event: &DownEvent) {
         let serial = event.serial;
         let slot = event.slot;
-        for_each_focused_touch(seat, self, seq, |touch| {
+
+        for_each_focused_touch(seat, self, |touch| {
             let client_scale = touch
                 .data::<TouchUserData<D>>()
                 .unwrap()
@@ -81,17 +93,17 @@ where
         })
     }
 
-    fn up(&self, seat: &Seat<D>, _data: &mut D, event: &UpEvent, seq: Serial) {
+    fn up(&self, seat: &Seat<D>, _data: &mut D, event: &UpEvent) {
         let serial = event.serial;
         let slot = event.slot;
-        for_each_focused_touch(seat, self, seq, |touch| {
+        for_each_focused_touch(seat, self, |touch| {
             touch.up(serial.into(), event.time, slot.into());
         })
     }
 
-    fn motion(&self, seat: &Seat<D>, _data: &mut D, event: &MotionEvent, seq: Serial) {
+    fn motion(&self, seat: &Seat<D>, _data: &mut D, event: &MotionEvent) {
         let slot = event.slot;
-        for_each_focused_touch(seat, self, seq, |touch| {
+        for_each_focused_touch(seat, self, |touch| {
             let client_scale = touch
                 .data::<TouchUserData<D>>()
                 .unwrap()
@@ -102,30 +114,39 @@ where
         })
     }
 
-    fn frame(&self, seat: &Seat<D>, _data: &mut D, seq: Serial) {
-        for_each_focused_touch(seat, self, seq, |touch| {
+    fn frame(&self, seat: &Seat<D>, data: &mut D, marker: FrameMarker) {
+        set_touch_frame_marker(data, self, marker);
+
+        for_each_focused_touch(seat, self, |touch| {
             touch.frame();
         })
     }
 
-    fn cancel(&self, seat: &Seat<D>, _data: &mut D, seq: Serial) {
-        for_each_focused_touch(seat, self, seq, |touch| {
+    fn cancel(&self, seat: &Seat<D>, data: &mut D, marker: FrameMarker) {
+        set_touch_frame_marker(data, self, marker);
+
+        for_each_focused_touch(seat, self, |touch| {
             touch.cancel();
         })
     }
 
-    fn shape(&self, seat: &Seat<D>, _data: &mut D, event: &ShapeEvent, seq: Serial) {
+    fn shape(&self, seat: &Seat<D>, _data: &mut D, event: &ShapeEvent) {
         let slot = event.slot;
-        for_each_focused_touch(seat, self, seq, |touch| {
+        for_each_focused_touch(seat, self, |touch| {
             touch.shape(slot.into(), event.major, event.minor);
         })
     }
 
-    fn orientation(&self, seat: &Seat<D>, _data: &mut D, event: &OrientationEvent, seq: Serial) {
+    fn orientation(&self, seat: &Seat<D>, _data: &mut D, event: &OrientationEvent) {
         let slot = event.slot;
-        for_each_focused_touch(seat, self, seq, |touch| {
+        for_each_focused_touch(seat, self, |touch| {
             touch.orientation(slot.into(), event.orientation);
         })
+    }
+
+    fn last_frame(&self, _seat: &Seat<D>, data: &mut D) -> Option<FrameMarker> {
+        self.client()
+            .and_then(|c| data.client_compositor_state(&c).last_touch_frame())
     }
 }
 
@@ -158,7 +179,7 @@ where
                 .known_instances
                 .lock()
                 .unwrap()
-                .retain(|(p, _)| p.id() != touch.id());
+                .retain(|p| p.id() != touch.id());
         }
     }
 }

--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -27,6 +27,7 @@
 //! ```
 //! # extern crate wayland_server;
 //! # #[macro_use] extern crate smithay;
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::wayland::selection::SelectionHandler;
 //! use smithay::wayland::selection::data_device::{WaylandDndGrabHandler, DataDeviceState, DataDeviceHandler};
 //! # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
@@ -43,6 +44,11 @@
 //! // ..
 //!
 //! // implement the necessary traits
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+//! # }
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = WlSurface;
 //! #     type PointerFocus = WlSurface;

--- a/src/wayland/selection/ext_data_control/mod.rs
+++ b/src/wayland/selection/ext_data_control/mod.rs
@@ -8,6 +8,7 @@
 //! ```
 //! # extern crate wayland_server;
 //! # #[macro_use] extern crate smithay;
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::wayland::selection::SelectionHandler;
 //! use smithay::wayland::selection::ext_data_control::{DataControlState, DataControlHandler};
 //! # use smithay::input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus};
@@ -24,6 +25,11 @@
 //! // ..
 //!
 //! // implement the necessary traits
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+//! # }
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = WlSurface;
 //! #     type PointerFocus = WlSurface;

--- a/src/wayland/selection/primary_selection/mod.rs
+++ b/src/wayland/selection/primary_selection/mod.rs
@@ -26,6 +26,7 @@
 //! ```
 //! # extern crate wayland_server;
 //! # #[macro_use] extern crate smithay;
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::wayland::selection::SelectionHandler;
 //! use smithay::wayland::selection::primary_selection::{PrimarySelectionState, PrimarySelectionHandler};
 //! # use smithay::input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus};
@@ -42,6 +43,11 @@
 //! // ..
 //!
 //! // implement the necessary traits
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+//! # }
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = WlSurface;
 //! #     type PointerFocus = WlSurface;

--- a/src/wayland/selection/wlr_data_control/mod.rs
+++ b/src/wayland/selection/wlr_data_control/mod.rs
@@ -8,6 +8,7 @@
 //! ```
 //! # extern crate wayland_server;
 //! # #[macro_use] extern crate smithay;
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::wayland::selection::SelectionHandler;
 //! use smithay::wayland::selection::wlr_data_control::{DataControlState, DataControlHandler};
 //! # use smithay::input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus};
@@ -24,6 +25,11 @@
 //! // ..
 //!
 //! // implement the necessary traits
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+//! # }
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = WlSurface;
 //! #     type PointerFocus = WlSurface;

--- a/src/wayland/shell/xdg/decoration.rs
+++ b/src/wayland/shell/xdg/decoration.rs
@@ -61,8 +61,14 @@
 //!     fn unset_mode(&mut self, toplevel: ToplevelSurface) { /* ... */ }
 //! }
 //!
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
 //!
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+//! # }
 //! type Target = wl_surface::WlSurface;
 //! impl SeatHandler for State {
 //!     type KeyboardFocus = Target;
@@ -83,7 +89,7 @@
 //!
 //! smithay::delegate_dispatch2!(State);
 //!
-//! // You are ready to go!  
+//! // You are ready to go!
 // TODO: Describe how to change decoration mode.
 
 use wayland_protocols::xdg::decoration::zv1::server::{

--- a/src/wayland/shell/xdg/dialog.rs
+++ b/src/wayland/shell/xdg/dialog.rs
@@ -49,8 +49,14 @@
 //!     fn dialog_hint_changed(&mut self, toplevel: ToplevelSurface, hint: ToplevelDialogHint) { /* ... */ }
 //! }
 //!
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
 //!
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+//! # }
 //! type Target = wl_surface::WlSurface;
 //! impl SeatHandler for State {
 //!     type KeyboardFocus = Target;
@@ -71,7 +77,7 @@
 //!
 //! smithay::delegate_dispatch2!(State);
 //!
-//! // You are ready to go!  
+//! // You are ready to go!
 
 use wayland_protocols::xdg::dialog::v1::server::{
     xdg_dialog_v1::{self, XdgDialogV1},

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -74,8 +74,14 @@
 //!     }
 //! }
 //!
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
 //!
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+//! # }
 //! type Target = wl_surface::WlSurface;
 //! impl SeatHandler for State {
 //!     type KeyboardFocus = Target;
@@ -377,7 +383,7 @@ xdg_role!(
     ToplevelCachedState
 );
 
-/// Data associated with XDG toplevel surface  
+/// Data associated with XDG toplevel surface
 ///
 /// ```no_run
 /// use smithay::wayland::compositor;
@@ -448,7 +454,7 @@ xdg_role!(
     PopupCachedState
 );
 
-/// Data associated with XDG popup surface  
+/// Data associated with XDG popup surface
 ///
 /// ```no_run
 /// use smithay::wayland::compositor;

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -13,8 +13,14 @@
 //!     &display.handle(), // the display
 //! );
 //! #
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! # use smithay::input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus};
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+//! # }
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = WlSurface;
 //! #     type PointerFocus = WlSurface;

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -25,7 +25,7 @@
 //! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
 //! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
+//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget, FrameMarker},
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
 //! #
@@ -66,13 +66,14 @@
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
 //! # impl TouchTarget<State> for Target {
-//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent, seq: Serial) {}
-//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent, seq: Serial) {}
-//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent, seq: Serial) {}
-//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, seq: Serial) {}
-//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent, seq: Serial) {}
-//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent, seq: Serial) {}
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent) {}
+//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent) {}
+//! #   fn last_frame(&self, seat: &Seat<State>, data: &mut State) -> Option<FrameMarker> { unimplemented!() }
 //! # }
 //! # impl SeatHandler for State {
 //! #     type KeyboardFocus = Target;

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -27,6 +27,7 @@
 //! # Example
 //!
 //! ```no_run
+//! #  use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! #  use smithay::wayland::xwayland_shell::{XWaylandShellHandler, XWaylandShellState};
 //! #  use smithay::wayland::selection::{SelectionTarget, SelectionHandler, data_device::{DataDeviceHandler, DataDeviceState, WaylandDndGrabHandler}};
 //! #  use smithay::xwayland::{XWayland, XWaylandEvent, X11Wm, X11Surface, XwmHandler, xwm::{XwmId, ResizeEdge, Reorder}};
@@ -52,6 +53,12 @@
 //! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget},
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
+//! #
+//! # impl CompositorHandler for State {
+//! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
+//! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
+//! #     fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {}
+//! # }
 //! #
 //! # type Target = WlSurface;
 //! # impl SeatHandler for State {
@@ -116,7 +123,7 @@
 //!             client.clone(),
 //!         )
 //!         .expect("Failed to attach X11 Window Manager");
-//!         
+//!
 //!         // store the WM somewhere
 //!     }
 //!     XWaylandEvent::Error => eprintln!("XWayland failed to start!"),
@@ -1205,7 +1212,7 @@ impl X11Wm {
     ///
     /// So if windows `A -> C` are given in order and the internal stack is `C -> B -> A`,
     /// no reordering will occur.
-    ///  
+    ///
     /// See [`X11Wm::update_stacking_order_downwards`] for a variant of this algorithm,
     /// which works from the top down or [`X11Wm::raise_window`] for an easier but
     /// much more limited way to reorder.

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -8,14 +8,14 @@ use crate::{
             GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
             GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
         },
-        touch::TouchTarget,
+        touch::{FrameMarker, TouchTarget},
     },
     utils::{
         Client, FrameExtents, HookId, IsAlive, Logical, Physical, Rectangle, Serial, Size,
         user_data::UserDataMap,
     },
     wayland::{
-        compositor::{self, RectangleKind, RegionAttributes, SurfaceAttributes},
+        compositor::{self, CompositorHandler, RectangleKind, RegionAttributes, SurfaceAttributes},
         seat::{WaylandFocus, keyboard::enter_internal},
     },
 };
@@ -2330,52 +2330,54 @@ impl<D: SeatHandler + 'static> PointerTarget<D> for X11Surface {
     }
 }
 
-impl<D: SeatHandler + 'static> TouchTarget<D> for X11Surface {
-    fn down(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::DownEvent, seq: Serial) {
+impl<D: SeatHandler + CompositorHandler + 'static> TouchTarget<D> for X11Surface {
+    fn down(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::DownEvent) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
-            TouchTarget::down(surface, seat, data, event, seq)
+            TouchTarget::down(surface, seat, data, event)
         }
     }
 
-    fn up(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::UpEvent, seq: Serial) {
+    fn up(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::UpEvent) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
-            TouchTarget::up(surface, seat, data, event, seq)
+            TouchTarget::up(surface, seat, data, event)
         }
     }
 
-    fn motion(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::MotionEvent, seq: Serial) {
+    fn motion(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::MotionEvent) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
-            TouchTarget::motion(surface, seat, data, event, seq)
+            TouchTarget::motion(surface, seat, data, event)
         }
     }
 
-    fn frame(&self, seat: &Seat<D>, data: &mut D, seq: Serial) {
+    fn frame(&self, seat: &Seat<D>, data: &mut D, marker: FrameMarker) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
-            TouchTarget::frame(surface, seat, data, seq)
+            TouchTarget::frame(surface, seat, data, marker)
         }
     }
 
-    fn cancel(&self, seat: &Seat<D>, data: &mut D, seq: Serial) {
+    fn cancel(&self, seat: &Seat<D>, data: &mut D, marker: FrameMarker) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
-            TouchTarget::cancel(surface, seat, data, seq)
+            TouchTarget::cancel(surface, seat, data, marker)
         }
     }
 
-    fn shape(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::ShapeEvent, seq: Serial) {
+    fn shape(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::ShapeEvent) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
-            TouchTarget::shape(surface, seat, data, event, seq)
+            TouchTarget::shape(surface, seat, data, event)
         }
     }
 
-    fn orientation(
-        &self,
-        seat: &Seat<D>,
-        data: &mut D,
-        event: &crate::input::touch::OrientationEvent,
-        seq: Serial,
-    ) {
+    fn orientation(&self, seat: &Seat<D>, data: &mut D, event: &crate::input::touch::OrientationEvent) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
-            TouchTarget::orientation(surface, seat, data, event, seq)
+            TouchTarget::orientation(surface, seat, data, event)
+        }
+    }
+
+    fn last_frame(&self, seat: &Seat<D>, data: &mut D) -> Option<FrameMarker> {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TouchTarget::last_frame(surface, seat, data)
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
## Description

This series rework the touch handling API with the following changes:
- frame serial are now internal to `TouchInternal`. They are only sent
  to the `TouchTarget` as part of a frame() or cancel() call.
  EDIT: Instead of a Serial, a new FrameMarker is used.
  - The frame serial are generated once per frame, and discarded on a call
  to frame or cancel.
  EDIT: That's still true, but since the FrameMarker type is an id, it's not as simple. TouchInternal::frame no longer discard the marker, as it may not be called. The id for the pending frame is now removed by TouchHandle on a call to `frame` or `cancel` instead. 
- `TouchInternal` is now responsible for de-duplicating frame and cancel
  events. It does so by retrieving the `last_serial` from the
  `TouchTarget` before sending the event.
  It's possible for a target to opt-out of this behavior by always returning None in `last_serial`
  EDIT: last serial was changed to `last_frame`

Closes #2066 

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
