### PR TITLE
dmabuf: expose and preserve buffer flags

### DIFF
--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -231,6 +231,8 @@ impl Dmabuf {
     }
 
     /// Returns the flags stored on this buffer without interpreting them.
+    ///
+    /// Bits unknown to this Smithay version are retained.
     pub fn flags(&self) -> DmabufFlags {
         self.0.flags
     }

--- a/src/backend/allocator/dmabuf.rs
+++ b/src/backend/allocator/dmabuf.rs
@@ -230,6 +230,11 @@ impl Dmabuf {
         self.0.modifier != Modifier::Invalid && self.0.modifier != Modifier::Linear
     }
 
+    /// Returns the flags stored on this buffer without interpreting them.
+    pub fn flags(&self) -> DmabufFlags {
+        self.0.flags
+    }
+
     /// Returns if the buffer is stored inverted on the y-axis
     pub fn y_inverted(&self) -> bool {
         self.0.flags.contains(DmabufFlags::Y_INVERT)

--- a/src/wayland/dmabuf/mod.rs
+++ b/src/wayland/dmabuf/mod.rs
@@ -222,6 +222,10 @@ use crate::{
 
 use super::{buffer::BufferHandler, compositor};
 
+fn dmabuf_flags_from_wire(raw: u32) -> DmabufFlags {
+    DmabufFlags::from_bits_retain(raw)
+}
+
 #[derive(Debug, Clone, PartialEq)]
 struct DmabufFeedbackTranche {
     target_device: libc::dev_t,
@@ -1142,7 +1146,7 @@ impl DmabufParamsData {
             (width, height),
             format,
             modifier,
-            DmabufFlags::from_bits_truncate(flags.into()),
+            dmabuf_flags_from_wire(flags.into()),
         );
 
         planes.sort_by_key(|plane| plane.plane_idx);


### PR DESCRIPTION
## Description
Expose `DmabufFlags` in the backend and preserve unknown flags received via the linux-dmabuf protocol.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
