### PR TITLE
input/tablet: Take `Seat<Self>` and `TabletToolHandle` in `tablet_tool_image()`

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -9,11 +9,8 @@ use std::{
 use tracing::{info, warn};
 
 use smithay::{
-    backend::{
-        input::TabletToolDescriptor,
-        renderer::element::{
-            RenderElementStates, default_primary_scanout_output_compare, utils::select_dmabuf_feedback,
-        },
+    backend::renderer::element::{
+        RenderElementStates, default_primary_scanout_output_compare, utils::select_dmabuf_feedback,
     },
     delegate_dispatch2,
     desktop::{
@@ -30,7 +27,7 @@ use smithay::{
         dnd::{DnDGrab, DndGrabHandler, DndTarget, GrabType, Source},
         keyboard::{Keysym, LedState, XkbConfig},
         pointer::{CursorImageStatus, Focus, PointerHandle},
-        tablet::TabletSeatHandler,
+        tablet::{TabletSeatHandler, tool::TabletToolHandle},
     },
     output::Output,
     reexports::{
@@ -330,7 +327,7 @@ impl<BackendData: Backend> SeatHandler for AnvilState<BackendData> {
 impl<BackendData: Backend> TabletSeatHandler for AnvilState<BackendData> {
     type ToolFocus = PointerFocusTarget;
 
-    fn tablet_tool_image(&mut self, _tool: &TabletToolDescriptor, image: CursorImageStatus) {
+    fn tablet_tool_image(&mut self, _tool: &TabletToolHandle<Self>, image: CursorImageStatus) {
         // TODO: tablet tools should have their own cursors
         self.cursor_status = image;
     }

--- a/src/input/tablet/mod.rs
+++ b/src/input/tablet/mod.rs
@@ -27,7 +27,7 @@
 //! #             GestureHoldBeginEvent, GestureHoldEndEvent},
 //! #   keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
 //! #   touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent, ShapeEvent, OrientationEvent, TouchTarget, FrameMarker},
-//! #   tablet::{Tablet, tool::{self, TabletToolTarget}},
+//! #   tablet::{Tablet, tool::{self, TabletToolHandle, TabletToolTarget}},
 //! # };
 //! # use smithay::utils::{IsAlive, Serial};
 //!
@@ -123,7 +123,7 @@
 //! impl TabletSeatHandler for State {
 //!     type ToolFocus = Target;
 //!
-//!     fn tablet_tool_image(&mut self, tool: &TabletToolDescriptor, image: CursorImageStatus) {
+//!     fn tablet_tool_image(&mut self, tool: &TabletToolHandle<Self>, image: CursorImageStatus) {
 //!         // handle new image for the given tool.
 //!     }
 //! }
@@ -319,7 +319,7 @@ pub trait TabletSeatHandler: SeatHandler + Sized {
     type ToolFocus: TabletToolTarget<Self> + PartialEq + Clone + 'static;
 
     /// Callback that will be notified whenever a client requests to set a custom tool image.
-    fn tablet_tool_image(&mut self, tool: &TabletToolDescriptor, image: CursorImageStatus) {
+    fn tablet_tool_image(&mut self, tool: &TabletToolHandle<Self>, image: CursorImageStatus) {
         let _ = tool;
         let _ = image;
     }

--- a/src/input/tablet/mod.rs
+++ b/src/input/tablet/mod.rs
@@ -123,7 +123,7 @@
 //! impl TabletSeatHandler for State {
 //!     type ToolFocus = Target;
 //!
-//!     fn tablet_tool_image(&mut self, tool: &TabletToolHandle<Self>, image: CursorImageStatus) {
+//!     fn tablet_tool_image(&mut self, seat: &Seat<Self>, tool: &TabletToolHandle<Self>, image: CursorImageStatus) {
 //!         // handle new image for the given tool.
 //!     }
 //! }
@@ -319,7 +319,13 @@ pub trait TabletSeatHandler: SeatHandler + Sized {
     type ToolFocus: TabletToolTarget<Self> + PartialEq + Clone + 'static;
 
     /// Callback that will be notified whenever a client requests to set a custom tool image.
-    fn tablet_tool_image(&mut self, tool: &TabletToolHandle<Self>, image: CursorImageStatus) {
+    fn tablet_tool_image(
+        &mut self,
+        seat: &Seat<Self>,
+        tool: &TabletToolHandle<Self>,
+        image: CursorImageStatus,
+    ) {
+        let _ = seat;
         let _ = tool;
         let _ = image;
     }

--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -308,8 +308,7 @@ where
                         }
 
                         let cursor_icon = shape_to_cursor_icon(shape);
-                        state
-                            .tablet_tool_image(&handle.arc.descriptor, CursorImageStatus::Named(cursor_icon));
+                        state.tablet_tool_image(&handle, CursorImageStatus::Named(cursor_icon));
                     }
                 }
             }

--- a/src/wayland/cursor_shape.rs
+++ b/src/wayland/cursor_shape.rs
@@ -125,7 +125,7 @@ use wayland_server::{Dispatch, DisplayHandle, backend::GlobalId};
 use crate::input::SeatHandler;
 use crate::input::WeakSeat;
 use crate::input::pointer::{CursorIcon, CursorImageStatus};
-use crate::input::tablet::TabletSeatHandler;
+use crate::input::tablet::{TabletSeatHandler, TabletSeatTrait};
 use crate::utils::Serial;
 use crate::wayland::seat::{WaylandFocus, pointer::allow_setting_cursor};
 use crate::wayland::tablet_manager::TabletToolUserData;
@@ -303,12 +303,22 @@ where
                             return;
                         };
 
+                        let Some(seat) = state
+                            .seat_state()
+                            .seats
+                            .iter()
+                            .find(|seat| seat.tablet_seat().get_tool(handle.descriptor()).is_some())
+                            .cloned()
+                        else {
+                            return;
+                        };
+
                         if !tablet_tool::allow_setting_cursor(&handle, Serial(serial), &resource.id()) {
                             return;
                         }
 
                         let cursor_icon = shape_to_cursor_icon(shape);
-                        state.tablet_tool_image(&handle, CursorImageStatus::Named(cursor_icon));
+                        state.tablet_tool_image(&seat, &handle, CursorImageStatus::Named(cursor_icon));
                     }
                 }
             }

--- a/src/wayland/tablet_manager/mod.rs
+++ b/src/wayland/tablet_manager/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! ```
 //! use smithay::input::{Seat, SeatState, SeatHandler, pointer::CursorImageStatus};
-//! use smithay::input::tablet::{TabletSeatHandler, TabletSeatTrait};
+//! use smithay::input::tablet::{tool::TabletToolHandle, TabletSeatHandler, TabletSeatTrait};
 //! use smithay::backend::input::TabletToolDescriptor;
 //! use smithay::wayland::tablet_manager::{TabletManagerState};
 //! use smithay::reexports::wayland_server::{Display, protocol::wl_surface::WlSurface};
@@ -56,7 +56,7 @@
 //! impl TabletSeatHandler for State {
 //!     type ToolFocus = WlSurface;
 //!
-//!     fn tablet_tool_image(&mut self, tool: &TabletToolDescriptor, image: CursorImageStatus) {
+//!     fn tablet_tool_image(&mut self, tool: &TabletToolHandle<Self>, image: CursorImageStatus) {
 //!         // handle new image for the given tool.
 //!     }
 //! }

--- a/src/wayland/tablet_manager/mod.rs
+++ b/src/wayland/tablet_manager/mod.rs
@@ -56,7 +56,7 @@
 //! impl TabletSeatHandler for State {
 //!     type ToolFocus = WlSurface;
 //!
-//!     fn tablet_tool_image(&mut self, tool: &TabletToolHandle<Self>, image: CursorImageStatus) {
+//!     fn tablet_tool_image(&mut self, seat: &Seat<Self>, tool: &TabletToolHandle<Self>, image: CursorImageStatus) {
 //!         // handle new image for the given tool.
 //!     }
 //! }

--- a/src/wayland/tablet_manager/tablet.rs
+++ b/src/wayland/tablet_manager/tablet.rs
@@ -3,9 +3,7 @@ use std::sync::{Arc, Mutex};
 use wayland_protocols::wp::tablet::zv2::server::{
     zwp_tablet_seat_v2::ZwpTabletSeatV2, zwp_tablet_v2::ZwpTabletV2,
 };
-use wayland_server::{
-    Client, Dispatch, DisplayHandle, Resource, Weak, backend::ObjectId, protocol::wl_surface::WlSurface,
-};
+use wayland_server::{Client, Dispatch, DisplayHandle, Resource, Weak, protocol::wl_surface::WlSurface};
 
 use crate::{
     input::tablet::{Tablet, TabletDescriptor, TabletRc, TabletSeat, TabletSeatHandler, WeakTablet},
@@ -70,7 +68,7 @@ impl<D: TabletSeatHandler + 'static> TabletSeat<D> {
 #[derive(Debug)]
 pub struct TabletUserData {
     tablet: WeakTablet,
-    seat_id: ObjectId,
+    tablet_seat: Weak<ZwpTabletSeatV2>,
 }
 
 #[derive(Default, Debug)]
@@ -101,7 +99,7 @@ impl WpTabletHandle {
                 seat.version(),
                 TabletUserData {
                     tablet: tablet.downgrade(),
-                    seat_id: seat.id(),
+                    tablet_seat: seat.downgrade(),
                 },
             )
             .unwrap();
@@ -126,12 +124,12 @@ impl WpTabletHandle {
     pub(crate) fn focused_tablet_for_seat(
         &self,
         surface: &WlSurface,
-        seat_id: &ObjectId,
+        tablet_seat: &Weak<ZwpTabletSeatV2>,
     ) -> Option<ZwpTabletV2> {
         self.known_instances.lock().unwrap().iter().find_map(|tablet| {
             tablet.upgrade().ok().filter(|wp_tablet| {
                 Resource::id(wp_tablet).same_client_as(&surface.id())
-                    && &wp_tablet.data::<TabletUserData>().unwrap().seat_id == seat_id
+                    && &wp_tablet.data::<TabletUserData>().unwrap().tablet_seat == tablet_seat
             })
         })
     }

--- a/src/wayland/tablet_manager/tablet_tool.rs
+++ b/src/wayland/tablet_manager/tablet_tool.rs
@@ -131,7 +131,7 @@ impl<D: TabletSeatHandler + 'static> TabletSeat<D> {
 #[derive(Debug)]
 pub struct TabletToolUserData<D: TabletSeatHandler> {
     pub(crate) handle: WeakTabletToolHandle<D>,
-    seat_id: ObjectId,
+    tablet_seat: Weak<ZwpTabletSeatV2>,
     client_scale: Arc<AtomicF64>,
 }
 
@@ -170,7 +170,7 @@ impl WpTabletToolHandle {
                 seat.version(),
                 TabletToolUserData {
                     handle: handle.downgrade(),
-                    seat_id: seat.id(),
+                    tablet_seat: seat.downgrade(),
                     client_scale,
                 },
             )
@@ -220,8 +220,10 @@ impl WpTabletToolHandle {
             if focus.same_client_as(&wp_tool.id()) {
                 if let Some(surface) = focus.wl_surface() {
                     let tablet = guard.tablet.as_ref().unwrap();
-                    if let Some(wp_tablet) =
-                        tablet.arc.wp_tablet.focused_tablet_for_seat(&surface, &seat.id())
+                    if let Some(wp_tablet) = tablet
+                        .arc
+                        .wp_tablet
+                        .focused_tablet_for_seat(&surface, &seat.downgrade())
                     {
                         let serial = self.last_proximity_in.lock().unwrap().unwrap();
                         wp_tool.proximity_in(serial.into(), &wp_tablet, &surface);
@@ -249,9 +251,9 @@ impl WpTabletToolHandle {
         *self.last_proximity_in.lock().unwrap() = Some(serial);
 
         self.for_each_focused_tool(surface, |wp_tool| {
-            let seat_id = &wp_tool.data::<TabletToolUserData<D>>().unwrap().seat_id;
+            let tablet_seat = &wp_tool.data::<TabletToolUserData<D>>().unwrap().tablet_seat;
 
-            let Some(wp_tablet) = tablet.arc.wp_tablet.focused_tablet_for_seat(surface, seat_id) else {
+            let Some(wp_tablet) = tablet.arc.wp_tablet.focused_tablet_for_seat(surface, tablet_seat) else {
                 return;
             };
 

--- a/src/wayland/tablet_manager/tablet_tool.rs
+++ b/src/wayland/tablet_manager/tablet_tool.rs
@@ -442,6 +442,16 @@ where
                     return;
                 }
 
+                let Some(seat) = state
+                    .seat_state()
+                    .seats
+                    .iter()
+                    .find(|seat| seat.tablet_seat().get_tool(handle.descriptor()).is_some())
+                    .cloned()
+                else {
+                    return;
+                };
+
                 let cursor_image = match surface {
                     Some(surface) => {
                         if compositor::give_role(&surface, CURSOR_IMAGE_ROLE).is_err()
@@ -486,7 +496,7 @@ where
                     None => CursorImageStatus::Hidden,
                 };
 
-                state.tablet_tool_image(&handle, cursor_image);
+                state.tablet_tool_image(&seat, &handle, cursor_image);
             }
             zwp_tablet_tool_v2::Request::Destroy => {
                 // Nothing to do

--- a/src/wayland/tablet_manager/tablet_tool.rs
+++ b/src/wayland/tablet_manager/tablet_tool.rs
@@ -484,7 +484,7 @@ where
                     None => CursorImageStatus::Hidden,
                 };
 
-                state.tablet_tool_image(handle.descriptor(), cursor_image);
+                state.tablet_tool_image(&handle, cursor_image);
             }
             zwp_tablet_tool_v2::Request::Destroy => {
                 // Nothing to do


### PR DESCRIPTION
## Description

Trying to properly implement tablet tool cursor images for cosmic-comp, I wonder if a `TabletToolDescriptor` is the most useful thing to have as an argument. Left as a draft while I still figure out how to use this, and may want other changes. (Perhaps having userdata for the tool handle would be a good place to store the cursor?.)

I see `TabletToolTarget` also takes `TabletToolDescriptor` instead of `TabletToolHandle`. While `TabletToolGrab` instead takes a `TabletToolInnerHandle`.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
