### PR TITLE
feat: add method to return the underlying `eis` connection

### DIFF
--- a/src/backend/libei/mod.rs
+++ b/src/backend/libei/mod.rs
@@ -125,6 +125,11 @@ impl EiInputConnection {
     pub fn flush(&self) -> rustix::io::Result<()> {
         self.0.connection.flush()
     }
+
+    /// Returns the underlying `eis` connection.
+    pub fn eis_connection(&self) -> &eis::Connection {
+        self.0.connection.connection()
+    }
 }
 
 /// An event produced by an [`EiInput`] event source.


### PR DESCRIPTION
## Description
This uniquely identifies the Ei client connection and can be used by a compositor to disambiguate devices and events coming from different ei connections.



## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
