### PR TITLE
xwm: Don't read `incr` prop into source_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,9 @@ check X11Surface::is_hidden() at mapping time and minimize the window appropriat
 Space::refresh() now clears stale outputs before emitting any enter events so no wl_surface.enter events
 are emitted with a stale wl_output anymore.
 
+The XWayland WM implementation previously incorrectly prefixed large transfers from X11 windows with
+the four INCR bytes.
+
 ## 0.7.0
 
 ### Breaking changes

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -2071,12 +2071,12 @@ where
                         .reply_unchecked()?
                     {
                         let type_ = prop.type_;
-                        transfer.read_selection_prop(prop);
                         if type_ == xwm.atoms.INCR {
                             transfer.incr = true;
                             return Ok(());
-                        } else if let Some(token) = transfer.token.as_ref() {
-                            let _ = loop_handle.enable(token);
+                        } else if transfer.token.is_some() {
+                            transfer.read_selection_prop(prop);
+                            let _ = loop_handle.enable(transfer.token.as_ref().unwrap());
                         } else {
                             selection.incoming.remove(&n.requestor);
                         }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

Reported here https://github.com/pop-os/cosmic-comp/issues/2717. This should fix it.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
