### PR TITLE
small blur fixes

### DIFF
--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -690,6 +690,7 @@ impl OutputDamageTracker {
         for (z_index, element) in render_elements
             .iter()
             .enumerate()
+            .rev()
             .filter(|(_, e)| e.is_framebuffer_effect())
         {
             let damage_index = if force_effect_redraw {

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -659,7 +659,7 @@ impl OutputDamageTracker {
         element_damage.extend_from_slice(&self.last_state.opaque_regions);
         element_damage =
             Rectangle::subtract_rects_many_in_place(element_damage, self.opaque_regions.iter().copied());
-        if !element_damage.is_empty() {
+        if element_damage.iter().any(|rect| !rect.is_empty()) {
             force_effect_redraw = true;
         }
         self.damage.extend_from_slice(&element_damage);


### PR DESCRIPTION
## Description

Before: update to one window, causes update to the panel, which then causes update to the windows touching that area. (damage moves up one layer to the panel and then down to all the windows below it, maybe a video in floating mode would've made more sense)

https://github.com/user-attachments/assets/ec0b5a05-c5a3-4ebd-8278-65a673439cd2



After:
update to one window only causes update to the panel

https://github.com/user-attachments/assets/eaee7fd2-ece4-411d-8164-c6c5f30764f1



## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
