### PR TITLE
tablet: add infrastructure for proper tablet support

### DIFF
--- a/anvil/src/focus.rs
+++ b/anvil/src/focus.rs
@@ -24,6 +24,7 @@ use smithay::{
             GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent,
             GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent,
         },
+        tablet::tool::TabletToolTarget,
         touch::{FrameMarker, TouchTarget},
     },
     reexports::wayland_server::DisplayHandle,
@@ -108,6 +109,17 @@ impl PointerFocusTarget {
     }
 
     fn inner_touch_target<BackendData: Backend>(&self) -> &dyn TouchTarget<AnvilState<BackendData>> {
+        match self {
+            Self::WlSurface(w) => w,
+            #[cfg(feature = "xwayland")]
+            Self::X11Surface(w) => w,
+            Self::SSD(w) => w,
+        }
+    }
+
+    fn inner_tablet_tool_target<BackendData: Backend>(
+        &self,
+    ) -> &dyn TabletToolTarget<AnvilState<BackendData>> {
         match self {
             Self::WlSurface(w) => w,
             #[cfg(feature = "xwayland")]
@@ -350,6 +362,96 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for PointerFocus
         data: &mut AnvilState<BackendData>,
     ) -> Option<FrameMarker> {
         self.inner_touch_target().last_frame(seat, data)
+    }
+}
+
+impl<BackendData: Backend> TabletToolTarget<AnvilState<BackendData>> for PointerFocusTarget {
+    fn proximity_in(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        tablet: &smithay::input::tablet::Tablet,
+        serial: Serial,
+    ) {
+        self.inner_tablet_tool_target()
+            .proximity_in(seat, data, tool_descriptor, tablet, serial);
+    }
+
+    fn proximity_out(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+    ) {
+        self.inner_tablet_tool_target()
+            .proximity_out(seat, data, tool_descriptor);
+    }
+
+    fn down(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        event: &smithay::input::tablet::tool::DownEvent,
+    ) {
+        self.inner_tablet_tool_target()
+            .down(seat, data, tool_descriptor, event);
+    }
+
+    fn up(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        event: &smithay::input::tablet::tool::UpEvent,
+    ) {
+        self.inner_tablet_tool_target()
+            .up(seat, data, tool_descriptor, event);
+    }
+
+    fn motion(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        event: &smithay::input::tablet::tool::MotionEvent,
+    ) {
+        self.inner_tablet_tool_target()
+            .motion(seat, data, tool_descriptor, event);
+    }
+
+    fn button(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        event: &smithay::input::tablet::tool::ButtonEvent,
+    ) {
+        self.inner_tablet_tool_target()
+            .button(seat, data, tool_descriptor, event);
+    }
+
+    fn axis(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        frame: smithay::input::tablet::tool::AxisFrame,
+    ) {
+        self.inner_tablet_tool_target()
+            .axis(seat, data, tool_descriptor, frame);
+    }
+
+    fn frame(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        time: u32,
+    ) {
+        self.inner_tablet_tool_target()
+            .frame(seat, data, tool_descriptor, time);
     }
 }
 

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -1098,7 +1098,6 @@ impl AnvilState<UdevData> {
 
         if let Some(pointer_location) = self.touch_location_transformed(&evt) {
             let tool = evt.tool();
-            tablet_seat.add_wp_tool(self, dh, &tool);
 
             let pointer = self.pointer.clone();
             let under = self.surface_under(pointer_location);

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -5,7 +5,7 @@ use crate::{AnvilState, focus::PointerFocusTarget, shell::FullscreenSurface};
 #[cfg(feature = "udev")]
 use crate::udev::UdevData;
 #[cfg(feature = "udev")]
-use smithay::backend::renderer::DebugFlags;
+use smithay::{backend::renderer::DebugFlags, input::tablet};
 
 use smithay::{
     backend::input::{
@@ -16,6 +16,7 @@ use smithay::{
     input::{
         keyboard::{FilterResult, Keysym, ModifiersState, keysyms as xkb},
         pointer::{AxisFrame, ButtonEvent, MotionEvent},
+        tablet::{TabletDescriptor, TabletSeatTrait},
         touch::{DownEvent, UpEvent},
     },
     output::Scale,
@@ -28,7 +29,6 @@ use smithay::{
         input_method::InputMethodSeat,
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
         shell::wlr_layer::{KeyboardInteractivity, Layer as WlrLayer},
-        tablet_manager::{TabletDescriptor, TabletSeatTrait},
     },
 };
 
@@ -534,7 +534,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         if device.has_capability(DeviceCapability::TabletTool) {
             self.seat
                 .tablet_seat()
-                .add_tablet::<Self>(dh, &TabletDescriptor::from(&device));
+                .add_wp_tablet(dh, &TabletDescriptor::from(&device));
         }
         if device.has_capability(DeviceCapability::Touch) && self.seat.get_touch().is_none() {
             self.seat.add_touch();
@@ -1045,8 +1045,8 @@ impl AnvilState<UdevData> {
         if let Some(pointer_location) = self.touch_location_transformed(&evt) {
             let pointer = self.pointer.clone();
             let under = self.surface_under(pointer_location);
-            let tablet = tablet_seat.get_tablet(&TabletDescriptor::from(&evt.device()));
             let tool = tablet_seat.get_tool(&evt.tool());
+            let time = self.clock.now().as_millis();
 
             pointer.motion(
                 self,
@@ -1054,37 +1054,35 @@ impl AnvilState<UdevData> {
                 &MotionEvent {
                     location: pointer_location,
                     serial: SCOUNTER.next_serial(),
-                    time: self.clock.now().as_millis(),
+                    time,
                 },
             );
 
-            if let (Some(tablet), Some(tool)) = (tablet, tool) {
-                if evt.pressure_has_changed() {
-                    tool.pressure(evt.pressure());
-                }
-                if evt.distance_has_changed() {
-                    tool.distance(evt.distance());
-                }
-                if evt.tilt_has_changed() {
-                    tool.tilt(evt.tilt());
-                }
-                if evt.slider_has_changed() {
-                    tool.slider_position(evt.slider_position());
-                }
-                if evt.rotation_has_changed() {
-                    tool.rotation(evt.rotation());
-                }
-                if evt.wheel_has_changed() {
-                    tool.wheel(evt.wheel_delta(), evt.wheel_delta_discrete());
-                }
+            if let Some(tool) = tool {
+                let frame = tablet::tool::AxisFrame {
+                    pressure: evt.pressure_has_changed().then(|| evt.pressure()),
+                    distance: evt.distance_has_changed().then(|| evt.distance()),
+                    tilt: evt.tilt_has_changed().then(|| evt.tilt()),
+                    rotation: evt.rotation_has_changed().then(|| evt.rotation()),
+                    slider: evt.slider_has_changed().then(|| evt.slider_position()),
+                    wheel: evt
+                        .wheel_has_changed()
+                        .then(|| (evt.wheel_delta(), evt.wheel_delta_discrete())),
+                };
+
+                tool.axis(self, frame);
 
                 tool.motion(
-                    pointer_location,
-                    under.and_then(|(f, loc)| f.wl_surface().map(|s| (s.into_owned(), loc))),
-                    &tablet,
-                    SCOUNTER.next_serial(),
-                    evt.time_msec(),
+                    self,
+                    under,
+                    &tablet::tool::MotionEvent {
+                        location: pointer_location,
+                        serial: SCOUNTER.next_serial(),
+                        time,
+                    },
                 );
+
+                tool.frame(self, time);
             }
 
             pointer.frame(self);
@@ -1100,12 +1098,14 @@ impl AnvilState<UdevData> {
 
         if let Some(pointer_location) = self.touch_location_transformed(&evt) {
             let tool = evt.tool();
-            tablet_seat.add_tool::<Self>(self, dh, &tool);
+            tablet_seat.add_wp_tool(self, dh, &tool);
 
             let pointer = self.pointer.clone();
             let under = self.surface_under(pointer_location);
             let tablet = tablet_seat.get_tablet(&TabletDescriptor::from(&evt.device()));
-            let tool = tablet_seat.get_tool(&tool);
+            let tool = tablet_seat
+                .get_tool(&tool)
+                .unwrap_or_else(|| tablet_seat.add_wp_tool(self, dh, &tool));
 
             pointer.motion(
                 self,
@@ -1118,20 +1118,49 @@ impl AnvilState<UdevData> {
             );
             pointer.frame(self);
 
-            if let (Some(under), Some(tablet), Some(tool)) = (
-                under.and_then(|(f, loc)| f.wl_surface().map(|s| (s.into_owned(), loc))),
-                tablet,
-                tool,
-            ) {
+            if let Some(tablet) = tablet {
+                let frame = tablet::tool::AxisFrame {
+                    pressure: evt.pressure_has_changed().then(|| evt.pressure()),
+                    distance: evt.distance_has_changed().then(|| evt.distance()),
+                    tilt: evt.tilt_has_changed().then(|| evt.tilt()),
+                    rotation: evt.rotation_has_changed().then(|| evt.rotation()),
+                    slider: evt.slider_has_changed().then(|| evt.slider_position()),
+                    wheel: evt
+                        .wheel_has_changed()
+                        .then(|| (evt.wheel_delta(), evt.wheel_delta_discrete())),
+                };
+
                 match evt.state() {
-                    ProximityState::In => tool.proximity_in(
-                        pointer_location,
-                        under,
-                        &tablet,
-                        SCOUNTER.next_serial(),
-                        evt.time_msec(),
-                    ),
-                    ProximityState::Out => tool.proximity_out(evt.time_msec()),
+                    ProximityState::In => {
+                        tool.proximity_in(
+                            self,
+                            under,
+                            tablet,
+                            &tablet::tool::ProximityInEvent {
+                                location: pointer_location,
+                                axis: Some(frame),
+                                serial: SCOUNTER.next_serial(),
+                                time: evt.time_msec(),
+                            },
+                        );
+
+                        // Doing this in an idle handler would allow other events (e.g. buttons) to be
+                        // sent as part of the same frame, which is closer to what the protocol
+                        // expect, and let well behaved clients accumulate events.
+                        tool.frame(self, evt.time_msec());
+                    }
+                    ProximityState::Out => {
+                        tool.proximity_out(
+                            self,
+                            &tablet::tool::ProximityOutEvent {
+                                serial: SCOUNTER.next_serial(),
+                                time: evt.time_msec(),
+                            },
+                        );
+
+                        // The tool left, we don't want to send a frame event here as it's sent as
+                        // part of the proximity out logic.
+                    }
                 }
             }
         }
@@ -1141,18 +1170,33 @@ impl AnvilState<UdevData> {
         let tool = self.seat.tablet_seat().get_tool(&evt.tool());
 
         if let Some(tool) = tool {
+            let serial = SCOUNTER.next_serial();
+
             match evt.tip_state() {
                 TabletToolTipState::Down => {
-                    let serial = SCOUNTER.next_serial();
-                    tool.tip_down(serial, evt.time_msec());
+                    tool.down(
+                        self,
+                        &tablet::tool::DownEvent {
+                            serial,
+                            time: evt.time_msec(),
+                        },
+                    );
 
                     // change the keyboard focus
                     self.update_keyboard_focus(self.pointer.current_location(), serial);
                 }
                 TabletToolTipState::Up => {
-                    tool.tip_up(evt.time_msec());
+                    tool.up(
+                        self,
+                        &tablet::tool::UpEvent {
+                            serial,
+                            time: evt.time_msec(),
+                        },
+                    );
                 }
             }
+
+            tool.frame(self, evt.time_msec());
         }
     }
 
@@ -1161,11 +1205,16 @@ impl AnvilState<UdevData> {
 
         if let Some(tool) = tool {
             tool.button(
-                evt.button(),
-                evt.button_state(),
-                SCOUNTER.next_serial(),
-                evt.time_msec(),
+                self,
+                &tablet::tool::ButtonEvent {
+                    serial: SCOUNTER.next_serial(),
+                    button: evt.button(),
+                    state: evt.button_state(),
+                    time: evt.time_msec(),
+                },
             );
+
+            tool.frame(self, evt.time_msec());
         }
     }
 

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -1143,11 +1143,6 @@ impl AnvilState<UdevData> {
                                 time: evt.time_msec(),
                             },
                         );
-
-                        // Doing this in an idle handler would allow other events (e.g. buttons) to be
-                        // sent as part of the same frame, which is closer to what the protocol
-                        // expect, and let well behaved clients accumulate events.
-                        tool.frame(self, evt.time_msec());
                     }
                     ProximityState::Out => {
                         tool.proximity_out(
@@ -1157,11 +1152,13 @@ impl AnvilState<UdevData> {
                                 time: evt.time_msec(),
                             },
                         );
-
-                        // The tool left, we don't want to send a frame event here as it's sent as
-                        // part of the proximity out logic.
                     }
                 }
+
+                // Doing this in an idle handler would allow other events (e.g. buttons) to be
+                // sent as part of the same frame, which is closer to what the protocol
+                // expect, and let well behaved clients accumulate events.
+                tool.frame(self, evt.time_msec());
             }
         }
     }

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -15,6 +15,7 @@ use smithay::{
             GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
             GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
         },
+        tablet::tool::TabletToolTarget,
         touch::{FrameMarker, TouchTarget},
     },
     output::Output,
@@ -294,11 +295,11 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for SSD {
         &self,
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
-        event: &smithay::input::touch::UpEvent,
+        _event: &smithay::input::touch::UpEvent,
     ) {
         let mut state = self.0.decoration_state();
         if state.is_ssd {
-            state.header_bar.touch_up(seat, data, &self.0, event.serial);
+            state.header_bar.touch_up(seat, data, &self.0);
         }
     }
 
@@ -354,6 +355,100 @@ impl<BackendData: Backend> TouchTarget<AnvilState<BackendData>> for SSD {
         // It would be more correct to store the marker on frame and cancel,
         // but since we're ignoring those anyway, no need for the added complexity.
         None
+    }
+}
+
+impl<BackendData: Backend> TabletToolTarget<AnvilState<BackendData>> for SSD {
+    fn proximity_in(
+        &self,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
+        _tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        _tablet: &smithay::input::tablet::Tablet,
+        _serial: Serial,
+    ) {
+    }
+
+    fn proximity_out(
+        &self,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
+        _tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+    ) {
+        let mut state = self.0.decoration_state();
+        if state.is_ssd {
+            state.header_bar.pointer_leave();
+        }
+    }
+
+    fn down(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        _tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        event: &smithay::input::tablet::tool::DownEvent,
+    ) {
+        let mut state = self.0.decoration_state();
+        if state.is_ssd {
+            state.header_bar.touch_down(seat, data, &self.0, event.serial);
+        }
+    }
+
+    fn up(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        _tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        _event: &smithay::input::tablet::tool::UpEvent,
+    ) {
+        let mut state = self.0.decoration_state();
+        if state.is_ssd {
+            state.header_bar.touch_up(seat, data, &self.0);
+        }
+    }
+
+    fn motion(
+        &self,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
+        _tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        event: &smithay::input::tablet::tool::MotionEvent,
+    ) {
+        let mut state = self.0.decoration_state();
+        if state.is_ssd {
+            state.header_bar.pointer_enter(event.location);
+        }
+    }
+
+    fn button(
+        &self,
+        seat: &Seat<AnvilState<BackendData>>,
+        data: &mut AnvilState<BackendData>,
+        _tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        event: &smithay::input::tablet::tool::ButtonEvent,
+    ) {
+        let mut state = self.0.decoration_state();
+        if state.is_ssd {
+            state.header_bar.clicked(seat, data, &self.0, event.serial);
+        }
+    }
+
+    fn axis(
+        &self,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
+        _tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        _frame: smithay::input::tablet::tool::AxisFrame,
+    ) {
+    }
+
+    fn frame(
+        &self,
+        _seat: &Seat<AnvilState<BackendData>>,
+        _data: &mut AnvilState<BackendData>,
+        _tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
+        _time: u32,
+    ) {
     }
 }
 

--- a/anvil/src/shell/ssd.rs
+++ b/anvil/src/shell/ssd.rs
@@ -141,7 +141,6 @@ impl HeaderBar {
         _seat: &Seat<AnvilState<BackendData>>,
         state: &mut AnvilState<BackendData>,
         window: &WindowElement,
-        _serial: Serial,
     ) {
         match self.pointer_loc.as_ref() {
             Some(loc) if loc.x >= (self.width - BUTTON_WIDTH) as f64 => {

--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -30,6 +30,7 @@ use smithay::{
         dnd::{DnDGrab, DndGrabHandler, DndTarget, GrabType, Source},
         keyboard::{Keysym, LedState, XkbConfig},
         pointer::{CursorImageStatus, Focus, PointerHandle},
+        tablet::TabletSeatHandler,
     },
     output::Output,
     reexports::{
@@ -87,7 +88,7 @@ use smithay::{
         shm::{ShmHandler, ShmState},
         single_pixel_buffer::SinglePixelBufferState,
         socket::ListeningSocketSource,
-        tablet_manager::{TabletManagerState, TabletSeatHandler},
+        tablet_manager::TabletManagerState,
         text_input::TextInputManagerState,
         viewporter::ViewporterState,
         virtual_keyboard::VirtualKeyboardManagerState,
@@ -324,6 +325,8 @@ impl<BackendData: Backend> SeatHandler for AnvilState<BackendData> {
 }
 
 impl<BackendData: Backend> TabletSeatHandler for AnvilState<BackendData> {
+    type ToolFocus = PointerFocusTarget;
+
     fn tablet_tool_image(&mut self, _tool: &TabletToolDescriptor, image: CursorImageStatus) {
         // TODO: tablet tools should have their own cursors
         self.cursor_status = image;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -111,7 +111,7 @@
 //! Once the seat is initialized, you can add capabilities to it.
 //!
 //! Currently, pointer, touch and keyboard capabilities are supported by this module.
-//! [`tablet_manager`](crate::wayland::tablet_manager) also provides client interaction for drawing tablets.
+//! [`tablet`] provides similar abstractions for drawing tablets.
 //!
 //! You can add these capabilities via methods of the [`Seat`] struct:
 //! [`Seat::add_keyboard`], [`Seat::add_pointer`] and [`Seat::add_touch`].
@@ -145,6 +145,7 @@ use crate::{
 pub mod dnd;
 pub mod keyboard;
 pub mod pointer;
+pub mod tablet;
 pub mod touch;
 
 /// Handler trait for Seats

--- a/src/input/tablet/mod.rs
+++ b/src/input/tablet/mod.rs
@@ -138,7 +138,7 @@
 //! You can add tablet and tools via methods of the [`TabletSeat`] struct:
 //! [`TabletSeat::add_tablet`] and [`TabletSeat::add_tool`].
 //! These method return handles that can be cloned and sent across thread, so you can keep them
-//! around in you event-handling code to forward inputs to your clients.
+//! around in your event-handling code to forward inputs to your clients.
 //!
 
 use std::{

--- a/src/input/tablet/mod.rs
+++ b/src/input/tablet/mod.rs
@@ -1,0 +1,574 @@
+//! Graphic tablet related types for smithay's input abstraction
+//!
+//! This module provides some types loosely resembling instances of wayland tablet seat, tablet and
+//! tablet tool. It is however not directly tied to wayland and can be used to multiplex various
+//! tablet-related operations between different handlers.
+//!
+//! If the `wayland_frontend`-feature is enabled, the `smithay::wayland::tablet_manager`-module
+//! provides additional functionality for the provided types of this module to map them to
+//! advertised wayland globals and objects.
+//!
+//! ## How to use it
+//!
+//! To start using this module, you need to create a [`TabletSeat`] from an existing [`Seat`].
+//! Additionally, you want to implement the [`TabletSeatHandler`] trait.
+//!
+//! ### Initialization
+//!
+//! ```
+//! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
+//! use smithay::input::tablet::{TabletSeatHandler, TabletSeatTrait};
+//! use smithay::backend::input::TabletToolDescriptor;
+//! # use smithay::backend::input::KeyState;
+//! # use smithay::input::{
+//! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
+//! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
+//! #             GesturePinchBeginEvent, GesturePinchUpdateEvent, GesturePinchEndEvent,
+//! #             GestureHoldBeginEvent, GestureHoldEndEvent},
+//! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
+//! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget, FrameMarker},
+//! #   tablet::{Tablet, tool::{self, TabletToolTarget}},
+//! # };
+//! # use smithay::utils::{IsAlive, Serial};
+//!
+//! struct State {
+//!     seat_state: SeatState<Self>,
+//!     // ...
+//! };
+//!
+//! let mut seat_state = SeatState::<State>::new();
+//!
+//! // create the seat
+//! let seat = seat_state.new_seat(
+//!     "seat-0",  // the name of the seat, will be advertized to clients
+//! );
+//! // create the associated tablet seat.
+//! let tablet_seat = seat.tablet_seat();
+//!
+//! # #[derive(Debug, Clone, PartialEq)]
+//! # struct Target;
+//! # impl IsAlive for Target {
+//! #   fn alive(&self) -> bool { true }
+//! # }
+//! # impl PointerTarget<State> for Target {
+//! #   fn enter(&self, seat: &Seat<State>, data: &mut State, event: &MotionEvent) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &MotionEvent) {}
+//! #   fn relative_motion(&self, seat: &Seat<State>, data: &mut State, event: &RelativeMotionEvent) {}
+//! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
+//! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
+//! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
+//! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
+//! #   fn gesture_pinch_begin(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchBeginEvent) {}
+//! #   fn gesture_pinch_update(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchUpdateEvent) {}
+//! #   fn gesture_pinch_end(&self, seat: &Seat<State>, data: &mut State, event: &GesturePinchEndEvent) {}
+//! #   fn gesture_hold_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldBeginEvent) {}
+//! #   fn gesture_hold_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldEndEvent) {}
+//! # }
+//! # impl KeyboardTarget<State> for Target {
+//! #   fn enter(&self, seat: &Seat<State>, data: &mut State, keys: Vec<KeysymHandle<'_>>, serial: Serial) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial) {}
+//! #   fn key(
+//! #       &self,
+//! #       seat: &Seat<State>,
+//! #       data: &mut State,
+//! #       key: KeysymHandle<'_>,
+//! #       state: KeyState,
+//! #       serial: Serial,
+//! #       time: u32,
+//! #   ) {}
+//! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
+//! # }
+//! # impl TouchTarget<State> for Target {
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, event: &DownEvent) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, event: &UpEvent) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, event: &TouchMotionEvent) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn cancel(&self, seat: &Seat<State>, data: &mut State, marker: FrameMarker) {}
+//! #   fn shape(&self, seat: &Seat<State>, data: &mut State, event: &ShapeEvent) {}
+//! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent) {}
+//! #   fn last_frame(&self, seat: &Seat<State>, data: &mut State) -> Option<FrameMarker> { unimplemented!() }
+//! # }
+//! # impl TabletToolTarget<State> for Target {
+//! #   fn proximity_in(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, tablet: &Tablet, serial: Serial) {}
+//! #   fn proximity_out(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor) {}
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::DownEvent) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::UpEvent) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::MotionEvent) {}
+//! #   fn axis(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, frame: tool::AxisFrame) {}
+//! #   fn button(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::ButtonEvent) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, time: u32) {}
+//! # }
+//!
+//! // implement the required traits
+//! impl SeatHandler for State {
+//!     type KeyboardFocus = Target;
+//!     type PointerFocus = Target;
+//!     type TouchFocus = Target;
+//!
+//!     fn seat_state(&mut self) -> &mut SeatState<Self> {
+//!         &mut self.seat_state
+//!     }
+//!
+//!     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&Target>) {
+//!         // handle focus changes, if you need to ...
+//!     }
+//!     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) {
+//!         // handle new images for the cursor ...
+//!     }
+//! }
+//!
+//! impl TabletSeatHandler for State {
+//!     type ToolFocus = Target;
+//!
+//!     fn tablet_tool_image(&mut self, tool: &TabletToolDescriptor, image: CursorImageStatus) {
+//!         // handle new image for the given tool.
+//!     }
+//! }
+//! ```
+//!
+//! ### Run usage
+//!
+//! Once the tablet seat is initialized, you can add tablet and tools to it.
+//!
+//! Currently, pads are unsupported by this module.
+//!
+//! You can add tablet and tools via methods of the [`TabletSeat`] struct:
+//! [`TabletSeat::add_tablet`] and [`TabletSeat::add_tool`].
+//! These method return handles that can be cloned and sent across thread, so you can keep them
+//! around in you event-handling code to forward inputs to your clients.
+//!
+
+use std::{
+    collections::HashMap,
+    fmt,
+    hash::Hash,
+    path::PathBuf,
+    sync::{Arc, Mutex, Weak},
+};
+
+use crate::{
+    backend::input::{Device, TabletToolDescriptor},
+    input::{
+        Seat, SeatHandler,
+        pointer::CursorImageStatus,
+        tablet::tool::{TabletToolGrab, TabletToolHandle, TabletToolTarget},
+    },
+};
+
+#[cfg(feature = "wayland_frontend")]
+use wayland_server::Weak as WlWeak;
+
+pub mod tool;
+
+/// Description of graphics tablet device
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct TabletDescriptor {
+    /// Tablet device name
+    pub name: String,
+    /// Tablet device USB (product,vendor) id
+    pub usb_id: Option<(u32, u32)>,
+    /// Path to the device
+    pub syspath: Option<PathBuf>,
+}
+
+impl<D: Device> From<&D> for TabletDescriptor {
+    #[inline]
+    fn from(device: &D) -> Self {
+        TabletDescriptor {
+            name: device.name(),
+            syspath: device.syspath(),
+            usb_id: device.usb_id(),
+        }
+    }
+}
+
+pub(crate) struct TabletRc {
+    pub(crate) descriptor: TabletDescriptor,
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) wp_tablet: crate::wayland::tablet_manager::tablet::WpTabletHandle,
+}
+
+#[cfg(not(feature = "wayland_frontend"))]
+impl fmt::Debug for TabletRc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TabletRc")
+            .field("descriptor", &self.descriptor)
+            .finish()
+    }
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl fmt::Debug for TabletRc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TabletRc")
+            .field("descriptor", &self.descriptor)
+            .field("wp_tablet", &self.wp_tablet)
+            .finish()
+    }
+}
+
+/// Handle to a tablet device
+///
+/// Tablet represents one graphics tablet device
+pub struct Tablet {
+    pub(crate) arc: Arc<TabletRc>,
+}
+
+impl Tablet {
+    pub(super) fn new(descriptor: TabletDescriptor) -> Self {
+        Self {
+            arc: Arc::new(TabletRc {
+                descriptor,
+                #[cfg(feature = "wayland_frontend")]
+                wp_tablet: Default::default(),
+            }),
+        }
+    }
+
+    /// Get a descriptor for this tablet
+    pub fn descriptor(&self) -> &TabletDescriptor {
+        &self.arc.descriptor
+    }
+}
+
+impl fmt::Debug for Tablet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Tablet").field("arc", &self.arc).finish()
+    }
+}
+
+impl Clone for Tablet {
+    fn clone(&self) -> Self {
+        Self {
+            arc: self.arc.clone(),
+        }
+    }
+}
+
+impl PartialEq for Tablet {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.arc, &other.arc)
+    }
+}
+
+impl Eq for Tablet {}
+
+impl Hash for Tablet {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.arc).hash(state)
+    }
+}
+
+/// Weak variant of a [`Tablet`]
+///
+/// Does not keep associated data alive, and can be used to refer to a potentially already destroyed
+/// tablet.
+#[derive(Debug)]
+pub struct WeakTablet(Weak<TabletRc>);
+
+impl Clone for WeakTablet {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl WeakTablet {
+    /// Try to retrieve the original `Tablet` if it still exists
+    pub fn upgrade(&self) -> Option<Tablet> {
+        self.0.upgrade().map(|arc| Tablet { arc })
+    }
+
+    /// Check if this tablet is still alive
+    pub fn is_alive(&self) -> bool {
+        self.0.strong_count() != 0
+    }
+}
+
+impl Tablet {
+    /// Create a weak reference to this tablet
+    pub fn downgrade(&self) -> WeakTablet {
+        WeakTablet(Arc::downgrade(&self.arc))
+    }
+}
+
+/// Extends [`Seat`] with graphic tablet specific functionality
+pub trait TabletSeatTrait<D: TabletSeatHandler> {
+    /// Get tablet seat associated with this seat
+    fn tablet_seat(&self) -> TabletSeat<D>;
+}
+
+/// Extends [`Seat`] with graphic tablet specific functionality.
+impl<D: SeatHandler + TabletSeatHandler + 'static> TabletSeatTrait<D> for Seat<D> {
+    fn tablet_seat(&self) -> TabletSeat<D> {
+        let user_data = self.user_data();
+        user_data.get_or_insert(TabletSeat::default).clone()
+    }
+}
+
+/// Handler trait for Tablet Seats
+pub trait TabletSeatHandler: SeatHandler + Sized {
+    /// Type used to represent the target currently holding the tablet's tool focus
+    type ToolFocus: TabletToolTarget<Self> + PartialEq + Clone + 'static;
+
+    /// Callback that will be notified whenever a client requests to set a custom tool image.
+    fn tablet_tool_image(&mut self, tool: &TabletToolDescriptor, image: CursorImageStatus) {
+        let _ = tool;
+        let _ = image;
+    }
+}
+
+/// Handle to a tablet seat
+///
+/// TabletSeat extends [`Seat`] with graphic tablet specific functionality. They can be used to
+/// advertise available graphics tablets and tools.
+pub struct TabletSeat<D: TabletSeatHandler> {
+    pub(crate) arc: Arc<Mutex<Inner<D>>>,
+}
+
+impl<D: TabletSeatHandler> Default for TabletSeat<D> {
+    fn default() -> Self {
+        Self {
+            arc: Default::default(),
+        }
+    }
+}
+
+impl<D: TabletSeatHandler> Clone for TabletSeat<D> {
+    fn clone(&self) -> Self {
+        Self {
+            arc: self.arc.clone(),
+        }
+    }
+}
+
+impl<D: TabletSeatHandler> fmt::Debug for TabletSeat<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TabletSeat").field("arc", &self.arc).finish()
+    }
+}
+
+impl<D: TabletSeatHandler> PartialEq for TabletSeat<D> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.arc, &other.arc)
+    }
+}
+
+impl<D: TabletSeatHandler> Eq for TabletSeat<D> {}
+
+impl<D: TabletSeatHandler> Hash for TabletSeat<D> {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.arc).hash(state)
+    }
+}
+
+/// Weak variant of a [`TabletSeat`].
+///
+/// Does not keep associated user data alive, and can be used to refer to a potentially already
+/// destroyed seat.
+#[derive(Debug)]
+pub struct WeakTabletSeat<D: TabletSeatHandler>(Weak<Mutex<Inner<D>>>);
+
+impl<D: TabletSeatHandler> Clone for WeakTabletSeat<D> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<D: TabletSeatHandler> WeakTabletSeat<D> {
+    /// Try to retrieve the original `TabletSeat`, if it still exists
+    pub fn upgrade(&self) -> Option<TabletSeat<D>> {
+        self.0.upgrade().map(|arc| TabletSeat { arc })
+    }
+
+    /// Check if the tablet seat is still alive
+    pub fn is_alive(&self) -> bool {
+        self.0.strong_count() != 0
+    }
+}
+
+pub(crate) struct Inner<D: TabletSeatHandler> {
+    pub(crate) tablets: HashMap<TabletDescriptor, Tablet>,
+    pub(crate) tools: HashMap<TabletToolDescriptor, TabletToolHandle<D>>,
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) instances:
+        Vec<WlWeak<wayland_protocols::wp::tablet::zv2::server::zwp_tablet_seat_v2::ZwpTabletSeatV2>>,
+}
+
+#[cfg(not(feature = "wayland_frontend"))]
+impl<D: TabletSeatHandler> fmt::Debug for Inner<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Inner")
+            .field("tablets", &self.tablets)
+            .field("tools", &self.tools)
+            .finish()
+    }
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl<D: TabletSeatHandler> fmt::Debug for Inner<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Inner")
+            .field("tablets", &self.tablets)
+            .field("tools", &self.tools)
+            .field("instances", &self.instances)
+            .finish()
+    }
+}
+
+impl<D: TabletSeatHandler> Default for Inner<D> {
+    fn default() -> Self {
+        Self {
+            tablets: HashMap::default(),
+            tools: HashMap::default(),
+            #[cfg(feature = "wayland_frontend")]
+            instances: Vec::default(),
+        }
+    }
+}
+
+impl<D: TabletSeatHandler + 'static> Inner<D> {
+    pub(crate) fn add_tablet(
+        &mut self,
+        tablet_desc: &TabletDescriptor,
+        default: impl FnOnce(TabletDescriptor) -> Tablet,
+    ) -> Tablet {
+        self.tablets.remove(tablet_desc);
+
+        self.tablets
+            .entry(tablet_desc.clone())
+            .or_insert_with(|| default(tablet_desc.clone()))
+            .clone()
+    }
+
+    pub(crate) fn add_tool<F>(
+        &mut self,
+        tool_desc: &TabletToolDescriptor,
+        default_grab: F,
+        default: impl FnOnce(TabletToolDescriptor, F) -> TabletToolHandle<D>,
+    ) -> TabletToolHandle<D>
+    where
+        F: Fn() -> Box<dyn TabletToolGrab<D>> + Send + 'static,
+    {
+        self.tools.remove(tool_desc);
+
+        self.tools
+            .entry(tool_desc.clone())
+            .or_insert_with(|| default(tool_desc.clone(), default_grab))
+            .clone()
+    }
+}
+
+impl<D: TabletSeatHandler + 'static> TabletSeat<D> {
+    /// Add a new tablet to a seat.
+    ///
+    /// You can either add tablet on [DeviceAdded] event, or you can add tablet based
+    /// on tool event, then clients will not know about devices that are not being used.
+    ///
+    /// If the tablet was already known it removes it and recreate a new handle. Because
+    /// [`TabletToolHandle`] will keep a handle to the [`Tablet`] while in proximity, it may appears
+    /// to clients that the tablet hasn't been removed until the tool leave its proximity.
+    ///
+    /// [DeviceAdded]: crate::backend::input::InputEvent::DeviceAdded
+    pub fn add_tablet(&self, tablet_desc: &TabletDescriptor) -> Tablet {
+        self.arc.lock().unwrap().add_tablet(tablet_desc, Tablet::new)
+    }
+
+    /// Get a handler to a tablet
+    pub fn get_tablet(&self, tablet_desc: &TabletDescriptor) -> Option<Tablet> {
+        self.arc.lock().unwrap().tablets.get(tablet_desc).cloned()
+    }
+
+    /// Count all tablet devices
+    pub fn count_tablets(&self) -> usize {
+        self.arc.lock().unwrap().tablets.len()
+    }
+
+    /// Remove tablet device
+    ///
+    /// Called when tablet is no longer available, for example on [DeviceRemoved] event.
+    ///
+    /// [DeviceRemoved]: crate::backend::input::InputEvent::DeviceRemoved
+    pub fn remove_tablet(&self, tablet_desc: &TabletDescriptor) {
+        self.arc.lock().unwrap().tablets.remove(tablet_desc);
+    }
+
+    /// Remove all tablet devices
+    pub fn clear_tablets(&self) {
+        self.arc.lock().unwrap().tablets.clear();
+    }
+
+    /// Add a new tool to a seat.
+    ///
+    /// Tool are usually added on [TabletToolProximityEvent] event.
+    ///
+    /// Calling this method on a seat that already has the same tool will overwrite it, and will be
+    /// seen by clients as if the tool was removed and a new one was added.
+    ///
+    /// [TabletToolProximityEvent]: crate::backend::input::InputEvent::TabletToolProximity
+    pub fn add_tool(&self, tool_desc: &TabletToolDescriptor) -> TabletToolHandle<D> {
+        self.add_tool_with_default_grab(tool_desc, || Box::new(tool::DefaultGrab))
+    }
+
+    /// Add a new tool to a seat and allows the use of a custom default [`TabletToolGrab`]
+    ///
+    /// The default ghrab is used in case no other grab is currently active. When using
+    /// [`TabletSeat::add_tool`], it will use [`tool::DefaultGrab`] which will install
+    /// [`tool::DownGrab`] on a down event. [`tool::DownGrab`] makes sure all further event will use
+    /// the same target until an up or physical proximity out event.
+    ///
+    /// See [`TabletSeat::add_tool`] for more information.
+    pub fn add_tool_with_default_grab<F>(
+        &self,
+        tool_desc: &TabletToolDescriptor,
+        default_grab: F,
+    ) -> TabletToolHandle<D>
+    where
+        F: Fn() -> Box<dyn TabletToolGrab<D>> + Send + 'static,
+    {
+        self.arc
+            .lock()
+            .unwrap()
+            .add_tool(tool_desc, default_grab, TabletToolHandle::new)
+    }
+
+    /// Get a handle to a tablet tool.
+    pub fn get_tool(&self, tool_desc: &TabletToolDescriptor) -> Option<TabletToolHandle<D>> {
+        self.arc.lock().unwrap().tools.get(tool_desc).cloned()
+    }
+
+    /// Count all tablet tool devices
+    pub fn count_tools(&self) -> usize {
+        self.arc.lock().unwrap().tools.len()
+    }
+
+    /// Run a callback on all available tablet tools
+    pub fn with_tools<T>(
+        &self,
+        callback: impl FnOnce(&HashMap<TabletToolDescriptor, TabletToolHandle<D>>) -> T,
+    ) -> T {
+        let guard = self.arc.lock().unwrap();
+
+        callback(&guard.tools)
+    }
+
+    /// Remove tablet tool device
+    ///
+    /// Policy of tool removal is a compositor-specific.
+    ///
+    /// One possible policy would be to remove a tool when all tablets the tool was used on are removed.
+    pub fn remove_tool(&self, tool_desc: &TabletToolDescriptor) {
+        self.arc.lock().unwrap().tools.remove(tool_desc);
+    }
+
+    /// Remove all tablet tool devices
+    pub fn clear_tools(&self) {
+        self.arc.lock().unwrap().tools.clear();
+    }
+}

--- a/src/input/tablet/tool/grab.rs
+++ b/src/input/tablet/tool/grab.rs
@@ -1,0 +1,311 @@
+use std::fmt;
+
+use downcast_rs::{Downcast, impl_downcast};
+
+use crate::{
+    input::{
+        pointer::Focus,
+        tablet::{
+            TabletSeatHandler,
+            tool::{
+                AxisFrame, ButtonEvent, DownEvent, MotionEvent, ProximityInEvent, ProximityOutEvent,
+                TabletToolInnerHandle, UpEvent,
+            },
+        },
+    },
+    utils::{Logical, Point},
+};
+
+/// A trait to implemenent a tablet tool grab
+///
+/// In some context, it is necessary to temporarily change the behavior of the tablet tool. This is
+/// typically known as a grab. A typical example would be, during a drag'n'drop operation, the
+/// underlying surfaces will no longer receive classic tool event, but rather special events.
+///
+/// This trait is the interface to intercept regular tool events and change them as needed. Its
+/// interface mimics the [`TabletToolHandle`] interface.
+///
+/// Any interaction with [`TabletToolHandle`] should be done using [`TabletToolInnerHandle`] as
+/// handle is borrowed;pcled before grab methods are called, so calling methods on
+/// [`TabletToolHandle`] would result in a deadlock.
+///
+/// Ig your logic decides that the grab should end, both [`TabletToolInnerHandle`] and
+/// [`TabletToolHandle`] have a method to change it.
+///
+/// When your grab ends (either as you requested it or if it was forcefully cancelled by the
+/// server), the struct implemented this trait will be dropped. As such, you should put clean-up
+/// logic in the destructor, rather than trying to guess when the grab will end.
+///
+/// [`TabletToolHandle`]: super::TabletToolHandle
+pub trait TabletToolGrab<D: TabletSeatHandler + 'static>: Send + Downcast {
+    /// The data about the event that started the grab.
+    fn start_data(&self) -> &GrabStartData<D>;
+
+    /// A physical proximity_in was reported.
+    ///
+    /// This method allows you to attach additional behavior to a proximity in event, possibly
+    /// altering it. You generally will want to invoke `TabletToolInnerHandle::proximity_in()` as part of
+    /// your processing. If you don't the rest of the compositor will behave as if the event never
+    /// occurred.
+    ///
+    /// Some grabs (such as drag'n'drop, shell resize and motion) unset the focus while they are
+    /// active, this is achieved by just setting the focus to None when invoking
+    /// `TabletToolInnerHandle::proximity_in()`.
+    ///
+    /// This event is only relevant for default grabs.
+    fn proximity_in(
+        &mut self,
+        data: &mut D,
+        handle: &mut TabletToolInnerHandle<'_, D>,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        event: &ProximityInEvent,
+    ) {
+        handle.proximity_in(data, focus, event);
+    }
+
+    /// A physical proximity_out was reported.
+    ///
+    /// This method allows you to attach additional behavior to a proximity out event. You generally
+    /// want to invoke `TabletToolInnerHandle::proximity_out()` as part of your processing. However,
+    /// since this event correspond to the physical removal of the tool, the compositor will always
+    /// act as if the function was invoked and remove the outstanding grab. Invoking it explicitly
+    /// gives you some control over events ordering.
+    fn proximity_out(
+        &mut self,
+        data: &mut D,
+        handle: &mut TabletToolInnerHandle<'_, D>,
+        event: &ProximityOutEvent,
+    ) {
+        handle.proximity_out(data, event);
+    }
+
+    /// A motion was reported
+    ///
+    /// This method allows you to attach additional behavior to a motion event, possibly altering
+    /// it. You generally want to invoke `TabletToolInnerHandle::motion()` as part of your
+    /// processing. If you don't, the rest of the compositor will behave as if the event never
+    /// occurred.
+    ///
+    /// Some grabs (such as drag'n'drop, shell resize and motion) unset the focus while they are
+    /// active, this is achieved by just setting the focus to `None` when invoking
+    /// `TabletToolInnerHandle::motion()`.
+    fn motion(
+        &mut self,
+        data: &mut D,
+        handle: &mut TabletToolInnerHandle<'_, D>,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        event: &MotionEvent,
+    );
+
+    /// A tip down was reported.
+    ///
+    /// This method allows you to attach additional behavior to a down event, possibly altering it.
+    /// You generally will want to invoke `TabletToolInnerHandle::down()` as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the down event never occurred.
+    fn down(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, event: &DownEvent);
+
+    /// A tip up was reported.
+    ///
+    /// This method allows you to attach additional behavior to an up event, possibly altering it.
+    /// You generally will want to invoke `TabletToolInnerHandle::up()` as part of your processing.
+    /// If you don't, the rest of the compositor will behave as if the down event never occurred.
+    fn up(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, event: &UpEvent);
+
+    /// A button press was reported
+    ///
+    /// This method allows you to attach additional behavior to an up event, possibly altering it.
+    /// You generally will want to invoke `TabletToolInnerHandle::button()` as part of your
+    /// processing. If you don't, the rest of the compositor will behave as if the down event never
+    /// occurred.
+    fn button(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, event: &ButtonEvent);
+
+    /// An axis frame was reported
+    ///
+    /// This method allows you to attach additional behavior to an up event, possibly altering it.
+    /// You generally will want to invoke `TabletToolInnerHandle::axis()` as part of your
+    /// processing. If you don't, the rest of the compositor will behave as if the down event never
+    /// occurred.
+    fn axis(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, frame: AxisFrame);
+
+    /// End of a tablet tool frame
+    ///
+    /// A frame groups associated events. This terminate the frame.
+    fn frame(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, time: u32);
+
+    /// The grab has been unset or replaced with another grab.
+    fn unset(&mut self, data: &mut D);
+}
+
+impl_downcast!(TabletToolGrab<D> where D: TabletSeatHandler);
+
+/// Event that caused the grab to start.
+#[derive(Debug, Clone, Copy)]
+pub enum GrabTrigger {
+    /// Grab was initiated following a ProximityIn event.
+    Proximity,
+    /// Grab was initiated following a TipDown event.
+    Tip,
+    /// Grab was initiated following a Button event.
+    Button(u32),
+}
+
+/// Data about the event that started the grab.
+pub struct GrabStartData<D: TabletSeatHandler> {
+    /// The focused surface and its location, if any, at the start of the grab.
+    ///
+    /// The location coordinates are in the global compositor space.
+    pub focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+    /// The event that triggered the grab.
+    pub trigger: GrabTrigger,
+    /// The location of the tool when the grab was initiated, in the global compositor space.
+    pub location: Point<f64, Logical>,
+}
+
+impl<D: TabletSeatHandler> fmt::Debug for GrabStartData<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GrabStartData")
+            .field("focus", &self.focus.as_ref().map(|_| "..."))
+            .field("trigger", &self.trigger)
+            .field("location", &self.location)
+            .finish()
+    }
+}
+
+impl<D: TabletSeatHandler> Clone for GrabStartData<D> {
+    fn clone(&self) -> Self {
+        GrabStartData {
+            focus: self.focus.clone(),
+            trigger: self.trigger,
+            location: self.location,
+        }
+    }
+}
+
+/// Tablet Tool default grab.
+#[derive(Debug)]
+pub struct DefaultGrab;
+
+impl<D: TabletSeatHandler + 'static> TabletToolGrab<D> for DefaultGrab {
+    fn start_data(&self) -> &GrabStartData<D> {
+        unreachable!();
+    }
+
+    fn motion(
+        &mut self,
+        data: &mut D,
+        handle: &mut TabletToolInnerHandle<'_, D>,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        event: &MotionEvent,
+    ) {
+        handle.motion(data, focus, event);
+    }
+
+    fn down(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, event: &DownEvent) {
+        handle.down(data, event);
+
+        handle.set_grab(
+            self,
+            data,
+            event.time,
+            event.serial,
+            Focus::Keep,
+            DownGrab {
+                start_data: GrabStartData {
+                    focus: handle.current_focus(),
+                    trigger: GrabTrigger::Tip,
+                    location: handle.current_location(),
+                },
+            },
+        );
+    }
+
+    fn up(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, event: &UpEvent) {
+        handle.up(data, event);
+    }
+
+    fn button(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, event: &ButtonEvent) {
+        handle.button(data, event);
+    }
+
+    fn axis(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, frame: AxisFrame) {
+        handle.axis(data, frame);
+    }
+
+    fn frame(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, time: u32) {
+        handle.frame(data, time);
+    }
+
+    fn unset(&mut self, _data: &mut D) {}
+}
+
+/// A down grab, basic grab started when a user touch the tablet with a tool above a surface, to
+/// maintain it focused until the user lift the tool.
+pub struct DownGrab<D: TabletSeatHandler> {
+    start_data: GrabStartData<D>,
+}
+
+impl<D: TabletSeatHandler + 'static> fmt::Debug for DownGrab<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DownGrab")
+            .field("start_data", &self.start_data)
+            .finish()
+    }
+}
+
+impl<D: TabletSeatHandler + 'static> TabletToolGrab<D> for DownGrab<D> {
+    fn start_data(&self) -> &GrabStartData<D> {
+        &self.start_data
+    }
+
+    fn proximity_in(
+        &mut self,
+        data: &mut D,
+        handle: &mut TabletToolInnerHandle<'_, D>,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        event: &ProximityInEvent,
+    ) {
+        handle.proximity_in(data, focus, event);
+    }
+
+    fn proximity_out(
+        &mut self,
+        data: &mut D,
+        handle: &mut TabletToolInnerHandle<'_, D>,
+        event: &ProximityOutEvent,
+    ) {
+        handle.proximity_out(data, event);
+    }
+
+    fn motion(
+        &mut self,
+        data: &mut D,
+        handle: &mut TabletToolInnerHandle<'_, D>,
+        _focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        event: &MotionEvent,
+    ) {
+        handle.motion(data, self.start_data.focus.clone(), event);
+    }
+
+    fn down(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, event: &DownEvent) {
+        handle.down(data, event);
+    }
+
+    fn up(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, event: &UpEvent) {
+        handle.up(data, event);
+        handle.unset_grab(self, data, event.serial, event.time, true);
+    }
+
+    fn button(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, event: &ButtonEvent) {
+        handle.button(data, event);
+    }
+
+    fn axis(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, frame: AxisFrame) {
+        handle.axis(data, frame);
+    }
+
+    fn frame(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, time: u32) {
+        handle.frame(data, time);
+    }
+
+    fn unset(&mut self, _data: &mut D) {}
+}

--- a/src/input/tablet/tool/grab.rs
+++ b/src/input/tablet/tool/grab.rs
@@ -66,10 +66,7 @@ pub trait TabletToolGrab<D: TabletSeatHandler + 'static>: Send + Downcast {
     /// A physical proximity_out was reported.
     ///
     /// This method allows you to attach additional behavior to a proximity out event. You generally
-    /// want to invoke `TabletToolInnerHandle::proximity_out()` as part of your processing. However,
-    /// since this event correspond to the physical removal of the tool, the compositor will always
-    /// act as if the function was invoked and remove the outstanding grab. Invoking it explicitly
-    /// gives you some control over events ordering.
+    /// want to invoke `TabletToolInnerHandle::proximity_out()` as part of your processing.
     fn proximity_out(
         &mut self,
         data: &mut D,

--- a/src/input/tablet/tool/grab.rs
+++ b/src/input/tablet/tool/grab.rs
@@ -72,9 +72,7 @@ pub trait TabletToolGrab<D: TabletSeatHandler + 'static>: Send + Downcast {
         data: &mut D,
         handle: &mut TabletToolInnerHandle<'_, D>,
         event: &ProximityOutEvent,
-    ) {
-        handle.proximity_out(data, event);
-    }
+    );
 
     /// A motion was reported
     ///
@@ -187,6 +185,15 @@ impl<D: TabletSeatHandler + 'static> TabletToolGrab<D> for DefaultGrab {
         unreachable!();
     }
 
+    fn proximity_out(
+        &mut self,
+        data: &mut D,
+        handle: &mut TabletToolInnerHandle<'_, D>,
+        event: &ProximityOutEvent,
+    ) {
+        handle.proximity_out(data, event);
+    }
+
     fn motion(
         &mut self,
         data: &mut D,
@@ -212,6 +219,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolGrab<D> for DefaultGrab {
                     trigger: GrabTrigger::Tip,
                     location: handle.current_location(),
                 },
+                focus: handle.current_focus(),
             },
         );
     }
@@ -239,6 +247,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolGrab<D> for DefaultGrab {
 /// maintain it focused until the user lift the tool.
 pub struct DownGrab<D: TabletSeatHandler> {
     start_data: GrabStartData<D>,
+    focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
 }
 
 impl<D: TabletSeatHandler + 'static> fmt::Debug for DownGrab<D> {
@@ -271,16 +280,24 @@ impl<D: TabletSeatHandler + 'static> TabletToolGrab<D> for DownGrab<D> {
         event: &ProximityOutEvent,
     ) {
         handle.proximity_out(data, event);
+        handle.unset_grab(self, data, event.serial, event.time, false);
     }
 
     fn motion(
         &mut self,
         data: &mut D,
         handle: &mut TabletToolInnerHandle<'_, D>,
-        _focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
-        handle.motion(data, self.start_data.focus.clone(), event);
+        if let (Some((new_target, new_location)), Some((grab_target, grab_location))) =
+            (&focus, self.focus.as_mut())
+        {
+            if *new_target == *grab_target {
+                *grab_location = *new_location;
+            }
+        }
+        handle.motion(data, self.focus.clone(), event);
     }
 
     fn down(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, event: &DownEvent) {

--- a/src/input/tablet/tool/mod.rs
+++ b/src/input/tablet/tool/mod.rs
@@ -1,0 +1,1235 @@
+//! Tablet Tool related types for smithay's input abstraction
+
+use core::fmt;
+use std::sync::{Arc, Mutex};
+use std::{hash::Hash, sync::Weak};
+
+use crate::{
+    backend::input::{ButtonState, TabletToolDescriptor},
+    input::{
+        GrabStatus, Seat, SeatHandler,
+        pointer::Focus,
+        tablet::{Tablet, TabletSeat, TabletSeatHandler},
+    },
+    utils::{IsAlive, Logical, Point, Serial},
+};
+
+pub(crate) mod grab;
+pub use grab::{DefaultGrab, DownGrab, GrabStartData, GrabTrigger, TabletToolGrab};
+
+pub(crate) struct TabletToolRc<D: TabletSeatHandler> {
+    pub(crate) descriptor: TabletToolDescriptor,
+    // We want to drop the wp_tablet_tool before the tablet stored in inner, so clients receive
+    // tool's destroy events before tablet's destroy.
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) wp_tablet_tool: crate::wayland::tablet_manager::tablet_tool::WpTabletToolHandle,
+    pub(crate) inner: Mutex<TabletToolInternal<D>>,
+}
+
+#[cfg(not(feature = "wayland_frontend"))]
+impl<D: TabletSeatHandler> fmt::Debug for TabletToolRc<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TabletToolRc")
+            .field("descriptor", &self.descriptor)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+#[cfg(feature = "wayland_frontend")]
+impl<D: TabletSeatHandler> fmt::Debug for TabletToolRc<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TabletToolRc")
+            .field("descriptor", &self.descriptor)
+            .field("wp_tablet_tool", &self.wp_tablet_tool)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+/// Handle to a tablet tool
+///
+/// It can be cloned and all clones manipulate the same internal state.
+///
+/// This handle gives you access to an interface to sent tablet tool events to your clients. When
+/// sending events using this handle, they will be intercepted by a tablet tool grab if any is
+/// active. See [`TabletToolGrab`] trait for details.
+///
+/// As a tablet tool must be in proximity to a tablet, most methods on this object expect a prior
+/// call to [`TabletToolHandle::proximity_in`].
+pub struct TabletToolHandle<D: TabletSeatHandler> {
+    pub(crate) arc: Arc<TabletToolRc<D>>,
+}
+
+impl<D: TabletSeatHandler> fmt::Debug for TabletToolHandle<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TabletToolHandle")
+            .field("arc", &self.arc)
+            .finish()
+    }
+}
+
+impl<D: TabletSeatHandler> Clone for TabletToolHandle<D> {
+    fn clone(&self) -> Self {
+        Self {
+            arc: self.arc.clone(),
+        }
+    }
+}
+
+impl<D: TabletSeatHandler> PartialEq for TabletToolHandle<D> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.arc, &other.arc)
+    }
+}
+
+impl<D: TabletSeatHandler> Eq for TabletToolHandle<D> {}
+
+impl<D: TabletSeatHandler> Hash for TabletToolHandle<D> {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.arc).hash(state);
+    }
+}
+
+impl<D: TabletSeatHandler + 'static> TabletToolHandle<D> {
+    pub(super) fn new<F>(descriptor: TabletToolDescriptor, default_grab: F) -> Self
+    where
+        F: Fn() -> Box<dyn TabletToolGrab<D>> + Send + 'static,
+    {
+        Self {
+            arc: Arc::new(TabletToolRc {
+                descriptor,
+                inner: Mutex::new(TabletToolInternal::new(default_grab)),
+                #[cfg(feature = "wayland_frontend")]
+                wp_tablet_tool: Default::default(),
+            }),
+        }
+    }
+
+    /// Change the current grab on this tablet tool to the provided grab.
+    ///
+    /// If focus is set to [`Focus::Clear`], any currently focused client object will be unfocused.
+    ///
+    /// Overwrites any current grab.
+    ///
+    /// Calling this function prior to calling proximity_in will not set the grab.
+    pub fn set_grab<G: TabletToolGrab<D> + 'static>(
+        &self,
+        data: &mut D,
+        grab: G,
+        time: u32,
+        serial: Serial,
+        focus: Focus,
+    ) {
+        let mut inner = self.arc.inner.lock().unwrap();
+        let seat = self.get_seat(data);
+
+        inner.set_grab(data, &seat, &self.arc.descriptor, grab, time, serial, focus);
+    }
+
+    /// Remove any current grab on this tablet tool, resetting it to the default behavior.
+    pub fn unset_grab(&self, data: &mut D, serial: Serial, time: u32) {
+        let mut inner = self.arc.inner.lock().unwrap();
+        let seat = self.get_seat(data);
+
+        inner.unset_grab(data, &seat, &self.arc.descriptor, serial, time, true);
+    }
+
+    /// Check if this tablet tool is currently grabbed with this serial
+    pub fn has_grab(&self, serial: Serial) -> bool {
+        let guard = self.arc.inner.lock().unwrap();
+
+        match guard.grab {
+            GrabStatus::Active(s, _) => s == serial,
+            _ => false,
+        }
+    }
+
+    /// Check if this tablet tool is currently being grabbed.
+    pub fn is_grabbed(&self) -> bool {
+        let guard = self.arc.inner.lock().unwrap();
+        !matches!(guard.grab, GrabStatus::None)
+    }
+
+    /// Return the start data for the grab, if any.
+    pub fn grab_start_data(&self) -> Option<GrabStartData<D>> {
+        let guard = self.arc.inner.lock().unwrap();
+        match &guard.grab {
+            GrabStatus::Active(_, g) => Some(g.start_data().clone()),
+            _ => None,
+        }
+    }
+
+    /// Call `f` with the active grab, if any.
+    pub fn with_grab<T>(&self, f: impl FnOnce(Serial, &dyn TabletToolGrab<D>) -> T) -> Option<T> {
+        let guard = self.arc.inner.lock().unwrap();
+        if let GrabStatus::Active(s, g) = &guard.grab {
+            Some(f(*s, &**g))
+        } else {
+            None
+        }
+    }
+
+    /// Notify that a tool entered physical proximity with a tablet.
+    ///
+    /// You must invoke this method before any other events. Failing to do so will make the
+    /// compositor ignore all other calls.
+    ///
+    /// You provide the location of the tool in the form of:
+    /// - The coordinates of the tool in the global compositor space
+    /// - The surface on top of which the tool is, and the coordinates of its origin in the global
+    ///   compositor space (or `None` if the tool is not over a client surface).
+    ///
+    /// This will internally generate the following event to the client object, if any:
+    /// - ProximityIn
+    /// - Axis, if an axis frame is available
+    /// - Motion
+    /// - Button press, if any button were held down.
+    ///
+    /// The [`Tablet`] will be stored until a call to `TabletToolHandle::proximity_out``.
+    ///
+    /// If this event is invoked while the tool is already in proximity with a tablet, a synthetic
+    /// ProximityOut will be generated to reset the instance to a sane state.
+    pub fn proximity_in(
+        &self,
+        data: &mut D,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        tablet: Tablet,
+        event: &ProximityInEvent,
+    ) {
+        let mut inner = self.arc.inner.lock().unwrap();
+        let seat = self.get_seat(data);
+
+        if inner.in_proximity() {
+            tracing::warn!("proximity_in was called, but the tool is already in proximity with a tablet.");
+            inner.proximity_out_impl(
+                data,
+                &seat,
+                &self.arc.descriptor,
+                &ProximityOutEvent {
+                    serial: event.serial,
+                    time: event.time,
+                },
+            );
+        }
+
+        inner.tablet = Some(tablet);
+        inner.location = Some(event.location);
+
+        inner.with_grab(data, &seat, &self.arc.descriptor, |data, handle, grab| {
+            grab.proximity_in(data, handle, focus, event);
+        });
+    }
+
+    /// Notify that a tool left physical proximity with a tablet.
+    ///
+    /// This will internally generate the following events:
+    /// - Button release, for any pressed button
+    /// - Up, if the tool tip was down
+    /// - ProximityOut
+    /// - frame
+    ///
+    /// Any active grab will then be unset. The `TabletToolHandle` will also be reset
+    pub fn proximity_out(&self, data: &mut D, event: &ProximityOutEvent) {
+        let mut inner = self.arc.inner.lock().unwrap();
+        if !inner.in_proximity() {
+            tracing::warn!("proximity_out was called, but the tool hasn't entered tablet proximity.");
+            return;
+        }
+
+        let seat = self.get_seat(data);
+
+        inner.proximity_out_impl(data, &seat, &self.arc.descriptor, event);
+    }
+
+    /// Notify that a tool moved above a tablet.
+    ///
+    /// You provide the new location of the tool, in the form of:
+    /// - The coordinates of the tool in the global compositor space
+    /// - The target on top of which the tool is, and the coordinates of its origin in the global
+    ///   compositor space (or `None` if the tool is not above a client's target.).
+    ///
+    /// This will internally take care of notifying the appropriate client objects of
+    /// proximity_in/motion/proximity_out events.
+    pub fn motion(
+        &self,
+        data: &mut D,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        event: &MotionEvent,
+    ) {
+        let mut inner = self.arc.inner.lock().unwrap();
+        if !inner.in_proximity() {
+            tracing::warn!("motion was called, but the tool hasn't entered tablet proximity.");
+            return;
+        }
+
+        inner.pending_focus.clone_from(&focus);
+        let seat = self.get_seat(data);
+
+        inner.with_grab(data, &seat, &self.arc.descriptor, |data, handle, grab| {
+            grab.motion(data, handle, focus, event);
+        });
+    }
+
+    /// Notify that a tool start touching the tablet surface.
+    ///
+    /// This will internally send the appropriate down event to the client objects matching the
+    /// currently focused target.
+    pub fn down(&self, data: &mut D, event: &DownEvent) {
+        let mut inner = self.arc.inner.lock().unwrap();
+        if !inner.in_proximity() {
+            tracing::warn!("down was called, but the tool hasn't entered tablet proximity.");
+            return;
+        }
+
+        let seat = self.get_seat(data);
+
+        inner.with_grab(data, &seat, &self.arc.descriptor, |data, handle, grab| {
+            grab.down(data, handle, event);
+        });
+    }
+
+    /// Notify that a tool sopped touching the tablet surface.
+    ///
+    /// This will internally send the appropriate up event to the client objects matching the
+    /// currently focused target.
+    pub fn up(&self, data: &mut D, event: &UpEvent) {
+        let mut inner = self.arc.inner.lock().unwrap();
+        if !inner.in_proximity() {
+            tracing::warn!("up was called, but the tool hasn't entered tablet proximity.");
+            return;
+        }
+
+        let seat = self.get_seat(data);
+
+        inner.with_grab(data, &seat, &self.arc.descriptor, |data, handle, grab| {
+            grab.up(data, handle, event);
+        });
+    }
+
+    /// Notify that a button state changed.
+    ///
+    /// This will internally send the appropriate button event to the client objects matching with
+    /// the currently focused target.
+    pub fn button(&self, data: &mut D, event: &ButtonEvent) {
+        let mut inner = self.arc.inner.lock().unwrap();
+        if !inner.in_proximity() {
+            tracing::warn!("button was called, but the tool hasn't entered tablet proximity.");
+            return;
+        }
+
+        let seat = self.get_seat(data);
+
+        if matches!(event.state, ButtonState::Pressed) {
+            inner.current_buttons.push(event.button);
+        } else {
+            inner.current_buttons.retain(|b| *b != event.button);
+        }
+
+        inner.with_grab(data, &seat, &self.arc.descriptor, |data, handle, grab| {
+            grab.button(data, handle, event);
+        });
+    }
+
+    /// Start an axis frame
+    ///
+    /// A single frame will group multiple axis events as if they happened in the same instance.
+    pub fn axis(&self, data: &mut D, frame: AxisFrame) {
+        let mut inner = self.arc.inner.lock().unwrap();
+        if !inner.in_proximity() {
+            tracing::warn!("axis was called, but the tool hasn't entered tablet proximity.");
+            return;
+        }
+
+        let seat = self.get_seat(data);
+
+        inner.with_grab(data, &seat, &self.arc.descriptor, |data, handle, grab| {
+            grab.axis(data, handle, frame);
+        });
+    }
+
+    /// End of a tool frame.
+    ///
+    /// A frame groups associated events. This terminates the frame.
+    pub fn frame(&self, data: &mut D, time: u32) {
+        let mut inner = self.arc.inner.lock().unwrap();
+        if !inner.in_proximity() {
+            tracing::warn!("frame was called, but the tool hasn't entered tablet proximity.");
+            return;
+        }
+
+        // If we don't have a pending frame, skip.
+        if !inner.frame_pending {
+            return;
+        }
+
+        let seat = self.get_seat(data);
+
+        inner.with_grab(data, &seat, &self.arc.descriptor, |data, handle, grab| {
+            grab.frame(data, handle, time);
+        });
+    }
+
+    /// Access the current location of this tablet tool in the global space
+    ///
+    /// This function will return None if the tool isn't above any tablet.
+    pub fn current_location(&self) -> Option<Point<f64, Logical>> {
+        self.arc.inner.lock().unwrap().location
+    }
+
+    /// Access the current tablet this tool is hovering over.
+    ///
+    /// This function will return None if the tool isn't above any tablet.
+    pub fn current_tablet(&self) -> Option<Tablet> {
+        self.arc.inner.lock().unwrap().tablet.clone()
+    }
+
+    /// Return the tablet tool descriptor.
+    pub fn descriptor(&self) -> &TabletToolDescriptor {
+        &self.arc.descriptor
+    }
+
+    fn get_seat(&self, data: &mut D) -> Seat<D> {
+        let seat_state = data.seat_state();
+        seat_state
+            .seats
+            .iter()
+            .find(|seat| {
+                let Some(tablet_seat) = seat.user_data().get::<TabletSeat<D>>() else {
+                    return false;
+                };
+
+                tablet_seat.get_tool(&self.arc.descriptor).as_ref() == Some(self)
+            })
+            .cloned()
+            .unwrap()
+    }
+}
+
+/// Weak variant of a [`TabletToolHandle`]
+///
+/// Does not keep associated data alive, and can be used to refer to a potentially already destroyed
+/// tablet tool.
+#[derive(Debug)]
+pub struct WeakTabletToolHandle<D: TabletSeatHandler>(Weak<TabletToolRc<D>>);
+
+impl<D: TabletSeatHandler> Clone for WeakTabletToolHandle<D> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<D: TabletSeatHandler> WeakTabletToolHandle<D> {
+    /// Try to retrieve the original `TabletToolHandle` if it still exists
+    pub fn upgrade(&self) -> Option<TabletToolHandle<D>> {
+        self.0.upgrade().map(|arc| TabletToolHandle { arc })
+    }
+
+    /// Check if this tablet tool is still alive
+    pub fn is_alive(&self) -> bool {
+        self.0.strong_count() != 0
+    }
+}
+
+impl<D: TabletSeatHandler> TabletToolHandle<D> {
+    /// Create a weak reference to this tablet tool
+    pub fn downgrade(&self) -> WeakTabletToolHandle<D> {
+        WeakTabletToolHandle(Arc::downgrade(&self.arc))
+    }
+}
+
+/// Trait representing object that can receive tablet tool interactions
+pub trait TabletToolTarget<D>: IsAlive + fmt::Debug + Send
+where
+    D: TabletSeatHandler + SeatHandler,
+{
+    /// A tool has entered proximity above this target.
+    ///
+    /// This event can be received when the tool has moved from one target to another, or when the
+    /// tool has come back into proximity above the target.
+    fn proximity_in(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+        tablet: &Tablet,
+        serial: Serial,
+    );
+
+    /// A tool has left this target.
+    fn proximity_out(&self, seat: &Seat<D>, data: &mut D, tool_descriptor: &TabletToolDescriptor);
+
+    /// The tool is in contact with the surface of the tablet.
+    fn down(&self, seat: &Seat<D>, data: &mut D, tool_descriptor: &TabletToolDescriptor, event: &DownEvent);
+    /// The tool is no longer in contact with the surface of the tablet.
+    fn up(&self, seat: &Seat<D>, data: &mut D, tool_descriptor: &TabletToolDescriptor, event: &UpEvent);
+
+    /// A tool has moved over this target.
+    fn motion(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+        event: &MotionEvent,
+    );
+
+    /// One or more of the tool axis has changed.
+    fn axis(&self, seat: &Seat<D>, data: &mut D, tool_descriptor: &TabletToolDescriptor, frame: AxisFrame);
+
+    /// One of the tool button has changed state.
+    fn button(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+        event: &ButtonEvent,
+    );
+
+    /// End of a tablet tool frame.
+    fn frame(&self, seat: &Seat<D>, data: &mut D, tool_descriptor: &TabletToolDescriptor, time: u32);
+}
+
+/// This inner handle is accessed from inside a tablet tool grab logic, and directly sends event to
+/// the client.
+pub struct TabletToolInnerHandle<'a, D: TabletSeatHandler> {
+    inner: &'a mut TabletToolInternal<D>,
+    descriptor: &'a TabletToolDescriptor,
+    seat: &'a Seat<D>,
+}
+
+impl<D: TabletSeatHandler> fmt::Debug for TabletToolInnerHandle<'_, D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TabletToolInnerHandle")
+            .field("inner", &self.inner)
+            .field("descriptor", &self.descriptor)
+            .field("seat", &self.seat)
+            .finish()
+    }
+}
+
+impl<D: TabletSeatHandler + 'static> TabletToolInnerHandle<'_, D> {
+    /// Change the current grab on this tool to the provided grab
+    ///
+    /// Overwrites any current grab.
+    pub fn set_grab<G: TabletToolGrab<D> + 'static>(
+        &mut self,
+        handler: &mut dyn TabletToolGrab<D>,
+        data: &mut D,
+        time: u32,
+        serial: Serial,
+        focus: Focus,
+        grab: G,
+    ) {
+        handler.unset(data);
+        self.inner
+            .set_grab(data, self.seat, self.descriptor, grab, time, serial, focus);
+    }
+
+    /// Remove any current grab on this tool, resetting it to the default behavior
+    ///
+    /// This will also restore the focus of the tool if `restore_focus` is true.
+    pub fn unset_grab(
+        &mut self,
+        handler: &mut dyn TabletToolGrab<D>,
+        data: &mut D,
+        serial: Serial,
+        time: u32,
+        restore_focus: bool,
+    ) {
+        handler.unset(data);
+        self.inner
+            .unset_grab(data, self.seat, self.descriptor, serial, time, restore_focus);
+    }
+
+    /// Access the current focus of this pointer
+    pub fn current_focus(&self) -> Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)> {
+        self.inner.focus.clone()
+    }
+
+    /// Access the current location of this tablet tool in the global space
+    pub fn current_location(&self) -> Point<f64, Logical> {
+        self.inner.location.unwrap()
+    }
+
+    /// Access the current tablet this tool is hovering over.
+    pub fn current_tablet(&self) -> Tablet {
+        self.inner.tablet.clone().unwrap()
+    }
+
+    /// A list of the currently physically pressed buttons
+    ///
+    /// This still includes buttons that your grab have intercepted and not sent to the target.
+    pub fn current_pressed(&self) -> &[u32] {
+        &self.inner.current_buttons
+    }
+
+    /// Notify that a tool entered proximity with a tablet.
+    ///
+    /// You provide the location of the tool in the form of:
+    /// - The coordinates of the tool in the global compositor space
+    /// - The surface on top of which the tool is, and the coordinates of its origin in the global
+    ///   compositor space (or `None` if the tool is not over a client surface).
+    ///
+    /// This will internally generate the following event to the client object, if any:
+    /// - ProximityIn
+    /// - Axis, if an axis frame is available
+    /// - Motion
+    pub fn proximity_in(
+        &mut self,
+        data: &mut D,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        event: &ProximityInEvent,
+    ) {
+        self.inner
+            .proximity_in(data, self.seat, self.descriptor, focus, event);
+    }
+
+    /// Notify that a tool left physical proximity with a tablet.
+    ///
+    /// This will internally generate the following events:
+    /// - Button release, for any pressed button
+    /// - Up, if the tool tip was down
+    /// - ProximityOut
+    /// - frame
+    pub fn proximity_out(&mut self, data: &mut D, event: &ProximityOutEvent) {
+        self.inner.proximity_out(data, self.seat, self.descriptor, event);
+    }
+
+    /// Notify that a tool moved above a tablet.
+    ///
+    /// You provide the new location of the tool, in the form of:
+    /// - The coordinates of the tool in the global compositor space
+    /// - The target on top of which the tool is, and the coordinates of its origin in the global
+    ///   compositor space (or `None` if the tool is not above a client's target.).
+    ///
+    /// This will internally take care of notifying the appropriate client objects of
+    /// proximity_in/motion/proximity_out events.
+    pub fn motion(
+        &mut self,
+        data: &mut D,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        event: &MotionEvent,
+    ) {
+        self.inner.motion(data, self.seat, self.descriptor, focus, event);
+    }
+
+    /// Notify that a tool start touching the tablet surface.
+    ///
+    /// This will internally send the appropriate down event to the client objects matching the
+    /// currently focused target.
+    pub fn down(&mut self, data: &mut D, event: &DownEvent) {
+        self.inner.down(data, self.seat, self.descriptor, event);
+    }
+
+    /// Notify that a tool sopped touching the tablet surface.
+    ///
+    /// This will internally send the appropriate up event to the client objects matching the
+    /// currently focused target.
+    pub fn up(&mut self, data: &mut D, event: &UpEvent) {
+        self.inner.up(data, self.seat, self.descriptor, event);
+    }
+
+    /// Notify that a button state changed.
+    ///
+    /// This will internally send the appropriate button event to the client objects matching with
+    /// the currently focused target.
+    pub fn button(&mut self, data: &mut D, event: &ButtonEvent) {
+        self.inner.button(data, self.seat, self.descriptor, event);
+    }
+
+    /// Start an axis frame
+    ///
+    /// A single frame will group multiple axis events as if they happened in the same instance.
+    pub fn axis(&mut self, data: &mut D, frame: AxisFrame) {
+        self.inner.axis(data, self.seat, self.descriptor, frame);
+    }
+
+    /// End of a tool frame.
+    ///
+    /// A frame groups associated events. This terminates the frame.
+    pub fn frame(&mut self, data: &mut D, time: u32) {
+        self.inner.frame(data, self.seat, self.descriptor, time);
+    }
+
+    /// Return the tablet tool descriptor.
+    pub fn descriptor(&self) -> &TabletToolDescriptor {
+        self.descriptor
+    }
+}
+
+pub(crate) struct TabletToolInternal<D: TabletSeatHandler> {
+    pub(crate) focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+    pending_focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+
+    location: Option<Point<f64, Logical>>,
+    tablet: Option<Tablet>,
+    current_buttons: Vec<u32>,
+    pressed_buttons: Vec<u32>,
+    tip_down: bool,
+    frame_pending: bool,
+
+    default_grab: Box<dyn Fn() -> Box<dyn TabletToolGrab<D>> + Send + 'static>,
+    grab: GrabStatus<dyn TabletToolGrab<D>>,
+}
+
+impl<D: TabletSeatHandler> fmt::Debug for TabletToolInternal<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TabletToolHandle")
+            .field("focus", &self.focus)
+            .field("grab", &self.grab)
+            .finish()
+    }
+}
+
+impl<D: TabletSeatHandler + 'static> TabletToolInternal<D> {
+    pub(crate) fn new<F>(default_grab: F) -> Self
+    where
+        F: Fn() -> Box<dyn TabletToolGrab<D>> + Send + 'static,
+    {
+        Self {
+            focus: Default::default(),
+            pending_focus: Default::default(),
+
+            location: None,
+            tablet: None,
+            current_buttons: Default::default(),
+            pressed_buttons: Default::default(),
+            tip_down: false,
+            frame_pending: false,
+
+            default_grab: Box::new(default_grab),
+            grab: GrabStatus::None,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn set_grab<G: TabletToolGrab<D> + 'static>(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        descriptor: &TabletToolDescriptor,
+        grab: G,
+        time: u32,
+        serial: Serial,
+        focus: Focus,
+    ) {
+        if let GrabStatus::Active(_, handler) = &mut self.grab {
+            handler.unset(data)
+        }
+
+        if self.tablet.is_none() || self.location.is_none() {
+            tracing::warn!("set_grab called with an out of proximity tool.");
+            return;
+        }
+
+        self.grab = GrabStatus::Active(serial, Box::new(grab));
+
+        if matches!(focus, Focus::Clear) {
+            let location = self.location.unwrap();
+
+            self.motion(
+                data,
+                seat,
+                descriptor,
+                None,
+                &MotionEvent {
+                    location,
+                    serial,
+                    time,
+                },
+            );
+        }
+    }
+
+    fn unset_grab(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        descriptor: &TabletToolDescriptor,
+        serial: Serial,
+        time: u32,
+        restore_focus: bool,
+    ) {
+        if let GrabStatus::Active(_, handler) = &mut self.grab {
+            handler.unset(data)
+        }
+        self.grab = GrabStatus::None;
+
+        if let Some(location) = self.location {
+            if restore_focus {
+                let focus = self.pending_focus.clone();
+
+                self.motion(
+                    data,
+                    seat,
+                    descriptor,
+                    focus,
+                    &MotionEvent {
+                        location,
+                        serial,
+                        time,
+                    },
+                );
+                self.frame(data, seat, descriptor, time);
+            }
+        }
+    }
+
+    fn with_grab<F>(&mut self, data: &mut D, seat: &Seat<D>, descriptor: &TabletToolDescriptor, f: F)
+    where
+        F: FnOnce(&mut D, &mut TabletToolInnerHandle<'_, D>, &mut dyn TabletToolGrab<D>),
+    {
+        let mut grab = std::mem::replace(&mut self.grab, GrabStatus::Borrowed);
+        match grab {
+            GrabStatus::Borrowed => {
+                panic!("Accessed a tablet tool grab from within a tablet tool grab access.")
+            }
+            GrabStatus::Active(_, ref mut handler) => {
+                if let Some((ref focus, _)) = handler.start_data().focus {
+                    if !focus.alive() {
+                        handler.unset(data);
+                        self.grab = GrabStatus::None;
+                        let mut default_grab = (self.default_grab)();
+                        f(
+                            data,
+                            &mut TabletToolInnerHandle {
+                                inner: self,
+                                descriptor,
+                                seat,
+                            },
+                            &mut *default_grab,
+                        );
+                        return;
+                    }
+                }
+
+                f(
+                    data,
+                    &mut TabletToolInnerHandle {
+                        inner: self,
+                        descriptor,
+                        seat,
+                    },
+                    &mut **handler,
+                );
+            }
+            GrabStatus::None => {
+                let mut default_grab = (self.default_grab)();
+                f(
+                    data,
+                    &mut TabletToolInnerHandle {
+                        inner: self,
+                        descriptor,
+                        seat,
+                    },
+                    &mut *default_grab,
+                );
+            }
+        }
+
+        if let GrabStatus::Borrowed = self.grab {
+            self.grab = grab;
+        }
+    }
+
+    fn in_proximity(&self) -> bool {
+        self.tablet.is_some() && self.location.is_some()
+    }
+
+    fn proximity_in(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        descriptor: &TabletToolDescriptor,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        event: &ProximityInEvent,
+    ) {
+        self.focus = focus;
+        if let Some((focused, loc)) = self.focus.as_mut() {
+            let location = event.location - *loc;
+            let serial = event.serial;
+            let time = event.time;
+
+            focused.proximity_in(seat, data, descriptor, self.tablet.as_ref().unwrap(), serial);
+
+            if let Some(axis) = event.axis.clone() {
+                focused.axis(seat, data, descriptor, axis);
+            }
+
+            focused.motion(
+                seat,
+                data,
+                descriptor,
+                &MotionEvent {
+                    location,
+                    serial,
+                    time,
+                },
+            );
+
+            if self.tip_down {
+                focused.down(seat, data, descriptor, &DownEvent { serial, time });
+            }
+
+            for button in self.pressed_buttons.iter() {
+                focused.button(
+                    seat,
+                    data,
+                    descriptor,
+                    &ButtonEvent {
+                        serial: event.serial,
+                        button: *button,
+                        state: ButtonState::Pressed,
+                        time: event.time,
+                    },
+                );
+            }
+        }
+
+        self.frame_pending = true;
+    }
+
+    fn proximity_out(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        descriptor: &TabletToolDescriptor,
+        event: &ProximityOutEvent,
+    ) {
+        if let Some((focused, _)) = self.focus.take() {
+            let time = event.time;
+
+            for button in self.pressed_buttons.iter() {
+                focused.button(
+                    seat,
+                    data,
+                    descriptor,
+                    &ButtonEvent {
+                        serial: event.serial,
+                        button: *button,
+                        state: ButtonState::Released,
+                        time,
+                    },
+                );
+            }
+
+            if self.tip_down {
+                focused.up(
+                    seat,
+                    data,
+                    descriptor,
+                    &UpEvent {
+                        serial: event.serial,
+                        time,
+                    },
+                );
+            }
+
+            focused.proximity_out(seat, data, descriptor);
+            focused.frame(seat, data, descriptor, event.time);
+        }
+
+        self.frame_pending = false;
+    }
+
+    fn motion(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        descriptor: &TabletToolDescriptor,
+        focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+        event: &MotionEvent,
+    ) {
+        self.location = Some(event.location);
+
+        let Some((focused, loc)) = focus else {
+            self.proximity_out(
+                data,
+                seat,
+                descriptor,
+                &ProximityOutEvent {
+                    serial: event.serial,
+                    time: event.time,
+                },
+            );
+            return;
+        };
+
+        if self
+            .focus
+            .as_ref()
+            .is_some_and(|(old_focused, _)| &focused == old_focused)
+        {
+            let event = MotionEvent {
+                location: event.location - loc,
+                serial: event.serial,
+                time: event.time,
+            };
+            // We were on top of a target and remained on it.
+            focused.motion(seat, data, descriptor, &event);
+        } else {
+            self.proximity_out(
+                data,
+                seat,
+                descriptor,
+                &ProximityOutEvent {
+                    serial: event.serial,
+                    time: event.time,
+                },
+            );
+            self.proximity_in(
+                data,
+                seat,
+                descriptor,
+                Some((focused, loc)),
+                &ProximityInEvent {
+                    location: event.location,
+                    axis: None,
+                    serial: event.serial,
+                    time: event.time,
+                },
+            );
+        }
+
+        self.frame_pending = true;
+    }
+
+    fn down(&mut self, data: &mut D, seat: &Seat<D>, descriptor: &TabletToolDescriptor, event: &DownEvent) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.down(seat, data, descriptor, event);
+        }
+
+        self.tip_down = true;
+        self.frame_pending = true;
+    }
+
+    fn up(&mut self, data: &mut D, seat: &Seat<D>, descriptor: &TabletToolDescriptor, event: &UpEvent) {
+        if self.tip_down {
+            if let Some((focused, _)) = self.focus.as_mut() {
+                focused.up(seat, data, descriptor, event);
+            }
+        }
+
+        self.tip_down = false;
+        self.frame_pending = true;
+    }
+
+    fn button(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        descriptor: &TabletToolDescriptor,
+        event: &ButtonEvent,
+    ) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.button(seat, data, descriptor, event);
+        }
+
+        if matches!(event.state, ButtonState::Pressed) {
+            self.pressed_buttons.push(event.button);
+        } else {
+            self.pressed_buttons.retain(|b| b != &event.button);
+        }
+
+        self.frame_pending = true;
+    }
+
+    fn axis(&mut self, data: &mut D, seat: &Seat<D>, descriptor: &TabletToolDescriptor, frame: AxisFrame) {
+        if let Some((focused, _)) = self.focus.as_mut() {
+            focused.axis(seat, data, descriptor, frame);
+        }
+
+        self.frame_pending = true;
+    }
+
+    fn frame(&mut self, data: &mut D, seat: &Seat<D>, descriptor: &TabletToolDescriptor, time: u32) {
+        if self.frame_pending {
+            if let Some((focused, _)) = self.focus.as_mut() {
+                focused.frame(seat, data, descriptor, time);
+            }
+        }
+
+        self.frame_pending = false;
+    }
+
+    fn proximity_out_impl(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        descriptor: &TabletToolDescriptor,
+        event: &ProximityOutEvent,
+    ) {
+        self.with_grab(data, seat, descriptor, |data, handle, grab| {
+            grab.proximity_out(data, handle, event);
+        });
+        // If the grab has forwarded the proximity_out, the function does nothing. If not, we need
+        // to send the proximity out anyway.
+        self.proximity_out(data, seat, descriptor, event);
+        self.unset_grab(data, seat, descriptor, event.serial, event.time, false);
+
+        // Now, reset everything so we don't get stale data later.
+        self.tip_down = false;
+        self.pressed_buttons.clear();
+        self.current_buttons.clear();
+        self.focus = None;
+        self.pending_focus = None;
+        self.tablet = None;
+        self.location = None;
+    }
+}
+
+/// Proximity in event.
+#[derive(Debug, Clone)]
+pub struct ProximityInEvent {
+    /// Location of the tool in compositor space
+    pub location: Point<f64, Logical>,
+    /// Axis frame to send along with the proximity in
+    pub axis: Option<AxisFrame>,
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+}
+
+/// Proximity out event.
+#[derive(Debug, Clone)]
+pub struct ProximityOutEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+}
+
+/// Tablet tool motion event
+#[derive(Debug, Clone)]
+pub struct MotionEvent {
+    /// Location of the tool in compositor space
+    pub location: Point<f64, Logical>,
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+}
+
+/// Tablet tool button event
+///
+/// Tool button click and release event. The location of the click is given by the last motion or
+/// proximity in event.
+#[derive(Debug, Clone)]
+pub struct ButtonEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Button that produced the event
+    pub button: u32,
+    /// Physical state of the button
+    pub state: ButtonState,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+}
+
+/// Tip down event.
+///
+/// The location of the tool is given by the last motion or proximity in event.
+#[derive(Debug, Clone)]
+pub struct DownEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+}
+
+/// Tip up event.
+///
+/// The location of the tool is given by the last motion or proximity in event.
+#[derive(Debug, Clone)]
+pub struct UpEvent {
+    /// Serial of the event
+    pub serial: Serial,
+    /// Timestamp of the event, with millisecond granularity
+    pub time: u32,
+}
+
+/// A frame of tablet tool axis events.
+/// Frames of axis events should be considered as one logical action.
+///
+/// Can be used with the builder pattern, e.g.:
+///
+/// ```ignore
+/// AxisFrame::new()
+///     .pressure(0.5)
+///     .distance(0.0)
+///     .tilt(15.0, 25.0);
+/// ```
+#[must_use = "AxisFrame uses a builder-like pattern, so its result must be used"]
+#[derive(Clone, Debug, Default)]
+pub struct AxisFrame {
+    /// Changes in the pressure axis of the tool
+    pub pressure: Option<f64>,
+    /// Changes in the distance axis
+    pub distance: Option<f64>,
+    /// Changes in the tool tilt
+    pub tilt: Option<(f64, f64)>,
+    /// Changes in the tool's z-rotation
+    pub rotation: Option<f64>,
+    /// Changes in the tool's slider position
+    pub slider: Option<f64>,
+    /// Changes in the tool's wheel position
+    pub wheel: Option<(f64, i32)>,
+}
+
+impl AxisFrame {
+    /// Create a new frame of axis events
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Value of the pressure event.
+    pub fn pressure(self, pressure: f64) -> Self {
+        Self {
+            pressure: Some(pressure),
+            ..self
+        }
+    }
+
+    /// Value of the distance event.
+    pub fn distance(self, distance: f64) -> Self {
+        Self {
+            distance: Some(distance),
+            ..self
+        }
+    }
+
+    /// Value of the tool tilt
+    pub fn tilt(self, tilt_x: f64, tilt_y: f64) -> Self {
+        Self {
+            tilt: Some((tilt_x, tilt_y)),
+            ..self
+        }
+    }
+
+    /// Value in the tool's z-rotation
+    pub fn rotation(self, rotation: f64) -> Self {
+        Self {
+            rotation: Some(rotation),
+            ..self
+        }
+    }
+
+    /// Value of the tool's slider position
+    pub fn slider(self, slider: f64) -> Self {
+        Self {
+            slider: Some(slider),
+            ..self
+        }
+    }
+
+    /// Value of the tool's wheel
+    pub fn wheel(self, degrees: f64, clicks: i32) -> Self {
+        Self {
+            wheel: Some((degrees, clicks)),
+            ..self
+        }
+    }
+}

--- a/src/input/tablet/tool/mod.rs
+++ b/src/input/tablet/tool/mod.rs
@@ -590,7 +590,6 @@ impl<D: TabletSeatHandler + 'static> TabletToolInnerHandle<'_, D> {
     /// - Button release, for any pressed button
     /// - Up, if the tool tip was down
     /// - ProximityOut
-    /// - frame
     pub fn proximity_out(&mut self, data: &mut D, event: &ProximityOutEvent) {
         self.inner.proximity_out(data, self.seat, self.descriptor, event);
     }

--- a/src/input/tablet/tool/mod.rs
+++ b/src/input/tablet/tool/mod.rs
@@ -217,6 +217,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolHandle<D> {
 
         inner.tablet = Some(tablet);
         inner.location = Some(event.location);
+        inner.pending_focus.clone_from(&focus);
 
         inner.with_grab(data, &seat, &self.arc.descriptor, |data, handle, grab| {
             grab.proximity_in(data, handle, focus, event);
@@ -229,9 +230,6 @@ impl<D: TabletSeatHandler + 'static> TabletToolHandle<D> {
     /// - Button release, for any pressed button
     /// - Up, if the tool tip was down
     /// - ProximityOut
-    /// - frame
-    ///
-    /// Any active grab will then be unset. The `TabletToolHandle` will also be reset
     pub fn proximity_out(&self, data: &mut D, event: &ProximityOutEvent) {
         let mut inner = self.arc.inner.lock().unwrap();
         if !inner.in_proximity() {
@@ -355,7 +353,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolHandle<D> {
     /// A frame groups associated events. This terminates the frame.
     pub fn frame(&self, data: &mut D, time: u32) {
         let mut inner = self.arc.inner.lock().unwrap();
-        if !inner.in_proximity() {
+        if !inner.in_proximity() && !inner.frame_pending {
             tracing::warn!("frame was called, but the tool hasn't entered tablet proximity.");
             return;
         }
@@ -662,6 +660,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolInnerHandle<'_, D> {
 pub(crate) struct TabletToolInternal<D: TabletSeatHandler> {
     pub(crate) focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
     pending_focus: Option<(<D as TabletSeatHandler>::ToolFocus, Point<f64, Logical>)>,
+    previous_focus: Option<<D as TabletSeatHandler>::ToolFocus>,
 
     location: Option<Point<f64, Logical>>,
     tablet: Option<Tablet>,
@@ -691,6 +690,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolInternal<D> {
         Self {
             focus: Default::default(),
             pending_focus: Default::default(),
+            previous_focus: Default::default(),
 
             location: None,
             tablet: None,
@@ -772,7 +772,6 @@ impl<D: TabletSeatHandler + 'static> TabletToolInternal<D> {
                         time,
                     },
                 );
-                self.frame(data, seat, descriptor, time);
             }
         }
     }
@@ -928,10 +927,17 @@ impl<D: TabletSeatHandler + 'static> TabletToolInternal<D> {
             }
 
             focused.proximity_out(seat, data, descriptor);
-            focused.frame(seat, data, descriptor, event.time);
+
+            // This should not happen, but in case a previous proximity_out wasn't acknowledged by a
+            // frame, we need to send one now.
+            if let Some(old_focus) = self.previous_focus.take_if(|f| f != &focused) {
+                old_focus.frame(seat, data, descriptor, time);
+            }
+
+            self.previous_focus = Some(focused);
         }
 
-        self.frame_pending = false;
+        self.frame_pending = true;
     }
 
     fn motion(
@@ -1048,6 +1054,13 @@ impl<D: TabletSeatHandler + 'static> TabletToolInternal<D> {
         if self.frame_pending {
             if let Some((focused, _)) = self.focus.as_mut() {
                 focused.frame(seat, data, descriptor, time);
+
+                // We don't want to send the frame twice.
+                self.previous_focus.take_if(|f| f == focused);
+            }
+
+            if let Some(focused) = self.previous_focus.take() {
+                focused.frame(seat, data, descriptor, time);
             }
         }
 
@@ -1064,10 +1077,6 @@ impl<D: TabletSeatHandler + 'static> TabletToolInternal<D> {
         self.with_grab(data, seat, descriptor, |data, handle, grab| {
             grab.proximity_out(data, handle, event);
         });
-        // If the grab has forwarded the proximity_out, the function does nothing. If not, we need
-        // to send the proximity out anyway.
-        self.proximity_out(data, seat, descriptor, event);
-        self.unset_grab(data, seat, descriptor, event.serial, event.time, false);
 
         // Now, reset everything so we don't get stale data later.
         self.tip_down = false;
@@ -1075,6 +1084,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolInternal<D> {
         self.current_buttons.clear();
         self.focus = None;
         self.pending_focus = None;
+        // We don't reset last_focus just yet as it's needed for the frame event.
         self.tablet = None;
         self.location = None;
     }

--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -11,7 +11,7 @@
 //!
 //! use smithay::wayland::cursor_shape::CursorShapeManagerState;
 //!
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::{KeyState, TabletToolDescriptor};
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -19,12 +19,12 @@
 //! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
 //! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget, FrameMarker},
+//! #   tablet::{Tablet, TabletSeatHandler, tool::{self, TabletToolTarget}},
 //! #   Seat, SeatHandler, SeatState,
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
 //! # use smithay::wayland::seat::WaylandFocus;
 //! # use wayland_server::protocol::wl_surface;
-//! # use smithay::wayland::tablet_manager::TabletSeatHandler;
 //!
 //! # #[derive(Debug, Clone, PartialEq)]
 //! # struct Target;
@@ -78,6 +78,16 @@
 //! #   fn orientation(&self, seat: &Seat<State>, data: &mut State, event: &OrientationEvent) {}
 //! #   fn last_frame(&self, seat: &Seat<State>, data: &mut State) -> Option<FrameMarker> { unimplemented!() }
 //! # }
+//! # impl TabletToolTarget<State> for Target {
+//! #   fn proximity_in(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, tablet: &Tablet, serial: Serial) {}
+//! #   fn proximity_out(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor) {}
+//! #   fn down(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::DownEvent) {}
+//! #   fn up(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::UpEvent) {}
+//! #   fn motion(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::MotionEvent) {}
+//! #   fn axis(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, frame: tool::AxisFrame) {}
+//! #   fn button(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::ButtonEvent) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, time: u32) {}
+//! # }
 //! # struct State {
 //! #     seat_state: SeatState<Self>,
 //! # };
@@ -91,7 +101,9 @@
 //! #         &mut self.seat_state
 //! #     }
 //! # }
-//! # impl TabletSeatHandler for State {}
+//! # impl TabletSeatHandler for State {
+//! #     type ToolFocus = Target;
+//! # }
 //!
 //! let state = CursorShapeManagerState::new::<State>(&display.handle());
 //!
@@ -113,12 +125,14 @@ use wayland_server::{Dispatch, DisplayHandle, backend::GlobalId};
 use crate::input::SeatHandler;
 use crate::input::WeakSeat;
 use crate::input::pointer::{CursorIcon, CursorImageStatus};
+use crate::input::tablet::TabletSeatHandler;
 use crate::utils::Serial;
 use crate::wayland::seat::{WaylandFocus, pointer::allow_setting_cursor};
+use crate::wayland::tablet_manager::TabletToolUserData;
+use crate::wayland::tablet_manager::tablet_tool;
 use crate::wayland::{Dispatch2, GlobalData, GlobalDispatch2};
 
 use super::seat::PointerUserData;
-use super::tablet_manager::{TabletSeatHandler, TabletToolUserData};
 
 /// State of the cursor shape manager.
 #[derive(Debug)]
@@ -239,6 +253,7 @@ impl<D> Dispatch2<CursorShapeDevice, D> for CursorShapeDeviceUserData<D>
 where
     D: SeatHandler + TabletSeatHandler,
     <D as SeatHandler>::PointerFocus: WaylandFocus,
+    <D as TabletSeatHandler>::ToolFocus: WaylandFocus,
     D: 'static,
 {
     fn request(
@@ -279,27 +294,22 @@ where
                             // When the zwp_tablet_tool_v2 is removed, the wp_cursor_shape_device_v1 object becomes inert.
                             return;
                         };
-                        let tablet_data = match tablet.data::<TabletToolUserData>() {
+                        let tablet_data = match tablet.data::<TabletToolUserData<D>>() {
                             Some(data) => data,
                             None => return,
                         };
 
-                        // Check that tablet focus matches.
-                        if !tablet_data
-                            .handle
-                            .inner
-                            .lock()
-                            .unwrap()
-                            .focus
-                            .as_ref()
-                            .map(|focus| focus.same_client_as(&tablet.id()))
-                            .unwrap_or(false)
-                        {
+                        let Some(handle) = tablet_data.handle.upgrade() else {
+                            return;
+                        };
+
+                        if !tablet_tool::allow_setting_cursor(&handle, Serial(serial), &resource.id()) {
                             return;
                         }
 
                         let cursor_icon = shape_to_cursor_icon(shape);
-                        state.tablet_tool_image(&tablet_data.desc, CursorImageStatus::Named(cursor_icon));
+                        state
+                            .tablet_tool_image(&handle.arc.descriptor, CursorImageStatus::Named(cursor_icon));
                     }
                 }
             }

--- a/src/wayland/tablet_manager/mod.rs
+++ b/src/wayland/tablet_manager/mod.rs
@@ -1,13 +1,19 @@
 //! Utilities for graphics tablet support
 //!
-//! This module provides helpers to handle graphics tablets.
+//! This module provides you with utilities for handling the tablet manager globals and the
+//! associated Wayland objects.
+//!
+//! ## How to use it
+//!
+//! ### Initialization
 //!
 //! ```
-//! use smithay::backend::input::TabletToolDescriptor;
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
-//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
-//! use smithay::wayland::tablet_manager::{TabletManagerState, TabletDescriptor, TabletSeatHandler};
+//! use smithay::input::tablet::{TabletSeatHandler, TabletSeatTrait};
+//! use smithay::backend::input::TabletToolDescriptor;
+//! use smithay::wayland::tablet_manager::{TabletManagerState};
 //! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
+//! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! # use smithay::reexports::wayland_server::Client;
 //!
 //! # struct State { seat_state: SeatState<Self> };
@@ -16,86 +22,67 @@
 //!
 //! let mut seat_state = SeatState::<State>::new();
 //! let tablet_state = TabletManagerState::new::<State>(&display_handle);
-//! // add the seat state to your state
+//! // add the seat state and tablet manager state to your state.
 //! // ...
 //!
 //! // create the seat
 //! let seat = seat_state.new_wl_seat(
-//!     &display_handle,          // the display
-//!     "seat-0",                 // the name of the seat, will be advertized to clients
+//!     &display_handle,            // the display
+//!     "seat-0",                   // the name of the seat, will be advertised to clients
 //! );
-//!
-//! use smithay::wayland::tablet_manager::TabletSeatTrait;
-//!
-//! seat
-//!    .tablet_seat()                     // Get TabletSeat asosiated with this seat
-//!    .add_tablet::<State>(              // Add a new tablet to a seat
-//!      &display_handle,
-//!      &TabletDescriptor {    
-//!        name: "Test".into(),
-//!        usb_id: None,
-//!        syspath: None,
-//!      }
-//!    );
+//! // create the associated tablet seat.
+//! let tablet_seat = seat.tablet_seat();
 //!
 //! // implement the required traits
 //! impl SeatHandler for State {
 //!     type KeyboardFocus = WlSurface;
 //!     type PointerFocus = WlSurface;
 //!     type TouchFocus = WlSurface;
+//!
 //!     fn seat_state(&mut self) -> &mut SeatState<Self> {
 //!         &mut self.seat_state
 //!     }
+//!
 //!     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) {
-//!         // ...
+//!         // handle focus changes, if you need to ...
 //!     }
 //!     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) {
-//!         // ...
+//!         // handle new images for the cursor ...
 //!     }
 //! }
 //!
 //! impl TabletSeatHandler for State {
+//!     type ToolFocus = WlSurface;
+//!
 //!     fn tablet_tool_image(&mut self, tool: &TabletToolDescriptor, image: CursorImageStatus) {
-//!         // ...
+//!         // handle new image for the given tool.
 //!     }
 //! }
+//!
+//! smithay::delegate_dispatch2!(State);
 //!
 //! # impl CompositorHandler for State {
 //! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
 //! #     fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState { unimplemented!() }
 //! #     fn commit(&mut self, surface: &WlSurface) {}
 //! # }
-//!
-//! smithay::delegate_dispatch2!(State);
 //! ```
-//! ```ignore
-//! // Init the manager global
-//! let state = TabletManagerState::new::<D>(&display);
 //!
-//! // Init the seat
-//! let seat = Seat::<D>::new(
-//!     &display,
-//!     "seat-0".into(),
-//!     None
-//! );
+//! ### Run usage
 //!
-//! use smithay::wyaldnd::tablet_manager::TabletSeatTrait;
+//! Once the seat is initialized, you can add tablet and tools to it.
 //!
-//! seat
-//!    .tablet_seat()                     // Get TabletSeat asosiated with this seat
-//!    .add_tablet(                       // Add a new tablet to a seat
-//!      display
-//!      &TabletDescriptor {    
-//!        name: "Test".into(),
-//!        usb_id: None,
-//!        syspath: None,
-//!      }
-//!    );
-//! ```
+//! You can add these via methods of the [`TabletSeat`] struct:
+//! [`TabletSeat::add_wp_tablet`] and [`TabletSeat::add_wp_tool`]. These methods return the same
+//! handle their non-wayland counterpart do, but additionally expose ZwpTablet* objects to wayland
+//! clients.
 
 use crate::{
-    input::{Seat, SeatHandler},
-    wayland::{Dispatch2, GlobalData, GlobalDispatch2},
+    input::{
+        Seat, SeatHandler,
+        tablet::{TabletSeat, TabletSeatHandler},
+    },
+    wayland::{Dispatch2, GlobalData, GlobalDispatch2, compositor::CompositorHandler},
 };
 use wayland_protocols::wp::tablet::zv2::server::{
     zwp_tablet_manager_v2::{self, ZwpTabletManagerV2},
@@ -103,33 +90,17 @@ use wayland_protocols::wp::tablet::zv2::server::{
     zwp_tablet_tool_v2::ZwpTabletToolV2,
     zwp_tablet_v2::ZwpTabletV2,
 };
-use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, backend::GlobalId};
 
+use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, backend::GlobalId};
 const MANAGER_VERSION: u32 = 1;
 
-mod tablet;
+pub(crate) mod tablet;
 mod tablet_seat;
 pub(crate) mod tablet_tool;
 
-pub use tablet::{TabletDescriptor, TabletHandle, TabletUserData};
-pub use tablet_seat::{TabletSeatHandle, TabletSeatHandler, TabletSeatUserData};
-pub use tablet_tool::{TabletToolHandle, TabletToolUserData};
-
-use super::compositor::CompositorHandler;
-
-/// Extends [Seat] with graphic tablet specific functionality
-pub trait TabletSeatTrait {
-    /// Get tablet seat associated with this seat
-    fn tablet_seat(&self) -> TabletSeatHandle;
-}
-
-impl<D: SeatHandler + 'static> TabletSeatTrait for Seat<D> {
-    fn tablet_seat(&self) -> TabletSeatHandle {
-        let user_data = self.user_data();
-        user_data.insert_if_missing(TabletSeatHandle::default);
-        user_data.get::<TabletSeatHandle>().unwrap().clone()
-    }
-}
+pub use tablet::TabletUserData;
+pub use tablet_seat::TabletSeatUserData;
+pub use tablet_tool::TabletToolUserData;
 
 /// State of wp tablet protocol
 #[derive(Debug)]
@@ -143,8 +114,9 @@ impl TabletManagerState {
     where
         D: GlobalDispatch<ZwpTabletManagerV2, GlobalData>,
         D: Dispatch<ZwpTabletManagerV2, GlobalData>,
-        D: Dispatch<ZwpTabletSeatV2, TabletSeatUserData>,
-        D: Dispatch<ZwpTabletToolV2, TabletToolUserData>,
+        D: Dispatch<ZwpTabletSeatV2, TabletSeatUserData<D>>,
+        D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
+        D: TabletSeatHandler,
         D: 'static,
     {
         let global = display.create_global::<D, ZwpTabletManagerV2, _>(MANAGER_VERSION, GlobalData);
@@ -161,8 +133,8 @@ impl TabletManagerState {
 impl<D> GlobalDispatch2<ZwpTabletManagerV2, D> for GlobalData
 where
     D: Dispatch<ZwpTabletManagerV2, GlobalData>,
-    D: Dispatch<ZwpTabletSeatV2, TabletSeatUserData>,
-    D: 'static,
+    D: Dispatch<ZwpTabletSeatV2, TabletSeatUserData<D>>,
+    D: TabletSeatHandler,
 {
     fn bind(
         &self,
@@ -178,9 +150,9 @@ where
 
 impl<D> Dispatch2<ZwpTabletManagerV2, D> for GlobalData
 where
-    D: Dispatch<ZwpTabletSeatV2, TabletSeatUserData>,
+    D: Dispatch<ZwpTabletSeatV2, TabletSeatUserData<D>>,
     D: Dispatch<ZwpTabletV2, TabletUserData>,
-    D: Dispatch<ZwpTabletToolV2, TabletToolUserData>,
+    D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
     D: SeatHandler + TabletSeatHandler + 'static,
     D: CompositorHandler,
 {
@@ -188,8 +160,8 @@ where
         &self,
         state: &mut D,
         client: &Client,
-        _: &ZwpTabletManagerV2,
-        request: zwp_tablet_manager_v2::Request,
+        _resource: &ZwpTabletManagerV2,
+        request: <ZwpTabletManagerV2 as wayland_server::Resource>::Request,
         dh: &DisplayHandle,
         data_init: &mut DataInit<'_, D>,
     ) {
@@ -198,9 +170,9 @@ where
                 let seat = Seat::<D>::from_resource(&seat).unwrap();
 
                 let user_data = seat.user_data();
-                user_data.insert_if_missing(TabletSeatHandle::default);
+                user_data.insert_if_missing(TabletSeat::<D>::default);
 
-                let handle = user_data.get::<TabletSeatHandle>().unwrap();
+                let handle = user_data.get::<TabletSeat<D>>().unwrap();
                 let instance = data_init.init(
                     tablet_seat,
                     TabletSeatUserData {
@@ -208,12 +180,20 @@ where
                     },
                 );
 
-                handle.add_instance::<D>(state, dh, &instance, client);
+                handle.add_instance(state, dh, &instance, client);
             }
             zwp_tablet_manager_v2::Request::Destroy => {
                 // Nothing to do
             }
             _ => unreachable!(),
         }
+    }
+
+    fn destroyed(
+        &self,
+        _state: &mut D,
+        _client: wayland_server::backend::ClientId,
+        _resource: &ZwpTabletManagerV2,
+    ) {
     }
 }

--- a/src/wayland/tablet_manager/tablet.rs
+++ b/src/wayland/tablet_manager/tablet.rs
@@ -1,108 +1,154 @@
-use std::{
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use wayland_protocols::wp::tablet::zv2::server::{
-    zwp_tablet_seat_v2::ZwpTabletSeatV2,
-    zwp_tablet_v2::{self, ZwpTabletV2},
+    zwp_tablet_seat_v2::ZwpTabletSeatV2, zwp_tablet_v2::ZwpTabletV2,
 };
 use wayland_server::{
-    Client, DataInit, Dispatch, DisplayHandle, Resource, Weak, backend::ClientId,
-    protocol::wl_surface::WlSurface,
+    Client, Dispatch, DisplayHandle, Resource, Weak, backend::ObjectId, protocol::wl_surface::WlSurface,
 };
 
-use crate::{backend::input::Device, wayland::Dispatch2};
+use crate::{
+    input::tablet::{Tablet, TabletDescriptor, TabletRc, TabletSeat, TabletSeatHandler, WeakTablet},
+    wayland::Dispatch2,
+};
 
-/// Description of graphics tablet device
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct TabletDescriptor {
-    /// Tablet device name
-    pub name: String,
-    /// Tablet device USB (product,vendor) id
-    pub usb_id: Option<(u32, u32)>,
-    /// Path to the device
-    pub syspath: Option<PathBuf>,
-}
-
-impl<D: Device> From<&D> for TabletDescriptor {
-    #[inline]
-    fn from(device: &D) -> Self {
-        TabletDescriptor {
-            name: device.name(),
-            syspath: device.syspath(),
-            usb_id: device.usb_id(),
+impl Tablet {
+    fn new_bound(descriptor: TabletDescriptor) -> Self {
+        Self {
+            arc: Arc::new(TabletRc {
+                descriptor,
+                #[cfg(feature = "wayland_frontend")]
+                wp_tablet: WpTabletHandle {
+                    bound: true,
+                    known_instances: Default::default(),
+                },
+            }),
         }
     }
 }
 
-#[derive(Debug, Default)]
-struct Tablet {
-    instances: Vec<Weak<ZwpTabletV2>>,
-}
-
-/// Handle to a tablet device
-///
-/// Tablet represents one graphics tablet device
-#[derive(Debug, Default, Clone)]
-pub struct TabletHandle {
-    inner: Arc<Mutex<Tablet>>,
-}
-
-impl TabletHandle {
-    pub(super) fn new_instance<D>(
-        &mut self,
-        client: &Client,
-        dh: &DisplayHandle,
-        seat: &ZwpTabletSeatV2,
-        tablet: &TabletDescriptor,
-    ) where
+impl<D: TabletSeatHandler + 'static> TabletSeat<D> {
+    /// Add a new tablet to a seat, and exposes it to wayland clients
+    ///
+    /// You can either add tablet on [DeviceAdded] event, or you can add tablet based
+    /// on tool event, then clients will not know about devices that are not being used.
+    ///
+    /// If the tablet was already known it removes it and recreate a new handle. Because
+    /// [`TabletToolHandle`] will keep a handle to the [`Tablet`] while in proximity, it may appears
+    /// to clients that the tablet hasn't been removed until the tool leave its proximity.
+    ///
+    /// [DeviceAdded]: crate::backend::input::InputEvent::DeviceAdded
+    /// [`TabletToolHandle`]: crate::input::tablet::tool::TabletToolHandle
+    pub fn add_wp_tablet(&self, dh: &DisplayHandle, tablet_desc: &TabletDescriptor) -> Tablet
+    where
         D: Dispatch<ZwpTabletV2, TabletUserData>,
         D: 'static,
     {
-        let wl_tablet = client
-            .create_resource::<ZwpTabletV2, _, D>(dh, seat.version(), TabletUserData { handle: self.clone() })
-            .unwrap();
+        let inner = &mut *self.arc.lock().unwrap();
 
-        seat.tablet_added(&wl_tablet);
+        let tablet = inner.add_tablet(tablet_desc, Tablet::new_bound);
+        let instances = &mut inner.instances;
 
-        wl_tablet.name(tablet.name.clone());
+        for seat in instances.iter() {
+            let Ok(seat) = seat.upgrade() else {
+                continue;
+            };
 
-        if let Some((id_product, id_vendor)) = tablet.usb_id {
-            wl_tablet.id(id_product, id_vendor);
+            if let Ok(client) = dh.get_client(seat.id()) {
+                tablet
+                    .arc
+                    .wp_tablet
+                    .new_instance::<D>(&client, dh, &seat, tablet.clone(), tablet_desc);
+            }
         }
 
-        if let Some(syspath) = tablet.syspath.as_ref().and_then(|p| p.to_str()) {
-            wl_tablet.path(syspath.to_owned());
-        }
-
-        wl_tablet.done();
-
-        self.inner.lock().unwrap().instances.push(wl_tablet.downgrade());
-    }
-
-    pub(super) fn with_focused_tablet<F>(&self, focus: &WlSurface, cb: F)
-    where
-        F: Fn(&ZwpTabletV2),
-    {
-        if let Some(instance) = self
-            .inner
-            .lock()
-            .unwrap()
-            .instances
-            .iter()
-            .find(|i| i.id().same_client_as(&focus.id()))
-            .and_then(|t| t.upgrade().ok())
-        {
-            cb(&instance);
-        }
+        tablet
     }
 }
 
 /// User data of ZwpTabletV2 object
 #[derive(Debug)]
 pub struct TabletUserData {
-    handle: TabletHandle,
+    tablet: WeakTablet,
+    seat_id: ObjectId,
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct WpTabletHandle {
+    bound: bool,
+    known_instances: Mutex<Vec<Weak<wayland_protocols::wp::tablet::zv2::server::zwp_tablet_v2::ZwpTabletV2>>>,
+}
+
+impl WpTabletHandle {
+    pub(super) fn new_instance<D>(
+        &self,
+        client: &Client,
+        dh: &DisplayHandle,
+        seat: &ZwpTabletSeatV2,
+        tablet: Tablet,
+        desc: &TabletDescriptor,
+    ) where
+        D: Dispatch<ZwpTabletV2, TabletUserData>,
+        D: 'static,
+    {
+        if !self.bound {
+            return;
+        }
+
+        let wp_tablet = client
+            .create_resource::<ZwpTabletV2, _, D>(
+                dh,
+                seat.version(),
+                TabletUserData {
+                    tablet: tablet.downgrade(),
+                    seat_id: seat.id(),
+                },
+            )
+            .unwrap();
+
+        seat.tablet_added(&wp_tablet);
+
+        wp_tablet.name(desc.name.clone());
+
+        if let Some((id_product, id_vendor)) = desc.usb_id {
+            wp_tablet.id(id_product, id_vendor);
+        }
+
+        if let Some(syspath) = desc.syspath.as_ref().and_then(|p| p.to_str()) {
+            wp_tablet.path(syspath.to_owned());
+        }
+
+        wp_tablet.done();
+
+        self.known_instances.lock().unwrap().push(wp_tablet.downgrade());
+    }
+
+    pub(crate) fn focused_tablet_for_seat(
+        &self,
+        surface: &WlSurface,
+        seat_id: &ObjectId,
+    ) -> Option<ZwpTabletV2> {
+        self.known_instances.lock().unwrap().iter().find_map(|tablet| {
+            tablet.upgrade().ok().filter(|wp_tablet| {
+                Resource::id(wp_tablet).same_client_as(&surface.id())
+                    && &wp_tablet.data::<TabletUserData>().unwrap().seat_id == seat_id
+            })
+        })
+    }
+}
+
+impl Drop for WpTabletHandle {
+    fn drop(&mut self) {
+        let mut guard = self.known_instances.lock().unwrap();
+
+        for wp_tablet in guard.drain(..) {
+            let Ok(wp_tablet) = wp_tablet.upgrade() else {
+                continue;
+            };
+
+            wp_tablet.removed();
+        }
+    }
 }
 
 impl<D> Dispatch2<ZwpTabletV2, D> for TabletUserData
@@ -112,20 +158,25 @@ where
     fn request(
         &self,
         _state: &mut D,
-        _client: &Client,
-        _tablet: &ZwpTabletV2,
-        _request: zwp_tablet_v2::Request,
-        _dh: &DisplayHandle,
-        _data_init: &mut DataInit<'_, D>,
+        _client: &wayland_server::Client,
+        _resource: &ZwpTabletV2,
+        _request: <ZwpTabletV2 as wayland_server::Resource>::Request,
+        _dhandle: &wayland_server::DisplayHandle,
+        _data_init: &mut wayland_server::DataInit<'_, D>,
     ) {
     }
 
-    fn destroyed(&self, _state: &mut D, _client: ClientId, tablet: &ZwpTabletV2) {
-        self.handle
-            .inner
+    fn destroyed(&self, _state: &mut D, _client: wayland_server::backend::ClientId, wp_tablet: &ZwpTabletV2) {
+        let Some(tablet) = self.tablet.upgrade() else {
+            return;
+        };
+
+        tablet
+            .arc
+            .wp_tablet
+            .known_instances
             .lock()
             .unwrap()
-            .instances
-            .retain(|i| i.id() != Resource::id(tablet));
+            .retain(|i| i.id() != Resource::id(wp_tablet));
     }
 }

--- a/src/wayland/tablet_manager/tablet_seat.rs
+++ b/src/wayland/tablet_manager/tablet_seat.rs
@@ -1,64 +1,19 @@
 use wayland_protocols::wp::tablet::zv2::server::{
-    zwp_tablet_seat_v2::{self, ZwpTabletSeatV2},
-    zwp_tablet_tool_v2::ZwpTabletToolV2,
-    zwp_tablet_v2::ZwpTabletV2,
+    zwp_tablet_seat_v2::ZwpTabletSeatV2, zwp_tablet_tool_v2::ZwpTabletToolV2, zwp_tablet_v2::ZwpTabletV2,
 };
-use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, Resource, Weak, backend::ClientId};
+use wayland_server::{Client, Dispatch, DisplayHandle, Resource};
 
-use crate::input::pointer::CursorImageStatus;
 use crate::{
-    backend::input::TabletToolDescriptor,
-    wayland::{Dispatch2, compositor::CompositorHandler},
+    input::tablet::{TabletSeat, TabletSeatHandler},
+    wayland::{
+        Dispatch2,
+        compositor::CompositorHandler,
+        tablet_manager::{TabletToolUserData, tablet::TabletUserData},
+    },
 };
 
-use super::tablet::{TabletDescriptor, TabletHandle};
-use super::{
-    tablet::TabletUserData,
-    tablet_tool::{TabletToolHandle, TabletToolUserData},
-};
-
-use std::collections::HashMap;
-use std::fmt;
-use std::sync::{Arc, Mutex};
-
-#[derive(Default)]
-pub(crate) struct TabletSeat {
-    instances: Vec<Weak<ZwpTabletSeatV2>>,
-    tablets: HashMap<TabletDescriptor, TabletHandle>,
-    tools: HashMap<TabletToolDescriptor, TabletToolHandle>,
-}
-
-impl fmt::Debug for TabletSeat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TabletSeat")
-            .field("instances", &self.instances)
-            .field("tablets", &self.tablets)
-            .field("tools", &self.tools)
-            .finish()
-    }
-}
-
-/// Handler trait for Tablet Seats
-pub trait TabletSeatHandler {
-    /// Callback that will be notified whenever a client requests to set a custom tool image.
-    fn tablet_tool_image(&mut self, tool: &TabletToolDescriptor, image: CursorImageStatus) {
-        let _ = tool;
-        let _ = image;
-    }
-}
-
-/// Handle to a tablet seat
-///
-/// TabletSeat extends `Seat` with graphic tablet specific functionality
-///
-/// TabletSeatHandle can be used to advertise available graphics tablets and tools to wayland clients
-#[derive(Default, Debug, Clone)]
-pub struct TabletSeatHandle {
-    pub(crate) inner: Arc<Mutex<TabletSeat>>,
-}
-
-impl TabletSeatHandle {
-    pub(super) fn add_instance<D>(
+impl<D: TabletSeatHandler + 'static> TabletSeat<D> {
+    pub(super) fn add_instance(
         &self,
         state: &mut D,
         dh: &DisplayHandle,
@@ -66,171 +21,53 @@ impl TabletSeatHandle {
         client: &Client,
     ) where
         D: Dispatch<ZwpTabletV2, TabletUserData>,
-        D: Dispatch<ZwpTabletToolV2, TabletToolUserData>,
-        D: TabletSeatHandler + 'static,
+        D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
         D: CompositorHandler,
-    {
-        let mut inner = self.inner.lock().unwrap();
-
-        // Notify new instance about available tablets
-        for (desc, tablet) in inner.tablets.iter_mut() {
-            tablet.new_instance::<D>(client, dh, seat, desc);
-        }
-
-        // Notify new instance about available tools
-        for (desc, tool) in inner.tools.iter_mut() {
-            tool.new_instance(state, client, dh, seat, desc);
-        }
-
-        inner.instances.push(seat.downgrade());
-    }
-
-    /// Add a new tablet to a seat.
-    ///
-    /// You can either add tablet on [input::Event::DeviceAdded](crate::backend::input::InputEvent::DeviceAdded) event,
-    /// or you can add tablet based on tool event, then clients will not know about devices that are not being used
-    ///
-    /// Returns new [TabletHandle] if tablet was not know by this seat, if tablet was already know it returns existing handle.
-    pub fn add_tablet<D>(&self, dh: &DisplayHandle, tablet_desc: &TabletDescriptor) -> TabletHandle
-    where
-        D: Dispatch<ZwpTabletV2, TabletUserData>,
         D: 'static,
     {
-        let inner = &mut *self.inner.lock().unwrap();
+        let mut inner = self.arc.lock().unwrap();
 
-        let tablets = &mut inner.tablets;
-        let instances = &inner.instances;
-
-        let tablet = tablets.entry(tablet_desc.clone()).or_insert_with(|| {
-            let mut tablet = TabletHandle::default();
-            // Create new tablet instance for every seat instance
-            for seat in instances.iter() {
-                let Ok(seat) = seat.upgrade() else {
-                    continue;
-                };
-
-                if let Ok(client) = dh.get_client(seat.id()) {
-                    tablet.new_instance::<D>(&client, dh, &seat, tablet_desc);
-                }
-            }
+        for (desc, tablet) in inner.tablets.iter_mut() {
             tablet
-        });
+                .arc
+                .wp_tablet
+                .new_instance::<D>(client, dh, seat, tablet.clone(), desc);
+        }
 
-        tablet.clone()
-    }
+        for (desc, tool) in inner.tools.iter_mut() {
+            tool.arc
+                .wp_tablet_tool
+                .new_instance::<D>(state, client, dh, seat, tool.clone(), desc)
+        }
 
-    /// Get a handle to a tablet
-    pub fn get_tablet(&self, tablet_desc: &TabletDescriptor) -> Option<TabletHandle> {
-        self.inner.lock().unwrap().tablets.get(tablet_desc).cloned()
-    }
-
-    /// Count all tablet devices
-    pub fn count_tablets(&self) -> usize {
-        self.inner.lock().unwrap().tablets.len()
-    }
-
-    /// Remove tablet device
-    ///
-    /// Called when tablet is no longer available
-    /// For example on [input::Event::DeviceRemoved](crate::backend::input::InputEvent::DeviceRemoved) event.
-    pub fn remove_tablet(&self, tablet_desc: &TabletDescriptor) {
-        self.inner.lock().unwrap().tablets.remove(tablet_desc);
-    }
-
-    /// Remove all tablet devices
-    pub fn clear_tablets(&self) {
-        self.inner.lock().unwrap().tablets.clear();
-    }
-
-    /// Add a new tool to a seat.
-    ///
-    /// Tool is usually added on [TabletToolProximityEvent](crate::backend::input::InputEvent::TabletToolProximity) event.
-    ///
-    /// Returns new [TabletToolHandle] if tool was not know by this seat, if tool was already know it returns existing handle,
-    /// it allows you to send tool input events to clients.
-    pub fn add_tool<D>(
-        &self,
-        state: &mut D,
-        dh: &DisplayHandle,
-        tool_desc: &TabletToolDescriptor,
-    ) -> TabletToolHandle
-    where
-        D: Dispatch<ZwpTabletToolV2, TabletToolUserData>,
-        D: TabletSeatHandler + 'static,
-        D: CompositorHandler,
-    {
-        let inner = &mut *self.inner.lock().unwrap();
-
-        let tools = &mut inner.tools;
-        let instances = &inner.instances;
-
-        let tool = tools.entry(tool_desc.clone()).or_insert_with(|| {
-            let mut tool = TabletToolHandle::default();
-            // Create new tool instance for every seat instance
-            for seat in instances.iter() {
-                let Ok(seat) = seat.upgrade() else {
-                    continue;
-                };
-
-                if let Ok(client) = dh.get_client(seat.id()) {
-                    tool.new_instance(state, &client, dh, &seat, tool_desc);
-                }
-            }
-            tool
-        });
-
-        tool.clone()
-    }
-
-    /// Get a handle to a tablet tool
-    pub fn get_tool(&self, tool_desc: &TabletToolDescriptor) -> Option<TabletToolHandle> {
-        self.inner.lock().unwrap().tools.get(tool_desc).cloned()
-    }
-
-    /// Count all tablet tool devices
-    pub fn count_tools(&self) -> usize {
-        self.inner.lock().unwrap().tools.len()
-    }
-
-    /// Remove tablet tool device
-    ///
-    /// Policy of tool removal is a compositor-specific.
-    ///
-    /// One possible policy would be to remove a tool when all tablets the tool was used on are removed.
-    pub fn remove_tool(&self, tool_desc: &TabletToolDescriptor) {
-        self.inner.lock().unwrap().tools.remove(tool_desc);
-    }
-
-    /// Remove all tablet tool devices
-    pub fn clear_tools(&self) {
-        self.inner.lock().unwrap().tools.clear();
+        inner.instances.push(seat.downgrade())
     }
 }
 
 /// User data of ZwpTabletSeatV2 object
 #[derive(Debug)]
-pub struct TabletSeatUserData {
-    pub(super) handle: TabletSeatHandle,
+pub struct TabletSeatUserData<D: TabletSeatHandler> {
+    pub(super) handle: TabletSeat<D>,
 }
 
-impl<D> Dispatch2<ZwpTabletSeatV2, D> for TabletSeatUserData
+impl<D> Dispatch2<ZwpTabletSeatV2, D> for TabletSeatUserData<D>
 where
-    D: 'static,
+    D: TabletSeatHandler + 'static,
 {
     fn request(
         &self,
         _state: &mut D,
         _client: &Client,
-        _seat: &ZwpTabletSeatV2,
-        _request: zwp_tablet_seat_v2::Request,
-        _dh: &DisplayHandle,
-        _data_init: &mut DataInit<'_, D>,
+        _resource: &ZwpTabletSeatV2,
+        _request: <ZwpTabletSeatV2 as wayland_server::Resource>::Request,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut wayland_server::DataInit<'_, D>,
     ) {
     }
 
-    fn destroyed(&self, _state: &mut D, _client: ClientId, seat: &ZwpTabletSeatV2) {
+    fn destroyed(&self, _state: &mut D, _client: wayland_server::backend::ClientId, seat: &ZwpTabletSeatV2) {
         self.handle
-            .inner
+            .arc
             .lock()
             .unwrap()
             .instances

--- a/src/wayland/tablet_manager/tablet_tool.rs
+++ b/src/wayland/tablet_manager/tablet_tool.rs
@@ -1,429 +1,352 @@
-use std::fmt;
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, atomic::Ordering};
 
-use crate::backend::input::{ButtonState, TabletToolCapabilities, TabletToolDescriptor, TabletToolType};
-use crate::input::pointer::{CursorImageAttributes, CursorImageStatus};
-use crate::utils::{Client as ClientCoords, Logical, Point};
-use crate::wayland::compositor::CompositorHandler;
-use crate::wayland::seat::CURSOR_IMAGE_ROLE;
 use portable_atomic::AtomicF64;
 use wayland_protocols::wp::tablet::zv2::server::{
     zwp_tablet_seat_v2::ZwpTabletSeatV2,
     zwp_tablet_tool_v2::{self, ZwpTabletToolV2},
 };
-use wayland_server::Weak;
-use wayland_server::protocol::wl_surface::WlSurface;
-use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, Resource, backend::ClientId};
-
-use crate::{
-    utils::Serial,
-    wayland::{Dispatch2, compositor},
+use wayland_server::{
+    Client, Dispatch, DisplayHandle, Resource, Weak,
+    backend::{ClientId, ObjectId},
+    protocol::wl_surface::WlSurface,
 };
 
-use super::tablet::TabletHandle;
-use super::tablet_seat::TabletSeatHandler;
+use crate::{
+    backend::input::{ButtonState, TabletToolCapabilities, TabletToolDescriptor, TabletToolType},
+    input::{
+        pointer::{CursorImageAttributes, CursorImageStatus},
+        tablet::{
+            Tablet, TabletSeat, TabletSeatHandler, TabletSeatTrait,
+            tool::{
+                self, AxisFrame, ButtonEvent, DownEvent, MotionEvent, TabletToolGrab, TabletToolHandle,
+                TabletToolInternal, TabletToolRc, TabletToolTarget, UpEvent, WeakTabletToolHandle,
+            },
+        },
+    },
+    utils::{Client as ClientCoords, Point, Serial, iter::new_locked_obj_iter_from_vec},
+    wayland::{
+        Dispatch2,
+        compositor::{self, CompositorHandler},
+        seat::{CURSOR_IMAGE_ROLE, WaylandFocus},
+    },
+};
 
-#[derive(Debug, Default)]
-pub(crate) struct TabletTool {
-    instances: Vec<Weak<ZwpTabletToolV2>>,
-    pub(crate) focus: Option<WlSurface>,
-
-    is_down: bool,
-
-    pending_pressure: Option<f64>,
-    pending_distance: Option<f64>,
-    pending_tilt: Option<(f64, f64)>,
-    pending_slider: Option<f64>,
-    pending_rotation: Option<f64>,
-    pending_wheel: Option<(f64, i32)>,
-}
-
-impl TabletTool {
-    fn proximity_in(
-        &mut self,
-        loc: Point<f64, Logical>,
-        (focus, sloc): (WlSurface, Point<f64, Logical>),
-        tablet: &TabletHandle,
-        serial: Serial,
-        time: u32,
-    ) {
-        let wl_tool = self.instances.iter().find(|i| i.id().same_client_as(&focus.id()));
-
-        if let Some(wl_tool) = wl_tool.and_then(|tool| tool.upgrade().ok()) {
-            tablet.with_focused_tablet(&focus, |wl_tablet| {
-                wl_tool.proximity_in(serial.into(), wl_tablet, &focus);
-                // proximity_in has to be followed by motion event (required by protocol)
-                let client_scale = wl_tool
-                    .data::<TabletToolUserData>()
-                    .unwrap()
-                    .client_scale
-                    .load(Ordering::Acquire);
-                let srel_loc = (loc - sloc).to_client(client_scale);
-                wl_tool.motion(srel_loc.x, srel_loc.y);
-                wl_tool.frame(time);
-            });
-        }
-
-        self.focus = Some(focus.clone());
-    }
-
-    fn proximity_out(&mut self, time: u32) {
-        if let Some(ref focus) = self.focus {
-            let wl_tool = self.instances.iter().find(|i| i.id().same_client_as(&focus.id()));
-
-            if let Some(wl_tool) = wl_tool.and_then(|tool| tool.upgrade().ok()) {
-                if self.is_down {
-                    wl_tool.pressure(0);
-                    wl_tool.up();
-                    self.is_down = false;
-                }
-                wl_tool.proximity_out();
-                wl_tool.frame(time);
-            }
-        }
-
-        self.focus = None;
-    }
-
-    fn tip_down(&mut self, serial: Serial, time: u32) {
-        if let Some(ref focus) = self.focus {
-            if let Some(wl_tool) = self
-                .instances
-                .iter()
-                .find(|i| i.id().same_client_as(&focus.id()))
-                .and_then(|tool| tool.upgrade().ok())
-            {
-                if !self.is_down {
-                    wl_tool.down(serial.into());
-                    wl_tool.frame(time);
-                }
-            }
-        }
-
-        self.is_down = true;
-    }
-
-    fn tip_up(&mut self, time: u32) {
-        if let Some(ref focus) = self.focus {
-            if let Some(wl_tool) = self
-                .instances
-                .iter()
-                .find(|i| i.id().same_client_as(&focus.id()))
-                .and_then(|tool| tool.upgrade().ok())
-            {
-                if self.is_down {
-                    wl_tool.pressure(0);
-                    wl_tool.up();
-                    wl_tool.frame(time);
-                }
-            }
-        }
-
-        self.is_down = false;
-    }
-
-    fn motion(
-        &mut self,
-        pos: Point<f64, Logical>,
-        focus: Option<(WlSurface, Point<f64, Logical>)>,
-        tablet: &TabletHandle,
-        serial: Serial,
-        time: u32,
-    ) {
-        match (focus, self.focus.as_ref()) {
-            (Some(focus), Some(prev_focus)) => {
-                if &focus.0 == prev_focus {
-                    if let Some(wl_tool) = self
-                        .instances
-                        .iter()
-                        .find(|i| i.id().same_client_as(&focus.0.id()))
-                        .and_then(|tool| tool.upgrade().ok())
-                    {
-                        let client_scale = wl_tool
-                            .data::<TabletToolUserData>()
-                            .unwrap()
-                            .client_scale
-                            .load(Ordering::Acquire);
-                        let srel_loc = (pos - focus.1).to_client(client_scale);
-                        wl_tool.motion(srel_loc.x, srel_loc.y);
-
-                        if let Some(pressure) = self.pending_pressure.take() {
-                            wl_tool.pressure((pressure * 65535.0).round() as u32);
-                        }
-
-                        if let Some(distance) = self.pending_distance.take() {
-                            wl_tool.distance((distance * 65535.0).round() as u32);
-                        }
-
-                        if let Some((x, y)) = self.pending_tilt.take() {
-                            wl_tool.tilt(x, y);
-                        }
-
-                        if let Some(slider) = self.pending_slider.take() {
-                            wl_tool.slider((slider * 65535.0).round() as i32);
-                        }
-
-                        if let Some(rotation) = self.pending_rotation.take() {
-                            wl_tool.rotation(rotation);
-                        }
-
-                        if let Some((degrees, clicks)) = self.pending_wheel.take() {
-                            wl_tool.wheel(degrees, clicks)
-                        }
-
-                        wl_tool.frame(time);
-                    }
-                } else {
-                    // If surface has changed
-
-                    // Unfocus previous surface
-                    self.proximity_out(time);
-                    // Focus a new one
-                    self.proximity_in(pos, focus, tablet, serial, time)
-                }
-            }
-            // New surface in focus
-            (Some(focus), None) => self.proximity_in(pos, focus, tablet, serial, time),
-            // No surface in focus
-            (None, _) => self.proximity_out(time),
+impl<D: TabletSeatHandler + 'static> TabletToolHandle<D> {
+    fn new_bound<F>(descriptor: TabletToolDescriptor, default_grab: F) -> Self
+    where
+        F: Fn() -> Box<dyn TabletToolGrab<D>> + Send + 'static,
+    {
+        Self {
+            arc: Arc::new(TabletToolRc {
+                descriptor,
+                inner: Mutex::new(TabletToolInternal::new(default_grab)),
+                wp_tablet_tool: WpTabletToolHandle {
+                    bound: true,
+                    last_proximity_in: Default::default(),
+                    known_instances: Default::default(),
+                },
+            }),
         }
     }
 
-    fn pressure(&mut self, pressure: f64) {
-        self.pending_pressure = Some(pressure);
+    /// Attempt to retrieve a [`TabletToolHandle`] from an existing resource
+    pub fn from_resource(tool: &ZwpTabletToolV2) -> Option<Self> {
+        tool.data::<TabletToolUserData<D>>()?.handle.upgrade()
     }
 
-    fn distance(&mut self, distance: f64) {
-        self.pending_distance = Some(distance);
-    }
-
-    fn tilt(&mut self, tilt: (f64, f64)) {
-        self.pending_tilt = Some(tilt);
-    }
-
-    fn rotation(&mut self, rotation: f64) {
-        self.pending_rotation = Some(rotation);
-    }
-
-    fn slider_position(&mut self, slider: f64) {
-        self.pending_slider = Some(slider);
-    }
-
-    fn wheel(&mut self, degrees: f64, clicks: i32) {
-        self.pending_wheel = Some((degrees, clicks));
-    }
-
-    /// Sent whenever a button on the tool is pressed or released.
-    fn button(&self, button: u32, state: ButtonState, serial: Serial, time: u32) {
-        if let Some(ref focus) = self.focus {
-            if let Some(wl_tool) = self
-                .instances
-                .iter()
-                .find(|i| i.id().same_client_as(&focus.id()))
-                .and_then(|tool| tool.upgrade().ok())
-            {
-                wl_tool.button(serial.into(), button, state.into());
-                wl_tool.frame(time);
-            }
-        }
+    /// Return the raw [`ZwpTabletToolV2`] instance for a particular [`Client`]
+    pub fn client_tools<'a>(&'a self, client: &Client) -> impl Iterator<Item = ZwpTabletToolV2> + 'a {
+        let guard = self.arc.wp_tablet_tool.known_instances.lock().unwrap();
+        new_locked_obj_iter_from_vec(guard, client.id())
     }
 }
 
-impl Drop for TabletTool {
-    fn drop(&mut self) {
-        for instance in self.instances.iter().filter_map(|tool| tool.upgrade().ok()) {
-            // This event is sent when the tool is removed from the system and will send no further events.
-            instance.removed();
+impl<D: TabletSeatHandler + 'static> TabletSeat<D> {
+    /// Add a new tool to a seat and exposes it to wayland clients.
+    ///
+    /// Tool are usually added on [TabletToolProximityEvent] event.
+    ///
+    /// Calling this method on a seat that already has the same tool will overwrite it, and will be
+    /// seen by clients as if the tool was removed and a new one was added.
+    ///
+    /// [TabletToolProximityEvent]: crate::backend::input::InputEvent::TabletToolProximity
+    pub fn add_wp_tool(
+        &self,
+        state: &mut D,
+        dh: &DisplayHandle,
+        tool_desc: &TabletToolDescriptor,
+    ) -> TabletToolHandle<D>
+    where
+        D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
+        D: CompositorHandler,
+    {
+        self.add_wp_tool_with_grab(state, dh, tool_desc, || Box::new(tool::grab::DefaultGrab))
+    }
+
+    /// Add a new tool to a seat and allows the use of a custom default [`TabletToolGrab`]
+    ///
+    /// The default ghrab is used in case no other grab is currently active. When using
+    /// [`TabletSeat::add_wp_tool`], it will use [`tool::DefaultGrab`] which will install
+    /// [`tool::DownGrab`] on a down event. [`tool::DownGrab`] makes sure all further event will use
+    /// the same target until an up or physical proximity out event.
+    ///
+    /// See [`TabletSeat::add_wp_tool`] for more information.
+    pub fn add_wp_tool_with_grab<F>(
+        &self,
+        state: &mut D,
+        dh: &DisplayHandle,
+        tool_desc: &TabletToolDescriptor,
+        default_grab: F,
+    ) -> TabletToolHandle<D>
+    where
+        D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
+        D: CompositorHandler,
+        F: Fn() -> Box<dyn TabletToolGrab<D>> + Send + 'static,
+    {
+        let inner = &mut self.arc.lock().unwrap();
+
+        let tool = inner.add_tool(tool_desc, default_grab, TabletToolHandle::new_bound);
+        let instances = &mut inner.instances;
+
+        for seat in instances.iter() {
+            let Ok(seat) = seat.upgrade() else {
+                continue;
+            };
+
+            if let Ok(client) = dh.get_client(seat.id()) {
+                tool.arc
+                    .wp_tablet_tool
+                    .new_instance(state, &client, dh, &seat, tool.clone(), tool_desc);
+            }
         }
+
+        tool
     }
 }
 
-/// Handle to a tablet tool device
-///
-/// TabletTool represents a physical tool that has been, or is currently in use with a tablet in seat.
-///
-/// A TabletTool relation to a physical tool depends on the tablet's ability to report serial numbers. If the tablet supports this capability, then the object represents a specific physical tool and can be identified even when used on multiple tablets.
-#[derive(Debug, Default, Clone)]
-pub struct TabletToolHandle {
-    pub(crate) inner: Arc<Mutex<TabletTool>>,
+/// User data for ZwpTabletToolV2 object
+#[derive(Debug)]
+pub struct TabletToolUserData<D: TabletSeatHandler> {
+    pub(crate) handle: WeakTabletToolHandle<D>,
+    seat_id: ObjectId,
+    client_scale: Arc<AtomicF64>,
 }
 
-impl TabletToolHandle {
+#[derive(Default, Debug)]
+pub(crate) struct WpTabletToolHandle {
+    pub(crate) bound: bool,
+    pub(crate) last_proximity_in: Mutex<Option<Serial>>,
+    known_instances: Mutex<Vec<Weak<ZwpTabletToolV2>>>,
+}
+
+impl WpTabletToolHandle {
     pub(super) fn new_instance<D>(
-        &mut self,
+        &self,
         state: &mut D,
         client: &Client,
         dh: &DisplayHandle,
         seat: &ZwpTabletSeatV2,
-        tool: &TabletToolDescriptor,
+        handle: TabletToolHandle<D>,
+        desc: &TabletToolDescriptor,
     ) where
-        D: Dispatch<ZwpTabletToolV2, TabletToolUserData>,
-        D: TabletSeatHandler + 'static,
+        D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
         D: CompositorHandler,
+        D: TabletSeatHandler,
+        D: 'static,
     {
-        let desc = tool.clone();
+        if !self.bound {
+            return;
+        }
 
         let client_scale = state.client_compositor_state(client).clone_client_scale();
-        let wl_tool = client
+        let wp_tool = client
             .create_resource::<ZwpTabletToolV2, _, D>(
                 dh,
                 seat.version(),
                 TabletToolUserData {
-                    handle: self.clone(),
-                    desc,
+                    handle: handle.downgrade(),
+                    seat_id: seat.id(),
                     client_scale,
                 },
             )
             .unwrap();
 
-        seat.tool_added(&wl_tool);
+        seat.tool_added(&wp_tool);
 
-        wl_tool._type(tool.tool_type.into());
+        wp_tool._type(desc.tool_type.into());
 
-        let high: u32 = (tool.hardware_serial >> 16) as u32;
-        let low: u32 = tool.hardware_serial as u32;
+        let high: u32 = (desc.hardware_serial >> 32) as u32;
+        let low: u32 = desc.hardware_serial as u32;
+        wp_tool.hardware_serial(high, low);
 
-        wl_tool.hardware_serial(high, low);
+        let high: u32 = (desc.hardware_id_wacom >> 32) as u32;
+        let low: u32 = desc.hardware_id_wacom as u32;
+        wp_tool.hardware_id_wacom(high, low);
 
-        let high: u32 = (tool.hardware_id_wacom >> 16) as u32;
-        let low: u32 = tool.hardware_id_wacom as u32;
-        wl_tool.hardware_id_wacom(high, low);
-
-        if tool.capabilities.contains(TabletToolCapabilities::PRESSURE) {
-            wl_tool.capability(zwp_tablet_tool_v2::Capability::Pressure);
+        if desc.capabilities.contains(TabletToolCapabilities::PRESSURE) {
+            wp_tool.capability(zwp_tablet_tool_v2::Capability::Pressure);
         }
 
-        if tool.capabilities.contains(TabletToolCapabilities::DISTANCE) {
-            wl_tool.capability(zwp_tablet_tool_v2::Capability::Distance);
+        if desc.capabilities.contains(TabletToolCapabilities::DISTANCE) {
+            wp_tool.capability(zwp_tablet_tool_v2::Capability::Distance);
         }
 
-        if tool.capabilities.contains(TabletToolCapabilities::TILT) {
-            wl_tool.capability(zwp_tablet_tool_v2::Capability::Tilt);
+        if desc.capabilities.contains(TabletToolCapabilities::TILT) {
+            wp_tool.capability(zwp_tablet_tool_v2::Capability::Tilt);
         }
 
-        if tool.capabilities.contains(TabletToolCapabilities::SLIDER) {
-            wl_tool.capability(zwp_tablet_tool_v2::Capability::Slider);
+        if desc.capabilities.contains(TabletToolCapabilities::SLIDER) {
+            wp_tool.capability(zwp_tablet_tool_v2::Capability::Slider);
         }
 
-        if tool.capabilities.contains(TabletToolCapabilities::ROTATION) {
-            wl_tool.capability(zwp_tablet_tool_v2::Capability::Rotation);
+        if desc.capabilities.contains(TabletToolCapabilities::ROTATION) {
+            wp_tool.capability(zwp_tablet_tool_v2::Capability::Rotation);
         }
 
-        if tool.capabilities.contains(TabletToolCapabilities::WHEEL) {
-            wl_tool.capability(zwp_tablet_tool_v2::Capability::Wheel);
+        if desc.capabilities.contains(TabletToolCapabilities::WHEEL) {
+            wp_tool.capability(zwp_tablet_tool_v2::Capability::Wheel);
         }
 
-        wl_tool.done();
-        self.inner.lock().unwrap().instances.push(wl_tool.downgrade());
+        wp_tool.done();
+        self.known_instances.lock().unwrap().push(wp_tool.downgrade());
     }
 
-    /// Notify that this tool is focused on a certain surface.
-    ///
-    /// You provide the location of the tool, in the form of:
-    ///
-    /// - The coordinates of the tool in the global compositor space
-    /// - The surface on top of which the tool is, and the coordinates of its
-    ///   origin in the global compositor space.
-    pub fn proximity_in(
+    fn proximity_in<D: TabletSeatHandler + 'static>(
         &self,
-        pos: Point<f64, Logical>,
-        focus: (WlSurface, Point<f64, Logical>),
-        tablet: &TabletHandle,
+        surface: &WlSurface,
+        tablet: &Tablet,
         serial: Serial,
-        time: u32,
     ) {
-        self.inner
-            .lock()
-            .unwrap()
-            .proximity_in(pos, focus, tablet, serial, time)
+        *self.last_proximity_in.lock().unwrap() = Some(serial);
+
+        self.for_each_focused_tool(surface, |wp_tool| {
+            let seat_id = &wp_tool.data::<TabletToolUserData<D>>().unwrap().seat_id;
+
+            let Some(wp_tablet) = tablet.arc.wp_tablet.focused_tablet_for_seat(surface, seat_id) else {
+                return;
+            };
+
+            wp_tool.proximity_in(serial.0, &wp_tablet, surface);
+        });
     }
 
-    /// Notify that this tool has left proximity.
-    pub fn proximity_out(&self, time: u32) {
-        self.inner.lock().unwrap().proximity_out(time);
+    fn proximity_out(&self, surface: &WlSurface) {
+        self.for_each_focused_tool(surface, |wp_tool| {
+            wp_tool.proximity_out();
+        });
+
+        *self.last_proximity_in.lock().unwrap() = None;
     }
 
-    /// Tablet tool is making contact
-    pub fn tip_down(&self, serial: Serial, time: u32) {
-        self.inner.lock().unwrap().tip_down(serial, time);
+    fn down(&self, surface: &WlSurface, event: &DownEvent) {
+        self.for_each_focused_tool(surface, |wp_tool| {
+            wp_tool.down(event.serial.0);
+        });
     }
 
-    /// Tablet tool is no longer making contact
-    pub fn tip_up(&self, time: u32) {
-        self.inner.lock().unwrap().tip_up(time);
+    fn up(&self, surface: &WlSurface) {
+        self.for_each_focused_tool(surface, |wp_tool| {
+            wp_tool.up();
+        });
     }
 
-    /// Notify that the tool moved
-    ///
-    /// You provide the new location of the tool, in the form of:
-    ///
-    /// - The coordinates of the tool in the global compositor space
-    /// - The surface on top of which the tool is, and the coordinates of its
-    ///   origin in the global compositor space (or `None` of the pointer is not
-    ///   on top of a client surface).
-    ///
-    /// This will internally take care of notifying the appropriate client objects
-    /// of proximity_in/proximity_out events.
-    pub fn motion(
-        &self,
-        pos: Point<f64, Logical>,
-        focus: Option<(WlSurface, Point<f64, Logical>)>,
-        tablet: &TabletHandle,
-        serial: Serial,
-        time: u32,
-    ) {
-        self.inner
-            .lock()
-            .unwrap()
-            .motion(pos, focus, tablet, serial, time)
+    fn motion<D: TabletSeatHandler + 'static>(&self, surface: &WlSurface, event: &MotionEvent) {
+        self.for_each_focused_tool(surface, |wp_tool| {
+            let client_scale = wp_tool
+                .data::<TabletToolUserData<D>>()
+                .unwrap()
+                .client_scale
+                .load(Ordering::Acquire);
+
+            let Point { x, y, .. } = event.location.to_client(client_scale);
+            wp_tool.motion(x, y);
+        })
     }
 
-    /// Queue tool pressure update
-    ///
-    /// It will be sent alongside next motion event
-    pub fn pressure(&self, pressure: f64) {
-        self.inner.lock().unwrap().pressure(pressure);
+    fn axis(&self, surface: &WlSurface, frame: AxisFrame) {
+        const NORMALIZE: f64 = 65535.0;
+        fn normalize(value: f64) -> u32 {
+            (value * NORMALIZE) as u32
+        }
+
+        self.for_each_focused_tool(surface, |wp_tool| {
+            let AxisFrame {
+                pressure,
+                distance,
+                tilt,
+                rotation,
+                slider,
+                wheel,
+            } = frame;
+
+            if let Some(pressure) = pressure.map(normalize) {
+                wp_tool.pressure(pressure);
+            }
+
+            if let Some(distance) = distance.map(normalize) {
+                wp_tool.distance(distance);
+            }
+
+            if let Some((tilt_x, tilt_y)) = tilt {
+                wp_tool.tilt(tilt_x, tilt_y);
+            }
+
+            if let Some(degrees) = rotation {
+                wp_tool.rotation(degrees);
+            }
+
+            if let Some(slider) = slider.map(|s| (s * NORMALIZE) as i32) {
+                wp_tool.slider(slider);
+            }
+
+            if let Some((degrees, clicks)) = wheel {
+                wp_tool.wheel(degrees, clicks);
+            }
+        });
     }
 
-    /// Queue tool distance update
-    ///
-    /// It will be sent alongside next motion event
-    pub fn distance(&self, distance: f64) {
-        self.inner.lock().unwrap().distance(distance);
+    fn button(&self, surface: &WlSurface, event: &ButtonEvent) {
+        self.for_each_focused_tool(surface, |wp_tool| {
+            let ButtonEvent {
+                serial,
+                button,
+                state,
+                ..
+            } = *event;
+            wp_tool.button(serial.0, button, state.into());
+        });
     }
 
-    /// Queue tool tilt update
-    ///
-    /// It will be sent alongside next motion event
-    pub fn tilt(&self, tilt: (f64, f64)) {
-        self.inner.lock().unwrap().tilt(tilt);
+    fn frame(&self, surface: &WlSurface, time: u32) {
+        self.for_each_focused_tool(surface, |wp_tool| {
+            wp_tool.frame(time);
+        });
     }
 
-    /// Queue tool rotation update
-    ///
-    /// It will be sent alongside next motion event
-    pub fn rotation(&self, rotation: f64) {
-        self.inner.lock().unwrap().rotation(rotation);
-    }
+    fn for_each_focused_tool(&self, surface: &WlSurface, mut f: impl FnMut(ZwpTabletToolV2)) {
+        let inner = self.known_instances.lock().unwrap();
 
-    /// Queue tool slider update
-    ///
-    /// It will be sent alongside next motion event
-    pub fn slider_position(&self, slider: f64) {
-        self.inner.lock().unwrap().slider_position(slider);
-    }
+        for tool in &*inner {
+            let Ok(tool) = tool.upgrade() else {
+                continue;
+            };
 
-    /// Queue tool wheel update
-    ///
-    /// It will be sent alongside next motion event
-    pub fn wheel(&self, degrees: f64, clicks: i32) {
-        self.inner.lock().unwrap().wheel(degrees, clicks);
+            if tool.id().same_client_as(&surface.id()) {
+                f(tool.clone())
+            }
+        }
     }
+}
 
-    /// Button on the tool was pressed or released
-    pub fn button(&self, button: u32, state: ButtonState, serial: Serial, time: u32) {
-        self.inner.lock().unwrap().button(button, state, serial, time);
+impl Drop for WpTabletToolHandle {
+    fn drop(&mut self) {
+        let mut guard = self.known_instances.lock().unwrap();
+
+        for tool in guard.drain(..) {
+            let Ok(wp_tool) = tool.upgrade() else { continue };
+
+            wp_tool.removed();
+        }
     }
 }
 
@@ -453,89 +376,81 @@ impl From<ButtonState> for zwp_tablet_tool_v2::ButtonState {
     }
 }
 
-/// User data of ZwpTabletToolV2 object
-pub struct TabletToolUserData {
-    pub(crate) handle: TabletToolHandle,
-    pub(crate) desc: TabletToolDescriptor,
-    client_scale: Arc<AtomicF64>,
-}
-
-impl fmt::Debug for TabletToolUserData {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TabletToolUserData")
-            .field("handle", &self.handle)
-            .field("desc", &self.desc)
-            .field("client_scale", &self.client_scale)
-            .finish()
-    }
-}
-
-impl<D> Dispatch2<ZwpTabletToolV2, D> for TabletToolUserData
+impl<D> Dispatch2<ZwpTabletToolV2, D> for TabletToolUserData<D>
 where
-    D: TabletSeatHandler + 'static,
+    D: TabletSeatHandler,
+    <D as TabletSeatHandler>::ToolFocus: WaylandFocus,
+    D: 'static,
 {
     fn request(
         &self,
         state: &mut D,
-        _client: &Client,
+        _client: &wayland_server::Client,
         tool: &ZwpTabletToolV2,
-        request: zwp_tablet_tool_v2::Request,
-        _dh: &DisplayHandle,
-        _data_init: &mut DataInit<'_, D>,
+        request: <ZwpTabletToolV2 as wayland_server::Resource>::Request,
+        _dhandle: &wayland_server::DisplayHandle,
+        _data_init: &mut wayland_server::DataInit<'_, D>,
     ) {
+        let Some(handle) = self.handle.upgrade() else {
+            return;
+        };
+
         match request {
             zwp_tablet_tool_v2::Request::SetCursor {
+                serial,
                 surface,
                 hotspot_x,
                 hotspot_y,
-                ..
             } => {
-                let focus = self.handle.inner.lock().unwrap().focus.clone();
+                if !allow_setting_cursor(&handle, Serial(serial), &tool.id()) {
+                    return;
+                }
 
-                if let Some(focus) = focus {
-                    if focus.id().same_client_as(&tool.id()) {
-                        if let Some(surface) = surface {
-                            // tolerate re-using the same surface
-                            if compositor::give_role(&surface, CURSOR_IMAGE_ROLE).is_err()
-                                && compositor::get_role(&surface) != Some(CURSOR_IMAGE_ROLE)
-                            {
-                                tool.post_error(
-                                    zwp_tablet_tool_v2::Error::Role,
-                                    "Given wl_surface has another role.",
-                                );
-                                return;
-                            }
+                let cursor_image = match surface {
+                    Some(surface) => {
+                        if compositor::give_role(&surface, CURSOR_IMAGE_ROLE).is_err()
+                            && compositor::get_role(&surface) != Some(CURSOR_IMAGE_ROLE)
+                        {
+                            tool.post_error(
+                                zwp_tablet_tool_v2::Error::Role,
+                                "Given wl_surface has another role.",
+                            );
+                            return;
+                        }
 
-                            compositor::with_states(&surface, |states| {
-                                states.data_map.insert_if_missing_threadsafe(|| {
-                                    Mutex::new(CursorImageAttributes {
-                                        hotspot: (0, 0).into(),
-                                    })
-                                });
-                                let client_scale = tool
-                                    .data::<TabletToolUserData>()
-                                    .unwrap()
-                                    .client_scale
-                                    .load(Ordering::Acquire);
-                                let hotspot = Point::<_, ClientCoords>::from((hotspot_x, hotspot_y))
-                                    .to_f64()
-                                    .to_logical(client_scale)
-                                    .to_i32_round();
-                                states
-                                    .data_map
-                                    .get::<Mutex<CursorImageAttributes>>()
-                                    .unwrap()
-                                    .lock()
-                                    .unwrap()
-                                    .hotspot = hotspot;
+                        compositor::with_states(&surface, |states| {
+                            states.data_map.insert_if_missing_threadsafe(|| {
+                                Mutex::new(CursorImageAttributes {
+                                    hotspot: (0, 0).into(),
+                                })
                             });
 
-                            state.tablet_tool_image(&self.desc, CursorImageStatus::Surface(surface));
-                        } else {
-                            state.tablet_tool_image(&self.desc, CursorImageStatus::Hidden);
-                        };
+                            let client_scale = tool
+                                .data::<TabletToolUserData<D>>()
+                                .unwrap()
+                                .client_scale
+                                .load(Ordering::Acquire);
+
+                            let hotspot = Point::<i32, ClientCoords>::from((hotspot_x, hotspot_y))
+                                .to_f64()
+                                .to_logical(client_scale)
+                                .to_i32_round();
+
+                            states
+                                .data_map
+                                .get::<Mutex<CursorImageAttributes>>()
+                                .unwrap()
+                                .lock()
+                                .unwrap()
+                                .hotspot = hotspot;
+                        });
+
+                        CursorImageStatus::Surface(surface)
                     }
-                }
+                    None => CursorImageStatus::Hidden,
+                };
+
+                state.tablet_tool_image(handle.descriptor(), cursor_image);
             }
             zwp_tablet_tool_v2::Request::Destroy => {
                 // Nothing to do
@@ -544,12 +459,175 @@ where
         }
     }
 
-    fn destroyed(&self, _state: &mut D, _client: ClientId, resource: &ZwpTabletToolV2) {
-        self.handle
-            .inner
+    fn destroyed(&self, _state: &mut D, _client: ClientId, tool: &ZwpTabletToolV2) {
+        let Some(handle) = self.handle.upgrade() else {
+            return;
+        };
+
+        handle
+            .arc
+            .wp_tablet_tool
+            .known_instances
             .lock()
             .unwrap()
-            .instances
-            .retain(|i| i.id() != resource.id());
+            .retain(|i| i.id() != tool.id())
     }
+}
+
+impl<D> TabletToolTarget<D> for WlSurface
+where
+    D: TabletSeatHandler + 'static,
+{
+    fn proximity_in(
+        &self,
+        seat: &crate::input::Seat<D>,
+        _data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+        tablet: &Tablet,
+        serial: Serial,
+    ) {
+        let tablet_seat = seat.tablet_seat();
+
+        if let Some(tool) = tablet_seat.get_tool(tool_descriptor) {
+            tool.arc.wp_tablet_tool.proximity_in::<D>(self, tablet, serial);
+        }
+    }
+
+    fn proximity_out(
+        &self,
+        seat: &crate::input::Seat<D>,
+        _data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+    ) {
+        let tablet_seat = seat.tablet_seat();
+
+        if let Some(tool) = tablet_seat.get_tool(tool_descriptor) {
+            tool.arc.wp_tablet_tool.proximity_out(self);
+        }
+    }
+
+    fn down(
+        &self,
+        seat: &crate::input::Seat<D>,
+        _data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+        event: &DownEvent,
+    ) {
+        let tablet_seat = seat.tablet_seat();
+
+        if let Some(tool) = tablet_seat.get_tool(tool_descriptor) {
+            tool.arc.wp_tablet_tool.down(self, event);
+        }
+    }
+
+    fn up(
+        &self,
+        seat: &crate::input::Seat<D>,
+        _data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+        _event: &UpEvent,
+    ) {
+        let tablet_seat = seat.tablet_seat();
+
+        if let Some(tool) = tablet_seat.get_tool(tool_descriptor) {
+            tool.arc.wp_tablet_tool.up(self);
+        }
+    }
+
+    fn motion(
+        &self,
+        seat: &crate::input::Seat<D>,
+        _data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+        event: &MotionEvent,
+    ) {
+        let tablet_seat = seat.tablet_seat();
+
+        if let Some(tool) = tablet_seat.get_tool(tool_descriptor) {
+            tool.arc.wp_tablet_tool.motion::<D>(self, event);
+        }
+    }
+
+    fn axis(
+        &self,
+        seat: &crate::input::Seat<D>,
+        _data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+        frame: AxisFrame,
+    ) {
+        let tablet_seat = seat.tablet_seat();
+
+        if let Some(tool) = tablet_seat.get_tool(tool_descriptor) {
+            tool.arc.wp_tablet_tool.axis(self, frame);
+        }
+    }
+
+    fn button(
+        &self,
+        seat: &crate::input::Seat<D>,
+        _data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+        event: &ButtonEvent,
+    ) {
+        let tablet_seat = seat.tablet_seat();
+
+        if let Some(tool) = tablet_seat.get_tool(tool_descriptor) {
+            tool.arc.wp_tablet_tool.button(self, event);
+        }
+    }
+
+    fn frame(
+        &self,
+        seat: &crate::input::Seat<D>,
+        _data: &mut D,
+        tool_descriptor: &TabletToolDescriptor,
+        time: u32,
+    ) {
+        let tablet_seat = seat.tablet_seat();
+
+        if let Some(tool) = tablet_seat.get_tool(tool_descriptor) {
+            tool.arc.wp_tablet_tool.frame(self, time);
+        }
+    }
+}
+
+pub(crate) fn allow_setting_cursor<D>(
+    handle: &TabletToolHandle<D>,
+    serial: Serial,
+    object_id: &ObjectId,
+) -> bool
+where
+    D: TabletSeatHandler + 'static,
+    <D as TabletSeatHandler>::ToolFocus: WaylandFocus,
+{
+    // Allow client if there is a tool grab for that client. Like drag and drop.
+    if handle
+        .grab_start_data()
+        .and_then(|data| data.focus)
+        .is_some_and(|focus| focus.0.same_client_as(object_id))
+    {
+        return true;
+    }
+
+    if !handle
+        .arc
+        .wp_tablet_tool
+        .last_proximity_in
+        .lock()
+        .unwrap()
+        .is_some_and(|last_serial| last_serial == serial)
+    {
+        return false; // Ignore mismatches in serial
+    }
+
+    // Only allow setting the cursor icon if the current tool focus is of the same
+    // client.
+    handle
+        .arc
+        .inner
+        .lock()
+        .unwrap()
+        .focus
+        .as_ref()
+        .is_some_and(|(focus, _)| focus.same_client_as(object_id))
 }

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -8,6 +8,7 @@ use crate::{
             GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
             GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
         },
+        tablet::{TabletSeatHandler, tool::TabletToolTarget},
         touch::{FrameMarker, TouchTarget},
     },
     utils::{
@@ -2378,6 +2379,104 @@ impl<D: SeatHandler + CompositorHandler + 'static> TouchTarget<D> for X11Surface
             TouchTarget::last_frame(surface, seat, data)
         } else {
             None
+        }
+    }
+}
+
+impl<D: TabletSeatHandler + CompositorHandler + 'static> TabletToolTarget<D> for X11Surface {
+    fn proximity_in(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &crate::backend::input::TabletToolDescriptor,
+        tablet: &crate::input::tablet::Tablet,
+        serial: Serial,
+    ) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TabletToolTarget::proximity_in(surface, seat, data, tool_descriptor, tablet, serial);
+        }
+    }
+
+    fn proximity_out(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &crate::backend::input::TabletToolDescriptor,
+    ) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TabletToolTarget::proximity_out(surface, seat, data, tool_descriptor);
+        }
+    }
+
+    fn down(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &crate::backend::input::TabletToolDescriptor,
+        event: &crate::input::tablet::tool::DownEvent,
+    ) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TabletToolTarget::down(surface, seat, data, tool_descriptor, event);
+        }
+    }
+
+    fn up(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &crate::backend::input::TabletToolDescriptor,
+        event: &crate::input::tablet::tool::UpEvent,
+    ) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TabletToolTarget::up(surface, seat, data, tool_descriptor, event);
+        }
+    }
+
+    fn motion(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &crate::backend::input::TabletToolDescriptor,
+        event: &crate::input::tablet::tool::MotionEvent,
+    ) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TabletToolTarget::motion(surface, seat, data, tool_descriptor, event);
+        }
+    }
+
+    fn button(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &crate::backend::input::TabletToolDescriptor,
+        event: &crate::input::tablet::tool::ButtonEvent,
+    ) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TabletToolTarget::button(surface, seat, data, tool_descriptor, event);
+        }
+    }
+
+    fn axis(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &crate::backend::input::TabletToolDescriptor,
+        frame: crate::input::tablet::tool::AxisFrame,
+    ) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TabletToolTarget::axis(surface, seat, data, tool_descriptor, frame);
+        }
+    }
+
+    fn frame(
+        &self,
+        seat: &Seat<D>,
+        data: &mut D,
+        tool_descriptor: &crate::backend::input::TabletToolDescriptor,
+        time: u32,
+    ) {
+        if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
+            TabletToolTarget::frame(surface, seat, data, tool_descriptor, time);
         }
     }
 }


### PR DESCRIPTION
## Description
This PR brings generic tablet support to the `input` module with similar semantics we already have for pointer, touch and keyboard.

The TabletSeat no longer depends on the `wayland_frontend` feature, and was moved to `input::tablet`. The main interfaces, `TabletToolHandle` and `Tablet` can be created via `TabletSeat::add_tool` and `TabletSeat::add_tablet` or their `add_wp_*` counterpart which additionally setup wayland integration.

`TabletToolHandle` is the main type user will interact with. It's API resemble the other `*Handle` and supports grab and abstract targets for focus handling.

`TabletToolTarget` trait can be used to implements arbitrary targets, and has been implemented for `WlSurface` and `X11Surface`.

`TabletSeatHandler` now has a `ToolFocus`, similar to `SeatHandler::PointerFocus` and `SeatHandler::TouchFocus`.

I'm leaving this in draft for now as some doc test must still be updated, comments need proofreading, and I want to have some more real-world tests done.

Fixes #1753 

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
