### PR TITLE
fix: support Iconic window map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,9 @@ connectors when a dock is unplugged, or across suspend/resume) leaked their CRTC
 indefinitely, which could accumulate until a newly connected output could no longer be assigned a
 CRTC.
 
+XWayland now honors WM_HINTS request to map the window in IconicState(minimized). Compositors should
+check X11Surface::is_hidden() at mapping time and minimize the window appropriately.
+
 ## 0.7.0
 
 ### Breaking changes

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -167,6 +167,7 @@ pub use x11rb::protocol::xproto::Window as X11Window;
 use x11rb::{
     connection::Connection as _,
     errors::{ReplyError, ReplyOrIdError},
+    properties::{WmHints, WmHintsState},
     protocol::{
         Event,
         composite::{ConnectionExt as _, Redirect},
@@ -1669,6 +1670,15 @@ where
                             for atom in states {
                                 state_lock.net_state.insert(atom);
                             }
+                        }
+                    }
+
+                    if let Ok(Some(hints)) = WmHints::get(&*conn, win)?.reply_unchecked() {
+                        let mut state = surface.state.lock().unwrap();
+                        if matches!(hints.initial_state, Some(WmHintsState::Iconic)) {
+                            state.net_state.insert(xwm.atoms._NET_WM_STATE_HIDDEN);
+                        } else {
+                            state.net_state.remove(&xwm.atoms._NET_WM_STATE_HIDDEN);
                         }
                     }
 


### PR DESCRIPTION
This is part of a fix for XCOM 2 not starting fullscreen.
X11 windows can ask to map minimized(IconicState) through WM_HINTS which we don't honor at all atm. This adds support for it by flagging the window as hidden.

## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [X] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
