### PR TITLE
Add new feature use_sha for opt-in sha2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ smallvec = "1.11"
 pixman = { version = "0.2.1", features = ["drm-fourcc", "sync"], optional = true }
 aliasable = { version = "0.1.3", optional = true }
 portable-atomic = { version = "1", features = ["float"] }
-sha2 = "0.10.9"
 tracy-client = { version = "0.18.4", default-features = false, optional = true }
 reis = { version = "0.7.0", features = ["calloop"] }
 glam = { version = "0.33.2", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ smallvec = "1.11"
 pixman = { version = "0.2.1", features = ["drm-fourcc", "sync"], optional = true }
 aliasable = { version = "0.1.3", optional = true }
 portable-atomic = { version = "1", features = ["float"] }
-sha2 = "0.10.9"
+sha2 = { version = "0.10.9", optional = true }
 tracy-client = { version = "0.18.4", default-features = false, optional = true }
 reis = { version = "0.7.0", features = ["calloop"] }
 glam = { version = "0.33.2", default-features = false, features = ["std"] }
@@ -116,6 +116,7 @@ wayland_frontend = ["wayland-server", "wayland-protocols", "wayland-protocols-wl
 x11rb_event_source = ["x11rb"]
 xwayland = ["encoding_rs", "wayland_frontend", "x11rb/composite", "x11rb/xfixes", "x11rb/randr", "x11rb_event_source", "scopeguard"]
 test_all_features = ["default", "use_system_lib", "renderer_glow", "renderer_test"]
+use_sha = ["dep:sha2"]
 
 [[example]]
 name = "minimal"

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -1,7 +1,6 @@
 use std::ffi::CString;
 use std::os::unix::io::{AsFd, BorrowedFd};
 
-use sha2::{Digest, Sha256};
 use tracing::error;
 use xkbcommon::xkb::{self, KEYMAP_FORMAT_TEXT_V1, Keymap};
 
@@ -11,12 +10,33 @@ use crate::utils::SealedFile;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct KeymapFileId([u8; 32]);
 
+// Generates a 32-byte (256-bit) hash using `std::hash::DefaultHasher`.
+// This is sufficient to prevent keymap collisions, but it is not cryptographically
+// secure or guaranteed to be stable across different Rust versions.
+fn hash(data: &[u8]) -> [u8; 32] {
+    use std::hash::{DefaultHasher, Hasher};
+    let mut output = [0u8; 32];
+    let mut prev_hash: Option<[u8; 8]> = None;
+
+    for i in (0..32).step_by(8) {
+        let mut hasher = DefaultHasher::new();
+        if let Some(prev_hash_val) = prev_hash {
+            hasher.write(&prev_hash_val);
+        }
+        hasher.write(data);
+        let hash = hasher.finish().to_le_bytes();
+        output[i..i + 8].copy_from_slice(&hash);
+        prev_hash = Some(hash);
+    }
+
+    output
+}
+
 impl KeymapFileId {
     fn for_keymap(keymap: &str) -> Self {
-        // Use a hash, so `keymap` events aren't sent when keymap hasn't changed, particularly
-        // with `virtual-keyboard-unstable-v1`.
-        #[allow(deprecated)]
-        Self(Sha256::digest(keymap).as_slice().try_into().unwrap())
+        // Use a hash to avoid sending redundant `keymap` events when the keymap has not changed,
+        // which is particularly useful for `virtual-keyboard-unstable-v1`.
+        Self(hash(keymap.as_bytes()))
     }
 }
 
@@ -101,5 +121,31 @@ impl KeymapFile {
     /// Get this keymap's unique ID.
     pub(crate) fn id(&self) -> KeymapFileId {
         self.id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xkbcommon::xkb;
+
+    #[test]
+    fn test_keymap_file_id() {
+        let id1 = KeymapFileId::for_keymap("keymap data 1");
+        let id2 = KeymapFileId::for_keymap("keymap data 2");
+        let id3 = KeymapFileId::for_keymap("keymap data 1");
+
+        assert_ne!(id1, id2);
+        assert_eq!(id1, id3);
+    }
+
+    #[test]
+    fn test_keymap_file_creation() {
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let xkb_config = crate::input::keyboard::XkbConfig::default();
+        let keymap = xkb_config.compile_keymap(&context).unwrap();
+        let keymap_file = KeymapFile::new(&keymap);
+
+        assert_ne!(keymap_file.id().0, [0u8; 32]);
     }
 }

--- a/src/input/keyboard/keymap_file.rs
+++ b/src/input/keyboard/keymap_file.rs
@@ -1,7 +1,6 @@
 use std::ffi::CString;
 use std::os::unix::io::{AsFd, BorrowedFd};
 
-use sha2::{Digest, Sha256};
 use tracing::error;
 use xkbcommon::xkb::{self, KEYMAP_FORMAT_TEXT_V1, Keymap};
 
@@ -11,12 +10,43 @@ use crate::utils::SealedFile;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct KeymapFileId([u8; 32]);
 
+#[cfg(not(feature = "use_sha"))]
+// Generates a 32-byte (256-bit) hash using only the standard library.
+// This is sufficient to prevent keymap collisions, but it is not cryptographically
+// secure or guaranteed to be stable/persistent across different Rust versions.
+fn hash(data: &[u8]) -> [u8; 32] {
+    use std::hash::{DefaultHasher, Hasher};
+    let mut output = [0u8; 32];
+    let mut prev_hash: Option<[u8; 8]> = None;
+
+    for i in (0..32).step_by(8) {
+        let mut hasher = DefaultHasher::new();
+        if let Some(prev_hash_val) = prev_hash {
+            hasher.write(&prev_hash_val);
+        }
+        hasher.write(data);
+        let hash = hasher.finish().to_le_bytes();
+        output[i..i + 8].copy_from_slice(&hash);
+        prev_hash = Some(hash);
+    }
+
+    output
+}
+
 impl KeymapFileId {
     fn for_keymap(keymap: &str) -> Self {
         // Use a hash, so `keymap` events aren't sent when keymap hasn't changed, particularly
         // with `virtual-keyboard-unstable-v1`.
-        #[allow(deprecated)]
-        Self(Sha256::digest(keymap).as_slice().try_into().unwrap())
+        #[cfg(feature = "use_sha")]
+        {
+            use sha2::{Digest, Sha256};
+            #[allow(deprecated)]
+            Self(Sha256::digest(keymap).as_slice().try_into().unwrap())
+        }
+        #[cfg(not(feature = "use_sha"))]
+        {
+            Self(hash(keymap.as_bytes()))
+        }
     }
 }
 
@@ -101,5 +131,31 @@ impl KeymapFile {
     /// Get this keymap's unique ID.
     pub(crate) fn id(&self) -> KeymapFileId {
         self.id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xkbcommon::xkb;
+
+    #[test]
+    fn test_keymap_file_id() {
+        let id1 = KeymapFileId::for_keymap("keymap data 1");
+        let id2 = KeymapFileId::for_keymap("keymap data 2");
+        let id3 = KeymapFileId::for_keymap("keymap data 1");
+
+        assert_ne!(id1, id2);
+        assert_eq!(id1, id3);
+    }
+
+    #[test]
+    fn test_keymap_file_creation() {
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let xkb_config = crate::input::keyboard::XkbConfig::default();
+        let keymap = xkb_config.compile_keymap(&context).unwrap();
+        let keymap_file = KeymapFile::new(&keymap);
+
+        assert_ne!(keymap_file.id().0, [0u8; 32]);
     }
 }


### PR DESCRIPTION
Introduce a new opt-in feature 'use_sha' to enable the 'sha2' dependency and use `Sha256` for keymap hashing.

When 'use_sha' is disabled (default), a custom hash function using built-in `DefaultHasher` is used instead, without 'sha2' dependency.

BREAKING CHANGE: If you want to keep the old behavior (using Sha256), you must explicitly enable the 'use_sha' feature. This breaking change is necessary because Cargo does not support excluding dependencies when a feature is enabled (features are strictly additive), so the dependency must be opt-in.

Tested:
- cargo test --lib --no-default-features --features wayland_frontend (default, using builtin hash)
- cargo test --lib --no-default-features --features wayland_frontend,use_sha (using Sha256)
- Added 'test_keymap_file_creation' test to verify KeymapFile works.

## Description
<!-- Please include a summary of the change -->

This adds a new `use_sha` feature and change default keymap id generation with chaining `DefaultHasher`.
To keep the old behavior explicit feature `use_sha` is required.


### Note
<!-- Any details that you think are important to review this PR? -->
This introduces breaking change. Tell me if you prefer not doing this, or completely remove the sha2 dependency


### Motivation
sha2 crates brings huge dependency while smithay only uses it for generating good hash value.

It would be helpful to provide an option to opt-in the sha2 crate usage.

### Existing Issue
<!-- Are there issues / other PRs related to this one? -->
https://github.com/Smithay/smithay/issues/2110

I created the issue with bit more details.


### Disclaimer about the AI uses
<!-- If your work contains any usage of generative AI, please read our Policy 
(https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

I haven't used AI for writing CL, but only used to proofread my commit message.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
