### PR TITLE
feat: add `ei_text` support

### DIFF
--- a/anvil/src/libei.rs
+++ b/anvil/src/libei.rs
@@ -39,7 +39,9 @@ pub fn listen_eis(handle: &calloop::LoopHandle<'static, AnvilState<UdevData>>) {
                         let dh = data.display_handle.clone();
                         data.process_input_event(&dh, event);
                     }
-                    EiInputEvent::TextKeysym { .. } | EiInputEvent::TextUtf8 { .. } => {}
+                    EiInputEvent::TextKeysym { .. } | EiInputEvent::TextUtf8 { .. } => {
+                        // Anvil doesn't add a text device to the libei seat
+                    }
                 })
                 .unwrap();
             Ok(calloop::PostAction::Continue)

--- a/anvil/src/libei.rs
+++ b/anvil/src/libei.rs
@@ -39,6 +39,7 @@ pub fn listen_eis(handle: &calloop::LoopHandle<'static, AnvilState<UdevData>>) {
                         let dh = data.display_handle.clone();
                         data.process_input_event(&dh, event);
                     }
+                    EiInputEvent::TextKeysym { .. } | EiInputEvent::TextUtf8 { .. } => {}
                 })
                 .unwrap();
             Ok(calloop::PostAction::Continue)

--- a/anvil/src/libei.rs
+++ b/anvil/src/libei.rs
@@ -31,7 +31,7 @@ pub fn listen_eis(handle: &calloop::LoopHandle<'static, AnvilState<UdevData>>) {
                         let seat = connection.add_seat("default");
                         let _ = seat.add_keyboard("virtual keyboard", XkbConfig::default());
                         seat.add_pointer("virtual pointer");
-                        seat.add_pointer_absolute("virtual absolute pointer");
+                        seat.add_pointer_absolute("virtual absolute pointer", &[]);
                         seat.add_touch("virtual touch");
                     }
                     EiInputEvent::Disconnected => {}

--- a/src/backend/libei/mod.rs
+++ b/src/backend/libei/mod.rs
@@ -28,6 +28,7 @@
 //!                 // Pass input event to compositor's input event handling logic
 //!                 // ...
 //!             }
+//!             EiInputEvent::TextKeysym { .. } | EiInputEvent::TextUtf8 { .. } => {}
 //!         }
 //!     }).unwrap();
 //!     Ok(calloop::PostAction::Continue)
@@ -47,7 +48,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::backend::input::InputEvent;
+use crate::backend::input::{InputEvent, KeyState};
 
 mod input;
 pub use input::ScrollEvent;
@@ -114,7 +115,8 @@ impl EiInputConnection {
                 | DeviceCapability::Keyboard
                 | DeviceCapability::Touch
                 | DeviceCapability::Scroll
-                | DeviceCapability::Button,
+                | DeviceCapability::Button
+                | DeviceCapability::Text,
         );
         let seat = EiInputSeat::new(self, seat, self.0.event_sender.clone());
         self.0.seats.lock().unwrap().push(seat.clone());
@@ -142,6 +144,20 @@ pub enum EiInputEvent {
     Disconnected,
     /// An input event has been received from the client.
     Event(InputEvent<EiInput>),
+    /// The client injected a keysym via the `ei_text` interface. Unlike [`InputEvent::Keyboard`]
+    /// (which carries a keycode), this is keymap-independent; the compositor is responsible for
+    /// turning the keysym into input.
+    TextKeysym {
+        /// The XKB keysym.
+        keysym: u32,
+        /// Whether the keysym is pressed or released.
+        state: KeyState,
+    },
+    /// The client injected UTF-8 text via the `ei_text` interface.
+    TextUtf8 {
+        /// The UTF-8 text.
+        text: String,
+    },
 }
 
 impl EventSource for EiInput {
@@ -203,6 +219,22 @@ impl EventSource for EiInput {
                     {
                         seat.bind(request.capabilities);
                     }
+                }
+                Ok(EisRequestSourceEvent::Request(EisRequest::TextKeysym(event))) => {
+                    let state = match event.state {
+                        eis::keyboard::KeyState::Press => KeyState::Pressed,
+                        eis::keyboard::KeyState::Released => KeyState::Released,
+                    };
+                    cb(
+                        EiInputEvent::TextKeysym {
+                            keysym: event.keysym,
+                            state,
+                        },
+                        connection,
+                    );
+                }
+                Ok(EisRequestSourceEvent::Request(EisRequest::TextUtf8(event))) => {
+                    cb(EiInputEvent::TextUtf8 { text: event.text }, connection);
                 }
                 Ok(EisRequestSourceEvent::Request(request)) => {
                     if let Some(input_event) = convert_request(request) {
@@ -268,7 +300,8 @@ fn convert_request(request: EisRequest) -> Option<InputEvent<EiInput>> {
         EisRequest::TouchCancel(event) => Some(InputEvent::TouchCancel { event }),
         EisRequest::DeviceClosed(event) => Some(InputEvent::DeviceRemoved { device: event.device }),
         EisRequest::Frame(_) => None,
-        // TODO: handle `TextKeysym`/`TextUtf8` once `add_text()` support is added.
+        // `TextKeysym`/`TextUtf8` are surfaced as `EiInputEvent::TextKeysym`/`TextUtf8` directly,
+        // so they never reach here.
         EisRequest::TextKeysym(_)
         | EisRequest::TextUtf8(_)
         | EisRequest::Disconnect

--- a/src/backend/libei/mod.rs
+++ b/src/backend/libei/mod.rs
@@ -20,7 +20,7 @@
 //!                 let seat = connection.add_seat("default");
 //!                 let _ = seat.add_keyboard("virtual keyboard", XkbConfig::default());
 //!                 seat.add_pointer("virtual pointer");
-//!                 seat.add_pointer_absolute("virtual absolute pointer");
+//!                 seat.add_pointer_absolute("virtual absolute pointer", &[]);
 //!                 seat.add_touch("virtual touch");
 //!             }
 //!             EiInputEvent::Disconnected => {}
@@ -52,7 +52,7 @@ use crate::backend::input::InputEvent;
 mod input;
 pub use input::ScrollEvent;
 mod seat;
-pub use seat::EiInputSeat;
+pub use seat::{EiInputSeat, EiRegion};
 
 /// An [`EventSource`] for receiving input from an EI sender context and
 /// converting to [`InputEvent`]s.

--- a/src/backend/libei/mod.rs
+++ b/src/backend/libei/mod.rs
@@ -210,6 +210,7 @@ impl EventSource for EiInput {
                     }
                 }
                 Err(err) => {
+                    cb(EiInputEvent::Disconnected, connection);
                     tracing::error!("Libei client error: {}", err);
                     return Ok(PostAction::Remove);
                 }

--- a/src/backend/libei/seat.rs
+++ b/src/backend/libei/seat.rs
@@ -57,10 +57,12 @@ impl EiInputSeat {
             pointer_absolute: None,
             pointer_absolute_regions: Vec::new(),
             touch: None,
+            text: None,
             device_keyboard: None,
             device_pointer: None,
             device_pointer_absolute: None,
             device_touch: None,
+            device_text: None,
             bound_capabilities: BitFlags::empty(),
         })))
     }
@@ -98,6 +100,26 @@ impl EiInputSeat {
         let mut inner = self.0.lock().unwrap();
         inner.device_keyboard = None;
         inner.keyboard = None;
+    }
+
+    /// Send the compositor's current modifier state to this seat's keyboard device via
+    /// `ei_keyboard.modifiers`, so the client keeps its keyboard state in sync with the
+    /// compositor (mirroring `wl_keyboard.modifiers`). No-op if there is no bound keyboard.
+    pub fn keyboard_modifiers(&self, depressed: u32, locked: u32, latched: u32, group: u32) {
+        let inner = self.0.lock().unwrap();
+        let Some(device) = inner.device_keyboard.as_ref() else {
+            return;
+        };
+        let Some(keyboard) = device.device.interface::<reis::eis::Keyboard>() else {
+            return;
+        };
+        let Some(connection) = inner.connection.upgrade() else {
+            return;
+        };
+        connection.connection.with_next_serial(|serial| {
+            keyboard.modifiers(serial, depressed, locked, latched, group);
+        });
+        let _ = connection.connection.flush();
     }
 
     /// Add a pointer device to the EI seat
@@ -168,6 +190,25 @@ impl EiInputSeat {
         inner.touch = None;
     }
 
+    /// Add a text device to the EI seat.
+    ///
+    /// A text device lets clients inject input by keysym or UTF-8 string (`ei_text`), independent
+    /// of any keymap. Calling on a seat that already has a text device will remove that device and
+    /// add a new one.
+    pub fn add_text(&self, name: &str) {
+        let mut inner = self.0.lock().unwrap();
+        inner.device_text = None;
+        inner.text = Some(name.to_string());
+        inner.refresh_devices();
+    }
+
+    /// Remove text device from the EI seat
+    pub fn remove_text(&self) {
+        let mut inner = self.0.lock().unwrap();
+        inner.device_text = None;
+        inner.text = None;
+    }
+
     /// Remove seat from EI connection
     pub fn remove(&self) {
         let inner = self.0.lock().unwrap();
@@ -195,11 +236,13 @@ struct EiInputSeatInner {
     // coordinate space(s) the client may address (see `EiRegion`).
     pointer_absolute_regions: Vec<EiRegion>,
     touch: Option<String>,
+    text: Option<String>,
     // Devices created in response to client bind
     device_keyboard: Option<DeviceDropWrapper>,
     device_pointer: Option<DeviceDropWrapper>,
     device_pointer_absolute: Option<DeviceDropWrapper>,
     device_touch: Option<DeviceDropWrapper>,
+    device_text: Option<DeviceDropWrapper>,
 }
 
 impl EiInputSeatInner {
@@ -295,6 +338,22 @@ impl EiInputSeatInner {
                     device: device.clone(),
                 });
                 self.device_touch = Some(DeviceDropWrapper::new(device, &self.event_sender));
+            }
+        }
+
+        if self.device_text.is_none() && self.bound_capabilities.contains(DeviceCapability::Text) {
+            if let Some(name) = self.text.as_ref() {
+                let device = self.seat.add_device(
+                    Some(name),
+                    DeviceType::Virtual,
+                    DeviceCapability::Text.into(),
+                    |_| {},
+                );
+                device.resumed();
+                let _ = self.event_sender.send(InputEvent::DeviceAdded {
+                    device: device.clone(),
+                });
+                self.device_text = Some(DeviceDropWrapper::new(device, &self.event_sender));
             }
         }
     }

--- a/src/backend/libei/seat.rs
+++ b/src/backend/libei/seat.rs
@@ -5,9 +5,32 @@ use xkbcommon::xkb;
 use crate::{
     backend::input::InputEvent,
     input::keyboard::{KeymapFile, XkbConfig},
+    utils::{Logical, Rectangle},
 };
 
 use super::{EiInput, EiInputConnection, EiInputConnectionInner};
+
+/// A region advertised on an EI absolute pointer device.
+///
+/// Describes a rectangular coordinate space the client may point within, in the
+/// compositor's logical coordinate system. Clients that capture at a different
+/// (e.g. physical) resolution use `scale` to convert their coordinates into the
+/// logical space the compositor expects.
+///
+/// `rect` is the logical offset and size of the region; `scale` the
+/// physical-to-logical scale of the underlying output (e.g. `2.0` for a 200%
+/// display). `mapping_id`, when set, identifies which screen/stream the region
+/// maps to (it must match the `mapping_id` the client sees for the corresponding
+/// screencast stream), letting a client correlate a region with the video it shows.
+#[derive(Clone, Debug, PartialEq)]
+pub struct EiRegion {
+    /// Logical offset and size of the region.
+    pub rect: Rectangle<i32, Logical>,
+    /// Physical-to-logical scale of the region (e.g. `2.0` at 200%).
+    pub scale: f32,
+    /// Identifier tying this region to a screencast stream (e.g. the output name).
+    pub mapping_id: Option<String>,
+}
 
 /// A seat advertised on an EI sender context
 #[derive(Clone, Debug)]
@@ -32,6 +55,7 @@ impl EiInputSeat {
             keyboard: None,
             pointer: None,
             pointer_absolute: None,
+            pointer_absolute_regions: Vec::new(),
             touch: None,
             device_keyboard: None,
             device_pointer: None,
@@ -102,12 +126,19 @@ impl EiInputSeat {
     /// The EI device will have button and scroll capabilities in addition
     /// to the pointer absolute capability.
     ///
+    /// `regions` describes the logical coordinate space(s) the client may point
+    /// within (see [`EiRegion`]). Pass an empty slice to advertise no region, in
+    /// which case the client must guess the coordinate space. Advertising a
+    /// region lets clients that capture at a different resolution (e.g. physical
+    /// pixels on a HiDPI output) convert their coordinates correctly.
+    ///
     /// Calling on a seat that already has an absolute pointer device will remove
     /// that device and add a new one.
-    pub fn add_pointer_absolute(&self, name: &str) {
+    pub fn add_pointer_absolute(&self, name: &str, regions: &[EiRegion]) {
         let mut inner = self.0.lock().unwrap();
         inner.device_pointer_absolute = None;
         inner.pointer_absolute = Some(name.to_string());
+        inner.pointer_absolute_regions = regions.to_vec();
         inner.refresh_devices();
     }
 
@@ -116,6 +147,7 @@ impl EiInputSeat {
         let mut inner = self.0.lock().unwrap();
         inner.device_pointer_absolute = None;
         inner.pointer_absolute = None;
+        inner.pointer_absolute_regions.clear();
     }
 
     /// Add a touch device to the EI seat
@@ -159,6 +191,9 @@ struct EiInputSeatInner {
     keyboard: Option<(String, KeymapFile)>,
     pointer: Option<String>,
     pointer_absolute: Option<String>,
+    // Regions advertised on the absolute pointer device, describing the logical
+    // coordinate space(s) the client may address (see `EiRegion`).
+    pointer_absolute_regions: Vec<EiRegion>,
     touch: Option<String>,
     // Devices created in response to client bind
     device_keyboard: Option<DeviceDropWrapper>,
@@ -213,11 +248,31 @@ impl EiInputSeatInner {
                 .contains(DeviceCapability::PointerAbsolute)
         {
             if let Some(name) = self.pointer_absolute.as_ref() {
+                let regions = self.pointer_absolute_regions.clone();
                 let device = self.seat.add_device(
                     Some(name),
                     DeviceType::Virtual,
                     DeviceCapability::PointerAbsolute | DeviceCapability::Button | DeviceCapability::Scroll,
-                    |_| {},
+                    |device| {
+                        // Advertise the coordinate space(s) the client may point within.
+                        // These `ei_device.region` events must be sent after the device is
+                        // created but before `done`, which is exactly when this closure runs.
+                        for region in &regions {
+                            // `region_mapping_id` applies to the region created by the
+                            // next `region` request, so send it first when present.
+                            if let Some(mapping_id) = &region.mapping_id {
+                                device.device().region_mapping_id(mapping_id);
+                            }
+                            // `ei_device.region` coordinates are unsigned
+                            device.device().region(
+                                region.rect.loc.x.max(0) as u32,
+                                region.rect.loc.y.max(0) as u32,
+                                region.rect.size.w.max(0) as u32,
+                                region.rect.size.h.max(0) as u32,
+                                region.scale,
+                            );
+                        }
+                    },
                 );
                 device.resumed();
                 let _ = self.event_sender.send(InputEvent::DeviceAdded {

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -1086,6 +1086,9 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
 
     /// Release every key currently held by `source` (e.g. when a virtual keyboard is destroyed
     /// or a libei connection drops), forwarding the resulting releases to the focused client.
+    ///
+    /// This is a teardown-only path: the releases are forwarded directly and do not run
+    /// the compositor's input filter, so a departing source can't trigger a key binding
     pub fn release_source(&self, data: &mut D, source: KeyboardSource) {
         let (transitioned, mods) = {
             let mut guard = self.arc.internal.lock().unwrap();
@@ -1357,6 +1360,10 @@ where
     <D as SeatHandler>::KeyboardFocus: crate::wayland::seat::WaylandFocus,
 {
     /// Inject a batch of keysyms as text into the currently focused client (KWin-style).
+    ///
+    /// This is a helper/fallback: a compositor should prefer delivering text through the
+    /// text-input protocol (`zwp_text_input_v3::commit_string`) when a text-input client is
+    /// focused, and fall back to this for clients that aren't (terminals, games, ...).
     ///
     /// Builds a throwaway keymap that binds each keysym to its own spare keycode at base level
     /// (so no modifiers are ever needed), hands that keymap to clients, taps each keycode on the

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -3,7 +3,7 @@
 use crate::backend::input::KeyState;
 use crate::utils::{IsAlive, SERIAL_COUNTER, Serial};
 use downcast_rs::{Downcast, impl_downcast};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 #[cfg(feature = "wayland_frontend")]
 use std::sync::RwLock;
 use std::{
@@ -203,10 +203,32 @@ impl fmt::Debug for Xkb {
 // same thread
 unsafe impl Send for Xkb {}
 
+/// Identifies which input source a key event comes from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyboardSource {
+    /// The physical keyboard(s) driven directly by the compositor's input backend.
+    Physical,
+    /// An auxiliary input source (e.g. a `zwp_virtual_keyboard_v1` instance or a libei
+    /// connection), distinguished by a compositor-assigned opaque id.
+    Auxiliary(u64),
+}
+
+impl KeyboardSource {
+    /// The default source used by [`KeyboardHandle::input`] (the physical keyboard).
+    pub const MAIN: KeyboardSource = KeyboardSource::Physical;
+
+    /// Mint a fresh, process-unique auxiliary source.
+    pub fn new_auxiliary() -> Self {
+        static NEXT_AUX_SOURCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+        KeyboardSource::Auxiliary(NEXT_AUX_SOURCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
+    }
+}
+
 pub(crate) struct KbdInternal<D: SeatHandler> {
     pub(crate) focus: Option<(<D as SeatHandler>::KeyboardFocus, Serial)>,
     pending_focus: Option<<D as SeatHandler>::KeyboardFocus>,
     pub(crate) pressed_keys: HashSet<Keycode>,
+    pub(crate) key_sources: HashMap<Keycode, HashSet<KeyboardSource>>,
     pub(crate) forwarded_pressed_keys: HashSet<Keycode>,
     pub(crate) mods_state: ModifiersState,
     xkb: Arc<Mutex<Xkb>>,
@@ -259,6 +281,7 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
             focus: None,
             pending_focus: None,
             pressed_keys: HashSet::new(),
+            key_sources: HashMap::new(),
             forwarded_pressed_keys: HashSet::new(),
             mods_state: ModifiersState::default(),
             xkb: Arc::new(Mutex::new(Xkb {
@@ -274,17 +297,40 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
         })
     }
 
-    // returns whether the modifiers or led state has changed
-    fn key_input(&mut self, keycode: Keycode, state: KeyState) -> (bool, bool) {
-        // track pressed keys as xkbcommon does not seem to expose it :(
+    // Feed a key event from `source` into the shared seat state. Returns
+    // `(modifiers_changed, leds_changed, is_transition)`.
+    //
+    // `is_transition` is `true` only when this event actually changes the combined pressed set
+    // i.e. the first source to press a keycode, or the last source to release it.
+    fn key_input(&mut self, source: KeyboardSource, keycode: Keycode, state: KeyState) -> (bool, bool, bool) {
+        // track pressed keys per source, the seat xkb only follows the *combined* set
         let direction = match state {
             KeyState::Pressed => {
+                let holders = self.key_sources.entry(keycode).or_default();
+                let was_held = !holders.is_empty();
+                holders.insert(source);
+                if was_held {
+                    // already down from another source: absorb
+                    return (false, false, false);
+                }
                 self.pressed_keys.insert(keycode);
                 xkb::KeyDirection::Down
             }
             KeyState::Released => {
-                self.pressed_keys.remove(&keycode);
-                xkb::KeyDirection::Up
+                match self.key_sources.get_mut(&keycode) {
+                    Some(holders) => {
+                        holders.remove(&source);
+                        if !holders.is_empty() {
+                            // still held by another source: absorb
+                            return (false, false, false);
+                        }
+                        self.key_sources.remove(&keycode);
+                        self.pressed_keys.remove(&keycode);
+                        xkb::KeyDirection::Up
+                    }
+                    // not tracked as held: absorb
+                    None => return (false, false, false),
+                }
             }
         };
 
@@ -298,7 +344,28 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
             self.mods_state.update_with(&xkb.state);
         }
         let leds_changed = self.led_state.update_with(&xkb.state, &self.led_mapping);
-        (modifiers_changed, leds_changed)
+        (modifiers_changed, leds_changed, true)
+    }
+
+    /// Release every keycode currently held by `source`, as if the source sent a release for
+    /// each. A keycode only actually transitions up (and gets forwarded) if no other source is
+    /// still holding it. Returns the keycodes that transitioned up, so the caller can forward
+    /// the releases to the focused client.
+    fn release_source_keys(&mut self, source: KeyboardSource) -> Vec<Keycode> {
+        let held: Vec<Keycode> = self
+            .key_sources
+            .iter()
+            .filter(|(_, holders)| holders.contains(&source))
+            .map(|(keycode, _)| *keycode)
+            .collect();
+        let mut transitioned = Vec::new();
+        for keycode in held {
+            let (_, _, is_transition) = self.key_input(source, keycode, KeyState::Released);
+            if is_transition {
+                transitioned.push(keycode);
+            }
+        }
+        transitioned
     }
 
     fn with_grab<F>(&mut self, data: &mut D, seat: &Seat<D>, f: F)
@@ -968,15 +1035,71 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     where
         F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> FilterResult<T>,
     {
-        let (filter_result, mods_changed) = self.input_intercept(data, keycode, state, filter);
-        if let FilterResult::Intercept(val) = filter_result {
-            // the filter returned `FilterResult::Intercept(T)`, we do not forward to client
+        self.input_from_source(KeyboardSource::MAIN, data, keycode, state, serial, time, filter)
+    }
+
+    /// Like [`KeyboardHandle::input`], but attributes the event to a specific [`KeyboardSource`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn input_from_source<T, F>(
+        &self,
+        source: KeyboardSource,
+        data: &mut D,
+        keycode: Keycode,
+        state: KeyState,
+        serial: Serial,
+        time: u32,
+        filter: F,
+    ) -> Option<T>
+    where
+        F: FnOnce(&mut D, &ModifiersState, KeysymHandle<'_>) -> FilterResult<T>,
+    {
+        trace!("Handling keystroke");
+
+        let mut guard = self.arc.internal.lock().unwrap();
+        let (mods_changed, leds_changed, is_transition) = guard.key_input(source, keycode, state);
+        let led_state = guard.led_state;
+        let mods_state = guard.mods_state;
+        let xkb = guard.xkb.clone();
+        std::mem::drop(guard);
+
+        if leds_changed {
+            let seat = self.get_seat(data);
+            data.led_state_changed(&seat, led_state);
+        }
+
+        // The event was absorbed because another source is holding this keycode: don't
+        // double-run the filter (avoids re-triggering shortcuts) and don't forward a duplicate.
+        if !is_transition {
+            return None;
+        }
+
+        let key_handle = KeysymHandle { xkb: &xkb, keycode };
+        trace!(mods_state = ?mods_state, sym = xkb::keysym_get_name(key_handle.modified_sym()), "Calling input filter");
+        if let FilterResult::Intercept(val) = filter(data, &mods_state, key_handle) {
             trace!("Input was intercepted by filter");
             return Some(val);
         }
 
         self.input_forward(data, keycode, state, serial, time, mods_changed);
         None
+    }
+
+    /// Release every key currently held by `source` (e.g. when a virtual keyboard is destroyed
+    /// or a libei connection drops), forwarding the resulting releases to the focused client.
+    pub fn release_source(&self, data: &mut D, source: KeyboardSource) {
+        let (transitioned, mods) = {
+            let mut guard = self.arc.internal.lock().unwrap();
+            let transitioned = guard.release_source_keys(source);
+            (transitioned, guard.mods_state)
+        };
+        let _ = mods;
+        let serial = SERIAL_COUNTER.next_serial();
+        let time = 0;
+        for keycode in transitioned {
+            // modifiers may have changed as a modifier key was released; let input_forward
+            // re-derive and send the current state.
+            self.input_forward(data, keycode, KeyState::Released, serial, time, true);
+        }
     }
 
     /// Update the state of the keyboard without forwarding the event to the focused client
@@ -999,7 +1122,8 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         trace!("Handling keystroke");
 
         let mut guard = self.arc.internal.lock().unwrap();
-        let (mods_changed, leds_changed) = guard.key_input(keycode, state);
+        let (mods_changed, leds_changed, _is_transition) =
+            guard.key_input(KeyboardSource::MAIN, keycode, state);
         let led_state = guard.led_state;
         let mods_state = guard.mods_state;
         let xkb = guard.xkb.clone();
@@ -1040,9 +1164,13 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
             }
         };
 
-        // forward to client if no keybinding is triggered
+        // forward to client if no keybinding is triggered.
+        // Modifiers are only sent when the shared seat state actually changed; the client
+        // resolves the following key event against them, so they must precede the key (handled
+        // in `KeyboardInnerHandle::input`).
         let seat = self.get_seat(data);
-        let modifiers = mods_changed.then_some(guard.mods_state);
+        let mods = guard.mods_state;
+        let modifiers = mods_changed.then_some(mods);
         guard.with_grab(data, &seat, |data, handle, grab| {
             grab.input(data, handle, keycode, state, modifiers, serial, time);
         });
@@ -1098,6 +1226,27 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
     /// Get the current modifiers state.
     pub fn modifier_state(&self) -> ModifiersState {
         self.arc.internal.lock().unwrap().mods_state
+    }
+
+    /// Find a keycode that produces `keysym` at *any* shift level of the currently active
+    /// layout, if any.
+    ///
+    /// Intended for injecting a keysym as a real key through the shared seat *while modifiers are
+    /// held* (e.g. a libei `ei_text.keysym` `c` arriving while Ctrl is down, or an uppercase `Y` while
+    /// Super is down)
+    pub fn keycode_for_keysym(&self, keysym: Keysym) -> Option<Keycode> {
+        let guard = self.arc.internal.lock().unwrap();
+        let xkb = guard.xkb.lock().unwrap();
+        let layout = xkb.state.serialize_layout(XKB_STATE_LAYOUT_EFFECTIVE);
+        (xkb.keymap.min_keycode().raw()..=xkb.keymap.max_keycode().raw())
+            .map(Keycode::new)
+            .find(|&keycode| {
+                (0..xkb.keymap.num_levels_for_key(keycode, layout)).any(|level| {
+                    xkb.keymap
+                        .key_get_syms_by_level(keycode, layout, level)
+                        .contains(&keysym)
+                })
+            })
     }
 
     /// Set the modifiers state.
@@ -1198,6 +1347,99 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
             .find(|seat| seat.get_keyboard().map(|h| &h == self).unwrap_or(false))
             .cloned()
             .unwrap()
+    }
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl<D> KeyboardHandle<D>
+where
+    D: SeatHandler + 'static,
+    <D as SeatHandler>::KeyboardFocus: crate::wayland::seat::WaylandFocus,
+{
+    /// Inject a batch of keysyms as text into the currently focused client (KWin-style).
+    ///
+    /// Builds a throwaway keymap that binds each keysym to its own spare keycode at base level
+    /// (so no modifiers are ever needed), hands that keymap to clients, taps each keycode on the
+    /// focused client, then restores the seat keymap. The compositor's own seat xkb state is
+    /// **never** touched, so shortcut handling and physical-keyboard state are unaffected.
+    /// `modifiers(0)` accompanies the injection keymap so any modifier the seat currently holds
+    /// (e.g. a physically-held Shift) doesn't alter the injected characters.
+    pub fn inject_text_keysyms(&self, data: &mut D, keysyms: &[Keysym]) {
+        const FIRST: u32 = 9;
+        let mut keycode_decls = String::new();
+        let mut symbol_decls = String::new();
+        let mut codes = Vec::with_capacity(keysyms.len());
+        for (i, keysym) in keysyms.iter().enumerate() {
+            let code = FIRST + i as u32;
+            if code > 255 {
+                break;
+            }
+            let name = xkb::keysym_get_name(*keysym);
+            if name.is_empty() || name == "NoSymbol" {
+                continue;
+            }
+            keycode_decls.push_str(&format!("    <K{code}> = {code};\n"));
+            symbol_decls.push_str(&format!("    key <K{code}> {{ [ {name} ] }};\n"));
+            codes.push(Keycode::new(code));
+        }
+        if codes.is_empty() {
+            return;
+        }
+
+        let custom = format!(
+            "xkb_keymap {{\n\
+             xkb_keycodes \"custom\" {{\n    minimum = 8;\n    maximum = 255;\n{keycode_decls}}};\n\
+             xkb_types \"(custom)\" {{ include \"complete\" }};\n\
+             xkb_compatibility \"custom\" {{ include \"complete\" }};\n\
+             xkb_symbols \"custom\" {{\n{symbol_decls}}};\n\
+             }};\n"
+        );
+
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let Some(keymap) = xkb::Keymap::new_from_string(
+            &context,
+            custom,
+            xkb::KEYMAP_FORMAT_TEXT_V1,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        ) else {
+            return;
+        };
+        let xkb = Mutex::new(Xkb {
+            state: xkb::State::new(&keymap),
+            keymap,
+            context,
+        });
+        let injection_keymap = KeymapFile::new(&xkb.lock().unwrap().keymap);
+
+        let seat = self.get_seat(data);
+        let mut guard = self.arc.internal.lock().unwrap();
+        if guard.focus.is_none() {
+            return;
+        }
+        let seat_mods = guard.mods_state;
+
+        // Switch the focused client to the injection keymap (with no modifiers), then tap keys.
+        {
+            let focus = guard.focus.as_mut().map(|(focus, _)| focus);
+            self.send_keymap(data, &focus, &injection_keymap, ModifiersState::default());
+        }
+        for keycode in codes {
+            let press = SERIAL_COUNTER.next_serial();
+            let release = SERIAL_COUNTER.next_serial();
+            if let Some((focus, _)) = guard.focus.as_mut() {
+                let handle = KeysymHandle { xkb: &xkb, keycode };
+                focus.key(&seat, data, handle, KeyState::Pressed, press, 0);
+            }
+            if let Some((focus, _)) = guard.focus.as_mut() {
+                let handle = KeysymHandle { xkb: &xkb, keycode };
+                focus.key(&seat, data, handle, KeyState::Released, release, 0);
+            }
+        }
+
+        // Restore the seat keymap (and the seat's real modifier state) to the client.
+        let seat_keymap = self.arc.keymap.lock().unwrap();
+        let focus = guard.focus.as_mut().map(|(focus, _)| focus);
+        self.send_keymap(data, &focus, &seat_keymap, seat_mods);
     }
 }
 
@@ -1302,7 +1544,6 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
             None => return,
         };
 
-        // Ensure keymap is up to date.
         #[cfg(feature = "wayland_frontend")]
         if let Some(keyboard_handle) = self.seat.get_keyboard() {
             let keymap_file = keyboard_handle.arc.keymap.lock().unwrap();
@@ -1310,17 +1551,17 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
             keyboard_handle.send_keymap(data, &Some(focus), &keymap_file, mods);
         }
 
-        // key event must be sent before modifiers event for libxkbcommon
-        // to process them correctly
         let key = KeysymHandle {
             xkb: &self.inner.xkb,
             keycode,
         };
 
-        focus.key(self.seat, data, key, key_state, serial, time);
+        // Modifiers must be sent before the key event so the client resolves the key against the
+        // updated modifier state.
         if let Some(mods) = modifiers {
             focus.modifiers(self.seat, data, mods, serial);
         }
+        focus.key(self.seat, data, key, key_state, serial, time);
     }
 
     /// Iterate over the currently pressed keys.
@@ -1336,6 +1577,22 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
             .map(|code| self.keysym_handle(*code))
             .collect();
         f(handles)
+    }
+
+    /// The forwarded held keys and modifier state to announce to a newly-focused target on a
+    /// focus change, from the seat's shared state.
+    fn focus_enter_state(&self) -> (Vec<KeysymHandle<'_>>, ModifiersState) {
+        (
+            self.inner
+                .forwarded_pressed_keys
+                .iter()
+                .map(|keycode| KeysymHandle {
+                    xkb: &self.inner.xkb,
+                    keycode: *keycode,
+                })
+                .collect(),
+            self.inner.mods_state,
+        )
     }
 
     /// Set the current focus of this keyboard
@@ -1358,32 +1615,16 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
                 }
                 (focus, Some((old_focus, _))) => {
                     trace!("Focus set to new surface");
-                    let keys = self
-                        .inner
-                        .forwarded_pressed_keys
-                        .iter()
-                        .map(|keycode| KeysymHandle {
-                            xkb: &self.inner.xkb,
-                            keycode: *keycode,
-                        })
-                        .collect();
+                    let (keys, mods) = self.focus_enter_state();
 
-                    focus.replace(old_focus, self.seat, data, keys, self.inner.mods_state, serial);
+                    focus.replace(old_focus, self.seat, data, keys, mods, serial);
                     data.focus_changed(self.seat, Some(&focus));
                 }
                 (focus, None) => {
-                    let keys = self
-                        .inner
-                        .forwarded_pressed_keys
-                        .iter()
-                        .map(|keycode| KeysymHandle {
-                            xkb: &self.inner.xkb,
-                            keycode: *keycode,
-                        })
-                        .collect();
+                    let (keys, mods) = self.focus_enter_state();
 
                     focus.enter(self.seat, data, keys, serial);
-                    focus.modifiers(self.seat, data, self.inner.mods_state, serial);
+                    focus.modifiers(self.seat, data, mods, serial);
                     data.focus_changed(self.seat, Some(&focus));
                 }
             }

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -69,7 +69,7 @@ impl InputMethodHandle {
     }
 
     /// Whether there's an active instance of input-method.
-    pub(crate) fn has_instance(&self) -> bool {
+    pub fn has_instance(&self) -> bool {
         self.inner.lock().unwrap().instance.is_some()
     }
 

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -253,8 +253,9 @@ pub(crate) fn enter_internal<D: SeatHandler + 'static>(
     // text-input global bound due to clients doing lazy global binding.
     text_input.set_focus(Some(surface.clone()));
 
-    // Only notify on `enter` once we have an actual IME.
-    if input_method.has_instance() {
+    // Notify on `enter` once we have an actual IME, or while the compositor is itself acting
+    // as the input method for this seat.
+    if input_method.has_instance() || text_input.compositor_input_method() {
         text_input.enter();
     }
 }
@@ -281,6 +282,9 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for WlSurface {
 
         if input_method.has_instance() {
             input_method.deactivate_input_method(state);
+        }
+        // Send `leave` for a real IME or while the compositor is acting as the input method.
+        if input_method.has_instance() || text_input.compositor_input_method() {
             text_input.leave();
         }
 

--- a/src/wayland/text_input/text_input_handle.rs
+++ b/src/wayland/text_input/text_input_handle.rs
@@ -17,6 +17,7 @@ pub(crate) struct TextInput {
     instances: Vec<Instance>,
     focus: Option<WlSurface>,
     active_text_input_id: Option<ObjectId>,
+    compositor_input_method: bool,
 }
 
 impl TextInput {
@@ -124,6 +125,33 @@ impl TextInputHandle {
         });
     }
 
+    /// Have the compositor act as the input method for this seat.
+    ///
+    /// While enabled, `enter` is delivered to the focused text-input even when no real
+    /// `zwp_input_method_v2` is bound, so the compositor can `commit_string` into it (e.g. for
+    /// remote-desktop text injection). Toggling this sends `enter`/`leave` for the current
+    /// focus immediately; subsequent focus changes are handled by the keyboard focus logic.
+    pub fn set_compositor_input_method(&self, active: bool) {
+        {
+            let mut inner = self.inner.lock().unwrap();
+            if inner.compositor_input_method == active {
+                return;
+            }
+            inner.compositor_input_method = active;
+        }
+        if active {
+            self.enter();
+        } else {
+            self.leave();
+        }
+    }
+
+    /// Whether the compositor is currently acting as the input method for this seat
+    /// (see [`set_compositor_input_method`](Self::set_compositor_input_method)).
+    pub fn compositor_input_method(&self) -> bool {
+        self.inner.lock().unwrap().compositor_input_method
+    }
+
     /// The `discard_state` is used when the input-method signaled that
     /// the state should be discarded and wrong serial sent.
     pub fn done(&self, discard_state: bool) {
@@ -205,8 +233,11 @@ where
             self.handle.increment_serial(resource);
         }
 
-        // Discard requests without any active input method instance.
-        if !self.input_method_handle.has_instance() {
+        // Discard requests without any active input method instance, unless the compositor
+        // itself is acting as the input method for this seat (the text-injection escape hatch).
+        // In that case we still process enable/commit so the focused client becomes the active
+        // text input and the compositor can `commit_string` into it.
+        if !self.input_method_handle.has_instance() && !self.handle.compositor_input_method() {
             debug!("discarding text-input request without IME running");
             return;
         }


### PR DESCRIPTION
## Description
Adds `Text` capability to the seat. Also adds `TextKeySym` and `TextUtf8` as EiInputEvents. 

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
