### PR TITLE
gles: Early fail dmabuf binding for external formats

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1467,6 +1467,9 @@ impl Bind<Dmabuf> for GlesRenderer {
     fn bind<'a>(&mut self, dmabuf: &'a mut Dmabuf) -> Result<GlesTarget<'a>, GlesError> {
         let mut bind = |dmabuf: &'a mut Dmabuf| {
             let texture = self.import_dmabuf(dmabuf, None)?;
+            if texture.0.is_external {
+                return Err(GlesError::FramebufferBindingError);
+            }
             self.bind_texture(&texture)
                 // SAFETY: The lifetime of the target only depends on the dmabuf,
                 // as the GlesTexture is cloned internally.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

https://github.com/Smithay/smithay/pull/2054 simplified our `Bind::<Dmabuf>` code path for GL ES by reusing the code to bind textures, however we can fail early, if the texture ends up being `external`, as we already know that binding to an FBO will fail in that case.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
