### PR TITLE
fix 32 bit build issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ profiling = "1.0.13"
 smallvec = "1.11"
 pixman = { version = "0.2.1", features = ["drm-fourcc", "sync"], optional = true }
 aliasable = { version = "0.1.3", optional = true }
-atomic_float = "1.1.0"
+portable-atomic = { version = "1", features = ["float"] }
 sha2 = "0.10.9"
 tracy-client = { version = "0.18.4", default-features = false, optional = true }
 reis = { version = "0.7.0", features = ["calloop"] }

--- a/src/backend/x11/window_inner.rs
+++ b/src/backend/x11/window_inner.rs
@@ -13,11 +13,8 @@ use crate::utils::{Logical, Size};
 
 use super::{Atoms, Window, X11Error, extension::Extensions};
 use drm_fourcc::DrmFourcc;
-use std::sync::{
-    Arc, Mutex, Weak,
-    atomic::{AtomicU32, AtomicU64},
-    mpsc::Sender,
-};
+use portable_atomic::{AtomicU32, AtomicU64};
+use std::sync::{Arc, Mutex, Weak, mpsc::Sender};
 use x11rb::{
     connection::Connection,
     protocol::{

--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -216,7 +216,9 @@ where
     fn add(self, rhs: T) -> Self::Output {
         let rhs = rhs.into();
         let tv_nsec = (self.tp.tv_nsec + rhs.tp.tv_nsec) % NANOS_PER_SEC;
-        let tv_sec = (self.tp.tv_sec + rhs.tp.tv_sec) + ((self.tp.tv_nsec + rhs.tp.tv_nsec) / NANOS_PER_SEC);
+        #[allow(clippy::useless_conversion)] // rust-clippy/issues/6466, PR 2103
+        let tv_sec =
+            (self.tp.tv_sec + rhs.tp.tv_sec) + i64::from((self.tp.tv_nsec + rhs.tp.tv_nsec) / NANOS_PER_SEC);
         Self::from(Timespec { tv_sec, tv_nsec })
     }
 }

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -126,7 +126,7 @@ use crate::utils::Transform;
 pub use crate::utils::hook::HookId;
 use crate::utils::{Buffer, Logical, Point, Rectangle, user_data::UserDataMap};
 use crate::wayland::GlobalData;
-use atomic_float::AtomicF64;
+use portable_atomic::AtomicF64;
 use wayland_server::backend::GlobalId;
 use wayland_server::protocol::wl_compositor::WlCompositor;
 use wayland_server::protocol::wl_subcompositor::WlSubcompositor;

--- a/src/wayland/output/handlers.rs
+++ b/src/wayland/output/handlers.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, atomic::Ordering};
 
-use atomic_float::AtomicF64;
+use portable_atomic::AtomicF64;
 use tracing::{trace, warn, warn_span};
 use wayland_protocols::xdg::xdg_output::zv1::server::{
     zxdg_output_manager_v1::{self, ZxdgOutputManagerV1},

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -79,7 +79,7 @@ use crate::{
     utils::iter::new_locked_obj_iter,
 };
 
-use atomic_float::AtomicF64;
+use portable_atomic::AtomicF64;
 use tracing::info;
 use wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_manager_v1::ZxdgOutputManagerV1;
 use wayland_server::{

--- a/src/wayland/pointer_gestures.rs
+++ b/src/wayland/pointer_gestures.rs
@@ -98,7 +98,7 @@
 
 use std::sync::{Arc, Mutex, atomic::Ordering};
 
-use atomic_float::AtomicF64;
+use portable_atomic::AtomicF64;
 use wayland_protocols::wp::pointer_gestures::zv1::server::{
     zwp_pointer_gesture_hold_v1::{self, ZwpPointerGestureHoldV1},
     zwp_pointer_gesture_pinch_v1::{self, ZwpPointerGesturePinchV1},

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -86,7 +86,7 @@
 
 use std::sync::{Arc, Mutex, atomic::Ordering};
 
-use atomic_float::AtomicF64;
+use portable_atomic::AtomicF64;
 use wayland_protocols::wp::relative_pointer::zv1::server::{
     zwp_relative_pointer_manager_v1::{self, ZwpRelativePointerManagerV1},
     zwp_relative_pointer_v1::{self, ZwpRelativePointerV1},

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex, atomic::Ordering};
 
-use atomic_float::AtomicF64;
+use portable_atomic::AtomicF64;
 use wayland_server::{
     Client, DisplayHandle, Resource, Weak,
     backend::{ClientId, ObjectId},

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, atomic::Ordering};
 
-use atomic_float::AtomicF64;
+use portable_atomic::AtomicF64;
 use wayland_server::{
     Client, DisplayHandle, Resource,
     backend::ClientId,

--- a/src/wayland/tablet_manager/tablet_tool.rs
+++ b/src/wayland/tablet_manager/tablet_tool.rs
@@ -7,7 +7,7 @@ use crate::input::pointer::{CursorImageAttributes, CursorImageStatus};
 use crate::utils::{Client as ClientCoords, Logical, Point};
 use crate::wayland::compositor::CompositorHandler;
 use crate::wayland::seat::CURSOR_IMAGE_ROLE;
-use atomic_float::AtomicF64;
+use portable_atomic::AtomicF64;
 use wayland_protocols::wp::tablet::zv2::server::{
     zwp_tablet_seat_v2::ZwpTabletSeatV2,
     zwp_tablet_tool_v2::{self, ZwpTabletToolV2},

--- a/src/xwayland/xwm/dnd.rs
+++ b/src/xwayland/xwm/dnd.rs
@@ -10,8 +10,8 @@ use std::{
     },
 };
 
-use atomic_float::AtomicF64;
 use calloop::LoopHandle;
+use portable_atomic::AtomicF64;
 use rustix::fs::OFlags;
 use smallvec::SmallVec;
 use tracing::{debug, trace, warn};

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -143,8 +143,8 @@ use crate::{
         xwayland_shell::{self, XWaylandShellHandler},
     },
 };
-use atomic_float::AtomicF64;
 use calloop::{Interest, LoopHandle, Mode, PostAction, generic::Generic, ping};
+use portable_atomic::AtomicF64;
 use rustix::fs::OFlags;
 use std::{
     cell::RefCell,

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -25,8 +25,8 @@ use crate::{
     utils::Point,
 };
 
-use atomic_float::AtomicF64;
 use encoding_rs::WINDOWS_1252;
+use portable_atomic::AtomicF64;
 use std::{
     borrow::Cow,
     collections::HashSet,


### PR DESCRIPTION
## Description

**Patch 1:** 32bit time
- tv_nsec (i32) + tv_sec (i64) needs a cast on 32 bit
- silence clippy, which detects cast as useless on 64bit

See-Also: https://github.com/rust-lang/rust-clippy/issues/6466
Closes: https://github.com/Smithay/smithay/issues/2102
Cherry-picked (https://github.com/Smithay/smithay/commit/d8973b798f55fb3af670f8b8d4c33e8a0ea16697) from: https://github.com/Smithay/smithay/pull/1866


**Patch 2:** 64bit atomics
- replace `std::atmoic` and `atomic_float` with `portable-atomic`
- Use native types when available and emulate them when not.

Closes: https://github.com/Smithay/smithay/issues/1834

<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->

## Details

**Tests**
I tested this PR (`cargo test --features renderer_test`) on
- 64bit: arm64/llvm/clang with rustc 1.96.1 
- 32bit: ppc/llvm/clang with rustc 1.96.1 

**Misc**
- This PR obsoletes https://github.com/Smithay/smithay/pull/1866
- Please consider adding a 32bit build/test to CI to prevent regressions

<!-- Are there issues / other PRs related to this one? -->
**Downstream Bugs**
- https://github.com/niri-wm/niri/issues/4331
- https://bugs.gentoo.org/979547

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
