### PR TITLE
fix: GPU-memory leaks in the allocator, GLES renderer, and multi-GPU paths

### DIFF
--- a/src/backend/allocator/swapchain.rs
+++ b/src/backend/allocator/swapchain.rs
@@ -118,7 +118,7 @@ impl<B: Buffer + AsDmabuf> AsDmabuf for Slot<B> {
         let maybe_dmabuf = self.userdata().get::<Dmabuf>();
         if maybe_dmabuf.is_none() {
             let dmabuf = (**self).export()?;
-            self.userdata().insert_if_missing(|| dmabuf);
+            self.userdata().insert_if_missing_threadsafe(|| dmabuf);
         }
 
         Ok(self.userdata().get::<Dmabuf>().cloned().unwrap())

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -212,7 +212,7 @@ where
             Ok(dmabuf) => dmabuf,
             Err(err) => return Err((swapchain.allocator, err.into())),
         };
-        buffer.userdata().insert_if_missing(|| fb);
+        buffer.userdata().insert_if_missing_threadsafe(|| fb);
 
         let handle = buffer.userdata().get::<GbmFramebuffer>().unwrap();
 
@@ -266,7 +266,7 @@ where
             if maybe_buffer.is_none() {
                 let fb = framebuffer_from_bo(self.drm.device_fd(), &slot, self.is_opaque)
                     .map_err(|err| Error::DrmError(err.into()))?;
-                slot.userdata().insert_if_missing(|| fb);
+                slot.userdata().insert_if_missing_threadsafe(|| fb);
             }
 
             self.next_fb = Some(slot);

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -911,7 +911,8 @@ impl ImportMemWl for GlesRenderer {
                         ptr.offset(offset as isize) as *const _,
                     );
                 } else {
-                    for region in damage.iter() {
+                    let buffer_rect = Rectangle::from_size(Size::from((width, height)));
+                    for region in damage.iter().filter_map(|r| r.intersection(buffer_rect)) {
                         trace!("Uploading partial shm texture");
                         self.gl.PixelStorei(ffi::UNPACK_SKIP_PIXELS, region.loc.x);
                         self.gl.PixelStorei(ffi::UNPACK_SKIP_ROWS, region.loc.y);

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1220,7 +1220,15 @@ impl ImportDma for GlesRenderer {
                 .create_image_from_dmabuf(buffer)
                 .map_err(GlesError::BindBufferEGLError)?;
 
-            let tex = self.import_egl_image(image, is_external, None)?;
+            let tex = match self.import_egl_image(image, is_external, None) {
+                Ok(tex) => tex,
+                Err(err) => {
+                    unsafe {
+                        ffi_egl::DestroyImageKHR(**self.egl.display().get_display_handle(), image);
+                    }
+                    return Err(err);
+                }
+            };
             let format = fourcc_to_gl_formats(buffer.format().code)
                 .map(|(internal, _, _)| internal)
                 .unwrap_or(ffi::RGBA8);

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1315,13 +1315,13 @@ impl ExportMem for GlesRenderer {
 
         let (_, has_alpha) = target.0.format().ok_or(GlesError::UnknownPixelFormat)?;
         let (_, format, layout) = fourcc_to_gl_formats(fourcc).ok_or(GlesError::UnknownPixelFormat)?;
+        let bpp = gl_bpp(format, layout).ok_or(GlesError::UnsupportedPixelLayout)? / 8;
 
         let mut pbo = 0;
         let err = unsafe {
             self.gl.GetError(); // clear errors
             self.gl.GenBuffers(1, &mut pbo);
             self.gl.BindBuffer(ffi::PIXEL_PACK_BUFFER, pbo);
-            let bpp = gl_bpp(format, layout).ok_or(GlesError::UnsupportedPixelLayout)? / 8;
             let size = (region.size.w * region.size.h * bpp as i32) as isize;
             self.gl
                 .BufferData(ffi::PIXEL_PACK_BUFFER, size, ptr::null(), ffi::STREAM_DRAW);
@@ -1355,8 +1355,14 @@ impl ExportMem for GlesRenderer {
                 mapping: AtomicPtr::new(ptr::null_mut()),
                 destruction_callback_sender: self.gles_cleanup().sender.clone(),
             }),
-            ffi::INVALID_ENUM | ffi::INVALID_OPERATION => Err(GlesError::UnsupportedPixelFormat(fourcc)),
-            _ => Err(GlesError::UnknownPixelFormat),
+            err => {
+                unsafe { self.gl.DeleteBuffers(1, &pbo) };
+                Err(if matches!(err, ffi::INVALID_ENUM | ffi::INVALID_OPERATION) {
+                    GlesError::UnsupportedPixelFormat(fourcc)
+                } else {
+                    GlesError::UnknownPixelFormat
+                })
+            }
         }
     }
 
@@ -1415,8 +1421,14 @@ impl ExportMem for GlesRenderer {
                 mapping: AtomicPtr::new(ptr::null_mut()),
                 destruction_callback_sender: self.gles_cleanup().sender.clone(),
             }),
-            ffi::INVALID_ENUM | ffi::INVALID_OPERATION => Err(GlesError::UnsupportedPixelFormat(fourcc)),
-            _ => Err(GlesError::UnknownPixelFormat),
+            err => {
+                unsafe { self.gl.DeleteBuffers(1, &pbo) };
+                Err(if matches!(err, ffi::INVALID_ENUM | ffi::INVALID_OPERATION) {
+                    GlesError::UnsupportedPixelFormat(fourcc)
+                } else {
+                    GlesError::UnknownPixelFormat
+                })
+            }
         }
     }
 

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1680,6 +1680,13 @@ struct MultiTextureInternal {
 //  Type erasure just forces us to do this instead.
 unsafe impl Send for MultiTextureInternal {}
 
+#[cfg(feature = "wayland_frontend")]
+pub(crate) fn clear_surface_textures(states: &crate::wayland::compositor::SurfaceData) {
+    if let Some(texture) = states.data_map.get::<Arc<Mutex<MultiTextureInternal>>>() {
+        texture.lock().unwrap().textures.clear();
+    }
+}
+
 type DamageAnyTextureMappings = Vec<(Rectangle<i32, BufferCoords>, Box<dyn Any + 'static>)>;
 
 #[derive(Debug)]

--- a/src/backend/renderer/utils/wayland.rs
+++ b/src/backend/renderer/utils/wayland.rs
@@ -404,6 +404,8 @@ pub fn on_commit_buffer_handler<D: 'static>(surface: &WlSurface) {
                     {
                         state.reset();
                     }
+                    #[cfg(feature = "renderer_multi")]
+                    crate::backend::renderer::multigpu::clear_surface_textures(data);
                 });
             });
         }


### PR DESCRIPTION

## Summary

Five independent fixes to GPU-resource handling, found while tracking a steady
VRAM climb in a multi-output [cosmic-comp](https://github.com/pop-os/cosmic-comp)
session on the proprietary NVIDIA driver. Four close GPU-memory or GL-handle
leaks; one (the shm-damage clamp) is a rendering-correctness fix for a
stale-texture bug surfaced by the same investigation.

The headline fix is the first commit — a thread-affine `UserData` cache that
leaked exported `Dmabuf`s whenever a swapchain slot was exported on one thread
and dropped on another. It dominated the byte count on a dual-output NVIDIA
session.

One residual remains on NVIDIA — VRAM not reclaimed for sampled, cross-process
dmabuf imports — but it reproduces with a standalone program containing no
smithay code, so it is an NVIDIA driver issue, not a smithay bug; none of these
fixes depend on it.

The NVIDIA driver issue has been reported [here](https://forums.developer.nvidia.com/t/bug-report-vram-not-reclaimed-for-sampled-cross-process-dma-buf-imports/374816).

## What's fixed

1. **Thread-affine `UserData` dmabuf cache** — `Slot::export` caches the exported
   `Dmabuf` in the slot's `UserDataMap` via `insert_if_missing`, which stamps it
   with the creating thread's id; `UserData::drop` then runs the destructor only
   on that thread and silently skips it on any other (to avoid dropping `!Send`
   data off-thread). So a slot exported on the main renderer during a reconfigure
   but dropped on a per-output thread never decrements its `Dmabuf`'s `Arc`,
   pinning the GBM buffer for the process lifetime — GPU memory that grows across
   output reconfigures. `Dmabuf` is `Send + Sync` (and `GbmFramebuffer`'s `Drop`
   is thread-safe), so cache both with `insert_if_missing_threadsafe`; the sibling
   framebuffer cache in `compositor` already does.
2. **PBO leak on `ExportMem` error paths** — `copy_framebuffer` / `copy_texture`
   allocate a `PIXEL_PACK_BUFFER` but build the owning `GlesMapping` (which frees
   it on `Drop`) only on the success path, so every failed readback leaks a
   region-sized GL buffer. Free the buffer on the error branches, and compute
   bytes-per-pixel before allocating it so an early return cannot leak it either.
3. **Stale shm damage not clamped (correctness, not a leak)** — `damage_since()`
   unions damage rectangles across commits, clamping each only to the buffer of
   the commit it came from; when a client shrinks its shm buffer (e.g. a cursor
   surface re-rendered after a fractional-scale change) the stale larger rects
   reach `TexSubImage2D`, which rejects the whole upload with `GL_INVALID_VALUE`
   and leaves the previous texture contents visible. Intersect each accumulated
   rect with the current buffer size before uploading.
4. **Multi-GPU per-surface texture cache** — `MultiRenderer` caches imported
   client textures per surface in `MultiTextureInternal` (in the surface
   `data_map`), holding their `GlesTexture`s and `EGLImage`s, but unlike
   `RendererSurfaceState` it had no destruction cleanup, so they outlived the
   surface until the last `WlSurface` reference dropped. Add `clear_surface_textures`
   and call it from the surface-destruction hook in `on_commit_buffer_handler`,
   mirroring `RendererSurfaceState`.
5. **Orphaned `EGLImage` on import failure** — `import_dmabuf` creates an
   `EGLImage` with `create_image_from_dmabuf`, then binds it with
   `import_egl_image`; if the bind errors, the image is dropped without any
   `GlesTexture` owning it, so it is never queued for `DestroyImageKHR` (and on
   drivers that back each import with a GPU allocation, the memory leaks too).
   Route the orphan through the same deferred-destruction queue a `GlesTexture`
   uses on drop. Defensive: the error path was not observed in our sessions, so
   normal operation is unchanged.

## Testing

Diagnosed and verified on a dual-output session running the proprietary NVIDIA
driver (595.71.05), using a SIGUSR1 GL-resource census plus the dma-buf debugfs
inventory:

- **Fix 1** dominates the byte count. The main renderer exports slots during
  `apply_config` while per-output threads drop them; with the fix the compositor's
  dma-buf inventory dropped from ~635 MiB to ~196 MiB and its per-process GPU
  memory from 234 MiB to 178 MiB. Orphaned render-target `Dmabuf`s no longer
  accumulate across monitor power-cycles.
- **Fix 3** eliminated the `GL_INVALID_VALUE` errors that appeared when moving the
  pointer between outputs of different scales (cursor buffer shrinking between
  commits); the cursor now updates correctly.
- **Fixes 2, 4, 5** are verified by inspection and compile cleanly. 2 and 5 close
  leaks on error paths; 4 closes a leak confirmed by the census (multi-GPU
  per-surface textures no longer outlive their surface).

Both the compositor and a matching instrumented build of this library were
tracked — census registries for swapchain slots, `Dmabuf` clones, and `EGLImage`
lifetimes — and over a continuous 3-day census every leak the instrumentation
surfaced read zero or bounded (GL objects all `created == destroyed`, every
cleanup queue drained). The only residual is an NVIDIA driver-side VRAM pool that
reproduces with no compositor code. 

## AI assistance

Per Smithay's [AI policy](https://github.com/Smithay/smithay/blob/master/AI.md),
use of AI assistance (Claude Code) is disclosed in every commit message. The
author understands each change in full and can respond to review.

## Checklist

* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
