### PR TITLE
gles: Disable unrelated scissor test for `BlitFrame::blit_to`

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -1624,7 +1624,13 @@ impl<'buffer> BlitFrame<GlesTarget<'buffer>> for GlesFrame<'_, '_> {
         dst: Rectangle<i32, Physical>,
         filter: TextureFilter,
     ) -> Result<SyncPoint, Self::Error> {
+        unsafe {
+            self.renderer.gl.Disable(ffi::SCISSOR_TEST);
+        }
         let res = self.renderer.blit(self.target, to, src, dst, filter);
+        unsafe {
+            self.renderer.gl.Enable(ffi::SCISSOR_TEST);
+        }
         self.target
             .0
             .make_current(&self.renderer.gl, &self.renderer.egl)?;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

I debugged this for waaay longer, than I want to admit. I suspected some geometry calculation mistake would explain, why my blur region was weirdly limited to what seemed to be an absolute of the output's resolution. Turns out, since a frame enables `SCISSOR_TEST` with the limits of the framebuffer for performance reasons, `BlitFrame::blit_to` has the bounds of the **source**-framebuffer active during the blit. So `BlitFrame::blit_from` and of course `Blit::blit` were totally fine, just this function had this weird limitation.

Lets fix this in the struct that conceptionally owns the `SCISSOR_TEST`-state, the `GlesFrame`, which enables it on creation and disables it on drop.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
