### PR TITLE
define Yuv420 and Nv12 formats

### DIFF
--- a/src/backend/allocator/format.rs
+++ b/src/backend/allocator/format.rs
@@ -363,8 +363,10 @@ format_tables! {
     // RGBA with 10-bit components packed in 64-bits per pixel, with 6-bits of unused padding per component
 
     // Axbxgxrx106106106106 has no direct non-alpha alternative.
-    Axbxgxrx106106106106 { alpha: true, bpp: 64, depth: 40 }
+    Axbxgxrx106106106106 { alpha: true, bpp: 64, depth: 40 },
 
+    Yuv420 {alpha: false, bpp: 12, depth: 12 },
+    Nv12 {alpha: false, bpp: 12, depth: 12 }
     // TODO: YUV and other formats
 }
 


### PR DESCRIPTION
use case:
application can advertise to the wayland client that it supports these formats. and can create shaders to convert dmabufs or shared memory buffers into RGBA formats

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
