### PR TITLE
Add remove_xsettings() and clear_xsettings() to X11Wm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,8 @@ allowing DnD operations between X11 and Wayland clients (both directions).
 
 `X11Surface` now parses and exposes the Motif WM hints via `motif_hints()`.
 
+`X11Wm` allows you to remove and clear XSETTINGS settings.
+
 xdg_shell and layer_shell now enforce the client acking a configure before committing a buffer, as required by the protocols.
 
 ```rs

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -1382,6 +1382,23 @@ impl X11Wm {
         Ok(())
     }
 
+    /// Removes settings from XSETTINGS.
+    pub fn remove_xsettings(&mut self, names: impl Iterator<Item = String>) -> Result<(), ConnectionError> {
+        let removed = names.fold(false, |any_removed, name| {
+            self.xsettings.remove(&name).is_some() | any_removed
+        });
+        if removed {
+            self.xsettings.update(&self.conn)?;
+        }
+        Ok(())
+    }
+
+    /// Clears all settings from XSETTINGS.
+    pub fn clear_xsettings(&mut self) -> Result<(), ConnectionError> {
+        self.xsettings.clear();
+        self.xsettings.update(&self.conn)
+    }
+
     /// Gets the current primary output as advertised by xrandr
     pub fn get_randr_primary_output(&self) -> Result<Option<String>, ReplyError> {
         let current_primary = self

--- a/src/xwayland/xwm/settings.rs
+++ b/src/xwayland/xwm/settings.rs
@@ -159,13 +159,16 @@ impl XSettings {
         self.values.get(name).map(|setting| &setting.val)
     }
 
-    #[allow(dead_code)]
     pub fn remove<Q>(&mut self, name: &Q) -> Option<Value>
     where
         Q: Hash + Eq + ?Sized,
         String: Borrow<Q>,
     {
         self.values.remove(name).map(|setting| setting.val)
+    }
+
+    pub fn clear(&mut self) {
+        self.values.clear();
     }
 
     fn serialize(&mut self) -> Vec<u8> {


### PR DESCRIPTION
## Description

Noticed you can add xsettings values, but not remove or clear them.  I need to be able to remove them when the corresponding setting is deleted from our configuration store (something a user can do), so that applications revert to the default for that setting.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
