### PR TITLE
Add Output::owns_xdg_output()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,8 @@ default implementations, which result in skipping the new functionality. As such
 - `lower_element()`: lowers an element to the bottom of the stack, respecting its z-index group.
 - `relocate_element()`: moves an element to a new location in the space without changing the stacking order.
 
+`Output` now has `owns_xdg_output()` which allows you to match an XDG output protocol object with an `Output`.
+
 ### Bugfixes
 
 `SimpleCrtcMapper` (in `smithay-drm-extras`) now releases the CRTC reservation of any connector that

--- a/src/wayland/output/mod.rs
+++ b/src/wayland/output/mod.rs
@@ -82,6 +82,7 @@ use crate::{
 use portable_atomic::AtomicF64;
 use tracing::info;
 use wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_manager_v1::ZxdgOutputManagerV1;
+use wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_v1::ZxdgOutputV1;
 use wayland_server::{
     Client, DisplayHandle, GlobalDispatch, Resource,
     backend::{ClientId, GlobalId},
@@ -268,6 +269,26 @@ impl Output {
             .instances
             .iter()
             .any(|o| o.id() == output.id())
+    }
+
+    /// Check if given [`xdg_output`](ZxdgOutputV1) instance is managed by this [`Output`].
+    pub fn owns_xdg_output(&self, output: &ZxdgOutputV1) -> bool {
+        self.inner
+            .0
+            .lock()
+            .unwrap()
+            .xdg_output
+            .as_ref()
+            .map(|xdg_output| {
+                xdg_output
+                    .inner
+                    .lock()
+                    .unwrap()
+                    .instances
+                    .iter()
+                    .any(|o| o.id() == output.id())
+            })
+            .unwrap_or(false)
     }
 
     /// This function returns all managed [WlOutput] matching the provided [Client]


### PR DESCRIPTION
## Description

Returns true if the passed `ZxdgOutputV1` protocol instance is owned by the `Output`.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
