### PR TITLE
Improve clarity and fix broken link to CONTRIBUTING.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,37 +16,37 @@
 
 ## Goals
 
-Smithay aims to provide building blocks to create wayland compositors in Rust. While not
+Smithay aims to provide building blocks to create Wayland compositors in Rust. While not
 being a full-blown compositor, it'll provide objects and interfaces implementing common
 functionalities that pretty much any compositor will need, in a generic fashion.
 
-It supports the [core Wayland protocols](https://gitlab.freedesktop.org/wayland/wayland), the official [protocol extensions](https://gitlab.freedesktop.org/wayland/wayland-protocols), and *some* external extensions, such as those made by and for [wlroots](https://gitlab.freedesktop.org/wlroots/wlr-protocols) and [KDE](https://invent.kde.org/libraries/plasma-wayland-protocols)
+It supports the [core Wayland protocols](https://gitlab.freedesktop.org/wayland/wayland), the official [protocol extensions](https://gitlab.freedesktop.org/wayland/wayland-protocols), and *some* external extensions, such as those made by and for [wlroots](https://gitlab.freedesktop.org/wlroots/wlr-protocols) and [KDE](https://invent.kde.org/libraries/plasma-wayland-protocols).
 <!-- https://github.com/Smithay/smithay/pull/779#discussion_r993640470 https://github.com/Smithay/smithay/issues/778 -->
 
 Also:
 
-- **Documented:** Smithay strives to maintain a clear and detailed documentation of its API and its
-  functionalities. Compiled documentations are available on [docs.rs](https://docs.rs/smithay) for released
+- **Documented:** Smithay strives to maintain clear and detailed documentation of its API and 
+  functionalities. Compiled documentation is available on [docs.rs](https://docs.rs/smithay) for released
   versions, and [here](https://smithay.github.io/smithay) for the master branch.
-- **Safety:** Smithay will target to be safe to use, because Rust.
-- **Modularity:** Smithay is not a framework, and will not be constraining. If there is a
-  part you don't want to use, you should not be forced to use it.
-- **High-level:** You should be able to not have to worry about gory low-level stuff (but 
-  Smithay won't stop you if you really want to dive into it).
+- **Safety:** Smithay aims to be memory-safe and reliable, thanks to Rust.
+- **Modularity:** Smithay is not a framework and does not impose constraints. You are never required
+  to use components you don’t need.
+- **High-level:** You should not have to worry about gory low-level stuff (but Smithay won't
+  stop you if you really want to dive into it).
 
 ## Getting started
 
-If you want to learn how to build a compositor with Smithay, consider this [getting started](https://github.com/Smithay/smithay/blob/master/GETTING_STARTED.md) guide.
+If you want to learn how to build a compositor with Smithay, the best place to start is the [getting started](https://github.com/Smithay/smithay/blob/master/GETTING_STARTED.md) guide.
 
 ## Anvil
 
-Smithay as a compositor library has its own sample compositor: anvil.
+Smithay as a compositor library has its own sample compositor: `anvil`.
 
-To get information about it and how you can run it visit [anvil README](https://github.com/Smithay/smithay/blob/master/anvil/README.md)
+To get information about it and how you can run it, check out the [`anvil` README](https://github.com/Smithay/smithay/blob/master/anvil/README.md)
 
 ## Other compositors that use Smithay
 
-- [Cosmic](https://github.com/pop-os/cosmic-epoch): Next generation Cosmic desktop environment
+- [Cosmic](https://github.com/pop-os/cosmic-epoch): Next-generation Cosmic desktop environment
 - [Catacomb](https://github.com/catacombing/catacomb): A Wayland Mobile Compositor
 - [emskin](https://github.com/emskin/emskin): A nested Wayland compositor for embedding any app inside Emacs
 - [MagmaWM](https://github.com/MagmaWM/MagmaWM): A versatile and customizable Wayland Compositor
@@ -61,7 +61,7 @@ Rust.
 
 ## System Dependencies
 
-(This list can depend on features you enable)
+(This list can depend on the features you enable)
 
 - `libwayland`
 - `libxkbcommon`
@@ -77,8 +77,8 @@ If you have questions or want to discuss the project with us, our main chatroom 
 
 ## Contributing
 
-General notes on contributing to Smithay can be found [here](https://github.com/Smithay/smithay/blob/master/Contributing.md).
+General notes on contributing to Smithay can be found [here](https://github.com/Smithay/smithay/blob/master/CONTRIBUTING.md).
 
-Please note that to submit code to Smithay, you have to agree to our [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
+Please note that to submit code to Smithay, you must agree to our [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
 
-If you are used to using generative AI, please ensure you read our [Policy](https://github.com/Smithay/smithay/blob/master/AI.md) before engaging.
+If you are used to using generative AI, please ensure you read our [Policy](https://github.com/Smithay/smithay/blob/master/AI.md) before starting.


### PR DESCRIPTION
## Description
Corrected grammar to improve clarity. Changed link in README.md from `Contributing.md` to the actual filename, `CONTRIBUTING.md`.
I don't think there are any other PRs, issues, or other needed info on this.

No generative AI used.

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
