### PR TITLE
Don't allow an unrelated client to unlock the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,13 @@ The `SpaceElement::geometry` impl for `X11Surface` is no longer equivalent to it
 `X11Surface::geometry` has been renamed to `X11Surface::last_configure`. `X11Surface::geometry` now returns the bounding
 box minus the surface's frame extents.
 
+`SessionLockHandler::unlock` will no longer be called if the `ext_session_lock_v1` instance that sent the
+`unlock_and_destroy` request is not the same instance as the one that successfully locked the session.
+
+`SessionLockHandler::new_surface` can be called for multiple `SessionLocker` instances that could be in-flight at the same
+time. `LockSurface::ext_session_lock` has been added to allow the compositor to disambiguate, and associate lock surfaces
+with the correct lock instance.
+
 ### Additions
 
 - ExtBackgroundEffect protocol is now available in `smithay::wayland::background_effect` module.

--- a/src/wayland/session_lock/lock.rs
+++ b/src/wayland/session_lock/lock.rs
@@ -1,6 +1,5 @@
 //! ext-session-lock lock.
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::wayland::compositor::SurfaceAttributes;
@@ -8,11 +7,12 @@ use crate::wayland::compositor::{self, BufferAssignment};
 use _session_lock::ext_session_lock_surface_v1::ExtSessionLockSurfaceV1;
 use _session_lock::ext_session_lock_v1::{Error, ExtSessionLockV1, Request};
 use wayland_protocols::ext::session_lock::v1::server::{self as _session_lock};
+use wayland_server::protocol::wl_output::WlOutput;
 use wayland_server::{Client, DataInit, Dispatch, DisplayHandle, Resource};
 
 use crate::wayland::Dispatch2;
-use crate::wayland::session_lock::SessionLockHandler;
 use crate::wayland::session_lock::surface::{ExtLockSurfaceUserData, LockSurface, LockSurfaceAttributes};
+use crate::wayland::session_lock::{LockStatus, SessionLockHandler};
 
 /// Surface role for ext-session-lock surfaces.
 const LOCK_SURFACE_ROLE: &str = "ext_session_lock_surface_v1";
@@ -20,13 +20,13 @@ const LOCK_SURFACE_ROLE: &str = "ext_session_lock_surface_v1";
 /// [`ExtSessionLockV1`] state.
 #[derive(Debug)]
 pub struct SessionLockState {
-    pub(crate) lock_status: Arc<AtomicBool>,
+    locked_outputs: Mutex<Vec<WlOutput>>,
 }
 
 impl SessionLockState {
-    pub(crate) fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
-            lock_status: Arc::new(AtomicBool::new(false)),
+            locked_outputs: Default::default(),
         }
     }
 }
@@ -55,12 +55,13 @@ where
                 }
 
                 // Ensure output is not already locked.
-                let lock_state = state.lock_state();
-                if lock_state.locked_outputs.contains(&output) {
+                let mut locked_outputs = self.locked_outputs.lock().unwrap();
+                if locked_outputs.contains(&output) {
                     lock.post_error(Error::DuplicateOutput, "Output is already locked.");
                     return;
                 }
-                lock_state.locked_outputs.push(output.clone());
+                locked_outputs.push(output.clone());
+                drop(locked_outputs);
 
                 // Ensure surface has no existing buffers attached.
                 let has_buffer = compositor::with_states(&surface, |states| {
@@ -101,24 +102,24 @@ where
                 compositor::add_pre_commit_hook::<D, _>(&surface, LockSurface::pre_commit_hook);
 
                 // Call compositor handler.
-                let lock_surface = LockSurface::new(surface, lock_surface);
+                let lock_surface = LockSurface::new(lock.clone(), surface, lock_surface);
                 state.new_surface(lock_surface.clone(), output);
 
                 // Send initial configure when the interface is bound.
                 lock_surface.send_configure();
             }
             Request::UnlockAndDestroy => {
-                // Ensure session is locked.
-                if !self.lock_status.load(Ordering::Relaxed) {
+                // Ensure session is locked, and with the same lock instance.
+                if !state.lock_state().lock_status.lock().unwrap().is_locked_by(lock) {
                     lock.post_error(Error::InvalidUnlock, "Session is not locked.");
+                } else {
+                    *state.lock_state().lock_status.lock().unwrap() = LockStatus::Unlocked;
+                    state.unlock();
                 }
-
-                state.lock_state().locked_outputs.clear();
-                state.unlock();
             }
             Request::Destroy => {
                 // Ensure session is not locked.
-                if self.lock_status.load(Ordering::Relaxed) {
+                if state.lock_state().lock_status.lock().unwrap().is_locked_by(lock) {
                     lock.post_error(Error::InvalidDestroy, "Cannot destroy session lock while locked.");
                 }
             }

--- a/src/wayland/session_lock/lock.rs
+++ b/src/wayland/session_lock/lock.rs
@@ -132,4 +132,14 @@ where
             _ => unreachable!(),
         }
     }
+
+    fn destroyed(&self, state: &mut D, _client: wayland_server::backend::ClientId, lock: &ExtSessionLockV1) {
+        let mut lock_status = state.lock_state().lock_status.lock().unwrap();
+        if lock_status.is_locked_by(lock) {
+            // The client has disconnected without unlocking the session, so reset our state.  It
+            // is up to the compositor's policy to decide whether it is allowed for another client
+            // to connect and take over the session-locker responsibility.
+            *lock_status = LockStatus::Defunct;
+        }
+    }
 }

--- a/src/wayland/session_lock/lock.rs
+++ b/src/wayland/session_lock/lock.rs
@@ -1,5 +1,6 @@
 //! ext-session-lock lock.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::wayland::compositor::SurfaceAttributes;
@@ -20,12 +21,14 @@ const LOCK_SURFACE_ROLE: &str = "ext_session_lock_surface_v1";
 /// [`ExtSessionLockV1`] state.
 #[derive(Debug)]
 pub struct SessionLockState {
+    pub(super) done: Arc<AtomicBool>,
     locked_outputs: Mutex<Vec<WlOutput>>,
 }
 
 impl SessionLockState {
     pub(super) fn new() -> Self {
         Self {
+            done: Arc::new(AtomicBool::new(false)),
             locked_outputs: Default::default(),
         }
     }
@@ -78,6 +81,7 @@ where
 
                 let data = ExtLockSurfaceUserData {
                     surface: surface.downgrade(),
+                    done: Arc::clone(&self.done),
                 };
                 let lock_surface = data_init.init(id, data);
 
@@ -101,12 +105,14 @@ where
                 // Add pre-commit hook for updating surface state.
                 compositor::add_pre_commit_hook::<D, _>(&surface, LockSurface::pre_commit_hook);
 
-                // Call compositor handler.
-                let lock_surface = LockSurface::new(lock.clone(), surface, lock_surface);
-                state.new_surface(lock_surface.clone(), output);
+                if !self.done.load(Ordering::Acquire) {
+                    // Call compositor handler.
+                    let lock_surface = LockSurface::new(lock.clone(), surface, lock_surface);
+                    state.new_surface(lock_surface.clone(), output);
 
-                // Send initial configure when the interface is bound.
-                lock_surface.send_configure();
+                    // Send initial configure when the interface is bound.
+                    lock_surface.send_configure();
+                }
             }
             Request::UnlockAndDestroy => {
                 // Ensure session is locked, and with the same lock instance.

--- a/src/wayland/session_lock/mod.rs
+++ b/src/wayland/session_lock/mod.rs
@@ -48,6 +48,7 @@
 //! // You're now ready to go!
 //! ```
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use _session_lock::ext_session_lock_manager_v1::{ExtSessionLockManagerV1, Request};
@@ -157,9 +158,10 @@ where
         match request {
             Request::Lock { id } => {
                 let lock_state = SessionLockState::new();
+                let done = Arc::clone(&lock_state.done);
                 let lock = data_init.init(id, lock_state);
                 let lock_status = Arc::clone(&state.lock_state().lock_status);
-                state.lock(SessionLocker::new(lock, lock_status));
+                state.lock(SessionLocker::new(lock, lock_status, done));
             }
             Request::Destroy => (),
             _ => unreachable!(),
@@ -186,6 +188,14 @@ pub trait SessionLockHandler {
     fn unlock(&mut self);
 
     /// Add a new lock surface for an output.
+    ///
+    /// Note that this may be called for surfaces created on different [`SessionLocker`] instances
+    /// if more than one client is racing to lock the screen, so you should match [`LockSurface`]
+    /// instances with [`SessionLocker`] instances using the underlying [`ExtSessionLockV1`]
+    /// instance of both.
+    ///
+    /// Once you have dropped the [`SessionLocker`] instances that will not be locking the session,
+    /// this function will no longer be called for surfaces created by those locker instances.
     fn new_surface(&mut self, surface: LockSurface, output: WlOutput);
 
     /// A surface has acknowledged a configure serial.
@@ -199,6 +209,7 @@ pub trait SessionLockHandler {
 pub struct SessionLocker {
     lock: Option<ExtSessionLockV1>,
     lock_status: Arc<Mutex<LockStatus>>,
+    done: Arc<AtomicBool>,
 }
 
 impl Drop for SessionLocker {
@@ -206,15 +217,17 @@ impl Drop for SessionLocker {
         // If the session wasn't locked, we notify clients about the failure.
         if let Some(lock) = self.lock.take() {
             lock.finished();
+            self.done.store(true, Ordering::Release);
         }
     }
 }
 
 impl SessionLocker {
-    fn new(lock: ExtSessionLockV1, lock_status: Arc<Mutex<LockStatus>>) -> Self {
+    fn new(lock: ExtSessionLockV1, lock_status: Arc<Mutex<LockStatus>>, done: Arc<AtomicBool>) -> Self {
         Self {
             lock: Some(lock),
             lock_status,
+            done,
         }
     }
 

--- a/src/wayland/session_lock/mod.rs
+++ b/src/wayland/session_lock/mod.rs
@@ -48,8 +48,7 @@
 //! // You're now ready to go!
 //! ```
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use _session_lock::ext_session_lock_manager_v1::{ExtSessionLockManagerV1, Request};
 use _session_lock::ext_session_lock_v1::ExtSessionLockV1;
@@ -71,10 +70,22 @@ pub use surface::{
 
 const MANAGER_VERSION: u32 = 1;
 
+#[derive(Debug)]
+enum LockStatus {
+    Unlocked,
+    Locked(ExtSessionLockV1),
+}
+
+impl LockStatus {
+    fn is_locked_by(&self, session_lock: &ExtSessionLockV1) -> bool {
+        matches!(self, Self::Locked(owning_session_lock) if owning_session_lock == session_lock)
+    }
+}
+
 /// State of the [`ExtSessionLockManagerV1`] Global.
 #[derive(Debug)]
 pub struct SessionLockManagerState {
-    pub(crate) locked_outputs: Vec<WlOutput>,
+    lock_status: Arc<Mutex<LockStatus>>,
 }
 
 impl SessionLockManagerState {
@@ -94,7 +105,7 @@ impl SessionLockManagerState {
         display.create_global::<D, ExtSessionLockManagerV1, _>(MANAGER_VERSION, data);
 
         Self {
-            locked_outputs: Vec::new(),
+            lock_status: Arc::new(Mutex::new(LockStatus::Unlocked)),
         }
     }
 }
@@ -146,8 +157,8 @@ where
         match request {
             Request::Lock { id } => {
                 let lock_state = SessionLockState::new();
-                let lock_status = lock_state.lock_status.clone();
                 let lock = data_init.init(id, lock_state);
+                let lock_status = Arc::clone(&state.lock_state().lock_status);
                 state.lock(SessionLocker::new(lock, lock_status));
             }
             Request::Destroy => (),
@@ -187,7 +198,7 @@ pub trait SessionLockHandler {
 #[derive(Debug)]
 pub struct SessionLocker {
     lock: Option<ExtSessionLockV1>,
-    lock_status: Arc<AtomicBool>,
+    lock_status: Arc<Mutex<LockStatus>>,
 }
 
 impl Drop for SessionLocker {
@@ -200,7 +211,7 @@ impl Drop for SessionLocker {
 }
 
 impl SessionLocker {
-    fn new(lock: ExtSessionLockV1, lock_status: Arc<AtomicBool>) -> Self {
+    fn new(lock: ExtSessionLockV1, lock_status: Arc<Mutex<LockStatus>>) -> Self {
         Self {
             lock: Some(lock),
             lock_status,
@@ -215,7 +226,7 @@ impl SessionLocker {
     /// Notify the client that the session lock was successful.
     pub fn lock(mut self) {
         if let Some(lock) = self.lock.take() {
-            self.lock_status.store(true, Ordering::Relaxed);
+            *self.lock_status.lock().unwrap() = LockStatus::Locked(lock.clone());
             lock.locked();
         }
     }

--- a/src/wayland/session_lock/mod.rs
+++ b/src/wayland/session_lock/mod.rs
@@ -73,8 +73,12 @@ const MANAGER_VERSION: u32 = 1;
 
 #[derive(Debug)]
 enum LockStatus {
+    /// The session is unlocked.
     Unlocked,
+    /// The session has been locked, and is owned by the specified instance.
     Locked(ExtSessionLockV1),
+    /// The session was locked, but the locking client disconnected without unlocking.
+    Defunct,
 }
 
 impl LockStatus {

--- a/src/wayland/session_lock/surface.rs
+++ b/src/wayland/session_lock/surface.rs
@@ -1,6 +1,7 @@
 //! ext-session-lock surface.
 
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use crate::backend::renderer::buffer_dimensions;
 use crate::utils::{IsAlive, Logical, SERIAL_COUNTER, Serial, Size};
@@ -23,6 +24,7 @@ pub struct ExtLockSurfaceUserData {
     // `ExtSessionLockSurfaceV1`. So this reference needs to be weak to avoid a
     // cycle.
     pub(crate) surface: Weak<WlSurface>,
+    pub(super) done: Arc<AtomicBool>,
 }
 
 impl<D> Dispatch2<ExtSessionLockSurfaceV1, D> for ExtLockSurfaceUserData
@@ -53,7 +55,11 @@ where
                 });
 
                 match configure {
-                    Some(configure) => state.ack_configure(surface.clone(), configure),
+                    Some(configure) => {
+                        if !self.done.load(Ordering::Acquire) {
+                            state.ack_configure(surface.clone(), configure);
+                        }
+                    }
                     None => lock_surface.post_error(
                         Error::InvalidSerial,
                         format!("wrong configure serial: {}", <u32>::from(serial)),

--- a/src/wayland/session_lock/surface.rs
+++ b/src/wayland/session_lock/surface.rs
@@ -8,6 +8,7 @@ use crate::wayland::compositor::{self, BufferAssignment, Cacheable, SurfaceAttri
 use crate::wayland::viewporter::{ViewportCachedState, ViewporterSurfaceState};
 use _session_lock::ext_session_lock_surface_v1::{Error, ExtSessionLockSurfaceV1, Request};
 use tracing::trace_span;
+use wayland_protocols::ext::session_lock::v1::server::ext_session_lock_v1::ExtSessionLockV1;
 use wayland_protocols::ext::session_lock::v1::server::{self as _session_lock, ext_session_lock_surface_v1};
 use wayland_server::protocol::wl_surface::WlSurface;
 use wayland_server::{Client, DataInit, DisplayHandle, Resource, Weak};
@@ -162,6 +163,7 @@ impl LockSurfaceAttributes {
 /// Handle for a ext-session-lock surface.
 #[derive(Clone, Debug)]
 pub struct LockSurface {
+    lock: ExtSessionLockV1,
     shell_surface: ExtSessionLockSurfaceV1,
     surface: WlSurface,
 }
@@ -174,8 +176,13 @@ impl PartialEq for LockSurface {
 }
 
 impl LockSurface {
-    pub(crate) fn new(surface: WlSurface, shell_surface: ExtSessionLockSurfaceV1) -> Self {
+    pub(crate) fn new(
+        lock: ExtSessionLockV1,
+        surface: WlSurface,
+        shell_surface: ExtSessionLockSurfaceV1,
+    ) -> Self {
         Self {
+            lock,
             surface,
             shell_surface,
         }
@@ -185,6 +192,11 @@ impl LockSurface {
     #[inline]
     pub fn alive(&self) -> bool {
         self.surface.alive()
+    }
+
+    /// Returns the lock instance this surface is associated with.
+    pub fn ext_session_lock(&self) -> &ExtSessionLockV1 {
+        &self.lock
     }
 
     /// Get the current pending configure state.


### PR DESCRIPTION
## Description

Here's the "attack" sequence that was possible:

1. Legit lock client binds to interface, sends `lock`, creates lock surfaces, and does things as expected.  Session is locked.
2. Malicious (or just buggy) client binds to the interface and sends `lock`.  Smithay calls `SessionLockHandler::lock()`.  Here the compositor does have enough information; it can know that the session is already locked, and that it's a different client requesting to lock, so it can drop the `SessionLocker` instance, which causes smithay to emit `finished` on the protocol object.
3. But `finished` is not a destructor, so the client still has a live `ext_session_lock_v1` object.  It can immediately request `unlock_and_destroy` on it.
4. Smithay's handler for `unlock_and_destroy` unconditionally clears the list of lock surfaces, and calls `SessionLockHandler::unlock()`. `unlock()` takes no parameters, so the compositor has no idea what client is asking to unlock the session.  Presumably it will unlock the session, without the user having authenticated.

One possible mitigation the compositor could do (which doesn't require changes to smithay) would be to immediately send a protocol error to the client after step #2, which would disconnect the client entirely.  I don't think that's a very nice solution, though, as it's possible the client isn't malicious or even buggy, but just raced the client that successfully locked the screen. Regardless, this would be a huge foot-gun for compositors; it's not obvious or clear that the compositor should have to do this, and arguably smithay should just do the thing that is correct in all circumstances.

So, this change:

1. Moves `lock_status` to `SessionLockManagerState`, since whether or not the session is locked is a property of the compositor/manager, not of a specific `ExtSessionLockV1` instance.
2. `lock_status` is now an enum that records the `ExtSessionLockV1` instance that the compositor allowed to successfully lock the session.
3. If another `ExtSessionLockV1` instance tries to unlock the session, an error is sent back (`invalid_unlock`), the internal list of lock surfaces is not cleared, and `unlock()` is not called on the compositor's handler.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
