### PR TITLE
typo fix: layer_map_for_output documentation

### DIFF
--- a/src/desktop/wayland/layer.rs
+++ b/src/desktop/wayland/layer.rs
@@ -44,7 +44,7 @@ pub struct LayerMap {
 /// to the output and returned on subsequent calls.
 ///
 /// Note: This function internally uses a [`Mutex`] per
-/// [`Output`] as exposed by its return type. Therefor
+/// [`Output`] as exposed by its return type. Therefore
 /// trying to hold on to multiple references of a [`LayerMap`]
 /// of the same output using this function *will* result in a deadlock.
 pub fn layer_map_for_output(o: &Output) -> MutexGuard<'_, LayerMap> {


### PR DESCRIPTION
Corrected a typo in the documentation comment. I saw it on docs.rs

## Description
I know this really isn't anything significant by any means, but I thought I might as well correct now and make the PR.


```rs
/// Note: This function internally uses a [`Mutex`] per
/// [`Output`] as exposed by its return type. Therefor  <-- missing `e`
/// trying to hold on to multiple references of a [`LayerMap`]
/// of the same output using this function *will* result in a deadlock.
```

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
