### PR TITLE
fix: incorrectly sending axis_discrete events

### DIFF
--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -997,6 +997,12 @@ pub struct AxisFrame {
     pub axis: (f64, f64),
     /// Discrete representation of scroll value per axis, if available
     pub v120: Option<(i32, i32)>,
+    /// Discrete scroll event to send for older versions of the protocol
+    ///
+    /// None corresponds to the default behavior, Some(None) corresponds to no
+    /// event, and Some(Some(x)) corresponds to sending a discrete scroll event
+    /// with a value of x.
+    pub discrete: (Option<Option<i32>>, Option<Option<i32>>),
     /// If the axis is considered having stopped movement
     ///
     /// Only useful in conjunction of AxisSource::Finger events
@@ -1100,6 +1106,7 @@ impl AxisFrame {
             time,
             axis: (0.0, 0.0),
             v120: None,
+            discrete: (None, None),
             stop: (false, false),
         }
     }
@@ -1156,6 +1163,27 @@ impl AxisFrame {
             }
             Axis::Vertical => {
                 self.axis.1 += value;
+            }
+        };
+        self
+    }
+
+    /// Specify forced discrete scroll events for older versions of the protocol
+    /// instead of default behavior. A value of None will prevent the
+    /// axis_discrete event from being sent, while a value of Some(x) will cause
+    /// x to be sent to the client. Only one of None or Some may be specified
+    /// per frame, but multiple of Some will accumulate.
+    pub fn discrete(mut self, axis: Axis, value: Option<i32>) -> Self {
+        match axis {
+            Axis::Horizontal => {
+                let old = self.discrete.0.flatten().unwrap_or(0);
+                let new = value.map(|x| x + old);
+                self.discrete.0 = Some(new);
+            }
+            Axis::Vertical => {
+                let old = self.discrete.1.flatten().unwrap_or(0);
+                let new = value.map(|x| x + old);
+                self.discrete.1 = Some(new);
             }
         };
         self

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -153,8 +153,10 @@ impl WlPointerHandle {
                                     ptr.axis_discrete(WlAxis::HorizontalScroll, x);
                                 }
                             }
-                            (None, Some((x120, _))) => {
-                                if x120.abs() < 120 {
+                            (None, Some((x120, _))) if x120 != 0 => {
+                                if matches!(details.source, Some(AxisSource::Wheel | AxisSource::WheelTilt))
+                                    && x120.abs() < 120
+                                {
                                     ptr.axis_discrete(WlAxis::HorizontalScroll, x120.signum());
                                     data.x = 0;
                                 } else {
@@ -175,8 +177,10 @@ impl WlPointerHandle {
                                     ptr.axis_discrete(WlAxis::VerticalScroll, y);
                                 }
                             }
-                            (None, Some((_, y120))) => {
-                                if y120.abs() < 120 {
+                            (None, Some((_, y120))) if y120 != 0 => {
+                                if matches!(details.source, Some(AxisSource::Wheel | AxisSource::WheelTilt))
+                                    && y120.abs() < 120
+                                {
                                     ptr.axis_discrete(WlAxis::VerticalScroll, y120.signum());
                                     data.y = 0;
                                 } else {

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -129,35 +129,57 @@ impl WlPointerHandle {
                     ptr.axis_source(source);
                 }
                 // axis discrete
-                if let Some((x, y)) = details.v120 {
-                    if ptr.version() >= 8 {
+                if ptr.version() >= 8 {
+                    if let Some((x, y)) = details.v120 {
                         if x != 0 {
                             ptr.axis_value120(WlAxis::HorizontalScroll, x);
                         }
                         if y != 0 {
                             ptr.axis_value120(WlAxis::VerticalScroll, y);
                         }
-                    } else {
-                        compositor::with_states(surface, |states| {
-                            let mut data = states
-                                .data_map
-                                .get_or_insert_threadsafe(Mutex::<V120UserData>::default)
-                                .lock()
-                                .unwrap();
-
-                            data.x += x;
-                            if data.x.abs() >= 120 {
-                                ptr.axis_discrete(WlAxis::HorizontalScroll, data.x / 120);
-                                data.x %= 120;
-                            }
-
-                            data.y += y;
-                            if data.y.abs() >= 120 {
-                                ptr.axis_discrete(WlAxis::VerticalScroll, data.y / 120);
-                                data.y %= 120;
-                            }
-                        });
                     }
+                } else {
+                    compositor::with_states(surface, |states| {
+                        let mut data = states
+                            .data_map
+                            .get_or_insert_threadsafe(Mutex::<V120UserData>::default)
+                            .lock()
+                            .unwrap();
+
+                        match (details.discrete.0, details.v120) {
+                            (Some(x), _) => {
+                                data.x = 0;
+                                if let Some(x) = x {
+                                    ptr.axis_discrete(WlAxis::HorizontalScroll, x);
+                                }
+                            }
+                            (None, Some((x120, _))) => {
+                                data.x += x120;
+                                if data.x.abs() >= 120 {
+                                    ptr.axis_discrete(WlAxis::HorizontalScroll, data.x / 120);
+                                    data.x %= 120
+                                }
+                            }
+                            _ => {}
+                        }
+
+                        match (details.discrete.1, details.v120) {
+                            (Some(y), _) => {
+                                data.y = 0;
+                                if let Some(y) = y {
+                                    ptr.axis_discrete(WlAxis::HorizontalScroll, y);
+                                }
+                            }
+                            (None, Some((_, y120))) => {
+                                data.y += y120;
+                                if data.y.abs() >= 120 {
+                                    ptr.axis_discrete(WlAxis::VerticalScroll, data.y / 120);
+                                    data.y %= 120
+                                }
+                            }
+                            _ => {}
+                        }
+                    });
                 }
                 // stop
                 if details.stop.0 {

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -154,10 +154,15 @@ impl WlPointerHandle {
                                 }
                             }
                             (None, Some((x120, _))) => {
-                                data.x += x120;
-                                if data.x.abs() >= 120 {
-                                    ptr.axis_discrete(WlAxis::HorizontalScroll, data.x / 120);
-                                    data.x %= 120
+                                if x120.abs() < 120 {
+                                    ptr.axis_discrete(WlAxis::HorizontalScroll, x120.signum());
+                                    data.x = 0;
+                                } else {
+                                    data.x += x120;
+                                    if data.x.abs() >= 120 {
+                                        ptr.axis_discrete(WlAxis::HorizontalScroll, data.x / 120);
+                                        data.x %= 120
+                                    }
                                 }
                             }
                             _ => {}
@@ -167,14 +172,19 @@ impl WlPointerHandle {
                             (Some(y), _) => {
                                 data.y = 0;
                                 if let Some(y) = y {
-                                    ptr.axis_discrete(WlAxis::HorizontalScroll, y);
+                                    ptr.axis_discrete(WlAxis::VerticalScroll, y);
                                 }
                             }
                             (None, Some((_, y120))) => {
-                                data.y += y120;
-                                if data.y.abs() >= 120 {
-                                    ptr.axis_discrete(WlAxis::VerticalScroll, data.y / 120);
-                                    data.y %= 120
+                                if y120.abs() < 120 {
+                                    ptr.axis_discrete(WlAxis::VerticalScroll, y120.signum());
+                                    data.y = 0;
+                                } else {
+                                    data.y += y120;
+                                    if data.y.abs() >= 120 {
+                                        ptr.axis_discrete(WlAxis::VerticalScroll, data.y / 120);
+                                        data.y %= 120
+                                    }
                                 }
                             }
                             _ => {}


### PR DESCRIPTION


## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

Allows manual consumer control over sending `axis_discrete` events and fixes the default behavior to prevent hiding events.

This is a sample implementation of the suggestions in #2068, and I'm not sure that this is the path that should be taken. I would appreciate any feedback and ideas on how this could be handled (although general ideas should probably be discussed in the issue instead).

Fixes #2068.

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
