### PR TITLE
ci: Deply docs using `deploy-pages` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,10 +421,15 @@ jobs:
             - name: Setup index
               run: cp ./doc_index.html ./target/doc/index.html
 
-            - name: Deploy
-              if: ${{ github.event_name == 'push' }}
-              uses: peaceiris/actions-gh-pages@v3
+            - name: Upload static files as artifact
+              uses: actions/upload-pages-artifact@v3
               with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  publish_dir: ./target/doc
-                  force_orphan: true
+                  path: ./target/doc
+
+            - name: Deploy to GitHub Pages
+              if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master'  }}
+              uses: actions/deploy-pages@v4
+
+permissions:
+  pages: write
+  id-token: write


### PR DESCRIPTION
## Description
This new mechanism of deploying Github Pages does not require pushing to a branch.

I've already updated wayland-rs like this (https://github.com/Smithay/wayland-rs/pull/945), so it should work here too. An admin will need to go to the settings of the repo, and change it to deploy Pages from github actions instead of a branch. Presumably that should be done before merging.

The `gh-pages` branch should then be safe to delete.

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
