### PR TITLE
Send enter/down/proximity_in to late-bound pointer/touch/tablet_tool

### DIFF
--- a/src/input/pointer/mod.rs
+++ b/src/input/pointer/mod.rs
@@ -702,7 +702,7 @@ impl<D: SeatHandler + 'static> PointerInnerHandle<'_, D> {
 pub(crate) struct PointerInternal<D: SeatHandler> {
     pub(crate) focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
     pending_focus: Option<(<D as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
-    location: Point<f64, Logical>,
+    pub(crate) location: Point<f64, Logical>,
     grab: GrabStatus<dyn PointerGrab<D>>,
     pressed_buttons: Vec<u32>,
 }

--- a/src/input/tablet/tool/mod.rs
+++ b/src/input/tablet/tool/mod.rs
@@ -662,7 +662,7 @@ pub(crate) struct TabletToolInternal<D: TabletSeatHandler> {
     previous_focus: Option<<D as TabletSeatHandler>::ToolFocus>,
 
     location: Option<Point<f64, Logical>>,
-    tablet: Option<Tablet>,
+    pub(crate) tablet: Option<Tablet>,
     current_buttons: Vec<u32>,
     pressed_buttons: Vec<u32>,
     tip_down: bool,

--- a/src/input/touch/mod.rs
+++ b/src/input/touch/mod.rs
@@ -44,6 +44,8 @@ pub struct TouchHandle<D: SeatHandler> {
     pub(crate) inner: Arc<Mutex<TouchInternal<D>>>,
     #[cfg(feature = "wayland_frontend")]
     pub(crate) known_instances: Arc<Mutex<Vec<Weak<wayland_server::protocol::wl_touch::WlTouch>>>>,
+    #[cfg(feature = "wayland_frontend")]
+    pub(crate) last_down: Arc<Mutex<HashMap<TouchSlot, Serial>>>,
     pub(crate) span: tracing::Span,
 }
 
@@ -60,6 +62,7 @@ impl<D: SeatHandler> fmt::Debug for TouchHandle<D> {
         f.debug_struct("TouchHandle")
             .field("inner", &self.inner)
             .field("known_instances", &self.known_instances)
+            .field("last_down", &self.last_down)
             .finish()
     }
 }
@@ -71,6 +74,8 @@ impl<D: SeatHandler> Clone for TouchHandle<D> {
             inner: self.inner.clone(),
             #[cfg(feature = "wayland_frontend")]
             known_instances: self.known_instances.clone(),
+            #[cfg(feature = "wayland_frontend")]
+            last_down: self.last_down.clone(),
             span: self.span.clone(),
         }
     }
@@ -93,7 +98,7 @@ impl<D: SeatHandler> std::cmp::PartialEq for TouchHandle<D> {
 impl<D: SeatHandler> std::cmp::Eq for TouchHandle<D> {}
 
 pub(crate) struct TouchInternal<D: SeatHandler> {
-    focus: HashMap<TouchSlot, TouchSlotState<D>>,
+    pub(crate) focus: HashMap<TouchSlot, TouchSlotState<D>>,
     pending_frame: Option<FrameMarker>,
     default_grab: Box<dyn Fn() -> Box<dyn TouchGrab<D>> + Send + 'static>,
     grab: GrabStatus<dyn TouchGrab<D>>,
@@ -107,9 +112,10 @@ impl<D: SeatHandler> Drop for TouchInternal<D> {
     }
 }
 
-struct TouchSlotState<D: SeatHandler> {
-    focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
+pub(crate) struct TouchSlotState<D: SeatHandler> {
+    pub(crate) focus: Option<(<D as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
     frame_pending: Option<<D as SeatHandler>::TouchFocus>,
+    pub(crate) location: Point<f64, Logical>,
     pending: FrameMarker,
     current: Option<FrameMarker>,
 }
@@ -119,6 +125,7 @@ impl<D: SeatHandler> fmt::Debug for TouchSlotState<D> {
         f.debug_struct("TouchSlotState")
             .field("focus", &self.focus)
             .field("frame_pending", &self.frame_pending)
+            .field("location", &self.location)
             .field("pending", &self.pending)
             .field("current", &self.current)
             .finish()
@@ -260,6 +267,8 @@ impl<D: SeatHandler + 'static> TouchHandle<D> {
             inner: Arc::new(Mutex::new(TouchInternal::new(default_grab))),
             #[cfg(feature = "wayland_frontend")]
             known_instances: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(feature = "wayland_frontend")]
+            last_down: Arc::new(Mutex::new(HashMap::new())),
             span: info_span!("input_touch"),
         }
     }
@@ -578,11 +587,13 @@ impl<D: SeatHandler + 'static> TouchInternal<D> {
             .and_modify(|state| {
                 state.pending = marker;
                 state.frame_pending = None;
+                state.location = event.location;
                 state.focus.clone_from(&focus);
             })
             .or_insert_with(|| TouchSlotState {
                 focus,
                 frame_pending: None,
+                location: event.location,
                 pending: marker,
                 current: None,
             });
@@ -622,6 +633,7 @@ impl<D: SeatHandler + 'static> TouchInternal<D> {
             return;
         };
         state.pending = marker;
+        state.location = event.location;
         if let Some((focus, loc)) = state.focus.as_ref() {
             let mut new_event = event.clone();
             new_event.location -= *loc;

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -234,6 +234,7 @@ where
     D: CompositorHandler,
     <D as SeatHandler>::PointerFocus: WaylandFocus,
     <D as SeatHandler>::KeyboardFocus: WaylandFocus,
+    <D as SeatHandler>::TouchFocus: WaylandFocus,
     D: 'static,
 {
     fn request(

--- a/src/wayland/seat/mod.rs
+++ b/src/wayland/seat/mod.rs
@@ -232,6 +232,7 @@ where
     D: Dispatch<WlTouch, TouchUserData<D>>,
     D: SeatHandler,
     D: CompositorHandler,
+    <D as SeatHandler>::PointerFocus: WaylandFocus,
     <D as SeatHandler>::KeyboardFocus: WaylandFocus,
     D: 'static,
 {
@@ -258,7 +259,7 @@ where
                 );
 
                 if let Some(ref ptr_handle) = inner.pointer {
-                    ptr_handle.wl_pointer.new_pointer(pointer);
+                    ptr_handle.wl_pointer.new_pointer::<D>(pointer);
                 } else {
                     // we should send a protocol error... but the protocol does not allow
                     // us, so this pointer will just remain inactive ¯\_(ツ)_/¯

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -66,8 +66,27 @@ pub(crate) struct WlPointerHandle {
 }
 
 impl WlPointerHandle {
-    pub(super) fn new_pointer(&self, pointer: WlPointer) {
+    pub(super) fn new_pointer<D: SeatHandler + 'static>(&self, pointer: WlPointer)
+    where
+        <D as SeatHandler>::PointerFocus: WaylandFocus,
+    {
         self.known_pointers.lock().unwrap().push(pointer.downgrade());
+
+        let data = pointer.data::<PointerUserData<D>>().unwrap();
+        let guard = data.handle.as_ref().unwrap().inner.lock().unwrap();
+        if let Some((focus, location)) = &guard.focus {
+            if focus.same_client_as(&pointer.id()) {
+                if let Some(surface) = focus.wl_surface() {
+                    let serial = self.last_enter.lock().unwrap().unwrap();
+                    let client_scale = data.client_scale.load(Ordering::Acquire);
+                    let location = (guard.location - *location).to_client(client_scale);
+                    pointer.enter(serial.into(), &surface, location.x, location.y);
+                    if pointer.version() >= 5 {
+                        pointer.frame();
+                    }
+                }
+            }
+        }
     }
 
     fn enter<D: SeatHandler + 'static>(&self, surface: &WlSurface, event: &MotionEvent) {

--- a/src/wayland/seat/touch.rs
+++ b/src/wayland/seat/touch.rs
@@ -8,11 +8,14 @@ use wayland_server::{
 };
 
 use super::SeatHandler;
-use crate::input::touch::TouchHandle;
-use crate::input::touch::TouchTarget;
 use crate::wayland::Dispatch2;
 use crate::wayland::compositor::CompositorHandler;
 use crate::wayland::seat::wl_surface::WlSurface;
+use crate::{input::touch::TouchHandle, wayland::seat::WaylandFocus};
+use crate::{
+    input::touch::TouchTarget,
+    utils::{Clock, Monotonic},
+};
 use crate::{
     input::{
         Seat,
@@ -21,10 +24,46 @@ use crate::{
     utils::iter::new_locked_obj_iter_from_vec,
 };
 
-impl<D: SeatHandler> TouchHandle<D> {
+impl<D: SeatHandler> TouchHandle<D>
+where
+    <D as SeatHandler>::TouchFocus: WaylandFocus,
+{
     pub(crate) fn new_touch(&self, touch: WlTouch) {
         let mut guard = self.known_instances.lock().unwrap();
         guard.push(touch.downgrade());
+
+        let mut time = None;
+        let data = touch.data::<TouchUserData<D>>().unwrap();
+        let guard = self.inner.lock().unwrap();
+        let mut sent = false;
+        for (slot, state) in &guard.focus {
+            if let Some((focus, location)) = &state.focus {
+                if focus.same_client_as(&touch.id()) {
+                    if let Some(surface) = focus.wl_surface() {
+                        let serial = data.handle.as_ref().unwrap().last_down.lock().unwrap()[slot];
+                        let time = *time.get_or_insert_with(|| Clock::<Monotonic>::new().now().as_millis());
+                        let client_scale = data.client_scale.load(Ordering::Acquire);
+                        let location = (state.location - *location).to_client(client_scale);
+
+                        touch.down(
+                            serial.into(),
+                            time,
+                            &surface,
+                            (*slot).into(),
+                            location.x,
+                            location.y,
+                        );
+                        sent = true;
+
+                        // TODO: send shape, orientation.
+                    }
+                }
+            }
+        }
+
+        if sent {
+            touch.frame();
+        }
     }
 }
 
@@ -83,6 +122,10 @@ where
         let serial = event.serial;
         let slot = event.slot;
 
+        if let Some(touch) = seat.get_touch() {
+            touch.last_down.lock().unwrap().insert(slot, serial);
+        }
+
         for_each_focused_touch(seat, self, |touch| {
             let client_scale = touch
                 .data::<TouchUserData<D>>()
@@ -106,7 +149,11 @@ where
         let slot = event.slot;
         for_each_focused_touch(seat, self, |touch| {
             touch.up(serial.into(), event.time, slot.into());
-        })
+        });
+
+        if let Some(touch) = seat.get_touch() {
+            touch.last_down.lock().unwrap().remove(&slot);
+        }
     }
 
     fn motion(&self, seat: &Seat<D>, _data: &mut D, event: &MotionEvent) {
@@ -135,7 +182,11 @@ where
 
         for_each_focused_touch(seat, self, |touch| {
             touch.cancel();
-        })
+        });
+
+        if let Some(touch) = seat.get_touch() {
+            touch.last_down.lock().unwrap().clear();
+        }
     }
 
     fn shape(&self, seat: &Seat<D>, _data: &mut D, event: &ShapeEvent) {

--- a/src/wayland/tablet_manager/mod.rs
+++ b/src/wayland/tablet_manager/mod.rs
@@ -84,7 +84,7 @@ use crate::{
         Seat, SeatHandler,
         tablet::{TabletSeat, TabletSeatHandler},
     },
-    wayland::{Dispatch2, GlobalData, GlobalDispatch2, compositor::CompositorHandler},
+    wayland::{Dispatch2, GlobalData, GlobalDispatch2, compositor::CompositorHandler, seat::WaylandFocus},
 };
 use wayland_protocols::wp::tablet::zv2::server::{
     zwp_tablet_manager_v2::{self, ZwpTabletManagerV2},
@@ -157,6 +157,7 @@ where
     D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
     D: SeatHandler + TabletSeatHandler + 'static,
     D: CompositorHandler,
+    <D as TabletSeatHandler>::ToolFocus: WaylandFocus,
 {
     fn request(
         &self,

--- a/src/wayland/tablet_manager/tablet_seat.rs
+++ b/src/wayland/tablet_manager/tablet_seat.rs
@@ -8,6 +8,7 @@ use crate::{
     wayland::{
         Dispatch2,
         compositor::CompositorHandler,
+        seat::WaylandFocus,
         tablet_manager::{TabletToolUserData, tablet::TabletUserData},
     },
 };
@@ -23,6 +24,7 @@ impl<D: TabletSeatHandler + 'static> TabletSeat<D> {
         D: Dispatch<ZwpTabletV2, TabletUserData>,
         D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
         D: CompositorHandler,
+        <D as TabletSeatHandler>::ToolFocus: WaylandFocus,
         D: 'static,
     {
         let mut inner = self.arc.lock().unwrap();

--- a/src/wayland/tablet_manager/tablet_tool.rs
+++ b/src/wayland/tablet_manager/tablet_tool.rs
@@ -23,7 +23,7 @@ use crate::{
             },
         },
     },
-    utils::{Client as ClientCoords, Point, Serial, iter::new_locked_obj_iter_from_vec},
+    utils::{Client as ClientCoords, Clock, Monotonic, Point, Serial, iter::new_locked_obj_iter_from_vec},
     wayland::{
         Dispatch2,
         compositor::{self, CompositorHandler},
@@ -43,6 +43,7 @@ impl<D: TabletSeatHandler + 'static> TabletToolHandle<D> {
                 wp_tablet_tool: WpTabletToolHandle {
                     bound: true,
                     last_proximity_in: Default::default(),
+                    last_down: Default::default(),
                     known_instances: Default::default(),
                 },
             }),
@@ -79,6 +80,7 @@ impl<D: TabletSeatHandler + 'static> TabletSeat<D> {
     where
         D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
         D: CompositorHandler,
+        <D as TabletSeatHandler>::ToolFocus: WaylandFocus,
     {
         self.add_wp_tool_with_grab(state, dh, tool_desc, || Box::new(tool::grab::DefaultGrab))
     }
@@ -101,6 +103,7 @@ impl<D: TabletSeatHandler + 'static> TabletSeat<D> {
     where
         D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
         D: CompositorHandler,
+        <D as TabletSeatHandler>::ToolFocus: WaylandFocus,
         F: Fn() -> Box<dyn TabletToolGrab<D>> + Send + 'static,
     {
         let inner = &mut self.arc.lock().unwrap();
@@ -136,6 +139,7 @@ pub struct TabletToolUserData<D: TabletSeatHandler> {
 pub(crate) struct WpTabletToolHandle {
     pub(crate) bound: bool,
     pub(crate) last_proximity_in: Mutex<Option<Serial>>,
+    pub(crate) last_down: Mutex<Option<Serial>>,
     known_instances: Mutex<Vec<Weak<ZwpTabletToolV2>>>,
 }
 
@@ -152,6 +156,7 @@ impl WpTabletToolHandle {
         D: Dispatch<ZwpTabletToolV2, TabletToolUserData<D>>,
         D: CompositorHandler,
         D: TabletSeatHandler,
+        <D as TabletSeatHandler>::ToolFocus: WaylandFocus,
         D: 'static,
     {
         if !self.bound {
@@ -209,6 +214,30 @@ impl WpTabletToolHandle {
 
         wp_tool.done();
         self.known_instances.lock().unwrap().push(wp_tool.downgrade());
+
+        let guard = handle.arc.inner.lock().unwrap();
+        if let Some((focus, _location)) = &guard.focus {
+            if focus.same_client_as(&wp_tool.id()) {
+                if let Some(surface) = focus.wl_surface() {
+                    let tablet = guard.tablet.as_ref().unwrap();
+                    if let Some(wp_tablet) =
+                        tablet.arc.wp_tablet.focused_tablet_for_seat(&surface, &seat.id())
+                    {
+                        let serial = self.last_proximity_in.lock().unwrap().unwrap();
+                        wp_tool.proximity_in(serial.into(), &wp_tablet, &surface);
+
+                        if let Some(serial) = *self.last_down.lock().unwrap() {
+                            wp_tool.down(serial.into());
+                        }
+
+                        // TODO: send axis, motion, button.
+
+                        let time = Clock::<Monotonic>::new().now().as_millis();
+                        wp_tool.frame(time);
+                    }
+                }
+            }
+        }
     }
 
     fn proximity_in<D: TabletSeatHandler + 'static>(
@@ -239,8 +268,11 @@ impl WpTabletToolHandle {
     }
 
     fn down(&self, surface: &WlSurface, event: &DownEvent) {
+        let serial = event.serial;
+        *self.last_down.lock().unwrap() = Some(serial);
+
         self.for_each_focused_tool(surface, |wp_tool| {
-            wp_tool.down(event.serial.0);
+            wp_tool.down(serial.0);
         });
     }
 
@@ -248,6 +280,8 @@ impl WpTabletToolHandle {
         self.for_each_focused_tool(surface, |wp_tool| {
             wp_tool.up();
         });
+
+        *self.last_down.lock().unwrap() = None;
     }
 
     fn motion<D: TabletSeatHandler + 'static>(&self, surface: &WlSurface, event: &MotionEvent) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->
Resolves https://github.com/Smithay/smithay/issues/2131.

Sending the rest of the state is left as an exercise for the future readers. As well as pointer button I guess.

The alternative is to not bother sending anything, but then we need to gate all motion() and other events behind "did this object enter() before", which sounds more error prone?

Both `same_client_as()` and `wl_surface()` are checked because apparently in Anvil's impl of `WaylandFocus`, when aiming at an SSD, it's possible to get `true` from the former and `None` from the latter.

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
