### PR TITLE
Make ClickGrab's motion focus better when the surface has moved

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -137,7 +137,10 @@ use self::{
     pointer::{CursorImageStatus, PointerHandle, PointerTarget},
     touch::TouchGrab,
 };
-use crate::utils::{Serial, user_data::UserDataMap};
+use crate::{
+    input::pointer::{ClickGrab, GrabStartData as PointerGrabStartData, PointerGrab},
+    utils::{Serial, user_data::UserDataMap},
+};
 
 pub mod dnd;
 pub mod keyboard;
@@ -145,7 +148,7 @@ pub mod pointer;
 pub mod touch;
 
 /// Handler trait for Seats
-pub trait SeatHandler: Sized {
+pub trait SeatHandler: Sized + 'static {
     /// Type used to represent the target currently holding the keyboard focus
     type KeyboardFocus: KeyboardTarget<Self> + PartialEq + Clone + 'static;
     /// Type used to represent the target currently holding the pointer focus
@@ -164,6 +167,15 @@ pub trait SeatHandler: Sized {
 
     /// Callback that will be notified whenever the keyboard led state changes.
     fn led_state_changed(&mut self, _seat: &Seat<Self>, _led_state: LedState) {}
+
+    /// Provides the implicit pointer grab for clicks
+    ///
+    /// When the user presses a pointer button, an implicit pointer grab is installed. If your
+    /// compositor needs custom behavior for this grab, you can implement this trait item and
+    /// return your own [`PointerGrab`] implementation.
+    fn click_grab(&mut self, start_data: PointerGrabStartData<Self>) -> impl PointerGrab<Self> {
+        ClickGrab::new(start_data)
+    }
 }
 /// Delegate type for all [Seat] globals.
 ///

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -244,6 +244,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
                         button: event.button,
                         location: handle.current_location(),
                     },
+                    focus: handle.current_focus(),
                 },
             );
         }
@@ -343,6 +344,7 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
 /// the grab once all are released.
 pub struct ClickGrab<D: SeatHandler> {
     start_data: GrabStartData<D>,
+    focus: Option<(D::PointerFocus, Point<f64, Logical>)>,
 }
 
 impl<D: SeatHandler + 'static> fmt::Debug for ClickGrab<D> {
@@ -361,11 +363,14 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
         focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
-        let focus = match (&focus, &self.start_data.focus) {
-            (Some((current, loc)), Some((start, _))) if current == start => Some((current.clone(), *loc)),
-            _ => self.start_data.focus.clone(),
-        };
-        handle.motion(data, focus, event);
+        if let (Some((new_target, new_location)), Some((grab_target, grab_location))) =
+            (&focus, self.focus.as_mut())
+        {
+            if *new_target == *grab_target {
+                *grab_location = *new_location;
+            }
+        }
+        handle.motion(data, self.focus.clone(), event);
     }
 
     fn relative_motion(

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -358,10 +358,14 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for ClickGrab<D> {
         &mut self,
         data: &mut D,
         handle: &mut PointerInnerHandle<'_, D>,
-        _focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
+        focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
-        handle.motion(data, self.start_data.focus.clone(), event);
+        let focus = match (&focus, &self.start_data.focus) {
+            (Some((current, loc)), Some((start, _))) if current == start => Some((current.clone(), *loc)),
+            _ => self.start_data.focus.clone(),
+        };
+        handle.motion(data, focus, event);
     }
 
     fn relative_motion(

--- a/src/input/pointer/grab.rs
+++ b/src/input/pointer/grab.rs
@@ -233,20 +233,12 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
     fn button(&mut self, data: &mut D, handle: &mut PointerInnerHandle<'_, D>, event: &ButtonEvent) {
         handle.button(data, event);
         if event.state == ButtonState::Pressed {
-            handle.set_grab(
-                self,
-                data,
-                event.serial,
-                Focus::Keep,
-                ClickGrab {
-                    start_data: GrabStartData {
-                        focus: handle.current_focus(),
-                        button: event.button,
-                        location: handle.current_location(),
-                    },
-                    focus: handle.current_focus(),
-                },
-            );
+            let grab = data.click_grab(GrabStartData {
+                focus: handle.current_focus(),
+                button: event.button,
+                location: handle.current_location(),
+            });
+            handle.set_grab(self, data, event.serial, Focus::Keep, grab);
         }
     }
 
@@ -345,6 +337,15 @@ impl<D: SeatHandler + 'static> PointerGrab<D> for DefaultGrab {
 pub struct ClickGrab<D: SeatHandler> {
     start_data: GrabStartData<D>,
     focus: Option<(D::PointerFocus, Point<f64, Logical>)>,
+}
+
+impl<D: SeatHandler> ClickGrab<D> {
+    pub(in crate::input) fn new(start_data: GrabStartData<D>) -> Self {
+        Self {
+            focus: start_data.focus.clone(),
+            start_data,
+        }
+    }
 }
 
 impl<D: SeatHandler + 'static> fmt::Debug for ClickGrab<D> {


### PR DESCRIPTION
## Description

If the focus target has moved since the grab has started, the focus
parameter in the start data will be out of date, and motion events will
be sent relative to the old/original position of the surface.

We ran into this with xfce4-panel's move code.  It's a layer-shell
surface, and when the user grabs the move handle and drags, it moves
itself by watching pointer motion events and calculating the diff from
the previous position, and then updating its margins.

With the motion events delivered with respect to the start data's focus
position, the panel move goes wild, because it is (unknowingly)
recomputing its margins based on the cumulative difference in the
pointer's location, rather than the diff.

I've broken this into three commits, because the first may be less objectionable than the second, which may be less objectionable than the third, even though the third is the only one that truly fixes the problem.

The first commit prefers the coordinates in the `focus` param to the function over that in `start_data.focus`.  This helps, but if the user moves the pointer fast enough that it's outside the focus target for any length of time, it has to go back to the start data, which again causes problems.

The second commit stores the last-known focus (that matches the target of the start focus) in `ClickGrab`, and when the `focus` param to the function is `None`, it falls back to the stored location.  While this is better, honestly it still doesn't behave very well in my testing; it's still very easy to get the panel to start moving wildly around the screen, completely divorced from the pointer's position (though it *is* a bit easier to carefully get the pointer back on top of the panel to fix the situation).

The third commit is the real fix: I've added an optional hook to `SeatHandler` to allow `ClickGrab` to ask the compositor the current location of the `PointerFocus`.  I'm not quite sure about the API here, if that's a reasonable place to put it, but this does completely fix the issue for me, at least.

Anyhow, happy to make any changes, and/or squash things down to whatever solution y'all feel is the correct one.  I looked at labwc and wayfire, and this is how they both work in the face of moving surfaces during an implicit pointer grab.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
