### PR TITLE
Add an `InputTime` type to use instead of `u32`/`u64`, with a `::now()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,8 @@ box minus the surface's frame extents.
 time. `LockSurface::ext_session_lock` has been added to allow the compositor to disambiguate, and associate lock surfaces
 with the correct lock instance.
 
-`backend::input` and `input` now use `backend::input::InputTime` for timestamps instead of `u32` or `u64`.
+`backend::input` and `input` now use `backend::input::InputTime` for timestamps instead of `u32` or `u64`. `InputTime::now()`
+is used for timestamps for synthesized events.
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ box minus the surface's frame extents.
 time. `LockSurface::ext_session_lock` has been added to allow the compositor to disambiguate, and associate lock surfaces
 with the correct lock instance.
 
+`backend::input` and `input` now use `backend::input::InputTime` for timestamps instead of `u32` or `u64`.
+
 ### Additions
 
 - ExtBackgroundEffect protocol is now available in `smithay::wayland::background_effect` module.

--- a/anvil/src/focus.rs
+++ b/anvil/src/focus.rs
@@ -5,7 +5,7 @@ use smithay::xwayland::X11Surface;
 #[cfg(feature = "xwayland")]
 use smithay::xwayland::xwm::XwmOfferData;
 pub use smithay::{
-    backend::input::KeyState,
+    backend::input::{InputTime, KeyState},
     desktop::{LayerSurface, PopupKind},
     input::{
         Seat,
@@ -178,7 +178,7 @@ impl<BackendData: Backend> PointerTarget<AnvilState<BackendData>> for PointerFoc
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         self.inner_pointer_target().leave(seat, data, serial, time)
     }
@@ -275,7 +275,7 @@ impl<BackendData: Backend> KeyboardTarget<AnvilState<BackendData>> for KeyboardF
         key: KeysymHandle<'_>,
         state: KeyState,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         self.inner_keyboard_target()
             .key(seat, data, key, state, serial, time)
@@ -448,7 +448,7 @@ impl<BackendData: Backend> TabletToolTarget<AnvilState<BackendData>> for Pointer
         seat: &Seat<AnvilState<BackendData>>,
         data: &mut AnvilState<BackendData>,
         tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
-        time: u32,
+        time: InputTime,
     ) {
         self.inner_tablet_tool_target()
             .frame(seat, data, tool_descriptor, time);
@@ -557,7 +557,7 @@ impl<BackendData: Backend> DndFocus<AnvilState<BackendData>> for PointerFocusTar
         offer: Option<&mut AnvilOfferData<S>>,
         seat: &Seat<AnvilState<BackendData>>,
         location: Point<f64, Logical>,
-        time: u32,
+        time: InputTime,
     ) {
         match self {
             PointerFocusTarget::WlSurface(surface) => {

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -686,7 +686,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 keycode,
                 KeyState::Released,
                 SCOUNTER.next_serial(),
-                InputTime::from_millis(0),
+                InputTime::now(),
                 |_, _, _| FilterResult::Forward::<bool>,
             );
         }
@@ -724,7 +724,7 @@ impl AnvilState<UdevData> {
                             &MotionEvent {
                                 location,
                                 serial: SCOUNTER.next_serial(),
-                                time: InputTime::from_micros(self.clock.now().as_micros()),
+                                time: InputTime::now(),
                             },
                         );
                         pointer.frame(self);
@@ -762,7 +762,7 @@ impl AnvilState<UdevData> {
                             &MotionEvent {
                                 location: pointer_location,
                                 serial: SCOUNTER.next_serial(),
-                                time: InputTime::from_micros(self.clock.now().as_micros()),
+                                time: InputTime::now(),
                             },
                         );
                         pointer.frame(self);
@@ -801,7 +801,7 @@ impl AnvilState<UdevData> {
                             &MotionEvent {
                                 location: pointer_location,
                                 serial: SCOUNTER.next_serial(),
-                                time: InputTime::from_micros(self.clock.now().as_micros()),
+                                time: InputTime::now(),
                             },
                         );
                         pointer.frame(self);
@@ -1046,7 +1046,7 @@ impl AnvilState<UdevData> {
             let pointer = self.pointer.clone();
             let under = self.surface_under(pointer_location);
             let tool = tablet_seat.get_tool(&evt.tool());
-            let time = InputTime::from_micros(self.clock.now().as_micros());
+            let time = InputTime::now();
 
             pointer.motion(
                 self,

--- a/anvil/src/input_handler.rs
+++ b/anvil/src/input_handler.rs
@@ -9,8 +9,8 @@ use smithay::{backend::renderer::DebugFlags, input::tablet};
 
 use smithay::{
     backend::input::{
-        self, Axis, AxisSource, Device, DeviceCapability, Event, InputBackend, InputEvent, KeyState,
-        KeyboardKeyEvent, PointerAxisEvent, PointerButtonEvent, TouchEvent,
+        self, Axis, AxisSource, Device, DeviceCapability, Event, InputBackend, InputEvent, InputTime,
+        KeyState, KeyboardKeyEvent, PointerAxisEvent, PointerButtonEvent, TouchEvent,
     },
     desktop::{WindowSurfaceType, layer_map_for_output},
     input::{
@@ -137,7 +137,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         let state = evt.state();
         debug!(?keycode, ?state, "key");
         let serial = SCOUNTER.next_serial();
-        let time = Event::time_msec(&evt);
+        let time = Event::time(&evt);
         let mut suppressed_keys = self.suppressed_keys.clone();
         let keyboard = self.seat.get_keyboard().unwrap();
 
@@ -233,7 +233,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 button,
                 state: state.try_into().unwrap(),
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
             },
         );
         pointer.frame(self);
@@ -405,7 +405,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
         let vertical_amount_discrete = evt.amount_v120(input::Axis::Vertical);
 
         {
-            let mut frame = AxisFrame::new(evt.time_msec()).source(evt.source());
+            let mut frame = AxisFrame::new(evt.time()).source(evt.source());
             if horizontal_amount != 0.0 {
                 frame = frame.relative_direction(Axis::Horizontal, evt.relative_direction(Axis::Horizontal));
                 frame = frame.value(Axis::Horizontal, horizontal_amount);
@@ -475,7 +475,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 slot: evt.slot(),
                 location: touch_location,
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
             },
         );
     }
@@ -490,7 +490,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             &UpEvent {
                 slot: evt.slot(),
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
             },
         )
     }
@@ -510,7 +510,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             &smithay::input::touch::MotionEvent {
                 slot: evt.slot(),
                 location: touch_location,
-                time: evt.time_msec(),
+                time: evt.time(),
             },
         );
     }
@@ -672,7 +672,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
             &MotionEvent {
                 location: pos,
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
             },
         );
         pointer.frame(self);
@@ -686,7 +686,7 @@ impl<BackendData: Backend> AnvilState<BackendData> {
                 keycode,
                 KeyState::Released,
                 SCOUNTER.next_serial(),
-                0,
+                InputTime::from_millis(0),
                 |_, _, _| FilterResult::Forward::<bool>,
             );
         }
@@ -724,7 +724,7 @@ impl AnvilState<UdevData> {
                             &MotionEvent {
                                 location,
                                 serial: SCOUNTER.next_serial(),
-                                time: self.clock.now().as_millis(),
+                                time: InputTime::from_micros(self.clock.now().as_micros()),
                             },
                         );
                         pointer.frame(self);
@@ -762,7 +762,7 @@ impl AnvilState<UdevData> {
                             &MotionEvent {
                                 location: pointer_location,
                                 serial: SCOUNTER.next_serial(),
-                                time: self.clock.now().as_millis(),
+                                time: InputTime::from_micros(self.clock.now().as_micros()),
                             },
                         );
                         pointer.frame(self);
@@ -801,7 +801,7 @@ impl AnvilState<UdevData> {
                             &MotionEvent {
                                 location: pointer_location,
                                 serial: SCOUNTER.next_serial(),
-                                time: self.clock.now().as_millis(),
+                                time: InputTime::from_micros(self.clock.now().as_micros()),
                             },
                         );
                         pointer.frame(self);
@@ -923,7 +923,7 @@ impl AnvilState<UdevData> {
             &RelativeMotionEvent {
                 delta: evt.delta(),
                 delta_unaccel: evt.delta_unaccel(),
-                utime: evt.time(),
+                time: evt.time(),
             },
         );
 
@@ -977,7 +977,7 @@ impl AnvilState<UdevData> {
             &MotionEvent {
                 location: pointer_location,
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
             },
         );
         pointer.frame(self);
@@ -1033,7 +1033,7 @@ impl AnvilState<UdevData> {
             &MotionEvent {
                 location: pointer_location,
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
             },
         );
         pointer.frame(self);
@@ -1046,7 +1046,7 @@ impl AnvilState<UdevData> {
             let pointer = self.pointer.clone();
             let under = self.surface_under(pointer_location);
             let tool = tablet_seat.get_tool(&evt.tool());
-            let time = self.clock.now().as_millis();
+            let time = InputTime::from_micros(self.clock.now().as_micros());
 
             pointer.motion(
                 self,
@@ -1112,7 +1112,7 @@ impl AnvilState<UdevData> {
                 &MotionEvent {
                     location: pointer_location,
                     serial: SCOUNTER.next_serial(),
-                    time: evt.time_msec(),
+                    time: evt.time(),
                 },
             );
             pointer.frame(self);
@@ -1139,7 +1139,7 @@ impl AnvilState<UdevData> {
                                 location: pointer_location,
                                 axis: Some(frame),
                                 serial: SCOUNTER.next_serial(),
-                                time: evt.time_msec(),
+                                time: evt.time(),
                             },
                         );
                     }
@@ -1148,7 +1148,7 @@ impl AnvilState<UdevData> {
                             self,
                             &tablet::tool::ProximityOutEvent {
                                 serial: SCOUNTER.next_serial(),
-                                time: evt.time_msec(),
+                                time: evt.time(),
                             },
                         );
                     }
@@ -1157,7 +1157,7 @@ impl AnvilState<UdevData> {
                 // Doing this in an idle handler would allow other events (e.g. buttons) to be
                 // sent as part of the same frame, which is closer to what the protocol
                 // expect, and let well behaved clients accumulate events.
-                tool.frame(self, evt.time_msec());
+                tool.frame(self, evt.time());
             }
         }
     }
@@ -1174,7 +1174,7 @@ impl AnvilState<UdevData> {
                         self,
                         &tablet::tool::DownEvent {
                             serial,
-                            time: evt.time_msec(),
+                            time: evt.time(),
                         },
                     );
 
@@ -1186,13 +1186,13 @@ impl AnvilState<UdevData> {
                         self,
                         &tablet::tool::UpEvent {
                             serial,
-                            time: evt.time_msec(),
+                            time: evt.time(),
                         },
                     );
                 }
             }
 
-            tool.frame(self, evt.time_msec());
+            tool.frame(self, evt.time());
         }
     }
 
@@ -1206,11 +1206,11 @@ impl AnvilState<UdevData> {
                     serial: SCOUNTER.next_serial(),
                     button: evt.button(),
                     state: evt.button_state(),
-                    time: evt.time_msec(),
+                    time: evt.time(),
                 },
             );
 
-            tool.frame(self, evt.time_msec());
+            tool.frame(self, evt.time());
         }
     }
 
@@ -1221,7 +1221,7 @@ impl AnvilState<UdevData> {
             self,
             &GestureSwipeBeginEvent {
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
                 fingers: evt.fingers(),
             },
         );
@@ -1232,7 +1232,7 @@ impl AnvilState<UdevData> {
         pointer.gesture_swipe_update(
             self,
             &GestureSwipeUpdateEvent {
-                time: evt.time_msec(),
+                time: evt.time(),
                 delta: evt.delta(),
             },
         );
@@ -1245,7 +1245,7 @@ impl AnvilState<UdevData> {
             self,
             &GestureSwipeEndEvent {
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
                 cancelled: evt.cancelled(),
             },
         );
@@ -1258,7 +1258,7 @@ impl AnvilState<UdevData> {
             self,
             &GesturePinchBeginEvent {
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
                 fingers: evt.fingers(),
             },
         );
@@ -1269,7 +1269,7 @@ impl AnvilState<UdevData> {
         pointer.gesture_pinch_update(
             self,
             &GesturePinchUpdateEvent {
-                time: evt.time_msec(),
+                time: evt.time(),
                 delta: evt.delta(),
                 scale: evt.scale(),
                 rotation: evt.rotation(),
@@ -1284,7 +1284,7 @@ impl AnvilState<UdevData> {
             self,
             &GesturePinchEndEvent {
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
                 cancelled: evt.cancelled(),
             },
         );
@@ -1297,7 +1297,7 @@ impl AnvilState<UdevData> {
             self,
             &GestureHoldBeginEvent {
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
                 fingers: evt.fingers(),
             },
         );
@@ -1310,7 +1310,7 @@ impl AnvilState<UdevData> {
             self,
             &GestureHoldEndEvent {
                 serial,
-                time: evt.time_msec(),
+                time: evt.time(),
                 cancelled: evt.cancelled(),
             },
         );

--- a/anvil/src/shell/element.rs
+++ b/anvil/src/shell/element.rs
@@ -1,9 +1,14 @@
 use std::{borrow::Cow, time::Duration};
 
 use smithay::{
-    backend::renderer::{
-        ImportAll, ImportMem, Renderer, Texture,
-        element::{AsRenderElements, solid::SolidColorRenderElement, surface::WaylandSurfaceRenderElement},
+    backend::{
+        input::InputTime,
+        renderer::{
+            ImportAll, ImportMem, Renderer, Texture,
+            element::{
+                AsRenderElements, solid::SolidColorRenderElement, surface::WaylandSurfaceRenderElement,
+            },
+        },
     },
     desktop::{
         Window, WindowSurface, WindowSurfaceType, space::SpaceElement, utils::OutputPresentationFeedback,
@@ -212,7 +217,7 @@ impl<BackendData: Backend> PointerTarget<AnvilState<BackendData>> for SSD {
         _seat: &Seat<AnvilState<BackendData>>,
         _data: &mut AnvilState<BackendData>,
         _serial: Serial,
-        _time: u32,
+        _time: InputTime,
     ) {
         let mut state = self.0.decoration_state();
         if state.is_ssd {
@@ -447,7 +452,7 @@ impl<BackendData: Backend> TabletToolTarget<AnvilState<BackendData>> for SSD {
         _seat: &Seat<AnvilState<BackendData>>,
         _data: &mut AnvilState<BackendData>,
         _tool_descriptor: &smithay::backend::input::TabletToolDescriptor,
-        _time: u32,
+        _time: InputTime,
     ) {
     }
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use ::winit::event_loop::pump_events::PumpStatus;
 use smithay::{
     backend::{
-        input::{InputEvent, KeyboardKeyEvent},
+        input::{InputEvent, InputTime, KeyboardKeyEvent},
         renderer::{
             Color32F, Frame, Renderer,
             element::{
@@ -181,7 +181,7 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
                         event.key_code(),
                         event.state(),
                         0.into(),
-                        0,
+                        InputTime::from_millis(0),
                         |_, _, _| {
                             //
                             FilterResult::Forward

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -181,7 +181,7 @@ pub fn run_winit() -> Result<(), Box<dyn std::error::Error>> {
                         event.key_code(),
                         event.state(),
                         0.into(),
-                        InputTime::from_millis(0),
+                        InputTime::now(),
                         |_, _, _| {
                             //
                             FilterResult::Forward

--- a/examples/seat.rs
+++ b/examples/seat.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             smithay::backend::input::Keycode::from(9u32),
             smithay::backend::input::KeyState::Pressed,
             0.into(),
-            InputTime::from_millis(0),
+            InputTime::now(),
             |_, _, _| {
                 if false {
                     FilterResult::Intercept(0)

--- a/examples/seat.rs
+++ b/examples/seat.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use smithay::backend::input::InputTime;
 use smithay::input::{Seat, SeatHandler, SeatState, keyboard::FilterResult};
 use smithay::reexports::wayland_server::{
     Display, ListeningSocket,
@@ -66,7 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             smithay::backend::input::Keycode::from(9u32),
             smithay::backend::input::KeyState::Pressed,
             0.into(),
-            0,
+            InputTime::from_millis(0),
             |_, _, _| {
                 if false {
                     FilterResult::Intercept(0)

--- a/smallvil/src/input.rs
+++ b/smallvil/src/input.rs
@@ -18,7 +18,7 @@ impl Smallvil {
         match event {
             InputEvent::Keyboard { event, .. } => {
                 let serial = SERIAL_COUNTER.next_serial();
-                let time = Event::time_msec(&event);
+                let time = Event::time(&event);
 
                 self.seat.get_keyboard().unwrap().input::<(), _>(
                     self,
@@ -49,7 +49,7 @@ impl Smallvil {
                     &MotionEvent {
                         location: pos,
                         serial,
-                        time: event.time_msec(),
+                        time: event.time(),
                     },
                 );
                 pointer.frame(self);
@@ -94,7 +94,7 @@ impl Smallvil {
                         button,
                         state: button_state,
                         serial,
-                        time: event.time_msec(),
+                        time: event.time(),
                     },
                 );
                 pointer.frame(self);
@@ -111,7 +111,7 @@ impl Smallvil {
                 let horizontal_amount_discrete = event.amount_v120(Axis::Horizontal);
                 let vertical_amount_discrete = event.amount_v120(Axis::Vertical);
 
-                let mut frame = AxisFrame::new(event.time_msec()).source(source);
+                let mut frame = AxisFrame::new(event.time()).source(source);
                 if horizontal_amount != 0.0 {
                     frame = frame.value(Axis::Horizontal, horizontal_amount);
                     if let Some(discrete) = horizontal_amount_discrete {

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -11,6 +11,34 @@ pub use tablet::{
     TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent, TabletToolTipState, TabletToolType,
 };
 
+/// Input timestamp in microseconds, with an undefined base.
+///
+/// Libinput does not guarantee that timestamps always increase monotonically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InputTime(u64);
+
+impl InputTime {
+    /// Input time from milliseconds
+    pub fn from_millis(milliseconds: u32) -> Self {
+        Self(u64::from(milliseconds) * 1000)
+    }
+
+    /// Input time from microseconds
+    pub fn from_micros(microseconds: u64) -> Self {
+        Self(microseconds)
+    }
+
+    /// Input time in milliseconds
+    pub fn millis(&self) -> u32 {
+        (self.0 / 1000) as u32
+    }
+
+    /// Input time in microseconds
+    pub fn micros(&self) -> u64 {
+        self.0
+    }
+}
+
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::protocol::wl_pointer;
 
@@ -52,18 +80,13 @@ pub enum DeviceCapability {
 
 /// Trait for generic functions every input event does provide
 pub trait Event<B: InputBackend> {
-    /// Timestamp in milliseconds
-    fn time_msec(&self) -> u32 {
-        (self.time() / 1000) as u32
-    }
-
     /// Timestamp in microseconds, with an undefined base.
     ///
     /// Libinput does not guarantee that timestamps always increase monotonically.
     // # TODO:
     // - check if events can even arrive out of order.
     // - Make stronger time guarantees, if possible
-    fn time(&self) -> u64;
+    fn time(&self) -> InputTime;
 
     /// Returns the device, that generated this event
     fn device(&self) -> B::Device;
@@ -79,7 +102,7 @@ pub trait Event<B: InputBackend> {
 pub enum UnusedEvent {}
 
 impl<B: InputBackend> Event<B> for UnusedEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         match *self {}
     }
 

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -14,7 +14,7 @@ pub use tablet::{
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::protocol::wl_pointer;
 
-use crate::utils::{Logical, Point, Raw, Size};
+use crate::utils::{Clock, Logical, Monotonic, Point, Raw, Size};
 
 /// Input timestamp in microseconds, with an undefined base.
 ///
@@ -23,6 +23,16 @@ use crate::utils::{Logical, Point, Raw, Size};
 pub struct InputTime(u64);
 
 impl InputTime {
+    /// Current input time, for synthesizing input events that do not come from
+    /// the input backend.
+    ///
+    /// This assumes the input backend uses `CLOCK_MONOTONIC` timestamps. This
+    /// is guaranteed by `libinput` and `libei` timestamps, but is not required
+    /// by Wayland itself. In practice, this should be true across backends.
+    pub fn now() -> Self {
+        Self::from_millis(Clock::<Monotonic>::new().now().as_millis())
+    }
+
     /// Input time from milliseconds
     pub fn from_millis(milliseconds: u32) -> Self {
         Self(u64::from(milliseconds) * 1000)

--- a/src/backend/input/mod.rs
+++ b/src/backend/input/mod.rs
@@ -16,6 +16,34 @@ use wayland_server::protocol::wl_pointer;
 
 use crate::utils::{Logical, Point, Raw, Size};
 
+/// Input timestamp in microseconds, with an undefined base.
+///
+/// Libinput does not guarantee that timestamps always increase monotonically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InputTime(u64);
+
+impl InputTime {
+    /// Input time from milliseconds
+    pub fn from_millis(milliseconds: u32) -> Self {
+        Self(u64::from(milliseconds) * 1000)
+    }
+
+    /// Input time from microseconds
+    pub fn from_micros(microseconds: u64) -> Self {
+        Self(microseconds)
+    }
+
+    /// Input time in milliseconds
+    pub fn millis(&self) -> u32 {
+        (self.0 / 1000) as u32
+    }
+
+    /// Input time in microseconds
+    pub fn micros(&self) -> u64 {
+        self.0
+    }
+}
+
 /// Trait for generic functions every input device does provide
 pub trait Device: PartialEq + Eq + std::hash::Hash {
     /// Backend-specific identifier for this device.
@@ -52,18 +80,13 @@ pub enum DeviceCapability {
 
 /// Trait for generic functions every input event does provide
 pub trait Event<B: InputBackend> {
-    /// Timestamp in milliseconds
-    fn time_msec(&self) -> u32 {
-        (self.time() / 1000) as u32
-    }
-
     /// Timestamp in microseconds, with an undefined base.
     ///
     /// Libinput does not guarantee that timestamps always increase monotonically.
     // # TODO:
     // - check if events can even arrive out of order.
     // - Make stronger time guarantees, if possible
-    fn time(&self) -> u64;
+    fn time(&self) -> InputTime;
 
     /// Returns the device, that generated this event
     fn device(&self) -> B::Device;
@@ -79,7 +102,7 @@ pub trait Event<B: InputBackend> {
 pub enum UnusedEvent {}
 
 impl<B: InputBackend> Event<B> for UnusedEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         match *self {}
     }
 

--- a/src/backend/libei/input.rs
+++ b/src/backend/libei/input.rs
@@ -6,7 +6,7 @@ use reis::{
 };
 use std::path::PathBuf;
 
-use crate::backend::input::{self, InputBackend};
+use crate::backend::input::{self, InputBackend, InputTime};
 
 use super::EiInput;
 
@@ -93,8 +93,8 @@ impl input::Device for request::Device {
 }
 
 impl<T: request::DeviceEvent + request::EventTime> input::Event<EiInput> for T {
-    fn time(&self) -> u64 {
-        request::EventTime::time(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(request::EventTime::time(self))
     }
 
     fn device(&self) -> request::Device {
@@ -120,7 +120,7 @@ impl input::KeyboardKeyEvent<EiInput> for request::KeyboardKey {
 }
 
 impl input::Event<EiInput> for ScrollEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         match self {
             Self::Delta(evt) => evt.time(),
             Self::Cancel(evt) => evt.time(),

--- a/src/backend/libei/input.rs
+++ b/src/backend/libei/input.rs
@@ -6,7 +6,7 @@ use reis::{
 };
 use std::path::PathBuf;
 
-use crate::backend::input::{self, InputBackend};
+use crate::backend::input::{self, InputBackend, InputTime};
 
 use super::EiInput;
 
@@ -93,8 +93,8 @@ impl input::Device for request::Device {
 }
 
 impl<T: request::DeviceEvent + request::EventTime> input::Event<EiInput> for T {
-    fn time(&self) -> u64 {
-        request::EventTime::time(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(request::EventTime::time(self))
     }
 
     fn device(&self) -> request::Device {
@@ -122,7 +122,7 @@ impl input::KeyboardKeyEvent<EiInput> for request::KeyboardKey {
 }
 
 impl input::Event<EiInput> for ScrollEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         match self {
             Self::Delta(evt) => evt.time(),
             Self::Cancel(evt) => evt.time(),

--- a/src/backend/libinput/mod.rs
+++ b/src/backend/libinput/mod.rs
@@ -1,7 +1,7 @@
 //! Implementation of input backend trait for types provided by `libinput`
 
 use crate::backend::input::{
-    self as backend, Axis, AxisRelativeDirection, AxisSource, InputBackend, InputEvent,
+    self as backend, Axis, AxisRelativeDirection, AxisSource, InputBackend, InputEvent, InputTime,
 };
 #[cfg(feature = "backend_session")]
 use crate::backend::session::{AsErrno, Session};
@@ -101,8 +101,8 @@ impl From<backend::DeviceCapability> for libinput::DeviceCapability {
 }
 
 impl backend::Event<LibinputInputBackend> for event::keyboard::KeyboardKeyEvent {
-    fn time(&self) -> u64 {
-        event::keyboard::KeyboardEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::keyboard::KeyboardEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -127,8 +127,8 @@ impl backend::KeyboardKeyEvent<LibinputInputBackend> for event::keyboard::Keyboa
 }
 
 impl backend::Event<LibinputInputBackend> for event::switch::SwitchToggleEvent {
-    fn time(&self) -> u64 {
-        event::switch::SwitchEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::switch::SwitchEventTrait::time_usec(self))
     }
 
     fn device(&self) -> <LibinputInputBackend as InputBackend>::Device {
@@ -178,12 +178,12 @@ impl PointerScrollAxis {
 }
 
 impl backend::Event<LibinputInputBackend> for PointerScrollAxis {
-    fn time(&self) -> u64 {
-        match self {
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(match self {
             Self::Wheel(evt) => event::pointer::PointerEventTrait::time_usec(evt),
             Self::Finger(evt) => event::pointer::PointerEventTrait::time_usec(evt),
             Self::Continuous(evt) => event::pointer::PointerEventTrait::time_usec(evt),
-        }
+        })
     }
 
     fn device(&self) -> libinput::Device {
@@ -242,8 +242,8 @@ impl backend::PointerAxisEvent<LibinputInputBackend> for PointerScrollAxis {
 }
 
 impl backend::Event<LibinputInputBackend> for event::pointer::PointerButtonEvent {
-    fn time(&self) -> u64 {
-        event::pointer::PointerEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::pointer::PointerEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -262,8 +262,8 @@ impl backend::PointerButtonEvent<LibinputInputBackend> for event::pointer::Point
 }
 
 impl backend::Event<LibinputInputBackend> for event::pointer::PointerMotionEvent {
-    fn time(&self) -> u64 {
-        event::pointer::PointerEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::pointer::PointerEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -290,8 +290,8 @@ impl backend::PointerMotionEvent<LibinputInputBackend> for event::pointer::Point
 }
 
 impl backend::Event<LibinputInputBackend> for event::pointer::PointerMotionAbsoluteEvent {
-    fn time(&self) -> u64 {
-        event::pointer::PointerEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::pointer::PointerEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -341,8 +341,8 @@ where
 }
 
 impl backend::Event<LibinputInputBackend> for event::gesture::GestureSwipeBeginEvent {
-    fn time(&self) -> u64 {
-        event::gesture::GestureEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::gesture::GestureEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -353,8 +353,8 @@ impl backend::Event<LibinputInputBackend> for event::gesture::GestureSwipeBeginE
 impl backend::GestureSwipeBeginEvent<LibinputInputBackend> for event::gesture::GestureSwipeBeginEvent {}
 
 impl backend::Event<LibinputInputBackend> for event::gesture::GestureSwipeUpdateEvent {
-    fn time(&self) -> u64 {
-        event::gesture::GestureEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::gesture::GestureEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -373,8 +373,8 @@ impl backend::GestureSwipeUpdateEvent<LibinputInputBackend> for event::gesture::
 }
 
 impl backend::Event<LibinputInputBackend> for event::gesture::GestureSwipeEndEvent {
-    fn time(&self) -> u64 {
-        event::gesture::GestureEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::gesture::GestureEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -385,8 +385,8 @@ impl backend::Event<LibinputInputBackend> for event::gesture::GestureSwipeEndEve
 impl backend::GestureSwipeEndEvent<LibinputInputBackend> for event::gesture::GestureSwipeEndEvent {}
 
 impl backend::Event<LibinputInputBackend> for event::gesture::GesturePinchBeginEvent {
-    fn time(&self) -> u64 {
-        event::gesture::GestureEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::gesture::GestureEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -397,8 +397,8 @@ impl backend::Event<LibinputInputBackend> for event::gesture::GesturePinchBeginE
 impl backend::GesturePinchBeginEvent<LibinputInputBackend> for event::gesture::GesturePinchBeginEvent {}
 
 impl backend::Event<LibinputInputBackend> for event::gesture::GesturePinchUpdateEvent {
-    fn time(&self) -> u64 {
-        event::gesture::GestureEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::gesture::GestureEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -425,8 +425,8 @@ impl backend::GesturePinchUpdateEvent<LibinputInputBackend> for event::gesture::
 }
 
 impl backend::Event<LibinputInputBackend> for event::gesture::GesturePinchEndEvent {
-    fn time(&self) -> u64 {
-        event::gesture::GestureEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::gesture::GestureEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -437,8 +437,8 @@ impl backend::Event<LibinputInputBackend> for event::gesture::GesturePinchEndEve
 impl backend::GesturePinchEndEvent<LibinputInputBackend> for event::gesture::GesturePinchEndEvent {}
 
 impl backend::Event<LibinputInputBackend> for event::gesture::GestureHoldBeginEvent {
-    fn time(&self) -> u64 {
-        event::gesture::GestureEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::gesture::GestureEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -449,8 +449,8 @@ impl backend::Event<LibinputInputBackend> for event::gesture::GestureHoldBeginEv
 impl backend::GestureHoldBeginEvent<LibinputInputBackend> for event::gesture::GestureHoldBeginEvent {}
 
 impl backend::Event<LibinputInputBackend> for event::gesture::GestureHoldEndEvent {
-    fn time(&self) -> u64 {
-        event::gesture::GestureEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::gesture::GestureEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -461,8 +461,8 @@ impl backend::Event<LibinputInputBackend> for event::gesture::GestureHoldEndEven
 impl backend::GestureHoldEndEvent<LibinputInputBackend> for event::gesture::GestureHoldEndEvent {}
 
 impl backend::Event<LibinputInputBackend> for event::touch::TouchDownEvent {
-    fn time(&self) -> u64 {
-        event::touch::TouchEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::touch::TouchEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -497,8 +497,8 @@ impl backend::AbsolutePositionEvent<LibinputInputBackend> for event::touch::Touc
 }
 
 impl backend::Event<LibinputInputBackend> for event::touch::TouchMotionEvent {
-    fn time(&self) -> u64 {
-        event::touch::TouchEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::touch::TouchEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -533,8 +533,8 @@ impl backend::AbsolutePositionEvent<LibinputInputBackend> for event::touch::Touc
 }
 
 impl backend::Event<LibinputInputBackend> for event::touch::TouchUpEvent {
-    fn time(&self) -> u64 {
-        event::touch::TouchEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::touch::TouchEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -551,8 +551,8 @@ impl backend::TouchEvent<LibinputInputBackend> for event::touch::TouchUpEvent {
 }
 
 impl backend::Event<LibinputInputBackend> for event::touch::TouchCancelEvent {
-    fn time(&self) -> u64 {
-        event::touch::TouchEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::touch::TouchEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {
@@ -569,8 +569,8 @@ impl backend::TouchEvent<LibinputInputBackend> for event::touch::TouchCancelEven
 }
 
 impl backend::Event<LibinputInputBackend> for event::touch::TouchFrameEvent {
-    fn time(&self) -> u64 {
-        event::touch::TouchEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(event::touch::TouchEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {

--- a/src/backend/libinput/tablet.rs
+++ b/src/backend/libinput/tablet.rs
@@ -1,5 +1,6 @@
 use crate::backend::input::{
-    self as backend, TabletToolCapabilities, TabletToolDescriptor, TabletToolTipState, TabletToolType,
+    self as backend, InputTime, TabletToolCapabilities, TabletToolDescriptor, TabletToolTipState,
+    TabletToolType,
 };
 
 use input as libinput;
@@ -20,8 +21,8 @@ impl<E> backend::Event<LibinputInputBackend> for E
 where
     E: IsTabletEvent,
 {
-    fn time(&self) -> u64 {
-        tablet_tool::TabletToolEventTrait::time_usec(self)
+    fn time(&self) -> InputTime {
+        InputTime::from_micros(tablet_tool::TabletToolEventTrait::time_usec(self))
     }
 
     fn device(&self) -> libinput::Device {

--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -7,7 +7,7 @@ use winit::{
 
 use crate::backend::input::{
     self, AbsolutePositionEvent, Axis, AxisRelativeDirection, AxisSource, ButtonState, Device,
-    DeviceCapability, Event, InputBackend, KeyState, KeyboardKeyEvent, Keycode, PointerAxisEvent,
+    DeviceCapability, Event, InputBackend, InputTime, KeyState, KeyboardKeyEvent, Keycode, PointerAxisEvent,
     PointerButtonEvent, PointerMotionAbsoluteEvent, TouchCancelEvent, TouchDownEvent, TouchEvent,
     TouchMotionEvent, TouchSlot, TouchUpEvent, UnusedEvent,
 };
@@ -48,14 +48,14 @@ impl Device for WinitVirtualDevice {
 /// Winit-Backend internal event wrapping `winit`'s types into a [`KeyboardKeyEvent`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WinitKeyboardInputEvent {
-    pub(crate) time: u64,
+    pub(crate) time: InputTime,
     pub(crate) key: u32,
     pub(crate) count: u32,
     pub(crate) state: ElementState,
 }
 
 impl Event<WinitInput> for WinitKeyboardInputEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         self.time
     }
 
@@ -81,13 +81,13 @@ impl KeyboardKeyEvent<WinitInput> for WinitKeyboardInputEvent {
 /// Winit-Backend internal event wrapping `winit`'s types into a [`PointerMotionAbsoluteEvent`]
 #[derive(Debug, Clone)]
 pub struct WinitMouseMovedEvent {
-    pub(crate) time: u64,
+    pub(crate) time: InputTime,
     pub(crate) position: RelativePosition,
     pub(crate) global_position: PhysicalPosition<f64>,
 }
 
 impl Event<WinitInput> for WinitMouseMovedEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         self.time
     }
 
@@ -118,12 +118,12 @@ impl AbsolutePositionEvent<WinitInput> for WinitMouseMovedEvent {
 /// Winit-Backend internal event wrapping `winit`'s types into a [`PointerAxisEvent`]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct WinitMouseWheelEvent {
-    pub(crate) time: u64,
+    pub(crate) time: InputTime,
     pub(crate) delta: MouseScrollDelta,
 }
 
 impl Event<WinitInput> for WinitMouseWheelEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         self.time
     }
 
@@ -166,14 +166,14 @@ impl PointerAxisEvent<WinitInput> for WinitMouseWheelEvent {
 /// Winit-Backend internal event wrapping `winit`'s types into a [`PointerButtonEvent`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WinitMouseInputEvent {
-    pub(crate) time: u64,
+    pub(crate) time: InputTime,
     pub(crate) button: WinitMouseButton,
     pub(crate) state: ElementState,
     pub(crate) is_x11: bool,
 }
 
 impl Event<WinitInput> for WinitMouseInputEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         self.time
     }
 
@@ -208,14 +208,14 @@ impl PointerButtonEvent<WinitInput> for WinitMouseInputEvent {
 /// Winit-Backend internal event wrapping `winit`'s types into a [`TouchDownEvent`]
 #[derive(Debug, Clone)]
 pub struct WinitTouchStartedEvent {
-    pub(crate) time: u64,
+    pub(crate) time: InputTime,
     pub(crate) position: RelativePosition,
     pub(crate) global_position: PhysicalPosition<f64>,
     pub(crate) id: u64,
 }
 
 impl Event<WinitInput> for WinitTouchStartedEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         self.time
     }
 
@@ -253,14 +253,14 @@ impl AbsolutePositionEvent<WinitInput> for WinitTouchStartedEvent {
 /// Winit-Backend internal event wrapping `winit`'s types into a [`TouchMotionEvent`]
 #[derive(Debug, Clone)]
 pub struct WinitTouchMovedEvent {
-    pub(crate) time: u64,
+    pub(crate) time: InputTime,
     pub(crate) position: RelativePosition,
     pub(crate) global_position: PhysicalPosition<f64>,
     pub(crate) id: u64,
 }
 
 impl Event<WinitInput> for WinitTouchMovedEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         self.time
     }
 
@@ -298,12 +298,12 @@ impl AbsolutePositionEvent<WinitInput> for WinitTouchMovedEvent {
 /// Winit-Backend internal event wrapping `winit`'s types into a `TouchUpEvent`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WinitTouchEndedEvent {
-    pub(crate) time: u64,
+    pub(crate) time: InputTime,
     pub(crate) id: u64,
 }
 
 impl Event<WinitInput> for WinitTouchEndedEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         self.time
     }
 
@@ -323,12 +323,12 @@ impl TouchEvent<WinitInput> for WinitTouchEndedEvent {
 /// Winit-Backend internal event wrapping `winit`'s types into a [`TouchCancelEvent`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WinitTouchCancelledEvent {
-    pub(crate) time: u64,
+    pub(crate) time: InputTime,
     pub(crate) id: u64,
 }
 
 impl Event<WinitInput> for WinitTouchCancelledEvent {
-    fn time(&self) -> u64 {
+    fn time(&self) -> InputTime {
         self.time
     }
 

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -47,7 +47,7 @@ use crate::{
             display::EGLDisplay,
             native,
         },
-        input::InputEvent,
+        input::{InputEvent, InputTime},
         renderer::{
             Bind,
             gles::{GlesError, GlesRenderer},
@@ -452,8 +452,8 @@ struct WinitEventLoopApp<'a, F: FnMut(WinitEvent)> {
 }
 
 impl<F: FnMut(WinitEvent)> WinitEventLoopApp<'_, F> {
-    fn timestamp(&self) -> u64 {
-        self.inner.clock.now().as_micros()
+    fn timestamp(&self) -> InputTime {
+        InputTime::from_micros(self.inner.clock.now().as_micros())
     }
 }
 

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -53,7 +53,7 @@ use crate::{
             gles::{GlesError, GlesRenderer},
         },
     },
-    utils::{Clock, Monotonic, Physical, Rectangle, Size},
+    utils::{Physical, Rectangle, Size},
 };
 
 mod input;
@@ -117,7 +117,6 @@ where
     let mut window_event_loop_inner = WinitEventLoopInner {
         window_attributes: attributes,
         scale_factor: 1.0,
-        clock: Clock::<Monotonic>::new(),
         key_counter: 0,
         // Will be initialized after window creation
         window: None,
@@ -389,7 +388,6 @@ struct WinitEventLoopInner {
     window_attributes: WindowAttributes,
     window: Option<Arc<dyn WinitWindow>>,
     window_create_error: Option<Error>,
-    clock: Clock<Monotonic>,
     key_counter: u32,
     is_x11: bool,
     scale_factor: f64,
@@ -453,7 +451,8 @@ struct WinitEventLoopApp<'a, F: FnMut(WinitEvent)> {
 
 impl<F: FnMut(WinitEvent)> WinitEventLoopApp<'_, F> {
     fn timestamp(&self) -> InputTime {
-        InputTime::from_micros(self.inner.clock.now().as_micros())
+        // TODO Get input time from X11 or Wayland?
+        InputTime::now()
     }
 }
 

--- a/src/backend/x11/input.rs
+++ b/src/backend/x11/input.rs
@@ -4,7 +4,7 @@ use super::{Window, WindowTemporary, window_inner::WindowInner};
 use crate::{
     backend::input::{
         self, AbsolutePositionEvent, Axis, AxisRelativeDirection, AxisSource, ButtonState, Device,
-        DeviceCapability, InputBackend, KeyState, KeyboardKeyEvent, Keycode, PointerAxisEvent,
+        DeviceCapability, InputBackend, InputTime, KeyState, KeyboardKeyEvent, Keycode, PointerAxisEvent,
         PointerButtonEvent, PointerMotionAbsoluteEvent, UnusedEvent,
     },
     utils::{Logical, Size},
@@ -64,8 +64,8 @@ impl X11KeyboardInputEvent {
 }
 
 impl input::Event<X11Input> for X11KeyboardInputEvent {
-    fn time(&self) -> u64 {
-        self.time as u64 * 1000
+    fn time(&self) -> InputTime {
+        InputTime::from_millis(self.time)
     }
 
     fn device(&self) -> X11VirtualDevice {
@@ -106,8 +106,8 @@ impl X11MouseWheelEvent {
 }
 
 impl input::Event<X11Input> for X11MouseWheelEvent {
-    fn time(&self) -> u64 {
-        self.time as u64 * 1000
+    fn time(&self) -> InputTime {
+        InputTime::from_millis(self.time)
     }
 
     fn device(&self) -> X11VirtualDevice {
@@ -160,8 +160,8 @@ impl X11MouseInputEvent {
 }
 
 impl input::Event<X11Input> for X11MouseInputEvent {
-    fn time(&self) -> u64 {
-        self.time as u64 * 1000
+    fn time(&self) -> InputTime {
+        InputTime::from_millis(self.time)
     }
 
     fn device(&self) -> X11VirtualDevice {
@@ -199,8 +199,8 @@ impl X11MouseMovedEvent {
 }
 
 impl input::Event<X11Input> for X11MouseMovedEvent {
-    fn time(&self) -> u64 {
-        self.time as u64 * 1000
+    fn time(&self) -> InputTime {
+        InputTime::from_millis(self.time)
     }
 
     fn device(&self) -> X11VirtualDevice {

--- a/src/desktop/wayland/popup/grab.rs
+++ b/src/desktop/wayland/popup/grab.rs
@@ -6,7 +6,7 @@ use std::{
 use wayland_server::{Resource, protocol::wl_surface::WlSurface};
 
 use crate::{
-    backend::input::{ButtonState, KeyState, Keycode},
+    backend::input::{ButtonState, InputTime, KeyState, Keycode},
     input::{
         SeatHandler,
         keyboard::{
@@ -446,7 +446,7 @@ where
         state: KeyState,
         modifiers: Option<ModifiersState>,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         // Check if the grab changed and update the focus
         // If the grab has ended this will return the root

--- a/src/input/dnd/grab.rs
+++ b/src/input/dnd/grab.rs
@@ -9,6 +9,7 @@ use crate::{wayland::seat::WaylandFocus, xwayland::XWaylandClientData};
 use wayland_server::Resource;
 
 use crate::{
+    backend::input::InputTime,
     input::{
         Seat, SeatHandler,
         dnd::OfferData,
@@ -229,7 +230,7 @@ where
         focus: Option<(F, Point<f64, Logical>)>,
         location: Point<f64, Logical>,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         if self
             .current_focus

--- a/src/input/dnd/mod.rs
+++ b/src/input/dnd/mod.rs
@@ -11,6 +11,7 @@ use wayland_server::DisplayHandle;
 #[cfg(feature = "xwayland")]
 use crate::wayland::seat::WaylandFocus;
 use crate::{
+    backend::input::InputTime,
     input::{Seat, SeatHandler},
     utils::{IsAlive, Logical, Point, Serial},
 };
@@ -114,7 +115,7 @@ pub trait DndFocus<D: SeatHandler>: WaylandFocus + IsAlive + PartialEq {
         offer: Option<&mut Self::OfferData<S>>,
         seat: &Seat<D>,
         location: Point<f64, Logical>,
-        time: u32,
+        time: InputTime,
     );
 
     /// An active Drag'n'Drop operation, which has previously
@@ -152,7 +153,7 @@ pub trait DndFocus<D: SeatHandler>: IsAlive + PartialEq {
         offer: Option<&mut Self::OfferData<S>>,
         seat: &Seat<D>,
         location: Point<f64, Logical>,
-        time: u32,
+        time: InputTime,
     );
 
     /// An active Drag'n'Drop operation, which has previously

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -1,6 +1,6 @@
 //! Keyboard-related types for smithay's input abstraction
 
-use crate::backend::input::KeyState;
+use crate::backend::input::{InputTime, KeyState};
 use crate::utils::{IsAlive, SERIAL_COUNTER, Serial};
 use downcast_rs::{Downcast, impl_downcast};
 use std::collections::{HashMap, HashSet};
@@ -49,7 +49,7 @@ where
         key: KeysymHandle<'_>,
         state: KeyState,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     );
     /// Hold modifiers were changed on a keyboard from a given seat
     fn modifiers(&self, seat: &Seat<D>, data: &mut D, modifiers: ModifiersState, serial: Serial);
@@ -677,7 +677,7 @@ pub trait KeyboardGrab<D: SeatHandler>: Downcast {
         state: KeyState,
         modifiers: Option<ModifiersState>,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     );
 
     /// A focus change was requested.
@@ -1029,7 +1029,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         keycode: Keycode,
         state: KeyState,
         serial: Serial,
-        time: u32,
+        time: InputTime,
         filter: F,
     ) -> Option<T>
     where
@@ -1047,7 +1047,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         keycode: Keycode,
         state: KeyState,
         serial: Serial,
-        time: u32,
+        time: InputTime,
         filter: F,
     ) -> Option<T>
     where
@@ -1097,7 +1097,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         };
         let _ = mods;
         let serial = SERIAL_COUNTER.next_serial();
-        let time = 0;
+        let time = InputTime::from_millis(0);
         for keycode in transitioned {
             // modifiers may have changed as a modifier key was released; let input_forward
             // re-derive and send the current state.
@@ -1154,7 +1154,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         keycode: Keycode,
         state: KeyState,
         serial: Serial,
-        time: u32,
+        time: InputTime,
         mods_changed: bool,
     ) {
         let mut guard = self.arc.internal.lock().unwrap();
@@ -1435,11 +1435,25 @@ where
             let release = SERIAL_COUNTER.next_serial();
             if let Some((focus, _)) = guard.focus.as_mut() {
                 let handle = KeysymHandle { xkb: &xkb, keycode };
-                focus.key(&seat, data, handle, KeyState::Pressed, press, 0);
+                focus.key(
+                    &seat,
+                    data,
+                    handle,
+                    KeyState::Pressed,
+                    press,
+                    InputTime::from_millis(0),
+                );
             }
             if let Some((focus, _)) = guard.focus.as_mut() {
                 let handle = KeysymHandle { xkb: &xkb, keycode };
-                focus.key(&seat, data, handle, KeyState::Released, release, 0);
+                focus.key(
+                    &seat,
+                    data,
+                    handle,
+                    KeyState::Released,
+                    release,
+                    InputTime::from_millis(0),
+                );
             }
         }
 
@@ -1544,7 +1558,7 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
         key_state: KeyState,
         modifiers: Option<ModifiersState>,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         let (focus, _) = match self.inner.focus.as_mut() {
             Some(focus) => focus,
@@ -1654,7 +1668,7 @@ impl<D: SeatHandler + 'static> KeyboardGrab<D> for DefaultGrab {
         state: KeyState,
         modifiers: Option<ModifiersState>,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         handle.input(data, keycode, state, modifiers, serial, time)
     }

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -1097,7 +1097,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         };
         let _ = mods;
         let serial = SERIAL_COUNTER.next_serial();
-        let time = InputTime::from_millis(0);
+        let time = InputTime::now();
         for keycode in transitioned {
             // modifiers may have changed as a modifier key was released; let input_forward
             // re-derive and send the current state.
@@ -1435,25 +1435,11 @@ where
             let release = SERIAL_COUNTER.next_serial();
             if let Some((focus, _)) = guard.focus.as_mut() {
                 let handle = KeysymHandle { xkb: &xkb, keycode };
-                focus.key(
-                    &seat,
-                    data,
-                    handle,
-                    KeyState::Pressed,
-                    press,
-                    InputTime::from_millis(0),
-                );
+                focus.key(&seat, data, handle, KeyState::Pressed, press, InputTime::now());
             }
             if let Some((focus, _)) = guard.focus.as_mut() {
                 let handle = KeysymHandle { xkb: &xkb, keycode };
-                focus.key(
-                    &seat,
-                    data,
-                    handle,
-                    KeyState::Released,
-                    release,
-                    InputTime::from_millis(0),
-                );
+                focus.key(&seat, data, handle, KeyState::Released, release, InputTime::now());
             }
         }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! ```
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::{InputTime, KeyState};
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -52,7 +52,7 @@
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
 //! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
-//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: InputTime) {}
 //! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
 //! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
 //! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
@@ -72,7 +72,7 @@
 //! #       key: KeysymHandle<'_>,
 //! #       state: KeyState,
 //! #       serial: Serial,
-//! #       time: u32,
+//! #       time: InputTime,
 //! #   ) {}
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
@@ -390,7 +390,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     ///
     /// ```no_run
     /// # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
-    /// # use smithay::backend::input::KeyState;
+    /// # use smithay::backend::input::{InputTime, KeyState};
     /// # use smithay::input::{
     /// #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
     /// #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -413,7 +413,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
     /// #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
     /// #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
-    /// #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+    /// #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: InputTime) {}
     /// #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
     /// #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
     /// #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
@@ -433,7 +433,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #       key: KeysymHandle<'_>,
     /// #       state: KeyState,
     /// #       serial: Serial,
-    /// #       time: u32,
+    /// #       time: InputTime,
     /// #   ) {}
     /// #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
     /// # }
@@ -512,7 +512,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     ///
     /// ```no_run
     /// # use smithay::input::{Seat, SeatState, SeatHandler, keyboard::XkbConfig, pointer::CursorImageStatus};
-    /// # use smithay::backend::input::KeyState;
+    /// # use smithay::backend::input::{InputTime, KeyState};
     /// # use smithay::input::{
     /// #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
     /// #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -535,7 +535,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
     /// #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
     /// #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
-    /// #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+    /// #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: InputTime) {}
     /// #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
     /// #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
     /// #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
@@ -555,7 +555,7 @@ impl<D: SeatHandler + 'static> Seat<D> {
     /// #       key: KeysymHandle<'_>,
     /// #       state: KeyState,
     /// #       serial: Serial,
-    /// #       time: u32,
+    /// #       time: InputTime,
     /// #   ) {}
     /// #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
     /// # }

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::{
-    backend::input::{Axis, AxisRelativeDirection, AxisSource, ButtonState},
+    backend::input::{Axis, AxisRelativeDirection, AxisSource, ButtonState, InputTime},
     input::{GrabStatus, Seat, SeatHandler},
     utils::Serial,
     utils::{Clock, IsAlive, Logical, Monotonic, Point},
@@ -128,7 +128,7 @@ where
     /// A pointer of a given seat ended a hold gesture
     fn gesture_hold_end(&self, seat: &Seat<D>, data: &mut D, event: &GestureHoldEndEvent);
     /// A pointer of a given seat left this handler
-    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32);
+    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: InputTime);
     /// A pointer of a given seat moved from another handler to this handler
     fn replace(
         &self,
@@ -175,7 +175,7 @@ impl<D: SeatHandler + 'static> PointerHandle<D> {
 
     /// Remove any current grab on this pointer, resetting it to the default behavior
     #[instrument(level = "debug", parent = &self.span, skip(self, data))]
-    pub fn unset_grab(&self, data: &mut D, serial: Serial, time: u32) {
+    pub fn unset_grab(&self, data: &mut D, serial: Serial, time: InputTime) {
         let seat = self.get_seat(data);
         self.inner
             .lock()
@@ -536,7 +536,7 @@ impl<D: SeatHandler + 'static> PointerInnerHandle<'_, D> {
         handler: &mut dyn PointerGrab<D>,
         data: &mut D,
         serial: Serial,
-        time: u32,
+        time: InputTime,
         restore_focus: bool,
     ) {
         handler.unset(data);
@@ -754,13 +754,20 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
                 &MotionEvent {
                     location,
                     serial,
-                    time: Clock::<Monotonic>::new().now().as_millis(),
+                    time: InputTime::from_millis(Clock::<Monotonic>::new().now().as_millis()),
                 },
             );
         }
     }
 
-    fn unset_grab(&mut self, data: &mut D, seat: &Seat<D>, serial: Serial, time: u32, restore_focus: bool) {
+    fn unset_grab(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        serial: Serial,
+        time: InputTime,
+        restore_focus: bool,
+    ) {
         if let GrabStatus::Active(_, handler) = &mut self.grab {
             handler.unset(data);
         }
@@ -936,8 +943,8 @@ pub struct MotionEvent {
     pub location: Point<f64, Logical>,
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Relative pointer motion event
@@ -948,7 +955,7 @@ pub struct RelativeMotionEvent {
     /// Unaccelerated motion vector
     pub delta_unaccel: Point<f64, Logical>,
     /// Timestamp in microseconds
-    pub utime: u64,
+    pub time: InputTime,
 }
 
 /// Pointer button event
@@ -959,8 +966,8 @@ pub struct RelativeMotionEvent {
 pub struct ButtonEvent {
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp with millisecond granularity, with an undefined base.
-    pub time: u32,
+    /// Timestamp with microsecond granularity, with an undefined base.
+    pub time: InputTime,
     /// Button that produced the event
     ///
     /// The button is a button code as defined in the
@@ -992,7 +999,7 @@ pub struct AxisFrame {
     /// Direction of the physical motion that caused axis event
     pub relative_direction: (AxisRelativeDirection, AxisRelativeDirection),
     /// Time of the axis event
-    pub time: u32,
+    pub time: InputTime,
     /// Raw scroll value per axis of the event
     pub axis: (f64, f64),
     /// Discrete representation of scroll value per axis, if available
@@ -1008,8 +1015,8 @@ pub struct AxisFrame {
 pub struct GestureSwipeBeginEvent {
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
     /// Number of fingers of the event
     pub fingers: u32,
 }
@@ -1017,8 +1024,8 @@ pub struct GestureSwipeBeginEvent {
 /// Gesture swipe update event
 #[derive(Debug, Clone)]
 pub struct GestureSwipeUpdateEvent {
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
     /// Offset of the logical center of the gesture relative to the previous event
     pub delta: Point<f64, Logical>,
 }
@@ -1028,8 +1035,8 @@ pub struct GestureSwipeUpdateEvent {
 pub struct GestureSwipeEndEvent {
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
     /// Whether the gesture was cancelled
     pub cancelled: bool,
 }
@@ -1039,8 +1046,8 @@ pub struct GestureSwipeEndEvent {
 pub struct GesturePinchBeginEvent {
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
     /// Number of fingers of the event
     pub fingers: u32,
 }
@@ -1048,8 +1055,8 @@ pub struct GesturePinchBeginEvent {
 /// Gesture pinch update event
 #[derive(Debug, Clone)]
 pub struct GesturePinchUpdateEvent {
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
     /// Offset of the logical center of the gesture relative to the previous event
     pub delta: Point<f64, Logical>,
     /// Absolute scale compared to the begin event
@@ -1063,8 +1070,8 @@ pub struct GesturePinchUpdateEvent {
 pub struct GesturePinchEndEvent {
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
     /// Whether the gesture was cancelled
     pub cancelled: bool,
 }
@@ -1074,8 +1081,8 @@ pub struct GesturePinchEndEvent {
 pub struct GestureHoldBeginEvent {
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
     /// Number of fingers of the event
     pub fingers: u32,
 }
@@ -1085,15 +1092,15 @@ pub struct GestureHoldBeginEvent {
 pub struct GestureHoldEndEvent {
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
     /// Whether the gesture was cancelled
     pub cancelled: bool,
 }
 
 impl AxisFrame {
     /// Create a new frame of axis events
-    pub fn new(time: u32) -> Self {
+    pub fn new(time: InputTime) -> Self {
         AxisFrame {
             source: None,
             relative_direction: (AxisRelativeDirection::Identical, AxisRelativeDirection::Identical),

--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     backend::input::{Axis, AxisRelativeDirection, AxisSource, ButtonState, InputTime},
     input::{GrabStatus, Seat, SeatHandler},
     utils::Serial,
-    utils::{Clock, IsAlive, Logical, Monotonic, Point},
+    utils::{IsAlive, Logical, Point},
 };
 
 mod cursor_image;
@@ -754,7 +754,7 @@ impl<D: SeatHandler + 'static> PointerInternal<D> {
                 &MotionEvent {
                     location,
                     serial,
-                    time: InputTime::from_millis(Clock::<Monotonic>::new().now().as_millis()),
+                    time: InputTime::now(),
                 },
             );
         }

--- a/src/input/tablet/mod.rs
+++ b/src/input/tablet/mod.rs
@@ -19,7 +19,7 @@
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
 //! use smithay::input::tablet::{TabletSeatHandler, TabletSeatTrait};
 //! use smithay::backend::input::TabletToolDescriptor;
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::{InputTime, KeyState};
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -57,7 +57,7 @@
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
 //! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
-//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: InputTime) {}
 //! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
 //! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
 //! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
@@ -77,7 +77,7 @@
 //! #       key: KeysymHandle<'_>,
 //! #       state: KeyState,
 //! #       serial: Serial,
-//! #       time: u32,
+//! #       time: InputTime,
 //! #   ) {}
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
@@ -99,7 +99,7 @@
 //! #   fn motion(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::MotionEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, frame: tool::AxisFrame) {}
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::ButtonEvent) {}
-//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, time: u32) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, time: InputTime) {}
 //! # }
 //!
 //! // implement the required traits

--- a/src/input/tablet/tool/grab.rs
+++ b/src/input/tablet/tool/grab.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use downcast_rs::{Downcast, impl_downcast};
 
 use crate::{
+    backend::input::InputTime,
     input::{
         pointer::Focus,
         tablet::{
@@ -125,7 +126,7 @@ pub trait TabletToolGrab<D: TabletSeatHandler + 'static>: Send + Downcast {
     /// End of a tablet tool frame
     ///
     /// A frame groups associated events. This terminate the frame.
-    fn frame(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, time: u32);
+    fn frame(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, time: InputTime);
 
     /// The grab has been unset or replaced with another grab.
     fn unset(&mut self, data: &mut D);
@@ -227,7 +228,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolGrab<D> for DefaultGrab {
         handle.axis(data, frame);
     }
 
-    fn frame(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, time: u32) {
+    fn frame(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, time: InputTime) {
         handle.frame(data, time);
     }
 
@@ -317,7 +318,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolGrab<D> for DownGrab<D> {
         handle.axis(data, frame);
     }
 
-    fn frame(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, time: u32) {
+    fn frame(&mut self, data: &mut D, handle: &mut TabletToolInnerHandle<'_, D>, time: InputTime) {
         handle.frame(data, time);
     }
 

--- a/src/input/tablet/tool/mod.rs
+++ b/src/input/tablet/tool/mod.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::{hash::Hash, sync::Weak};
 
 use crate::{
-    backend::input::{ButtonState, TabletToolDescriptor},
+    backend::input::{ButtonState, InputTime, TabletToolDescriptor},
     input::{
         GrabStatus, Seat, SeatHandler,
         pointer::Focus,
@@ -119,7 +119,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolHandle<D> {
         &self,
         data: &mut D,
         grab: G,
-        time: u32,
+        time: InputTime,
         serial: Serial,
         focus: Focus,
     ) {
@@ -130,7 +130,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolHandle<D> {
     }
 
     /// Remove any current grab on this tablet tool, resetting it to the default behavior.
-    pub fn unset_grab(&self, data: &mut D, serial: Serial, time: u32) {
+    pub fn unset_grab(&self, data: &mut D, serial: Serial, time: InputTime) {
         let mut inner = self.arc.inner.lock().unwrap();
         let seat = self.get_seat(data);
 
@@ -351,7 +351,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolHandle<D> {
     /// End of a tool frame.
     ///
     /// A frame groups associated events. This terminates the frame.
-    pub fn frame(&self, data: &mut D, time: u32) {
+    pub fn frame(&self, data: &mut D, time: InputTime) {
         let mut inner = self.arc.inner.lock().unwrap();
         if !inner.in_proximity() && !inner.frame_pending {
             tracing::warn!("frame was called, but the tool hasn't entered tablet proximity.");
@@ -486,7 +486,7 @@ where
     );
 
     /// End of a tablet tool frame.
-    fn frame(&self, seat: &Seat<D>, data: &mut D, tool_descriptor: &TabletToolDescriptor, time: u32);
+    fn frame(&self, seat: &Seat<D>, data: &mut D, tool_descriptor: &TabletToolDescriptor, time: InputTime);
 }
 
 /// This inner handle is accessed from inside a tablet tool grab logic, and directly sends event to
@@ -515,7 +515,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolInnerHandle<'_, D> {
         &mut self,
         handler: &mut dyn TabletToolGrab<D>,
         data: &mut D,
-        time: u32,
+        time: InputTime,
         serial: Serial,
         focus: Focus,
         grab: G,
@@ -533,7 +533,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolInnerHandle<'_, D> {
         handler: &mut dyn TabletToolGrab<D>,
         data: &mut D,
         serial: Serial,
-        time: u32,
+        time: InputTime,
         restore_focus: bool,
     ) {
         handler.unset(data);
@@ -646,7 +646,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolInnerHandle<'_, D> {
     /// End of a tool frame.
     ///
     /// A frame groups associated events. This terminates the frame.
-    pub fn frame(&mut self, data: &mut D, time: u32) {
+    pub fn frame(&mut self, data: &mut D, time: InputTime) {
         self.inner.frame(data, self.seat, self.descriptor, time);
     }
 
@@ -710,7 +710,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolInternal<D> {
         seat: &Seat<D>,
         descriptor: &TabletToolDescriptor,
         grab: G,
-        time: u32,
+        time: InputTime,
         serial: Serial,
         focus: Focus,
     ) {
@@ -748,7 +748,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolInternal<D> {
         seat: &Seat<D>,
         descriptor: &TabletToolDescriptor,
         serial: Serial,
-        time: u32,
+        time: InputTime,
         restore_focus: bool,
     ) {
         if let GrabStatus::Active(_, handler) = &mut self.grab {
@@ -1049,7 +1049,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolInternal<D> {
         self.frame_pending = true;
     }
 
-    fn frame(&mut self, data: &mut D, seat: &Seat<D>, descriptor: &TabletToolDescriptor, time: u32) {
+    fn frame(&mut self, data: &mut D, seat: &Seat<D>, descriptor: &TabletToolDescriptor, time: InputTime) {
         if self.frame_pending {
             if let Some((focused, _)) = self.focus.as_mut() {
                 focused.frame(seat, data, descriptor, time);
@@ -1098,8 +1098,8 @@ pub struct ProximityInEvent {
     pub axis: Option<AxisFrame>,
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Proximity out event.
@@ -1107,8 +1107,8 @@ pub struct ProximityInEvent {
 pub struct ProximityOutEvent {
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Tablet tool motion event
@@ -1118,8 +1118,8 @@ pub struct MotionEvent {
     pub location: Point<f64, Logical>,
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Tablet tool button event
@@ -1134,8 +1134,8 @@ pub struct ButtonEvent {
     pub button: u32,
     /// Physical state of the button
     pub state: ButtonState,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Tip down event.
@@ -1145,8 +1145,8 @@ pub struct ButtonEvent {
 pub struct DownEvent {
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Tip up event.
@@ -1156,8 +1156,8 @@ pub struct DownEvent {
 pub struct UpEvent {
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// A frame of tablet tool axis events.

--- a/src/input/touch/mod.rs
+++ b/src/input/touch/mod.rs
@@ -8,7 +8,7 @@ use tracing::{info_span, instrument};
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::Weak;
 
-use crate::backend::input::TouchSlot;
+use crate::backend::input::{InputTime, TouchSlot};
 use crate::utils::{IsAlive, Logical, Point, Serial};
 
 pub use grab::{DefaultGrab, GrabStartData, TouchDownGrab, TouchGrab};
@@ -144,8 +144,8 @@ pub struct DownEvent {
     pub location: Point<f64, Logical>,
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Pointer motion event
@@ -155,8 +155,8 @@ pub struct UpEvent {
     pub slot: TouchSlot,
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Pointer motion event
@@ -166,8 +166,8 @@ pub struct MotionEvent {
     pub slot: TouchSlot,
     /// Location of the touch in compositor space
     pub location: Point<f64, Logical>,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Pointer motion event

--- a/src/input/touch/mod.rs
+++ b/src/input/touch/mod.rs
@@ -8,7 +8,7 @@ use tracing::{info_span, instrument};
 #[cfg(feature = "wayland_frontend")]
 use wayland_server::Weak;
 
-use crate::backend::input::TouchSlot;
+use crate::backend::input::{InputTime, TouchSlot};
 use crate::utils::{IsAlive, Logical, Point, Serial};
 
 pub use grab::{DefaultGrab, GrabStartData, TouchDownGrab, TouchGrab};
@@ -151,8 +151,8 @@ pub struct DownEvent {
     pub location: Point<f64, Logical>,
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Pointer motion event
@@ -162,8 +162,8 @@ pub struct UpEvent {
     pub slot: TouchSlot,
     /// Serial of the event
     pub serial: Serial,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Pointer motion event
@@ -173,8 +173,8 @@ pub struct MotionEvent {
     pub slot: TouchSlot,
     /// Location of the touch in compositor space
     pub location: Point<f64, Logical>,
-    /// Timestamp of the event, with millisecond granularity
-    pub time: u32,
+    /// Timestamp of the event, with microsecond granularity
+    pub time: InputTime,
 }
 
 /// Pointer motion event

--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -11,7 +11,7 @@
 //!
 //! use smithay::wayland::cursor_shape::CursorShapeManagerState;
 //!
-//! # use smithay::backend::input::{KeyState, TabletToolDescriptor};
+//! # use smithay::backend::input::{InputTime, KeyState, TabletToolDescriptor};
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -44,7 +44,7 @@
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
 //! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
-//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: InputTime) {}
 //! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
 //! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
 //! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
@@ -64,7 +64,7 @@
 //! #       key: KeysymHandle<'_>,
 //! #       state: KeyState,
 //! #       serial: Serial,
-//! #       time: u32,
+//! #       time: InputTime,
 //! #   ) {}
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
@@ -86,7 +86,7 @@
 //! #   fn motion(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::MotionEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, frame: tool::AxisFrame) {}
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, event: &tool::ButtonEvent) {}
-//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, time: u32) {}
+//! #   fn frame(&self, seat: &Seat<State>, data: &mut State, tool_descriptor: &TabletToolDescriptor, time: InputTime) {}
 //! # }
 //! # struct State {
 //! #     seat_state: SeatState<Self>,

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -17,7 +17,7 @@ use crate::input::{
 };
 use crate::wayland::text_input::TextInputHandle;
 use crate::{
-    backend::input::{KeyState, Keycode},
+    backend::input::{InputTime, KeyState, Keycode},
     utils::Serial,
     wayland::Dispatch2,
 };
@@ -46,14 +46,14 @@ where
         key_state: KeyState,
         modifiers: Option<ModifiersState>,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         let inner = self.inner.lock().unwrap();
         let keyboard = inner.grab.as_ref().unwrap();
         inner
             .text_input_handle
             .active_text_input_serial_or_default(serial.0, |serial| {
-                keyboard.key(serial, time, keycode.raw() - 8, key_state.into());
+                keyboard.key(serial, time.millis(), keycode.raw() - 8, key_state.into());
                 if let Some(serialized) = modifiers.map(|m| m.serialized) {
                     keyboard.modifiers(
                         serial,

--- a/src/wayland/pointer_gestures.rs
+++ b/src/wayland/pointer_gestures.rs
@@ -44,7 +44,7 @@
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
 //! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
-//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: InputTime) {}
 //! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
 //! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
 //! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
@@ -64,7 +64,7 @@
 //! #       key: KeysymHandle<'_>,
 //! #       state: KeyState,
 //! #       serial: Serial,
-//! #       time: u32,
+//! #       time: InputTime,
 //! #   ) {}
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
@@ -112,6 +112,7 @@ use wayland_server::{
 };
 
 use crate::{
+    backend::input::InputTime,
     input::{
         SeatHandler,
         pointer::{
@@ -146,13 +147,18 @@ impl WpPointerGesturePointerHandle {
         self.known_hold_gestures.lock().unwrap().push(gesture);
     }
 
-    pub(super) fn leave<D: SeatHandler + 'static>(&self, surface: &WlSurface, serial: Serial, time: u32) {
+    pub(super) fn leave<D: SeatHandler + 'static>(
+        &self,
+        surface: &WlSurface,
+        serial: Serial,
+        time: InputTime,
+    ) {
         self.for_each_focused_swipe_gesture(surface, |gesture| {
             let data = gesture.data::<PointerGestureUserData<D>>().unwrap();
             let ongoing = data.in_progress_on.lock().unwrap().take();
             if ongoing.is_some() {
                 // Cancel the ongoing gesture.
-                gesture.end(serial.into(), time, 1);
+                gesture.end(serial.into(), time.millis(), 1);
             }
         });
         self.for_each_focused_pinch_gesture(surface, |gesture| {
@@ -160,7 +166,7 @@ impl WpPointerGesturePointerHandle {
             let ongoing = data.in_progress_on.lock().unwrap().take();
             if ongoing.is_some() {
                 // Cancel the ongoing gesture.
-                gesture.end(serial.into(), time, 1);
+                gesture.end(serial.into(), time.millis(), 1);
             }
         });
         self.for_each_focused_hold_gesture(surface, |gesture| {
@@ -168,7 +174,7 @@ impl WpPointerGesturePointerHandle {
             let ongoing = data.in_progress_on.lock().unwrap().take();
             if ongoing.is_some() {
                 // Cancel the ongoing gesture.
-                gesture.end(serial.into(), time, 1);
+                gesture.end(serial.into(), time.millis(), 1);
             }
         });
     }
@@ -183,9 +189,9 @@ impl WpPointerGesturePointerHandle {
             let ongoing = data.in_progress_on.lock().unwrap().replace(surface.clone());
             if ongoing.is_some() {
                 // Cancel an ongoing gesture for a different surface.
-                gesture.end(event.serial.into(), event.time, 1);
+                gesture.end(event.serial.into(), event.time.millis(), 1);
             }
-            gesture.begin(event.serial.into(), event.time, surface, event.fingers);
+            gesture.begin(event.serial.into(), event.time.millis(), surface, event.fingers);
         });
     }
 
@@ -201,10 +207,10 @@ impl WpPointerGesturePointerHandle {
             if ongoing.as_ref() == Some(surface) {
                 let client_scale = data.client_scale.load(Ordering::Acquire);
                 let delta = event.delta.to_client(client_scale);
-                gesture.update(event.time, delta.x, delta.y);
+                gesture.update(event.time.millis(), delta.x, delta.y);
             } else if ongoing.take().is_some() {
                 // If it was for a different surface, cancel it.
-                gesture.end(SERIAL_COUNTER.next_serial().into(), event.time, 1);
+                gesture.end(SERIAL_COUNTER.next_serial().into(), event.time.millis(), 1);
             }
         });
     }
@@ -225,7 +231,7 @@ impl WpPointerGesturePointerHandle {
                     // If the gesture was ongoing for any other surface then cancel it.
                     true
                 };
-                gesture.end(event.serial.into(), event.time, cancelled.into());
+                gesture.end(event.serial.into(), event.time.millis(), cancelled.into());
             }
         });
     }
@@ -240,9 +246,9 @@ impl WpPointerGesturePointerHandle {
             let ongoing = data.in_progress_on.lock().unwrap().replace(surface.clone());
             if ongoing.is_some() {
                 // Cancel an ongoing gesture for a different surface.
-                gesture.end(event.serial.into(), event.time, 1);
+                gesture.end(event.serial.into(), event.time.millis(), 1);
             }
-            gesture.begin(event.serial.into(), event.time, surface, event.fingers);
+            gesture.begin(event.serial.into(), event.time.millis(), surface, event.fingers);
         });
     }
 
@@ -258,10 +264,10 @@ impl WpPointerGesturePointerHandle {
             if ongoing.as_ref() == Some(surface) {
                 let client_scale = data.client_scale.load(Ordering::Acquire);
                 let delta = event.delta.to_client(client_scale);
-                gesture.update(event.time, delta.x, delta.y, event.scale, event.rotation);
+                gesture.update(event.time.millis(), delta.x, delta.y, event.scale, event.rotation);
             } else if ongoing.take().is_some() {
                 // If it was for a different surface, cancel it.
-                gesture.end(SERIAL_COUNTER.next_serial().into(), event.time, 1);
+                gesture.end(SERIAL_COUNTER.next_serial().into(), event.time.millis(), 1);
             }
         });
     }
@@ -282,7 +288,7 @@ impl WpPointerGesturePointerHandle {
                     // If the gesture was ongoing for any other surface then cancel it.
                     true
                 };
-                gesture.end(event.serial.into(), event.time, cancelled.into());
+                gesture.end(event.serial.into(), event.time.millis(), cancelled.into());
             }
         });
     }
@@ -297,9 +303,9 @@ impl WpPointerGesturePointerHandle {
             let ongoing = data.in_progress_on.lock().unwrap().replace(surface.clone());
             if ongoing.is_some() {
                 // Cancel an ongoing gesture for a different surface.
-                gesture.end(event.serial.into(), event.time, 1);
+                gesture.end(event.serial.into(), event.time.millis(), 1);
             }
-            gesture.begin(event.serial.into(), event.time, surface, event.fingers);
+            gesture.begin(event.serial.into(), event.time.millis(), surface, event.fingers);
         });
     }
 
@@ -319,7 +325,7 @@ impl WpPointerGesturePointerHandle {
                     // If the gesture was ongoing for any other surface then cancel it.
                     true
                 };
-                gesture.end(event.serial.into(), event.time, cancelled.into());
+                gesture.end(event.serial.into(), event.time.millis(), cancelled.into());
             }
         });
     }

--- a/src/wayland/pointer_gestures.rs
+++ b/src/wayland/pointer_gestures.rs
@@ -20,7 +20,7 @@
 //! extern crate smithay;
 //!
 //! use smithay::wayland::pointer_gestures::PointerGesturesState;
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::{InputTime, KeyState};
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -44,7 +44,7 @@
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
 //! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
-//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: InputTime) {}
 //! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
 //! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
 //! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
@@ -64,7 +64,7 @@
 //! #       key: KeysymHandle<'_>,
 //! #       state: KeyState,
 //! #       serial: Serial,
-//! #       time: u32,
+//! #       time: InputTime,
 //! #   ) {}
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
@@ -112,6 +112,7 @@ use wayland_server::{
 };
 
 use crate::{
+    backend::input::InputTime,
     input::{
         SeatHandler,
         pointer::{
@@ -146,13 +147,18 @@ impl WpPointerGesturePointerHandle {
         self.known_hold_gestures.lock().unwrap().push(gesture);
     }
 
-    pub(super) fn leave<D: SeatHandler + 'static>(&self, surface: &WlSurface, serial: Serial, time: u32) {
+    pub(super) fn leave<D: SeatHandler + 'static>(
+        &self,
+        surface: &WlSurface,
+        serial: Serial,
+        time: InputTime,
+    ) {
         self.for_each_focused_swipe_gesture(surface, |gesture| {
             let data = gesture.data::<PointerGestureUserData<D>>().unwrap();
             let ongoing = data.in_progress_on.lock().unwrap().take();
             if ongoing.is_some() {
                 // Cancel the ongoing gesture.
-                gesture.end(serial.into(), time, 1);
+                gesture.end(serial.into(), time.millis(), 1);
             }
         });
         self.for_each_focused_pinch_gesture(surface, |gesture| {
@@ -160,7 +166,7 @@ impl WpPointerGesturePointerHandle {
             let ongoing = data.in_progress_on.lock().unwrap().take();
             if ongoing.is_some() {
                 // Cancel the ongoing gesture.
-                gesture.end(serial.into(), time, 1);
+                gesture.end(serial.into(), time.millis(), 1);
             }
         });
         self.for_each_focused_hold_gesture(surface, |gesture| {
@@ -168,7 +174,7 @@ impl WpPointerGesturePointerHandle {
             let ongoing = data.in_progress_on.lock().unwrap().take();
             if ongoing.is_some() {
                 // Cancel the ongoing gesture.
-                gesture.end(serial.into(), time, 1);
+                gesture.end(serial.into(), time.millis(), 1);
             }
         });
     }
@@ -183,9 +189,9 @@ impl WpPointerGesturePointerHandle {
             let ongoing = data.in_progress_on.lock().unwrap().replace(surface.clone());
             if ongoing.is_some() {
                 // Cancel an ongoing gesture for a different surface.
-                gesture.end(event.serial.into(), event.time, 1);
+                gesture.end(event.serial.into(), event.time.millis(), 1);
             }
-            gesture.begin(event.serial.into(), event.time, surface, event.fingers);
+            gesture.begin(event.serial.into(), event.time.millis(), surface, event.fingers);
         });
     }
 
@@ -201,10 +207,10 @@ impl WpPointerGesturePointerHandle {
             if ongoing.as_ref() == Some(surface) {
                 let client_scale = data.client_scale.load(Ordering::Acquire);
                 let delta = event.delta.to_client(client_scale);
-                gesture.update(event.time, delta.x, delta.y);
+                gesture.update(event.time.millis(), delta.x, delta.y);
             } else if ongoing.take().is_some() {
                 // If it was for a different surface, cancel it.
-                gesture.end(SERIAL_COUNTER.next_serial().into(), event.time, 1);
+                gesture.end(SERIAL_COUNTER.next_serial().into(), event.time.millis(), 1);
             }
         });
     }
@@ -225,7 +231,7 @@ impl WpPointerGesturePointerHandle {
                     // If the gesture was ongoing for any other surface then cancel it.
                     true
                 };
-                gesture.end(event.serial.into(), event.time, cancelled.into());
+                gesture.end(event.serial.into(), event.time.millis(), cancelled.into());
             }
         });
     }
@@ -240,9 +246,9 @@ impl WpPointerGesturePointerHandle {
             let ongoing = data.in_progress_on.lock().unwrap().replace(surface.clone());
             if ongoing.is_some() {
                 // Cancel an ongoing gesture for a different surface.
-                gesture.end(event.serial.into(), event.time, 1);
+                gesture.end(event.serial.into(), event.time.millis(), 1);
             }
-            gesture.begin(event.serial.into(), event.time, surface, event.fingers);
+            gesture.begin(event.serial.into(), event.time.millis(), surface, event.fingers);
         });
     }
 
@@ -258,10 +264,10 @@ impl WpPointerGesturePointerHandle {
             if ongoing.as_ref() == Some(surface) {
                 let client_scale = data.client_scale.load(Ordering::Acquire);
                 let delta = event.delta.to_client(client_scale);
-                gesture.update(event.time, delta.x, delta.y, event.scale, event.rotation);
+                gesture.update(event.time.millis(), delta.x, delta.y, event.scale, event.rotation);
             } else if ongoing.take().is_some() {
                 // If it was for a different surface, cancel it.
-                gesture.end(SERIAL_COUNTER.next_serial().into(), event.time, 1);
+                gesture.end(SERIAL_COUNTER.next_serial().into(), event.time.millis(), 1);
             }
         });
     }
@@ -282,7 +288,7 @@ impl WpPointerGesturePointerHandle {
                     // If the gesture was ongoing for any other surface then cancel it.
                     true
                 };
-                gesture.end(event.serial.into(), event.time, cancelled.into());
+                gesture.end(event.serial.into(), event.time.millis(), cancelled.into());
             }
         });
     }
@@ -297,9 +303,9 @@ impl WpPointerGesturePointerHandle {
             let ongoing = data.in_progress_on.lock().unwrap().replace(surface.clone());
             if ongoing.is_some() {
                 // Cancel an ongoing gesture for a different surface.
-                gesture.end(event.serial.into(), event.time, 1);
+                gesture.end(event.serial.into(), event.time.millis(), 1);
             }
-            gesture.begin(event.serial.into(), event.time, surface, event.fingers);
+            gesture.begin(event.serial.into(), event.time.millis(), surface, event.fingers);
         });
     }
 
@@ -319,7 +325,7 @@ impl WpPointerGesturePointerHandle {
                     // If the gesture was ongoing for any other surface then cancel it.
                     true
                 };
-                gesture.end(event.serial.into(), event.time, cancelled.into());
+                gesture.end(event.serial.into(), event.time.millis(), cancelled.into());
             }
         });
     }

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -131,8 +131,9 @@ impl WpRelativePointerHandle {
             let delta = event.delta.to_client(client_scale);
             let delta_unaccel = event.delta_unaccel;
 
-            let utime_hi = (event.utime >> 32) as u32;
-            let utime_lo = (event.utime & 0xffffffff) as u32;
+            let utime = event.time.micros();
+            let utime_hi = (utime >> 32) as u32;
+            let utime_lo = (utime & 0xffffffff) as u32;
             ptr.relative_motion(
                 utime_hi,
                 utime_lo,

--- a/src/wayland/relative_pointer.rs
+++ b/src/wayland/relative_pointer.rs
@@ -8,7 +8,7 @@
 //! extern crate smithay;
 //!
 //! use smithay::wayland::relative_pointer::RelativePointerManagerState;
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::{InputTime, KeyState};
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -32,7 +32,7 @@
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
 //! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
-//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: InputTime) {}
 //! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
 //! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
 //! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
@@ -52,7 +52,7 @@
 //! #       key: KeysymHandle<'_>,
 //! #       state: KeyState,
 //! #       serial: Serial,
-//! #       time: u32,
+//! #       time: InputTime,
 //! #   ) {}
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }
@@ -131,8 +131,9 @@ impl WpRelativePointerHandle {
             let delta = event.delta.to_client(client_scale);
             let delta_unaccel = event.delta_unaccel;
 
-            let utime_hi = (event.utime >> 32) as u32;
-            let utime_lo = (event.utime & 0xffffffff) as u32;
+            let utime = event.time.micros();
+            let utime_hi = (utime >> 32) as u32;
+            let utime_lo = (utime & 0xffffffff) as u32;
             ptr.relative_motion(
                 utime_hi,
                 utime_lo,

--- a/src/wayland/seat/keyboard.rs
+++ b/src/wayland/seat/keyboard.rs
@@ -12,7 +12,7 @@ use wayland_server::{
 
 use super::WaylandFocus;
 use crate::{
-    backend::input::{KeyState, Keycode},
+    backend::input::{InputTime, KeyState, Keycode},
     input::{
         Seat, SeatHandler, WeakSeat,
         keyboard::{KeyboardHandle, KeyboardTarget, KeysymHandle, ModifiersState},
@@ -298,10 +298,15 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for WlSurface {
         key: KeysymHandle<'_>,
         state: KeyState,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         for_each_focused_kbds(seat, self, |kbd| {
-            kbd.key(serial.into(), time, key.raw_code().raw() - 8, state.into())
+            kbd.key(
+                serial.into(),
+                time.millis(),
+                key.raw_code().raw() - 8,
+                state.into(),
+            )
         })
     }
 

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -14,7 +14,7 @@ use wayland_server::{
 };
 
 use crate::{
-    backend::input::{Axis, AxisSource, ButtonState},
+    backend::input::{Axis, AxisSource, ButtonState, InputTime},
     input::{
         Seat,
         pointer::{
@@ -81,7 +81,7 @@ impl WlPointerHandle {
         })
     }
 
-    fn leave(&self, surface: &WlSurface, serial: Serial, _time: u32) {
+    fn leave(&self, surface: &WlSurface, serial: Serial, _time: InputTime) {
         self.for_each_focused_pointer(surface, |ptr| {
             ptr.leave(serial.into(), surface);
             if ptr.version() >= 5 {
@@ -100,13 +100,18 @@ impl WlPointerHandle {
                 .client_scale
                 .load(Ordering::Acquire);
             let location = event.location.to_client(client_scale);
-            ptr.motion(event.time, location.x, location.y);
+            ptr.motion(event.time.millis(), location.x, location.y);
         })
     }
 
     fn button(&self, surface: &WlSurface, event: &ButtonEvent) {
         self.for_each_focused_pointer(surface, |ptr| {
-            ptr.button(event.serial.into(), event.time, event.button, event.state.into());
+            ptr.button(
+                event.serial.into(),
+                event.time.millis(),
+                event.button,
+                event.state.into(),
+            );
         })
     }
 
@@ -161,7 +166,7 @@ impl WlPointerHandle {
                 }
                 // stop
                 if details.stop.0 {
-                    ptr.axis_stop(details.time, WlAxis::HorizontalScroll);
+                    ptr.axis_stop(details.time.millis(), WlAxis::HorizontalScroll);
 
                     compositor::with_states(surface, |states| {
                         if let Some(data) = states.data_map.get::<Mutex<V120UserData>>() {
@@ -170,7 +175,7 @@ impl WlPointerHandle {
                     });
                 }
                 if details.stop.1 {
-                    ptr.axis_stop(details.time, WlAxis::VerticalScroll);
+                    ptr.axis_stop(details.time.millis(), WlAxis::VerticalScroll);
 
                     compositor::with_states(surface, |states| {
                         if let Some(data) = states.data_map.get::<Mutex<V120UserData>>() {
@@ -193,7 +198,7 @@ impl WlPointerHandle {
                     );
                 }
                 ptr.axis(
-                    details.time,
+                    details.time.millis(),
                     WlAxis::HorizontalScroll,
                     details.axis.0 * client_scale,
                 );
@@ -203,7 +208,7 @@ impl WlPointerHandle {
                     ptr.axis_relative_direction(WlAxis::VerticalScroll, details.relative_direction.1.into());
                 }
                 ptr.axis(
-                    details.time,
+                    details.time.millis(),
                     WlAxis::VerticalScroll,
                     details.axis.1 * client_scale,
                 );
@@ -243,7 +248,7 @@ where
         }
     }
 
-    fn leave(&self, seat: &Seat<D>, _data: &mut D, serial: Serial, time: u32) {
+    fn leave(&self, seat: &Seat<D>, _data: &mut D, serial: Serial, time: InputTime) {
         if let Some(pointer) = seat.get_pointer() {
             pointer.wp_pointer_gestures.leave::<D>(self, serial, time);
             pointer.wl_pointer.leave(self, serial, time);

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -14,7 +14,7 @@ use wayland_server::{
 };
 
 use crate::{
-    backend::input::{Axis, AxisSource, ButtonState},
+    backend::input::{Axis, AxisSource, ButtonState, InputTime},
     input::{
         Seat,
         pointer::{
@@ -103,7 +103,7 @@ impl WlPointerHandle {
         })
     }
 
-    fn leave(&self, surface: &WlSurface, serial: Serial, _time: u32) {
+    fn leave(&self, surface: &WlSurface, serial: Serial, _time: InputTime) {
         self.for_each_focused_pointer(surface, |ptr| {
             ptr.leave(serial.into(), surface);
             if ptr.version() >= 5 {
@@ -122,13 +122,18 @@ impl WlPointerHandle {
                 .client_scale
                 .load(Ordering::Acquire);
             let location = event.location.to_client(client_scale);
-            ptr.motion(event.time, location.x, location.y);
+            ptr.motion(event.time.millis(), location.x, location.y);
         })
     }
 
     fn button(&self, surface: &WlSurface, event: &ButtonEvent) {
         self.for_each_focused_pointer(surface, |ptr| {
-            ptr.button(event.serial.into(), event.time, event.button, event.state.into());
+            ptr.button(
+                event.serial.into(),
+                event.time.millis(),
+                event.button,
+                event.state.into(),
+            );
         })
     }
 
@@ -183,7 +188,7 @@ impl WlPointerHandle {
                 }
                 // stop
                 if details.stop.0 {
-                    ptr.axis_stop(details.time, WlAxis::HorizontalScroll);
+                    ptr.axis_stop(details.time.millis(), WlAxis::HorizontalScroll);
 
                     compositor::with_states(surface, |states| {
                         if let Some(data) = states.data_map.get::<Mutex<V120UserData>>() {
@@ -192,7 +197,7 @@ impl WlPointerHandle {
                     });
                 }
                 if details.stop.1 {
-                    ptr.axis_stop(details.time, WlAxis::VerticalScroll);
+                    ptr.axis_stop(details.time.millis(), WlAxis::VerticalScroll);
 
                     compositor::with_states(surface, |states| {
                         if let Some(data) = states.data_map.get::<Mutex<V120UserData>>() {
@@ -215,7 +220,7 @@ impl WlPointerHandle {
                     );
                 }
                 ptr.axis(
-                    details.time,
+                    details.time.millis(),
                     WlAxis::HorizontalScroll,
                     details.axis.0 * client_scale,
                 );
@@ -225,7 +230,7 @@ impl WlPointerHandle {
                     ptr.axis_relative_direction(WlAxis::VerticalScroll, details.relative_direction.1.into());
                 }
                 ptr.axis(
-                    details.time,
+                    details.time.millis(),
                     WlAxis::VerticalScroll,
                     details.axis.1 * client_scale,
                 );
@@ -267,7 +272,7 @@ where
         }
     }
 
-    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {
+    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: InputTime) {
         if let Some(pointer) = seat.get_pointer() {
             pointer.wp_pointer_gestures.leave::<D>(self, serial, time);
             pointer.wl_pointer.leave(self, serial, time);

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -92,7 +92,7 @@ where
             let location = event.location.to_client(client_scale);
             touch.down(
                 serial.into(),
-                event.time,
+                event.time.millis(),
                 self,
                 slot.into(),
                 location.x,
@@ -105,7 +105,7 @@ where
         let serial = event.serial;
         let slot = event.slot;
         for_each_focused_touch(seat, self, |touch| {
-            touch.up(serial.into(), event.time, slot.into());
+            touch.up(serial.into(), event.time.millis(), slot.into());
         })
     }
 
@@ -118,7 +118,7 @@ where
                 .client_scale
                 .load(Ordering::Acquire);
             let location = event.location.to_client(client_scale);
-            touch.motion(event.time, slot.into(), location.x, location.y);
+            touch.motion(event.time.millis(), slot.into(), location.x, location.y);
         })
     }
 

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -135,7 +135,7 @@ where
             let location = event.location.to_client(client_scale);
             touch.down(
                 serial.into(),
-                event.time,
+                event.time.millis(),
                 self,
                 slot.into(),
                 location.x,
@@ -148,7 +148,7 @@ where
         let serial = event.serial;
         let slot = event.slot;
         for_each_focused_touch(seat, self, |touch| {
-            touch.up(serial.into(), event.time, slot.into());
+            touch.up(serial.into(), event.time.millis(), slot.into());
         });
 
         if let Some(touch) = seat.get_touch() {
@@ -165,7 +165,7 @@ where
                 .client_scale
                 .load(Ordering::Acquire);
             let location = event.location.to_client(client_scale);
-            touch.motion(event.time, slot.into(), location.x, location.y);
+            touch.motion(event.time.millis(), slot.into(), location.x, location.y);
         })
     }
 

--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -95,6 +95,7 @@ use wayland_server::{
 };
 
 use crate::{
+    backend::input::InputTime,
     input::{
         Seat, SeatHandler,
         dnd::{DndAction, DndFocus, GrabType, OfferData, Source},
@@ -501,7 +502,7 @@ impl<D: SeatHandler + DataDeviceHandler + 'static> DndFocus<D> for WlSurface {
         offer: Option<&mut WlOfferData<S>>,
         seat: &Seat<D>,
         location: Point<f64, Logical>,
-        time: u32,
+        time: InputTime,
     ) {
         let seat_data = seat
             .user_data()
@@ -525,7 +526,7 @@ impl<D: SeatHandler + DataDeviceHandler + 'static> DndFocus<D> for WlSurface {
 
         for device in seat_data.known_data_devices() {
             if device.id().same_client_as(&self.id()) {
-                device.motion(time, location.x, location.y);
+                device.motion(time.millis(), location.x, location.y);
             }
         }
     }

--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -97,6 +97,7 @@ use wayland_server::{
 };
 
 use crate::{
+    backend::input::InputTime,
     input::{
         Seat, SeatHandler,
         dnd::{DndAction, DndFocus, GrabType, OfferData, Source},
@@ -503,7 +504,7 @@ impl<D: SeatHandler + DataDeviceHandler + 'static> DndFocus<D> for WlSurface {
         offer: Option<&mut WlOfferData<S>>,
         seat: &Seat<D>,
         location: Point<f64, Logical>,
-        time: u32,
+        time: InputTime,
     ) {
         let seat_data = seat
             .user_data()
@@ -527,7 +528,7 @@ impl<D: SeatHandler + DataDeviceHandler + 'static> DndFocus<D> for WlSurface {
 
         for device in seat_data.known_data_devices() {
             if device.id().same_client_as(&self.id()) {
-                device.motion(time, location.x, location.y);
+                device.motion(time.millis(), location.x, location.y);
             }
         }
     }

--- a/src/wayland/tablet_manager/tablet_tool.rs
+++ b/src/wayland/tablet_manager/tablet_tool.rs
@@ -12,7 +12,7 @@ use wayland_server::{
 };
 
 use crate::{
-    backend::input::{ButtonState, TabletToolCapabilities, TabletToolDescriptor, TabletToolType},
+    backend::input::{ButtonState, InputTime, TabletToolCapabilities, TabletToolDescriptor, TabletToolType},
     input::{
         pointer::{CursorImageAttributes, CursorImageStatus},
         tablet::{
@@ -351,9 +351,9 @@ impl WpTabletToolHandle {
         });
     }
 
-    fn frame(&self, surface: &WlSurface, time: u32) {
+    fn frame(&self, surface: &WlSurface, time: InputTime) {
         self.for_each_focused_tool(surface, |wp_tool| {
-            wp_tool.frame(time);
+            wp_tool.frame(time.millis());
         });
     }
 
@@ -615,7 +615,7 @@ where
         seat: &crate::input::Seat<D>,
         _data: &mut D,
         tool_descriptor: &TabletToolDescriptor,
-        time: u32,
+        time: InputTime,
     ) {
         let tablet_seat = seat.tablet_seat();
 

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -52,7 +52,7 @@ use wayland_server::{
 };
 
 use crate::{
-    backend::input::{KeyState, Keycode},
+    backend::input::{InputTime, KeyState, Keycode},
     input::{
         Seat, SeatHandler,
         keyboard::{self, KeyboardGrab, KeyboardInnerHandle},
@@ -118,7 +118,7 @@ impl<D: XWaylandKeyboardGrabHandler + 'static> KeyboardGrab<D> for XWaylandKeybo
         state: KeyState,
         modifiers: Option<keyboard::ModifiersState>,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         handle.set_focus(data, self.start_data.focus.clone(), serial);
 

--- a/src/wayland/xwayland_keyboard_grab.rs
+++ b/src/wayland/xwayland_keyboard_grab.rs
@@ -54,7 +54,7 @@ use wayland_server::{
 };
 
 use crate::{
-    backend::input::{KeyState, Keycode},
+    backend::input::{InputTime, KeyState, Keycode},
     input::{
         Seat, SeatHandler,
         keyboard::{self, KeyboardGrab, KeyboardInnerHandle},
@@ -120,7 +120,7 @@ impl<D: XWaylandKeyboardGrabHandler + 'static> KeyboardGrab<D> for XWaylandKeybo
         state: KeyState,
         modifiers: Option<keyboard::ModifiersState>,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         handle.set_focus(data, self.start_data.focus.clone(), serial);
 

--- a/src/wayland/xwayland_shell.rs
+++ b/src/wayland/xwayland_shell.rs
@@ -18,7 +18,7 @@
 //! #
 //! # use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 //! # use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
-//! # use smithay::backend::input::KeyState;
+//! # use smithay::backend::input::{InputTime, KeyState};
 //! # use smithay::input::{
 //! #   pointer::{PointerTarget, AxisFrame, MotionEvent, ButtonEvent, RelativeMotionEvent,
 //! #             GestureSwipeBeginEvent, GestureSwipeUpdateEvent, GestureSwipeEndEvent,
@@ -41,7 +41,7 @@
 //! #   fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {}
 //! #   fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {}
 //! #   fn frame(&self, seat: &Seat<State>, data: &mut State) {}
-//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {}
+//! #   fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: InputTime) {}
 //! #   fn gesture_swipe_begin(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeBeginEvent) {}
 //! #   fn gesture_swipe_update(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeUpdateEvent) {}
 //! #   fn gesture_swipe_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureSwipeEndEvent) {}
@@ -61,7 +61,7 @@
 //! #       key: KeysymHandle<'_>,
 //! #       state: KeyState,
 //! #       serial: Serial,
-//! #       time: u32,
+//! #       time: InputTime,
 //! #   ) {}
 //! #   fn modifiers(&self, seat: &Seat<State>, data: &mut State, modifiers: ModifiersState, serial: Serial) {}
 //! # }

--- a/src/xwayland/xwm/dnd.rs
+++ b/src/xwayland/xwm/dnd.rs
@@ -33,6 +33,7 @@ use x11rb::{
 };
 
 use crate::{
+    backend::input::InputTime,
     input::{
         Seat, SeatHandler,
         dnd::{DnDGrab, DndAction, DndFocus, DndGrabHandler, OfferData, Source, SourceMetadata},
@@ -1068,7 +1069,14 @@ impl<D: XwmHandler + SeatHandler> DndFocus<D> for X11Surface {
                 source: offer.source.clone(),
             });
 
-            DndFocus::motion(self, data, Some(&mut offer), seat, location, 0);
+            DndFocus::motion(
+                self,
+                data,
+                Some(&mut offer),
+                seat,
+                location,
+                InputTime::from_millis(0),
+            );
             Some(offer)
         }
     }
@@ -1079,7 +1087,7 @@ impl<D: XwmHandler + SeatHandler> DndFocus<D> for X11Surface {
         offer: Option<&mut XwmOfferData<S>>,
         _seat: &Seat<D>,
         location: Point<f64, Logical>,
-        _time: u32,
+        _time: InputTime,
     ) {
         let Some(offer) = offer else { return };
         let mut state = offer.state.lock().unwrap();

--- a/src/xwayland/xwm/dnd.rs
+++ b/src/xwayland/xwm/dnd.rs
@@ -1069,14 +1069,7 @@ impl<D: XwmHandler + SeatHandler> DndFocus<D> for X11Surface {
                 source: offer.source.clone(),
             });
 
-            DndFocus::motion(
-                self,
-                data,
-                Some(&mut offer),
-                seat,
-                location,
-                InputTime::from_millis(0),
-            );
+            DndFocus::motion(self, data, Some(&mut offer), seat, location, InputTime::now());
             Some(offer)
         }
     }

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -1,5 +1,8 @@
 use crate::{
-    backend::{input::KeyState, renderer::utils::RendererSurfaceStateUserData},
+    backend::{
+        input::{InputTime, KeyState},
+        renderer::utils::RendererSurfaceStateUserData,
+    },
     input::{
         Seat, SeatHandler,
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
@@ -2211,7 +2214,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for X11Surface {
         key: KeysymHandle<'_>,
         state: KeyState,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         let mut xstate = self.state.lock().unwrap();
         if let Some(surface) = xstate.wl_surface.as_ref() {
@@ -2275,7 +2278,7 @@ impl<D: SeatHandler + 'static> PointerTarget<D> for X11Surface {
         }
     }
 
-    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {
+    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: InputTime) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
             PointerTarget::leave(surface, seat, data, serial, time);
         }

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -1,5 +1,8 @@
 use crate::{
-    backend::{input::KeyState, renderer::utils::RendererSurfaceStateUserData},
+    backend::{
+        input::{InputTime, KeyState},
+        renderer::utils::RendererSurfaceStateUserData,
+    },
     input::{
         Seat, SeatHandler,
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
@@ -2215,7 +2218,7 @@ impl<D: SeatHandler + 'static> KeyboardTarget<D> for X11Surface {
         key: KeysymHandle<'_>,
         state: KeyState,
         serial: Serial,
-        time: u32,
+        time: InputTime,
     ) {
         let mut xstate = self.state.lock().unwrap();
         if let Some(surface) = xstate.wl_surface.as_ref() {
@@ -2279,7 +2282,7 @@ impl<D: SeatHandler + PointerConstraintsHandler + 'static> PointerTarget<D> for 
         }
     }
 
-    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: u32) {
+    fn leave(&self, seat: &Seat<D>, data: &mut D, serial: Serial, time: InputTime) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
             PointerTarget::leave(surface, seat, data, serial, time);
         }
@@ -2476,7 +2479,7 @@ impl<D: TabletSeatHandler + CompositorHandler + 'static> TabletToolTarget<D> for
         seat: &Seat<D>,
         data: &mut D,
         tool_descriptor: &crate::backend::input::TabletToolDescriptor,
-        time: u32,
+        time: InputTime,
     ) {
         if let Some(surface) = self.state.lock().unwrap().wl_surface.as_ref() {
             TabletToolTarget::frame(surface, seat, data, tool_descriptor, time);

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -6,7 +6,7 @@ use std::{
 
 use smithay::{
     backend::{
-        input::ButtonState,
+        input::{ButtonState, InputTime},
         renderer::{
             damage::OutputDamageTracker,
             element::AsRenderElements,
@@ -218,7 +218,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>) {
         WlcsEvent::PointerMoveAbsolute { location, .. } => {
             let serial = SCOUNTER.next_serial();
             let under = state.surface_under(location);
-            let time = Duration::from(state.clock.now()).as_millis() as u32;
+            let time = InputTime::from_micros(state.clock.now().as_micros());
             let ptr = state.pointer.clone();
             ptr.motion(
                 state,
@@ -235,8 +235,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>) {
             let pointer_location = state.pointer.current_location() + delta;
             let serial = SCOUNTER.next_serial();
             let under = state.surface_under(pointer_location);
-            let time = Duration::from(state.clock.now()).as_millis() as u32;
-            let utime = Duration::from(state.clock.now()).as_micros() as u64;
+            let time = InputTime::from_micros(state.clock.now().as_micros());
             let ptr = state.pointer.clone();
             ptr.motion(
                 state,
@@ -253,7 +252,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>) {
                 &RelativeMotionEvent {
                     delta,
                     delta_unaccel: delta,
-                    utime,
+                    time,
                 },
             );
             ptr.frame(state);
@@ -275,7 +274,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>) {
                     .unwrap()
                     .set_focus(state, under.map(Into::into), serial);
             }
-            let time = Duration::from(state.clock.now()).as_millis() as u32;
+            let time = InputTime::from_micros(state.clock.now().as_micros());
             ptr.button(
                 state,
                 &ButtonEvent {
@@ -289,7 +288,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>) {
         }
         WlcsEvent::PointerButtonUp { button_id, .. } => {
             let serial = SCOUNTER.next_serial();
-            let time = Duration::from(state.clock.now()).as_millis() as u32;
+            let time = InputTime::from_micros(state.clock.now().as_micros());
             let ptr = state.seat.get_pointer().unwrap();
             ptr.button(
                 state,

--- a/wlcs_anvil/src/main_loop.rs
+++ b/wlcs_anvil/src/main_loop.rs
@@ -218,7 +218,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>) {
         WlcsEvent::PointerMoveAbsolute { location, .. } => {
             let serial = SCOUNTER.next_serial();
             let under = state.surface_under(location);
-            let time = InputTime::from_micros(state.clock.now().as_micros());
+            let time = InputTime::now();
             let ptr = state.pointer.clone();
             ptr.motion(
                 state,
@@ -235,7 +235,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>) {
             let pointer_location = state.pointer.current_location() + delta;
             let serial = SCOUNTER.next_serial();
             let under = state.surface_under(pointer_location);
-            let time = InputTime::from_micros(state.clock.now().as_micros());
+            let time = InputTime::now();
             let ptr = state.pointer.clone();
             ptr.motion(
                 state,
@@ -274,7 +274,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>) {
                     .unwrap()
                     .set_focus(state, under.map(Into::into), serial);
             }
-            let time = InputTime::from_micros(state.clock.now().as_micros());
+            let time = InputTime::now();
             ptr.button(
                 state,
                 &ButtonEvent {
@@ -288,7 +288,7 @@ fn handle_event(event: WlcsEvent, state: &mut AnvilState<TestState>) {
         }
         WlcsEvent::PointerButtonUp { button_id, .. } => {
             let serial = SCOUNTER.next_serial();
-            let time = InputTime::from_micros(state.clock.now().as_micros());
+            let time = InputTime::now();
             let ptr = state.seat.get_pointer().unwrap();
             ptr.button(
                 state,


### PR DESCRIPTION
## Description
I've been wondering if it would be good if `time`  was a newtype instead of just an integer for a while.

Making the event structs in `src/input` using microsecond precision instead of just millisecond would presumably be a prerequisite for https://wayland.app/protocols/input-timestamps-unstable-v1.

But I ran into that trying to add `wl_keyboard.warp`, as an `is_warp: bool` field of `MotionEvent`. (I'm still not entirely sure on doing that vs having a separate `WarpEvent`; if all the logic for handling it is the same as motion events, it may make sense and save a lot of duplication). But with a fallback to send `motion` and a 0 `relative_motion` on clients not binding the latest version. `relative_motion` requires a microsecond time.

Going through this also reminds me that in some cases smithay synthesizes input events with a time of 0, which is probably not correct. In at  least one place it synthesizes an event using `CLOCK_MONOTONIC`. That does match libinput (https://wayland.freedesktop.org/libinput/doc/latest/timestamps.html) but technically isn't guranteed if we had a Wayland backend. I think X also was typically `CLOCK_MONOTONIC` but not technically guaranteed?

I still need to update anvil/etc.

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
