### PR TITLE
add patch for build crate in e2k cpu architecture

### DIFF
--- a/src/backend/drm/device/fd.rs
+++ b/src/backend/drm/device/fd.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use drm::{Device as BasicDevice, control::Device as ControlDevice};
 use std::{
     os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd},
@@ -94,7 +96,18 @@ impl DrmDeviceFd {
 
     /// Returns the `dev_t` of the underlying device
     pub fn dev_id(&self) -> rustix::io::Result<libc::dev_t> {
-        Ok(rustix::fs::fstat(&self.0.fd)?.st_rdev)
+        let dev: libc::dev_t = {
+            #[cfg(not(target_arch = "e2k"))]
+            {
+                rustix::fs::fstat(&self.0.fd)?.st_rdev
+            }
+
+            #[cfg(target_arch = "e2k")]
+            {
+                rustix::fs::fstat(&self.0.fd)?.st_rdev as u64
+            }
+        };
+        Ok(dev)
     }
 
     /// Returns a weak reference to the underlying device

--- a/src/backend/drm/device/fd.rs
+++ b/src/backend/drm/device/fd.rs
@@ -1,5 +1,3 @@
-#![allow(unexpected_cfgs)]
-
 use drm::{Device as BasicDevice, control::Device as ControlDevice};
 use std::{
     os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd},
@@ -96,17 +94,9 @@ impl DrmDeviceFd {
 
     /// Returns the `dev_t` of the underlying device
     pub fn dev_id(&self) -> rustix::io::Result<libc::dev_t> {
-        let dev: libc::dev_t = {
-            #[cfg(not(target_arch = "e2k"))]
-            {
-                rustix::fs::fstat(&self.0.fd)?.st_rdev
-            }
-
-            #[cfg(target_arch = "e2k")]
-            {
-                rustix::fs::fstat(&self.0.fd)?.st_rdev as u64
-            }
-        };
+        // Hack (u64 as libc::dev_t) for E2K CPU architecture
+        #[allow(clippy::unnecessary_cast)]
+        let dev = rustix::fs::fstat(&self.0.fd)?.st_rdev as libc::dev_t;
         Ok(dev)
     }
 

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -37,8 +37,6 @@
 //! See also `anvil/src/udev.rs` for pure hardware backed example of a compositor utilizing this
 //! backend.
 
-#![allow(unexpected_cfgs)]
-
 #[cfg(feature = "backend_drm")]
 use drm::node::{DrmNode, NodeType};
 use libc::dev_t;

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -37,6 +37,8 @@
 //! See also `anvil/src/udev.rs` for pure hardware backed example of a compositor utilizing this
 //! backend.
 
+#![allow(unexpected_cfgs)]
+
 #[cfg(feature = "backend_drm")]
 use drm::node::{DrmNode, NodeType};
 use libc::dev_t;
@@ -98,7 +100,17 @@ impl UdevBackend {
             .into_iter()
             // Create devices
             .flat_map(|path| match stat(&path) {
-                Ok(stat) => Some((stat.st_rdev, path)),
+                Ok(stat) => Some({
+                    #[cfg(not(target_arch = "e2k"))]
+                    {
+                        (stat.st_rdev, path)
+                    }
+
+                    #[cfg(target_arch = "e2k")]
+                    {
+                        (stat.st_rdev as u64, path)
+                    }
+                }),
                 Err(err) => {
                     warn!("Unable to get id of {:?}, Error: {:?}. Skipping", path, err);
                     None

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -101,15 +101,9 @@ impl UdevBackend {
             // Create devices
             .flat_map(|path| match stat(&path) {
                 Ok(stat) => Some({
-                    #[cfg(not(target_arch = "e2k"))]
-                    {
-                        (stat.st_rdev, path)
-                    }
-
-                    #[cfg(target_arch = "e2k")]
-                    {
-                        (stat.st_rdev as u64, path)
-                    }
+                    // Hack (u64 as u64) for E2K CPU architecture
+                    #[allow(clippy::unnecessary_cast)]
+                    (stat.st_rdev as u64, path)
                 }),
                 Err(err) => {
                     warn!("Unable to get id of {:?}, Error: {:?}. Skipping", path, err);


### PR DESCRIPTION
Good afternoon!

When generating code for the "linux-raw-sys" crate using "bindgen" on the "E2K (Elbrus 2000)" processor architecture, one of the types for the "st_rdev" field does not match the type implemented for the "x86_64" architecture (u32 instead of u64). A small patch is required to fix the error.

- [x]  I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
