### PR TITLE
wayland/drm_lease: Allow unauthenticated file descriptors

### DIFF
--- a/src/wayland/drm_lease/mod.rs
+++ b/src/wayland/drm_lease/mod.rs
@@ -370,10 +370,11 @@ fn get_non_master_fd<P: AsRef<Path>>(path: P) -> Result<OwnedFd, Error> {
 
     // Attempt to drop master unconditionally. EINVAL means the fd never had
     // master to begin with (common on drivers like nvidia-drm that mark all
-    // clients as authenticated regardless of master status)
+    // clients as authenticated regardless of master status). EPERM means
+    // the file descriptor is not authenticated in the first place.
     match drm_ffi::auth::release_master(fd.as_fd()) {
         Ok(()) => {}
-        Err(e) if e.kind() == io::ErrorKind::InvalidInput => {}
+        Err(e) if e.kind() == io::ErrorKind::InvalidInput || e.kind() == io::ErrorKind::PermissionDenied => {}
         Err(e) => return Err(Error::UnableToDropMaster(e)),
     }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

Ever since https://github.com/Smithay/smithay/pull/2057/changes  smithay based compositors don't advertise any drm_lease globals anymore on most systems.

Reason being, that we previously checked if the client was marked as authenticated in the first place, before trying to drop master. If the client isn't authenticated, attempting to `release_master` will just return `EPERM`, so lets treat that as successful as well.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
