### PR TITLE
Don't create an extra XdgOutput struct on get_xdg_output

### DIFF
--- a/src/wayland/output/handlers.rs
+++ b/src/wayland/output/handlers.rs
@@ -169,23 +169,22 @@ where
                 let output = Output::from_resource(&wl_output).unwrap();
                 let mut inner = output.inner.0.lock().unwrap();
 
-                let xdg_output = XdgOutput::new(&inner);
-
                 if inner.xdg_output.is_none() {
-                    inner.xdg_output = Some(xdg_output.clone());
+                    inner.xdg_output = Some(XdgOutput::new(&inner));
                 }
+                let xdg_output = inner.xdg_output.as_ref().unwrap();
 
                 let client_scale = state.client_compositor_state(client).clone_client_scale();
                 let id = data_init.init(
                     id,
                     XdgOutputUserData {
-                        xdg_output,
+                        xdg_output: xdg_output.clone(),
                         last_client_scale: AtomicF64::new(client_scale.load(Ordering::Acquire)),
                         client_scale,
                     },
                 );
 
-                inner.xdg_output.as_ref().unwrap().add_instance(&id, &wl_output);
+                xdg_output.add_instance(&id, &wl_output);
             }
             zxdg_output_manager_v1::Request::Destroy => {}
             _ => {}


### PR DESCRIPTION
## Description

The `xdg_output_manager.get_xdg_output` handler was creating an `XdgOutput` unconditionally, and then setting it as `OutputInner`'s `xdg_output` member only if that member was `None`.

If it *wasn't* `None,` then the newly-created `XdgOutput` instance is used as the `xdg_output `member of `XdgOutputUserData` for that protocol object, instead of the "canonical" `XdgOutput` instance inside `OutputInner`.

Then the `ZxdgOutputV1` protocol object is inserted into the "canonical" `XdgOutput`'s instances list (that is, the one that is in `OutputInner`). This is correct, and is why the protocol functions correctly for clients.

However, the prior step means that when a client (that was *not* the first client to call `get_xdg_output` for that `Output`) destroys the `ZxdgOutputV1` protocol object, its instance will never actually get removed from the instances list, because it's not actually in the `XdgOutputUserData`'s `XdgOutput` instances list, because it's only in the "canonical" one as created by the `Output`'s first-ever `get_xdg_output` call.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
