### PR TITLE
wlr-layer-shell: skip pre-commit validation for destroyed surfaces

### DIFF
--- a/src/wayland/shell/wlr_layer/mod.rs
+++ b/src/wayland/shell/wlr_layer/mod.rs
@@ -484,6 +484,10 @@ impl LayerSurface {
         compositor::with_states(surface, |states| {
             let mut role = states.data_map.get::<LayerSurfaceData>().unwrap().lock().unwrap();
 
+            if !role.surface.alive() {
+                return;
+            }
+
             let mut guard_layer = states.cached_state.get::<LayerSurfaceCachedState>();
             let pending = guard_layer.pending();
 


### PR DESCRIPTION
## Description
I hit an issue while using gtk4-layer-shell: the client gets disconnected the moment it hides a layer-shell window.

To hide a window, gtk4-layer-shell destroys the `zwlr_layer_surface_v1` and then commits the `wl_surface` (with a nil buffer).
On destroy the cached layer state is reset to defaults (size 0, no anchors), but the pre-commit hook is still attached to the surface, so that commit runs it. The state now matches the `pending.size.w == 0 && !pending.anchor.anchored_horizontally()` check, which posts InvalidSize ("width 0 requested without setting left and right anchors") and takes down the whole client.

This PR just skips the pre-commit validation once the `zwlr_layer_surface_v1` has been destroyed. It only short-circuits the hook; it doesn't affect how the surface is torn down.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
