### PR TITLE
wayland/pointer_constraints: call remove_constraint when pointer leave surface

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -64,7 +64,9 @@ use smithay::{
             KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
         },
         output::{OutputHandler, OutputManagerState},
-        pointer_constraints::{PointerConstraintsHandler, PointerConstraintsState, with_pointer_constraint},
+        pointer_constraints::{
+            PointerConstraint, PointerConstraintsHandler, PointerConstraintsState, with_pointer_constraint,
+        },
         pointer_gestures::PointerGesturesState,
         presentation::PresentationState,
         relative_pointer::RelativePointerManagerState,
@@ -380,23 +382,26 @@ impl<BackendData: Backend> PointerConstraintsHandler for AnvilState<BackendData>
         }
     }
 
-    fn remove_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>) {
-        if with_pointer_constraint(surface, pointer, |constraint| constraint.is_none()) {
-            if let Some((hint_surface, hint_location)) = &self.cursor_position_hint {
-                let origin = self
-                    .space
-                    .elements()
-                    .find_map(|window| {
-                        (window.wl_surface().as_deref() == Some(hint_surface)).then(|| window.geometry())
-                    })
-                    .unwrap_or_default()
-                    .loc
-                    .to_f64();
+    fn remove_constraint(
+        &mut self,
+        _surface: &WlSurface,
+        pointer: &PointerHandle<Self>,
+        _constraint: Option<&PointerConstraint>,
+    ) {
+        if let Some((hint_surface, hint_location)) = &self.cursor_position_hint {
+            let origin = self
+                .space
+                .elements()
+                .find_map(|window| {
+                    (window.wl_surface().as_deref() == Some(hint_surface)).then(|| window.geometry())
+                })
+                .unwrap_or_default()
+                .loc
+                .to_f64();
 
-                pointer.set_location(origin + *hint_location);
-            }
-            self.cursor_position_hint = None;
+            pointer.set_location(origin + *hint_location);
         }
+        self.cursor_position_hint = None;
     }
 
     fn cursor_position_hint(

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -24,6 +24,7 @@ use smithay::{
             CompositorClientState, CompositorHandler, CompositorState, SurfaceAttributes, TraversalAction,
             with_surface_tree_downward,
         },
+        pointer_constraints::PointerConstraintsHandler,
         selection::{
             SelectionHandler,
             data_device::{DataDeviceHandler, DataDeviceState, WaylandDndGrabHandler},
@@ -115,6 +116,8 @@ impl SeatHandler for App {
     fn focus_changed(&mut self, _seat: &Seat<Self>, _focused: Option<&WlSurface>) {}
     fn cursor_image(&mut self, _seat: &Seat<Self>, _image: smithay::input::pointer::CursorImageStatus) {}
 }
+
+impl PointerConstraintsHandler for App {}
 
 struct App {
     compositor_state: CompositorState,

--- a/examples/seat.rs
+++ b/examples/seat.rs
@@ -7,6 +7,7 @@ use smithay::reexports::wayland_server::{
     protocol::wl_surface::WlSurface,
 };
 use smithay::wayland::compositor::{CompositorClientState, CompositorHandler, CompositorState};
+use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 
 struct App {
     compositor_state: CompositorState,
@@ -26,6 +27,8 @@ impl SeatHandler for App {
     fn focus_changed(&mut self, _seat: &Seat<Self>, _focused: Option<&WlSurface>) {}
     fn cursor_image(&mut self, _seat: &Seat<Self>, _image: smithay::input::pointer::CursorImageStatus) {}
 }
+
+impl PointerConstraintsHandler for App {}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut display: Display<App> = Display::new()?;

--- a/smallvil/src/handlers/mod.rs
+++ b/smallvil/src/handlers/mod.rs
@@ -14,6 +14,7 @@ use smithay::reexports::wayland_server::Resource;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::Serial;
 use smithay::wayland::output::OutputHandler;
+use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 use smithay::wayland::selection::SelectionHandler;
 use smithay::wayland::selection::data_device::{
     DataDeviceHandler, DataDeviceState, WaylandDndGrabHandler, set_data_device_focus,
@@ -36,6 +37,8 @@ impl SeatHandler for Smallvil {
         set_data_device_focus(dh, seat, client);
     }
 }
+
+impl PointerConstraintsHandler for Smallvil {}
 
 //
 // Wl Data Device

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -655,6 +655,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     ///
     /// ```no_run
     /// # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
+    /// # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
     /// # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
     /// # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
     /// #
@@ -672,6 +673,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
     /// #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
     /// # }
+    /// # impl PointerConstraintsHandler for State {}
     /// # let mut seat: Seat<State> = unimplemented!();
     /// let touch_handle = seat.add_touch();
     /// ```

--- a/src/wayland/idle_notify/mod.rs
+++ b/src/wayland/idle_notify/mod.rs
@@ -7,6 +7,7 @@
 //! use smithay::wayland::idle_notify::{IdleNotifierState, IdleNotifierHandler};
 //! # use smithay::input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus};
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //!
 //! struct State { idle_notifier: IdleNotifierState<Self> }
 //! # let mut event_loop = smithay::reexports::calloop::EventLoop::<State>::try_new().unwrap();
@@ -33,6 +34,7 @@
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
 //! # }
+//! # impl PointerConstraintsHandler for State {}
 //! impl IdleNotifierHandler for State {
 //!     fn idle_notifier_state(&mut self) -> &mut IdleNotifierState<Self> {
 //!         &mut self.idle_notifier

--- a/src/wayland/input_method/mod.rs
+++ b/src/wayland/input_method/mod.rs
@@ -9,6 +9,7 @@
 //! use smithay::wayland::input_method::{InputMethodManagerState, InputMethodHandler, PopupSurface};
 //! use smithay::wayland::text_input::TextInputManagerState;
 //! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //! # use smithay::reexports::wayland_server::Client;
 //! use smithay::utils::{Rectangle, Logical};
 //!
@@ -41,6 +42,7 @@
 //!     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //!     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
 //! }
+//! # impl PointerConstraintsHandler for State {}
 //!
 //! # impl CompositorHandler for State {
 //! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }

--- a/src/wayland/keyboard_shortcuts_inhibit/mod.rs
+++ b/src/wayland/keyboard_shortcuts_inhibit/mod.rs
@@ -185,6 +185,7 @@ pub trait KeyboardShortcutsInhibitorSeat {
     /// use smithay::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat;
     /// # use smithay::input::{SeatHandler, SeatState, pointer::CursorImageStatus};
     /// # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+    /// # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
     /// # struct State;
     /// # impl CompositorHandler for State {
     /// #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
@@ -199,6 +200,7 @@ pub trait KeyboardShortcutsInhibitorSeat {
     /// #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
     /// #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
     /// # }
+    /// # impl PointerConstraintsHandler for State {}
     ///
     /// # let wl_surface: WlSurface = todo!();
     ///

--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -35,12 +35,18 @@ pub trait PointerConstraintsHandler: SeatHandler {
     /// Pointer lock or confinement constraint created for `pointer` on `surface`
     ///
     /// Use [`with_pointer_constraint`] to access the constraint.
-    fn new_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>);
+    fn new_constraint(&mut self, _surface: &WlSurface, _pointer: &PointerHandle<Self>) {}
 
-    /// Constraint removed for `pointer` on `surface`
+    /// Pointer constraint removed for `pointer` on `surface`
     ///
-    /// Use [`with_pointer_constraint`] to access the constraint.
-    fn remove_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>);
+    /// Don't use [`with_pointer_constraint`] to access the constraint
+    fn remove_constraint(
+        &mut self,
+        _surface: &WlSurface,
+        _pointer: &PointerHandle<Self>,
+        _constraint: Option<&PointerConstraint>,
+    ) {
+    }
 
     /// The client holding a LockedPointer has committed a cursor position hint.
     ///
@@ -49,10 +55,11 @@ pub trait PointerConstraintsHandler: SeatHandler {
     /// Use [`with_pointer_constraint`] to access the constraint and check if it is active.
     fn cursor_position_hint(
         &mut self,
-        surface: &WlSurface,
-        pointer: &PointerHandle<Self>,
-        location: Point<f64, Logical>,
-    );
+        _surface: &WlSurface,
+        _pointer: &PointerHandle<Self>,
+        _location: Point<f64, Logical>,
+    ) {
+    }
 }
 
 /// Constraint confining pointer to a region of the surface
@@ -121,7 +128,7 @@ impl<D: SeatHandler + 'static> ops::Deref for PointerConstraintRef<'_, D> {
     }
 }
 
-impl<D: SeatHandler + 'static> PointerConstraintRef<'_, D> {
+impl<D: SeatHandler + PointerConstraintsHandler + 'static> PointerConstraintRef<'_, D> {
     /// Send `locked`/`unlocked`
     ///
     /// This is not sent automatically since compositors may have different
@@ -147,7 +154,7 @@ impl<D: SeatHandler + 'static> PointerConstraintRef<'_, D> {
     ///
     /// This is sent automatically when the surface loses pointer focus, but
     /// may also be invoked while the surface is focused.
-    pub fn deactivate(self) {
+    pub fn deactivate(self, state: &mut D, surface: &WlSurface, pointer: &PointerHandle<D>) {
         let deactivated = match self.entry.get() {
             PointerConstraint::Confined(confined) => {
                 if confined.active.swap(false, Ordering::SeqCst) {
@@ -166,6 +173,11 @@ impl<D: SeatHandler + 'static> PointerConstraintRef<'_, D> {
                 }
             }
         };
+
+        if deactivated {
+            let constraint = self.entry.get();
+            state.remove_constraint(surface, pointer, Some(constraint));
+        }
 
         if deactivated && self.lifetime() == WEnum::Value(Lifetime::Oneshot) {
             self.entry.remove_entry();
@@ -354,17 +366,19 @@ fn remove_constraint<D: SeatHandler + PointerConstraintsHandler + 'static>(
     surface: &WlSurface,
     pointer: &PointerHandle<D>,
 ) {
-    let is_removed = with_constraint_data::<D, _, _>(surface, |data| {
+    let (is_removed, constraint) = with_constraint_data::<D, _, _>(surface, |data| {
         if let Some(data) = data {
-            if let Some(_constraint) = data.constraints.remove(pointer) {
-                return true;
+            if let Some(constraint) = data.constraints.remove(pointer) {
+                return (true, Some(constraint));
             }
         }
-        false
+        (false, None)
     });
 
     if is_removed {
-        state.remove_constraint(surface, pointer);
+        if let Some(constraint) = constraint {
+            state.remove_constraint(surface, pointer, Some(&constraint));
+        }
     }
 }
 
@@ -476,7 +490,8 @@ where
 
 impl<D> Dispatch2<ZwpConfinedPointerV1, D> for PointerConstraintUserData<D>
 where
-    D: SeatHandler + PointerConstraintsHandler,
+    D: SeatHandler,
+    D: PointerConstraintsHandler,
     D: 'static,
 {
     fn request(
@@ -523,7 +538,8 @@ where
 
 impl<D> Dispatch2<ZwpLockedPointerV1, D> for PointerConstraintUserData<D>
 where
-    D: SeatHandler + PointerConstraintsHandler,
+    D: SeatHandler,
+    D: PointerConstraintsHandler,
     D: 'static,
 {
     fn request(

--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -375,8 +375,10 @@ fn remove_constraint<D: SeatHandler + PointerConstraintsHandler + 'static>(
         (false, None)
     });
 
-    if is_removed && let Some(constraint) = constraint {
-        state.remove_constraint(surface, pointer, Some(&constraint));
+    if is_removed {
+        if let Some(constraint) = constraint {
+            state.remove_constraint(surface, pointer, Some(&constraint));
+        }
     }
 }
 

--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -35,12 +35,18 @@ pub trait PointerConstraintsHandler: SeatHandler {
     /// Pointer lock or confinement constraint created for `pointer` on `surface`
     ///
     /// Use [`with_pointer_constraint`] to access the constraint.
-    fn new_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>);
+    fn new_constraint(&mut self, _surface: &WlSurface, _pointer: &PointerHandle<Self>) {}
 
-    /// Constraint removed for `pointer` on `surface`
+    /// Pointer constraint removed for `pointer` on `surface`
     ///
-    /// Use [`with_pointer_constraint`] to access the constraint.
-    fn remove_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>);
+    /// Don't use [`with_pointer_constraint`] to access the constraint
+    fn remove_constraint(
+        &mut self,
+        _surface: &WlSurface,
+        _pointer: &PointerHandle<Self>,
+        _constraint: Option<&PointerConstraint>,
+    ) {
+    }
 
     /// The client holding a LockedPointer has committed a cursor position hint.
     ///
@@ -49,10 +55,11 @@ pub trait PointerConstraintsHandler: SeatHandler {
     /// Use [`with_pointer_constraint`] to access the constraint and check if it is active.
     fn cursor_position_hint(
         &mut self,
-        surface: &WlSurface,
-        pointer: &PointerHandle<Self>,
-        location: Point<f64, Logical>,
-    );
+        _surface: &WlSurface,
+        _pointer: &PointerHandle<Self>,
+        _location: Point<f64, Logical>,
+    ) {
+    }
 }
 
 /// Constraint confining pointer to a region of the surface
@@ -121,7 +128,7 @@ impl<D: SeatHandler + 'static> ops::Deref for PointerConstraintRef<'_, D> {
     }
 }
 
-impl<D: SeatHandler + 'static> PointerConstraintRef<'_, D> {
+impl<D: SeatHandler + PointerConstraintsHandler + 'static> PointerConstraintRef<'_, D> {
     /// Send `locked`/`unlocked`
     ///
     /// This is not sent automatically since compositors may have different
@@ -147,7 +154,7 @@ impl<D: SeatHandler + 'static> PointerConstraintRef<'_, D> {
     ///
     /// This is sent automatically when the surface loses pointer focus, but
     /// may also be invoked while the surface is focused.
-    pub fn deactivate(self) {
+    pub fn deactivate(self, state: &mut D, surface: &WlSurface, pointer: &PointerHandle<D>) {
         let deactivated = match self.entry.get() {
             PointerConstraint::Confined(confined) => {
                 if confined.active.swap(false, Ordering::SeqCst) {
@@ -166,6 +173,11 @@ impl<D: SeatHandler + 'static> PointerConstraintRef<'_, D> {
                 }
             }
         };
+
+        if deactivated {
+            let constraint = self.entry.get();
+            state.remove_constraint(surface, pointer, Some(constraint));
+        }
 
         if deactivated && self.lifetime() == WEnum::Value(Lifetime::Oneshot) {
             self.entry.remove_entry();
@@ -354,17 +366,17 @@ fn remove_constraint<D: SeatHandler + PointerConstraintsHandler + 'static>(
     surface: &WlSurface,
     pointer: &PointerHandle<D>,
 ) {
-    let is_removed = with_constraint_data::<D, _, _>(surface, |data| {
+    let (is_removed, constraint) = with_constraint_data::<D, _, _>(surface, |data| {
         if let Some(data) = data {
-            if let Some(_constraint) = data.constraints.remove(pointer) {
-                return true;
+            if let Some(constraint) = data.constraints.remove(pointer) {
+                return (true, Some(constraint));
             }
         }
-        false
+        (false, None)
     });
 
-    if is_removed {
-        state.remove_constraint(surface, pointer);
+    if is_removed && let Some(constraint) = constraint {
+        state.remove_constraint(surface, pointer, Some(&constraint));
     }
 }
 
@@ -476,7 +488,8 @@ where
 
 impl<D> Dispatch2<ZwpConfinedPointerV1, D> for PointerConstraintUserData<D>
 where
-    D: SeatHandler + PointerConstraintsHandler,
+    D: SeatHandler,
+    D: PointerConstraintsHandler,
     D: 'static,
 {
     fn request(
@@ -523,7 +536,8 @@ where
 
 impl<D> Dispatch2<ZwpLockedPointerV1, D> for PointerConstraintUserData<D>
 where
-    D: SeatHandler + PointerConstraintsHandler,
+    D: SeatHandler,
+    D: PointerConstraintsHandler,
     D: 'static,
 {
     fn request(

--- a/src/wayland/pointer_warp.rs
+++ b/src/wayland/pointer_warp.rs
@@ -15,6 +15,7 @@
 //! # let mut display = wayland_server::Display::<State>::new().unwrap();
 //! #
 //! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //! # use smithay::reexports::wayland_server::Client;
 //! # impl CompositorHandler for State {
 //! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
@@ -30,6 +31,7 @@
 //! #         todo!()
 //! #     }
 //! # }
+//! # impl PointerConstraintsHandler for State {}
 //!
 //! PointerWarpManager::new::<State>(
 //!     &display.handle(),

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -11,6 +11,7 @@
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
 //! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
 //! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //! # use smithay::reexports::wayland_server::Client;
 //!
 //! # struct State { seat_state: SeatState<Self> };
@@ -42,6 +43,7 @@
 //!         // ...
 //!     }
 //! }
+//! # impl PointerConstraintsHandler for State {}
 //!
 //! smithay::delegate_dispatch2!(State);
 //!

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -25,7 +25,10 @@ use crate::{
         },
     },
     utils::{Client as ClientCoords, Point, Serial, iter::new_locked_obj_iter_from_vec},
-    wayland::{Dispatch2, compositor, pointer_constraints::with_pointer_constraint},
+    wayland::{
+        Dispatch2, compositor,
+        pointer_constraints::{PointerConstraintsHandler, with_pointer_constraint},
+    },
 };
 
 use super::{SeatHandler, WaylandFocus};
@@ -235,7 +238,9 @@ impl WlPointerHandle {
 
 impl<D> PointerTarget<D> for WlSurface
 where
-    D: SeatHandler + 'static,
+    D: SeatHandler,
+    D: PointerConstraintsHandler,
+    D: 'static,
 {
     fn enter(&self, seat: &Seat<D>, _data: &mut D, event: &MotionEvent) {
         if let Some(pointer) = seat.get_pointer() {
@@ -243,14 +248,14 @@ where
         }
     }
 
-    fn leave(&self, seat: &Seat<D>, _data: &mut D, serial: Serial, time: u32) {
+    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {
         if let Some(pointer) = seat.get_pointer() {
             pointer.wp_pointer_gestures.leave::<D>(self, serial, time);
             pointer.wl_pointer.leave(self, serial, time);
 
             with_pointer_constraint(self, &pointer, |constraint| {
                 if let Some(constraint) = constraint {
-                    constraint.deactivate();
+                    constraint.deactivate(data, self, &pointer);
                 }
             });
         }

--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -32,6 +32,7 @@
 //! use smithay::wayland::selection::data_device::{WaylandDndGrabHandler, DataDeviceState, DataDeviceHandler};
 //! # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //!
 //! # struct State { data_device_state: DataDeviceState }
 //! # let mut display = wayland_server::Display::<State>::new().unwrap();
@@ -57,6 +58,7 @@
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
 //! # }
+//! # impl PointerConstraintsHandler for State {}
 //! impl WaylandDndGrabHandler for State {
 //!     // ... implement `dnd_requested` to handle drag&drop operations
 //! }

--- a/src/wayland/selection/ext_data_control/mod.rs
+++ b/src/wayland/selection/ext_data_control/mod.rs
@@ -13,6 +13,7 @@
 //! use smithay::wayland::selection::ext_data_control::{DataControlState, DataControlHandler};
 //! # use smithay::input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus};
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //!
 //! # struct State { data_control_state: DataControlState }
 //! # let mut display = wayland_server::Display::<State>::new().unwrap();
@@ -38,6 +39,7 @@
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
 //! # }
+//! # impl PointerConstraintsHandler for State {}
 //! impl SelectionHandler for State {
 //!     type SelectionUserData = ();
 //! }

--- a/src/wayland/selection/primary_selection/mod.rs
+++ b/src/wayland/selection/primary_selection/mod.rs
@@ -31,6 +31,7 @@
 //! use smithay::wayland::selection::primary_selection::{PrimarySelectionState, PrimarySelectionHandler};
 //! # use smithay::input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus};
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //!
 //! # struct State { primary_selection_state: PrimarySelectionState }
 //! # let mut display = wayland_server::Display::<State>::new().unwrap();
@@ -56,6 +57,7 @@
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
 //! # }
+//! # impl PointerConstraintsHandler for State {}
 //! impl SelectionHandler for State {
 //!     type SelectionUserData = ();
 //! }

--- a/src/wayland/selection/wlr_data_control/mod.rs
+++ b/src/wayland/selection/wlr_data_control/mod.rs
@@ -13,6 +13,7 @@
 //! use smithay::wayland::selection::wlr_data_control::{DataControlState, DataControlHandler};
 //! # use smithay::input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus};
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //!
 //! # struct State { data_control_state: DataControlState }
 //! # let mut display = wayland_server::Display::<State>::new().unwrap();
@@ -38,6 +39,7 @@
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
 //! # }
+//! # impl PointerConstraintsHandler for State {}
 //! impl SelectionHandler for State {
 //!     type SelectionUserData = ();
 //! }

--- a/src/wayland/shell/xdg/decoration.rs
+++ b/src/wayland/shell/xdg/decoration.rs
@@ -63,6 +63,7 @@
 //!
 //! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //!
 //! # impl CompositorHandler for State {
 //! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
@@ -86,6 +87,7 @@
 //!         // handle new images for the cursor ...
 //!     }
 //! }
+//! # impl PointerConstraintsHandler for State {}
 //!
 //! smithay::delegate_dispatch2!(State);
 //!

--- a/src/wayland/shell/xdg/dialog.rs
+++ b/src/wayland/shell/xdg/dialog.rs
@@ -51,6 +51,7 @@
 //!
 //! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //!
 //! # impl CompositorHandler for State {
 //! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
@@ -74,6 +75,7 @@
 //!         // handle new images for the cursor ...
 //!     }
 //! }
+//! # impl PointerConstraintsHandler for State {}
 //!
 //! smithay::delegate_dispatch2!(State);
 //!

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -76,6 +76,7 @@
 //!
 //! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //!
 //! # impl CompositorHandler for State {
 //! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
@@ -99,6 +100,7 @@
 //!         // handle new images for the cursor ...
 //!     }
 //! }
+//! # impl PointerConstraintsHandler for State {}
 //!
 //! smithay::delegate_dispatch2!(State);
 //!

--- a/src/wayland/tablet_manager/mod.rs
+++ b/src/wayland/tablet_manager/mod.rs
@@ -14,6 +14,7 @@
 //! use smithay::wayland::tablet_manager::{TabletManagerState};
 //! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
 //! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //! # use smithay::reexports::wayland_server::Client;
 //!
 //! # struct State { seat_state: SeatState<Self> };
@@ -50,6 +51,7 @@
 //!         // handle new images for the cursor ...
 //!     }
 //! }
+//! # impl PointerConstraintsHandler for State {}
 //!
 //! impl TabletSeatHandler for State {
 //!     type ToolFocus = WlSurface;

--- a/src/wayland/text_input/mod.rs
+++ b/src/wayland/text_input/mod.rs
@@ -10,6 +10,7 @@
 //! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::wayland::text_input::TextInputManagerState;
 //! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //! # use smithay::reexports::wayland_server::Client;
 //!
 //! # struct State { seat_state: SeatState<Self> };
@@ -32,6 +33,7 @@
 //!     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //!     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
 //! }
+//! # impl PointerConstraintsHandler for State {}
 //!
 //! // Add the seat state to your state and create manager global
 //! TextInputManagerState::new::<State>(&display_handle);

--- a/src/wayland/virtual_keyboard/mod.rs
+++ b/src/wayland/virtual_keyboard/mod.rs
@@ -9,6 +9,7 @@
 //! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! use smithay::wayland::virtual_keyboard::VirtualKeyboardManagerState;
 //! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //! # use smithay::reexports::wayland_server::Client;
 //!
 //! # struct State { seat_state: SeatState<Self> };
@@ -31,6 +32,7 @@
 //!     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //!     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
 //! }
+//! # impl PointerConstraintsHandler for State {}
 //!
 //! // Add the seat state to your state, create manager global and add client filter
 //! // to avoid untrusted clients requesting a new keyboard

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -16,6 +16,7 @@
 //! # use smithay::wayland::compositor::{CompositorHandler, CompositorState, CompositorClientState};
 //! # use smithay::input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus};
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //! # impl CompositorHandler for State {
 //! #     fn compositor_state(&mut self) -> &mut CompositorState { unimplemented!() }
 //! #     fn client_compositor_state<'a>(&self, client: &'a wayland_server::Client) -> &'a CompositorClientState { unimplemented!() }
@@ -29,6 +30,7 @@
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) { unimplemented!() }
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) { unimplemented!() }
 //! # }
+//! # impl PointerConstraintsHandler for State {}
 //!
 //! impl XWaylandKeyboardGrabHandler for State {
 //!     fn keyboard_focus_for_xsurface(&self, _: &WlSurface) -> Option<Self::KeyboardFocus> {

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -42,6 +42,7 @@
 //! #     }
 //! # }
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+//! # use smithay::wayland::pointer_constraints::PointerConstraintsHandler;
 //! # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus, dnd::DndGrabHandler};
 //! # use smithay::backend::input::KeyState;
 //! # use smithay::input::{
@@ -69,6 +70,7 @@
 //! #     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&Target>) {}
 //! #     fn cursor_image(&mut self, seat: &Seat<Self>, image: CursorImageStatus) {}
 //! # }
+//! # impl PointerConstraintsHandler for State {}
 //! # impl DndGrabHandler for State {}
 //! # impl DataDeviceHandler for State {
 //! #     fn data_device_state(&mut self) -> &mut DataDeviceState { unreachable!() }

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     wayland::{
         compositor::{self, CompositorHandler, RectangleKind, RegionAttributes, SurfaceAttributes},
+        pointer_constraints::PointerConstraintsHandler,
         seat::{WaylandFocus, keyboard::enter_internal},
     },
 };
@@ -2239,7 +2240,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for X11Surface {
     }
 }
 
-impl<D: SeatHandler + 'static> PointerTarget<D> for X11Surface {
+impl<D: SeatHandler + PointerConstraintsHandler + 'static> PointerTarget<D> for X11Surface {
     fn enter(&self, seat: &Seat<D>, data: &mut D, event: &MotionEvent) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
             PointerTarget::enter(surface, seat, data, event);


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

related: https://github.com/Smithay/smithay/pull/2027#issuecomment-5032154662

The implementation ensures that remove_constraint() is invoked when the pointer leaves the surface, allowing the last saved cursor position hint to be applied.

This both improves the expected behavior of `Lifetime::Persistent` and ensures that pointer focus changes are handled immediately.

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
