### PR TITLE
xwayland/xwm: Don't error when setting primary output if already set

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1440,8 +1440,8 @@ impl X11Wm {
                     let cookie = self.conn.randr_set_output_primary(self.screen.root, output_xid)?;
                     self.sequences_to_ignore
                         .push(Reverse(cookie.sequence_number() as u16));
-                    return Ok(());
                 }
+                return Ok(());
             }
         }
 


### PR DESCRIPTION
## Description
Currently if setting output to already primary output set_randr_primary_output returns `Err(PrimaryOutputError::OutputUnknown)`.
Changed it to return `Ok(())` without any extra work.

## Checklist
* [X] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
