### PR TITLE
backend/drm: async page flip (tearing) support for DrmSurface/DrmCompositor

### DIFF
--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -967,6 +967,10 @@ where
 struct QueuedFrame<A: Allocator, F: ExportFramebuffer<<A as Allocator>::Buffer>, U> {
     prepared_frame: PreparedFrame<A, F>,
     user_data: U,
+    /// Whether this specific queued frame should attempt an async (tearing) page flip.
+    /// Scoped to the frame (rather than the compositor) so it cannot leak onto a later,
+    /// unrelated `queue_frame` call.
+    async_flip: bool,
 }
 
 impl<A, F, U> std::fmt::Debug for QueuedFrame<A, F, U>
@@ -981,6 +985,7 @@ where
         f.debug_struct("QueuedFrame")
             .field("prepared_frame", &self.prepared_frame)
             .field("user_data", &self.user_data)
+            .field("async_flip", &self.async_flip)
             .finish()
     }
 }
@@ -1067,7 +1072,6 @@ where
     primary_plane_damage_bag: DamageBag<i32, BufferCoords>,
     supports_fencing: bool,
     reset_pending: bool,
-    pending_async_flip: bool,
     signaled_fence: Option<Arc<OwnedFd>>,
 
     framebuffer_exporter: F,
@@ -1254,7 +1258,6 @@ where
                         primary_plane_damage_bag: DamageBag::new(4),
                         primary_is_opaque: is_opaque,
                         reset_pending: true,
-                        pending_async_flip: false,
                         signaled_fence,
                         current_frame,
                         pending_frame: None,
@@ -1437,7 +1440,6 @@ where
             primary_plane_damage_bag: DamageBag::new(4),
             primary_is_opaque: is_opaque,
             reset_pending: true,
-            pending_async_flip: false,
             signaled_fence,
             current_frame,
             pending_frame: None,
@@ -2436,15 +2438,14 @@ where
     /// driver to perform an asynchronous page flip for this frame, which may present it
     /// immediately (potentially tearing) instead of waiting for the next vblank. If the
     /// driver rejects the async flip (e.g. `EINVAL`/`EBUSY` because it is not supported
-    /// for the current configuration), the same frame is automatically retried once as a
-    /// regular synchronous flip, so this call still succeeds/fails exactly as
-    /// [`DrmCompositor::queue_frame`] would. Any other flags are ignored.
+    /// for the current configuration), this specific frame is automatically retried once
+    /// as a regular synchronous flip. The request is scoped to this single frame only and
+    /// never affects any other queued frame. Any other flags are ignored.
     ///
     /// See [`DrmCompositor::queue_frame`] for the general semantics of queuing a frame.
-    #[profiling::function]
     pub fn queue_frame_with_flags(&mut self, user_data: U, flags: FrameFlags) -> FrameResult<(), A, F> {
-        self.pending_async_flip = flags.contains(FrameFlags::ALLOW_ASYNC_PAGE_FLIP);
-        self.queue_frame(user_data)
+        let async_flip = flags.contains(FrameFlags::ALLOW_ASYNC_PAGE_FLIP);
+        self.queue_frame_internal(user_data, async_flip)
     }
 
     /// Queues the current frame for scan-out.
@@ -2463,8 +2464,12 @@ where
     /// Otherwise the underlying swapchain will eventually run out of buffers.
     ///
     /// `user_data` can be used to attach some data to a specific buffer and later retrieved with [`DrmCompositor::frame_submitted`]
-    #[profiling::function]
     pub fn queue_frame(&mut self, user_data: U) -> FrameResult<(), A, F> {
+        self.queue_frame_internal(user_data, false)
+    }
+
+    #[profiling::function]
+    fn queue_frame_internal(&mut self, user_data: U, async_flip: bool) -> FrameResult<(), A, F> {
         if !self.surface.is_active() {
             return Err(FrameErrorType::<A, F>::DrmError(DrmError::DeviceInactive));
         }
@@ -2490,6 +2495,7 @@ where
         self.queued_frame = Some(QueuedFrame {
             prepared_frame,
             user_data,
+            async_flip,
         });
         if self.pending_frame.is_none() {
             self.submit()?;
@@ -2568,13 +2574,8 @@ where
         let QueuedFrame {
             mut prepared_frame,
             user_data,
+            async_flip,
         } = self.queued_frame.take().unwrap();
-
-        // Consume the pending async-flip request for this submit attempt. Reset
-        // unconditionally so a rejected/retried or failed attempt never leaks the
-        // request into a later, unrelated submit.
-        let async_flip = self.pending_async_flip;
-        self.pending_async_flip = false;
 
         let allow_partial_update = prepared_frame.kind == PreparedFrameKind::Partial;
         let flip = if self.surface.commit_pending() {

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1093,6 +1093,10 @@ where
 
     debug_flags: DebugFlags,
     span: tracing::Span,
+
+    /// Set once the first async page-flip rejection has been logged at
+    /// `info!` level, so subsequent rejections fall back to `debug!`.
+    async_flip_rejection_logged: bool,
 }
 
 impl<A, F, U, G> DrmCompositor<A, F, U, G>
@@ -1279,6 +1283,7 @@ where
                         supports_fencing,
                         debug_flags: DebugFlags::empty(),
                         span,
+                        async_flip_rejection_logged: false,
                     };
 
                     return Ok(drm_renderer);
@@ -1461,6 +1466,7 @@ where
             supports_fencing,
             debug_flags: DebugFlags::empty(),
             span,
+            async_flip_rejection_logged: false,
         };
 
         Ok(drm_renderer)
@@ -2593,7 +2599,14 @@ where
 
             match flip {
                 Err(ref err) if async_flip && Self::is_async_flip_rejected(err) => {
-                    tracing::debug!("async_flip_rejected, retried synchronously");
+                    if !self.async_flip_rejection_logged {
+                        self.async_flip_rejection_logged = true;
+                        tracing::info!(
+                            "async page flip rejected by driver, retried synchronously (further rejections logged at debug)"
+                        );
+                    } else {
+                        tracing::debug!("async_flip_rejected, retried synchronously");
+                    }
                     prepared_frame.frame.page_flip(
                         &self.surface,
                         self.supports_fencing,

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -750,11 +750,13 @@ impl<B: Buffer, F: Framebuffer> FrameState<B, F> {
         supports_fencing: bool,
         allow_partial_update: bool,
         event: bool,
+        async_flip: bool,
     ) -> Result<(), crate::backend::drm::error::Error> {
         debug_assert!(!self.planes.iter().any(|(_, state)| state.needs_test));
         surface.page_flip(
             self.build_planes(surface, supports_fencing, allow_partial_update),
             event,
+            async_flip,
         )
     }
 
@@ -2552,7 +2554,7 @@ where
         } else {
             prepared_frame
                 .frame
-                .page_flip(&self.surface, self.supports_fencing, allow_partial_update, true)
+                .page_flip(&self.surface, self.supports_fencing, allow_partial_update, true, false)
         };
 
         let res = self.handle_flip(&prepared_frame, flip);

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -1036,6 +1036,9 @@ bitflags::bitflags! {
         const ALLOW_CURSOR_PLANE_SCANOUT = 8;
         /// Return `EmptyFrame`, if only the cursor plane would have been updated
         const SKIP_CURSOR_ONLY_UPDATES = 16;
+        /// Attempt to present this frame with an async (tearing) page flip.
+        /// Falls back to a synchronous flip if the driver rejects it.
+        const ALLOW_ASYNC_PAGE_FLIP = 32;
         /// Allow to realize the frame by assigning elements on any plane
         const ALLOW_SCANOUT = Self::ALLOW_PRIMARY_PLANE_SCANOUT.bits() | Self::ALLOW_OVERLAY_PLANE_SCANOUT.bits() | Self::ALLOW_CURSOR_PLANE_SCANOUT.bits();
         /// Safe default set of flags
@@ -1064,6 +1067,7 @@ where
     primary_plane_damage_bag: DamageBag<i32, BufferCoords>,
     supports_fencing: bool,
     reset_pending: bool,
+    pending_async_flip: bool,
     signaled_fence: Option<Arc<OwnedFd>>,
 
     framebuffer_exporter: F,
@@ -1250,6 +1254,7 @@ where
                         primary_plane_damage_bag: DamageBag::new(4),
                         primary_is_opaque: is_opaque,
                         reset_pending: true,
+                        pending_async_flip: false,
                         signaled_fence,
                         current_frame,
                         pending_frame: None,
@@ -1432,6 +1437,7 @@ where
             primary_plane_damage_bag: DamageBag::new(4),
             primary_is_opaque: is_opaque,
             reset_pending: true,
+            pending_async_flip: false,
             signaled_fence,
             current_frame,
             pending_frame: None,
@@ -2423,6 +2429,24 @@ where
         Ok(frame_reference)
     }
 
+    /// Queues the current frame for scan-out, optionally requesting an async (tearing)
+    /// page flip via [`FrameFlags::ALLOW_ASYNC_PAGE_FLIP`].
+    ///
+    /// When [`FrameFlags::ALLOW_ASYNC_PAGE_FLIP`] is set, the compositor will ask the
+    /// driver to perform an asynchronous page flip for this frame, which may present it
+    /// immediately (potentially tearing) instead of waiting for the next vblank. If the
+    /// driver rejects the async flip (e.g. `EINVAL`/`EBUSY` because it is not supported
+    /// for the current configuration), the same frame is automatically retried once as a
+    /// regular synchronous flip, so this call still succeeds/fails exactly as
+    /// [`DrmCompositor::queue_frame`] would. Any other flags are ignored.
+    ///
+    /// See [`DrmCompositor::queue_frame`] for the general semantics of queuing a frame.
+    #[profiling::function]
+    pub fn queue_frame_with_flags(&mut self, user_data: U, flags: FrameFlags) -> FrameResult<(), A, F> {
+        self.pending_async_flip = flags.contains(FrameFlags::ALLOW_ASYNC_PAGE_FLIP);
+        self.queue_frame(user_data)
+    }
+
     /// Queues the current frame for scan-out.
     ///
     /// If `render_frame` has not been called prior to this function or returned no damage
@@ -2546,15 +2570,39 @@ where
             user_data,
         } = self.queued_frame.take().unwrap();
 
+        // Consume the pending async-flip request for this submit attempt. Reset
+        // unconditionally so a rejected/retried or failed attempt never leaks the
+        // request into a later, unrelated submit.
+        let async_flip = self.pending_async_flip;
+        self.pending_async_flip = false;
+
         let allow_partial_update = prepared_frame.kind == PreparedFrameKind::Partial;
         let flip = if self.surface.commit_pending() {
             prepared_frame
                 .frame
                 .commit(&self.surface, self.supports_fencing, allow_partial_update, true)
         } else {
-            prepared_frame
-                .frame
-                .page_flip(&self.surface, self.supports_fencing, allow_partial_update, true, false)
+            let flip = prepared_frame.frame.page_flip(
+                &self.surface,
+                self.supports_fencing,
+                allow_partial_update,
+                true,
+                async_flip,
+            );
+
+            match flip {
+                Err(ref err) if async_flip && Self::is_async_flip_rejected(err) => {
+                    tracing::debug!("async_flip_rejected, retried synchronously");
+                    prepared_frame.frame.page_flip(
+                        &self.surface,
+                        self.supports_fencing,
+                        allow_partial_update,
+                        true,
+                        false,
+                    )
+                }
+                other => other,
+            }
         };
 
         let res = self.handle_flip(&prepared_frame, flip);
@@ -2567,6 +2615,18 @@ where
         }
 
         res
+    }
+
+    /// Returns `true` if `err` indicates the driver rejected an async (tearing) page
+    /// flip specifically (as opposed to any other commit failure), meaning a synchronous
+    /// retry of the same frame is worth attempting.
+    fn is_async_flip_rejected(err: &crate::backend::drm::error::Error) -> bool {
+        matches!(
+            err,
+            crate::backend::drm::error::Error::Access(access)
+                if access.source.kind() == ErrorKind::InvalidInput
+                    || rustix::io::Errno::from_io_error(&access.source) == Some(rustix::io::Errno::BUSY)
+        )
     }
 
     fn handle_flip(

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -2601,7 +2601,7 @@ where
                 Err(ref err) if async_flip && Self::is_async_flip_rejected(err) => {
                     if !self.async_flip_rejection_logged {
                         self.async_flip_rejection_logged = true;
-                        tracing::info!(
+                        tracing::warn!(
                             "async page flip rejected by driver, retried synchronously (further rejections logged at debug)"
                         );
                     } else {

--- a/src/backend/drm/surface/atomic.rs
+++ b/src/backend/drm/surface/atomic.rs
@@ -869,6 +869,7 @@ impl AtomicDrmSurface {
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,
         event: bool,
+        async_flip: bool,
     ) -> Result<(), Error> {
         if !self.active.load(Ordering::SeqCst) {
             return Err(Error::DeviceInactive);
@@ -896,10 +897,16 @@ impl AtomicDrmSurface {
         let res = self
             .fd
             .atomic_commit(
-                if event {
-                    AtomicCommitFlags::PAGE_FLIP_EVENT | AtomicCommitFlags::NONBLOCK
-                } else {
-                    AtomicCommitFlags::NONBLOCK
+                {
+                    let mut flags = if event {
+                        AtomicCommitFlags::PAGE_FLIP_EVENT | AtomicCommitFlags::NONBLOCK
+                    } else {
+                        AtomicCommitFlags::NONBLOCK
+                    };
+                    if async_flip {
+                        flags |= AtomicCommitFlags::PAGE_FLIP_ASYNC;
+                    }
+                    flags
                 },
                 req.build()?,
             )

--- a/src/backend/drm/surface/gbm.rs
+++ b/src/backend/drm/surface/gbm.rs
@@ -398,7 +398,7 @@ where
         let flip = if self.drm.commit_pending() {
             self.drm.commit([plane_state], true)
         } else {
-            self.drm.page_flip([plane_state], true)
+            self.drm.page_flip([plane_state], true, false)
         };
         if flip.is_ok() {
             self.pending_fb = Some((slot, user_data));

--- a/src/backend/drm/surface/legacy.rs
+++ b/src/backend/drm/surface/legacy.rs
@@ -331,6 +331,7 @@ impl LegacyDrmSurface {
         Ok(())
     }
 
+    // legacy KMS has no async flip support here; tearing is atomic-only (MVP)
     #[instrument(level = "trace", parent = &self.span, skip(self))]
     #[profiling::function]
     pub fn page_flip(&self, framebuffer: framebuffer::Handle, event: bool) -> Result<(), Error> {

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -426,6 +426,11 @@ impl DrmSurface {
     ///
     /// This operation is not blocking and will produce a `vblank` event once swapping is done.
     /// Make sure to have the device registered in your event loop to not miss the event.
+    ///
+    /// If `async_flip` is `true`, an async (tearing) page flip is requested via
+    /// `DRM_MODE_PAGE_FLIP_ASYNC`: the new framebuffer is presented immediately, without
+    /// waiting for the next vblank. This only applies to atomic surfaces; legacy surfaces
+    /// silently ignore this flag.
     #[profiling::function]
     pub fn page_flip<'a>(
         &self,

--- a/src/backend/drm/surface/mod.rs
+++ b/src/backend/drm/surface/mod.rs
@@ -431,11 +431,13 @@ impl DrmSurface {
         &self,
         planes: impl IntoIterator<Item = PlaneState<'a>>,
         event: bool,
+        async_flip: bool,
     ) -> Result<(), Error> {
         match &*self.internal {
-            DrmSurfaceInternal::Atomic(surf) => surf.page_flip(planes, event),
+            DrmSurfaceInternal::Atomic(surf) => surf.page_flip(planes, event, async_flip),
             DrmSurfaceInternal::Legacy(surf) => {
                 let fb = ensure_legacy_planes(self, planes)?;
+                // legacy KMS has no async flip support here; tearing is atomic-only (MVP)
                 surf.page_flip(fb, event)
             }
         }


### PR DESCRIPTION
## What

Adds async page flip (tearing) support to the DRM backend:

- `DrmSurface::page_flip(planes, event, async_flip)` — when `async_flip` is true on an atomic surface, the commit carries `DRM_MODE_PAGE_FLIP_ASYNC` (presented immediately, no vblank wait). Legacy surfaces currently ignore the flag (documented).
- `FrameFlags::ALLOW_ASYNC_PAGE_FLIP` + `DrmCompositor::queue_frame_with_flags(user_data, flags)` — async intent is scoped to the specific queued frame (carried in `QueuedFrame`, so deferred submits and interleaved plain `queue_frame` calls can never inherit a stale flag).
- Driver rejection (EINVAL/EBUSY) is retried once synchronously in the same submit — callers degrade to normal vsync behavior with no state divergence; first rejection is logged.

The existing `queue_frame` API and all default paths are behavior-identical (flag threading only, `false` everywhere).

## Why

Compositors need this to implement `wp_tearing_control_v1`. Smithay currently offers no path to `DRM_MODE_PAGE_FLIP_ASYNC` — `NONBLOCK` commits are still vblank-aligned.

## Validation

Consumed by a cosmic-comp branch implementing tearing-control (PR linked in comments). End-to-end on real hardware (i915 eDP scanout, kernel 7.x, `DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP=1`): fullscreen Vulkan client at 240fps on a 144Hz panel with visible tearing, zero rejected flips over extended play; with the feature unused, behavior is byte-identical to before (verified by review of the flag paths and by an unmodified consumer compiling and running unchanged).

## Open questions (draft status)

- No capability gating yet: callers can request async on hardware without `DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP`; today that costs one rejected ioctl + sync retry per frame. Should `DrmSurface`/`DrmCompositor` expose the cap (and/or refuse early)?
- `queue_frame_with_flags` accepts full `FrameFlags` but only honors `ALLOW_ASYNC_PAGE_FLIP` — happy to reshape (dedicated parameter/type) to taste.
- Rejection outcome is not surfaced to the caller (only logged). Compositors may want accept/reject counts — worth an API?
- `wp_presentation` feedback still reports `Kind::Vsync` for async-flipped frames; fixing that properly probably belongs in this PR's scope — guidance welcome.
- Legacy KMS also supports `PAGE_FLIP_ASYNC`; currently ignored on the legacy path. Support or hard error?

Implementation was developed with AI assistance and human review/testing on real hardware; happy to iterate per maintainer direction.
