### PR TITLE
renderer/multigpu: Allow disabling cross-device dmabuf exports

### DIFF
--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -732,6 +732,13 @@ pub trait ApiDevice: fmt::Debug {
     /// Returns whether the underlying renderer can in principle do cross-device imports.
     /// (With no guarantee on being able to import a specific buffer.)
     fn can_do_cross_device_imports(&self) -> bool;
+
+    /// Returns whether the [`MultiRenderer`] should attempt exporting buffers from this
+    /// device to other devices. By default this always returns `true`, but can be used
+    /// to implement quirks for buggy hardware.
+    fn should_do_cross_device_exports(&self) -> bool {
+        true
+    }
 }
 
 /// Renderer, that transparently copies rendering results to another gpu,
@@ -1370,7 +1377,7 @@ where
     <<R::Device as ApiDevice>::Renderer as RendererSuper>::Error: 'static,
     <<T::Device as ApiDevice>::Renderer as RendererSuper>::Error: 'static,
 {
-    if !target.device.can_do_cross_device_imports() {
+    if !target.device.can_do_cross_device_imports() || !src.should_do_cross_device_exports() {
         return Err(Error::ImportFailed);
     }
 
@@ -2339,7 +2346,7 @@ where
 {
     if target
         .as_ref()
-        .is_some_and(|target| !target.can_do_cross_device_imports())
+        .is_some_and(|target| !target.can_do_cross_device_imports() || !src.should_do_cross_device_exports())
     {
         return Err(Error::ImportFailed);
     }


### PR DESCRIPTION
This is useful for downstream to implement quirks in the compositor similar to https://github.com/pop-os/cosmic-workspaces-epoch/pull/218.

## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
