### PR TITLE
xwm: parse and expose Motif WM hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,8 @@ allowing DnD operations between X11 and Wayland clients (both directions).
 
 `X11Surface` now has a new `surface_under`-method, which is also internally used by `SpaceElement::is_in_input_region` and `crate::desktop::Window::surface_under`. Any direct usage of `under_from_surface_tree` on the underlying `wl_surface` of an `X11Surface` should be replaced with this method for XDND to work correctly.
 
+`X11Surface` now parses and exposes the Motif WM hints via `motif_hints()`.
+
 xdg_shell and layer_shell now enforce the client acking a configure before committing a buffer, as required by the protocols.
 
 ```rs

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -187,6 +187,8 @@ use x11rb::{
 };
 
 mod dnd;
+mod mwm;
+pub use self::mwm::*;
 pub mod settings;
 use settings::{NameError, Value, XSettings};
 mod selection;

--- a/src/xwayland/xwm/mwm.rs
+++ b/src/xwayland/xwm/mwm.rs
@@ -1,0 +1,140 @@
+/// The Motif WM Hints
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct MwmHints {
+    /// Lists the actions that can be done on the window.
+    ///
+    /// If `None`, all actions are assumed available.
+    pub functions: Option<MwmFunctionsHint>,
+
+    /// List decorations (if any) that the app has requested be shown.
+    ///
+    /// If `None`, all decorations should be shown.
+    pub decorations: Option<MwmDecorationsHint>,
+
+    /// The app's requested input mode.
+    pub input_mode: Option<MwmInputMode>,
+
+    /// The app's requested window status (type).
+    pub status: Option<MwmStatusHint>,
+}
+
+bitflags::bitflags! {
+    /// Functions available for the window.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct MwmFunctionsHint: u32 {
+        /// All functions available, *except* for those specified by other present bits.
+        const ALL = (1 << 0);
+        /// The window can be resized.
+        const RESIZE = (1 << 1);
+        /// The window can be moved.
+        const MOVE = (1 << 2);
+        /// The window can be hidden.
+        const MINIMIZE = (1 << 3);
+        /// The window can be maximized.
+        const MAXIMIZE = (1 << 4);
+        /// The window can be closed.
+        const CLOSE = (1 << 5);
+    }
+}
+
+bitflags::bitflags! {
+    /// Decoration parts the app would like shown.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct MwmDecorationsHint: u32 {
+        /// All decoration parts should be shown, *except* for those specified by other present bits.
+        const ALL = (1 << 0);
+        /// A border/frame should be drawn around the window.
+        const BORDER = (1 << 1);
+        /// Resize handles should be shown.
+        const RESIZEH = (1 << 2);
+        /// The window's title bar should be displayed.
+        const TITLE = (1 << 3);
+        /// A window menu button should be shown.
+        const MENU = (1 << 4);
+        /// A minimize button should be shown.
+        const MINIMIZE = (1 << 5);
+        /// A maximize button should be shown.
+        const MAXIMIZE = (1 << 6);
+    }
+}
+
+/// The requested input mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum MwmInputMode {
+    /// Input goes to any window.
+    Modeless = 0,
+    /// Input does not go to ancestors of this window.
+    PrimaryApplicationModal = 1,
+    /// Input goes only to this window.
+    SystemModal = 2,
+    /// Input does not go to other windows in this application.
+    FullApplicationModal = 3,
+}
+
+bitflags::bitflags! {
+    /// Other status information about the window.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct MwmStatusHint: u32 {
+        /// The window was "torn off" another window.
+        const TEAROFF_WINDOW = (1 << 0);
+    }
+}
+
+bitflags::bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct MwmHintsFlags: u32 {
+        const FUNCTIONS = (1 << 0);
+        const DECORATIONS = (1 << 1);
+        const INPUT_MODE = (1 << 2);
+        const STATUS = (1 << 3);
+    }
+}
+
+impl TryFrom<u32> for MwmInputMode {
+    type Error = std::io::Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Modeless),
+            1 => Ok(Self::PrimaryApplicationModal),
+            2 => Ok(Self::SystemModal),
+            3 => Ok(Self::FullApplicationModal),
+            other => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("{other} is not valid for MWM input mode"),
+            )),
+        }
+    }
+}
+
+impl MwmHints {
+    pub(super) fn parse(data: &[u32]) -> Option<MwmHints> {
+        match data {
+            [flags, functions, decorations, input_mode, status] => {
+                let flags = MwmHintsFlags::from_bits(*flags)?;
+                let functions = flags
+                    .contains(MwmHintsFlags::FUNCTIONS)
+                    .then(|| MwmFunctionsHint::from_bits_truncate(*functions));
+                let decorations = flags
+                    .contains(MwmHintsFlags::DECORATIONS)
+                    .then(|| MwmDecorationsHint::from_bits_truncate(*decorations));
+                let input_mode = flags
+                    .contains(MwmHintsFlags::INPUT_MODE)
+                    .then(|| MwmInputMode::try_from(*input_mode).ok())
+                    .flatten();
+                let status = flags
+                    .contains(MwmHintsFlags::STATUS)
+                    .then(|| MwmStatusHint::from_bits_truncate(*status));
+
+                Some(Self {
+                    functions,
+                    decorations,
+                    input_mode,
+                    status,
+                })
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -19,6 +19,7 @@ use crate::{
         compositor::{self, CompositorHandler, RectangleKind, RegionAttributes, SurfaceAttributes},
         seat::{WaylandFocus, keyboard::enter_internal},
     },
+    xwayland::xwm::MwmHints,
 };
 #[cfg(feature = "desktop")]
 use crate::{
@@ -93,10 +94,6 @@ pub enum PingError {
     Connection(#[from] ConnectionError),
 }
 
-const MWM_HINTS_FLAGS_FIELD: usize = 0;
-const MWM_HINTS_DECORATIONS_FIELD: usize = 2;
-const MWM_HINTS_DECORATIONS: u32 = 1 << 1;
-
 const DEFAULT_SYNC_REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
 // From http://fishsoup.net/misc/wm-spec-synchronization.html
 //   "If the client is continually redrawing, then the last seen value may be out of date when the
@@ -163,7 +160,7 @@ pub(crate) struct SharedSurfaceState {
     normal_hints: Option<WmSizeHints>,
     transient_for: Option<X11Window>,
     pub(super) net_state: HashSet<Atom>,
-    motif_hints: Vec<u32>,
+    motif_hints: MwmHints,
     window_type: Vec<Atom>,
     pub(crate) opacity: Option<u32>,
     opaque_region: Option<RegionAttributes>,
@@ -368,7 +365,7 @@ impl X11Surface {
                 normal_hints: None,
                 transient_for: None,
                 net_state: HashSet::new(),
-                motif_hints: vec![0; 5],
+                motif_hints: MwmHints::default(),
                 window_type: Vec::new(),
                 opacity: None,
                 opaque_region: None,
@@ -1288,10 +1285,17 @@ impl X11Surface {
     /// Returns true if the window is client-side decorated
     pub fn is_decorated(&self) -> bool {
         let state = self.state.lock().unwrap();
-        if (state.motif_hints[MWM_HINTS_FLAGS_FIELD] & MWM_HINTS_DECORATIONS) != 0 {
-            return state.motif_hints[MWM_HINTS_DECORATIONS_FIELD] == 0;
-        }
-        false
+        state
+            .motif_hints
+            .decorations
+            .as_ref()
+            .is_some_and(|decorations| decorations.is_empty())
+    }
+
+    /// Returns the Motif WM hints set on the window.
+    pub fn motif_hints(&self) -> MwmHints {
+        let state = self.state.lock().unwrap();
+        state.motif_hints.clone()
     }
 
     /// Sets the window as maximized or not.
@@ -1668,12 +1672,10 @@ impl X11Surface {
             return Ok(());
         };
 
-        if hints.len() < 5 {
-            return Ok(());
+        if let Some(hints) = MwmHints::parse(&hints) {
+            let mut state = self.state.lock().unwrap();
+            state.motif_hints = hints;
         }
-
-        let mut state = self.state.lock().unwrap();
-        state.motif_hints = hints;
         Ok(())
     }
 


### PR DESCRIPTION
## Description

`X11Surface` already fetchs and tracks `_MOTIF_WM_HINTS` for `is_decorated()`, but otherwise doesn't parse or do anything with the data.  This exposes a `MwmHints` struct with the various bitfields and enum for each part of the property, and adds a `motif_hints()` accessor to `X11Surface`.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
