### PR TITLE
fix: clear stale outputs in Space::refresh first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,9 @@ CRTC.
 XWayland now honors WM_HINTS request to map the window in IconicState(minimized). Compositors should
 check X11Surface::is_hidden() at mapping time and minimize the window appropriately.
 
+Space::refresh() now clears stale outputs before emitting any enter events so no wl_surface.enter events
+are emitted with a stale wl_output anymore.
+
 ## 0.7.0
 
 ### Breaking changes

--- a/src/desktop/space/mod.rs
+++ b/src/desktop/space/mod.rs
@@ -436,8 +436,16 @@ impl<E: SpaceElement + PartialEq> Space<E> {
             })
             .collect::<Vec<_>>();
         for e in &mut self.elements {
-            let bbox = e.bbox();
+            e.outputs.retain(|output, _| {
+                if !outputs.iter().any(|(o, _)| o == output) {
+                    e.element.output_leave(output);
+                    false
+                } else {
+                    true
+                }
+            });
 
+            let bbox = e.bbox();
             for (output, output_geometry) in &outputs {
                 // Check if the bounding box of the toplevel intersects with the output
                 if let Some(mut overlap) = output_geometry.intersection(bbox) {
@@ -451,14 +459,6 @@ impl<E: SpaceElement + PartialEq> Space<E> {
                     e.element.output_leave(output);
                 }
             }
-            e.outputs.retain(|output, _| {
-                if !outputs.iter().any(|(o, _)| o == output) {
-                    e.element.output_leave(output);
-                    false
-                } else {
-                    true
-                }
-            });
         }
 
         self.elements.iter().for_each(|e| e.element.refresh());


### PR DESCRIPTION
## Description
Smithay could emit surface.enter events with removed wl_output. This was encountered in mpv. turning the monitor off and back on would crash mpv with a nullpointer dereference as the enter events was forwarded by libwayland with a nullptr for the wl_output(as it was sent a zombie value, libwayland replaces those with nullptr).

e.outputs was cleared only after the enter were emitted and some(specifically https://github.com/Smithay/smithay/blob/master/src/desktop/space/wayland/window.rs#L39 ) calls self.refresh() => output_update => output.enter on a stale output.

This just reorders things, making sure the stale outputs in the elements are removed first before checking if enter events need to be sent.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [X] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
