### PR TITLE
[Renderer] Use `Affine2` where possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ atomic_float = "1.1.0"
 sha2 = "0.10.9"
 tracy-client = { version = "0.18.4", default-features = false, optional = true }
 reis = { version = "0.7.0", features = ["calloop"] }
-glam = { version = "0.33.2", default-features = false, features = ["float-types", "std"] }
+glam = { version = "0.33.2", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/benches/geometry.rs
+++ b/benches/geometry.rs
@@ -17,9 +17,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     let max_x = stage.w - element_size.w;
     let max_y = stage.h - element_size.h;
 
-    let mut rand = rand::thread_rng();
-    let x = rand.gen_range(0..max_x);
-    let y = rand.gen_range(0..max_y);
+    let mut rand = rand::rng();
+    let x = rand.random_range(0..max_x);
+    let y = rand.random_range(0..max_y);
     let test_element = Rectangle::new((x, y).into(), element_size);
 
     let x_min = (test_element.loc.x - element_size.w) + 1;
@@ -33,8 +33,8 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let opaque_regions = (0..2048)
         .map(|_| {
-            let x = rand.gen_range(x_min..=x_max);
-            let y = rand.gen_range(y_min..=y_max);
+            let x = rand.random_range(x_min..=x_max);
+            let y = rand.random_range(y_min..=y_max);
             Rectangle::new((x, y).into(), element_size)
         })
         .collect::<Vec<_>>();

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -4,7 +4,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use core::slice;
-use glam::{Mat3, Vec2};
+use glam::{Affine2, Mat3, Vec2};
 use std::{
     collections::HashMap,
     ffi::{CStr, CString},
@@ -2141,8 +2141,8 @@ impl Renderer for GlesRenderer {
 
         // replicate https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glOrtho.xml
         // glOrtho(0, width, 0, height, 1, 1);
-        let mut renderer = Mat3::IDENTITY;
-        let t = Mat3::IDENTITY;
+        let mut renderer = Affine2::IDENTITY;
+        let t = Affine2::IDENTITY;
         let x = 2.0 / (output_size.w as f32);
         let y = 2.0 / (output_size.h as f32);
 
@@ -2157,9 +2157,9 @@ impl Renderer for GlesRenderer {
         renderer.z_axis.y = -(1.0f32.copysign(renderer.x_axis.y + renderer.y_axis.y));
 
         // We account for OpenGLs coordinate system here
-        let flip180 = Mat3::from_cols_array(&[1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0]);
+        let flip180 = Affine2::from_cols_array(&[1.0, 0.0, 0.0, -1.0, 0.0, 0.0]);
 
-        let current_projection = flip180 * transform.matrix() * renderer;
+        let current_projection = (flip180 * transform.matrix() * renderer).into();
         let span = span!(parent: &self.span, Level::DEBUG, "renderer_gles2_frame", current_projection = ?current_projection, size = ?output_size, transform = ?transform).entered();
 
         Ok(GlesFrame {
@@ -3153,38 +3153,38 @@ fn build_texture_mat(
     let dst_src_size = transform.transform_size(src.size);
     let scale = dst_src_size.to_f64() / dest.size.to_f64();
 
-    let mut tex_mat = Mat3::IDENTITY;
+    let mut tex_mat = Affine2::IDENTITY;
 
     // first bring the damage into src scale
-    tex_mat = Mat3::from_scale(Vec2::new(scale.x as f32, scale.y as f32)) * tex_mat;
+    tex_mat = Affine2::from_scale(Vec2::new(scale.x as f32, scale.y as f32)) * tex_mat;
 
     // then compensate for the texture transform
     let transform_mat = transform.matrix();
     let translation = match transform {
-        Transform::Normal => Mat3::IDENTITY,
-        Transform::_90 => Mat3::from_translation(Vec2::new(0f32, dst_src_size.w as f32)),
-        Transform::_180 => Mat3::from_translation(Vec2::new(dst_src_size.w as f32, dst_src_size.h as f32)),
-        Transform::_270 => Mat3::from_translation(Vec2::new(dst_src_size.h as f32, 0f32)),
-        Transform::Flipped => Mat3::from_translation(Vec2::new(dst_src_size.w as f32, 0f32)),
-        Transform::Flipped90 => Mat3::IDENTITY,
-        Transform::Flipped180 => Mat3::from_translation(Vec2::new(0f32, dst_src_size.h as f32)),
+        Transform::Normal => Affine2::IDENTITY,
+        Transform::_90 => Affine2::from_translation(Vec2::new(0f32, dst_src_size.w as f32)),
+        Transform::_180 => Affine2::from_translation(Vec2::new(dst_src_size.w as f32, dst_src_size.h as f32)),
+        Transform::_270 => Affine2::from_translation(Vec2::new(dst_src_size.h as f32, 0f32)),
+        Transform::Flipped => Affine2::from_translation(Vec2::new(dst_src_size.w as f32, 0f32)),
+        Transform::Flipped90 => Affine2::IDENTITY,
+        Transform::Flipped180 => Affine2::from_translation(Vec2::new(0f32, dst_src_size.h as f32)),
         Transform::Flipped270 => {
-            Mat3::from_translation(Vec2::new(dst_src_size.h as f32, dst_src_size.w as f32))
+            Affine2::from_translation(Vec2::new(dst_src_size.h as f32, dst_src_size.w as f32))
         }
     };
     tex_mat = transform_mat * tex_mat;
     tex_mat = translation * tex_mat;
 
     // now we can add the src crop loc, the size already done implicit by the src size
-    tex_mat = Mat3::from_translation(Vec2::new(src.loc.x as f32, src.loc.y as f32)) * tex_mat;
+    tex_mat = Affine2::from_translation(Vec2::new(src.loc.x as f32, src.loc.y as f32)) * tex_mat;
 
     // at last we have to normalize the values for UV space
-    tex_mat = Mat3::from_scale(Vec2::new(
+    tex_mat = Affine2::from_scale(Vec2::new(
         (1.0f64 / texture.w as f64) as f32,
         (1.0f64 / texture.h as f64) as f32,
     )) * tex_mat;
 
-    tex_mat
+    tex_mat.into()
 }
 
 /// Guard type wrapping the underlying [`GlesRenderer`] of a [`GlesFrame`].

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -8,7 +8,7 @@
 //! - Raw OpenGL ES 2
 
 use crate::utils::{Buffer as BufferCoord, Physical, Point, Rectangle, Scale, Size, Transform, ids::id_gen};
-use glam::Mat3;
+use glam::Affine2;
 use std::{
     any::TypeId,
     cmp::Ordering,
@@ -179,16 +179,16 @@ pub enum TextureFilter {
 impl Transform {
     /// A projection matrix to apply this transformation
     #[inline]
-    pub fn matrix(&self) -> Mat3 {
+    pub fn matrix(&self) -> Affine2 {
         match self {
-            Transform::Normal => Mat3::from_cols_array(&[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]),
-            Transform::_90 => Mat3::from_cols_array(&[0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
-            Transform::_180 => Mat3::from_cols_array(&[-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0]),
-            Transform::_270 => Mat3::from_cols_array(&[0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
-            Transform::Flipped => Mat3::from_cols_array(&[-1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]),
-            Transform::Flipped90 => Mat3::from_cols_array(&[0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
-            Transform::Flipped180 => Mat3::from_cols_array(&[1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0]),
-            Transform::Flipped270 => Mat3::from_cols_array(&[0.0, -1.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
+            Transform::Normal => Affine2::IDENTITY,
+            Transform::_90 => Affine2::from_cols_array(&[0.0, -1.0, 1.0, 0.0, 0.0, 0.0]),
+            Transform::_180 => Affine2::from_cols_array(&[-1.0, 0.0, 0.0, -1.0, 0.0, 0.0]),
+            Transform::_270 => Affine2::from_cols_array(&[0.0, 1.0, -1.0, 0.0, 0.0, 0.0]),
+            Transform::Flipped => Affine2::from_cols_array(&[-1.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
+            Transform::Flipped90 => Affine2::from_cols_array(&[0.0, 1.0, 1.0, 0.0, 0.0, 0.0]),
+            Transform::Flipped180 => Affine2::from_cols_array(&[1.0, 0.0, 0.0, -1.0, 0.0, 0.0]),
+            Transform::Flipped270 => Affine2::from_cols_array(&[0.0, -1.0, -1.0, 0.0, 0.0, 0.0]),
         }
     }
 }

--- a/wlcs_anvil/Cargo.toml
+++ b/wlcs_anvil/Cargo.toml
@@ -14,6 +14,3 @@ smithay = { path = "..", default-features=false, features=["wayland_frontend", "
 anvil = { path = "../anvil", default-features=false }
 wayland-sys = { version = "0.31.1", features = ["client", "server"] }
 wlcs = "0.1"
-libc = "0.2"
-memoffset = "0.9"
-cgmath = "0.18"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

This changes things that don't directly interact with OpenGL to use `Affine2` instead of `Mat3`, since it's more efficient for 2D affine transformations, and is 16 byte aligned for SIMD. Also removes the `float-types` feature from glam, since it's only for f64 types (e.g. DMat3).

Also addresses deprecated method warnings in benches for rand.

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
