### PR TITLE
xwayland/xwm: Fix missing WM_STATE update on Unmap

### DIFF
--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1855,6 +1855,13 @@ where
                         if let Some(frame) = state.mapped_onto.take() {
                             conn.destroy_window(frame)?;
                         }
+                        conn.change_property32(
+                            PropMode::REPLACE,
+                            n.window,
+                            xwm.atoms.WM_STATE,
+                            xwm.atoms.WM_STATE,
+                            &[0 /*WithdrawnState*/, 0 /*WINDOW_NONE*/],
+                        )?;
                     }
                 }
                 drop(_guard);


### PR DESCRIPTION
## Description
WM_STATE was never set to WithdrawnState after root window was unmaped.
This was found as wine's x11drv expect this to be set and games wait on that signal to map the window again(and thus would leave the game rendering in the background, invisible).
ref: https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.3.1

## Checklist
* [X] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
