### PR TITLE
Update rand dep to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ libc = "0.2.103"
 libseat = { version = "0.2.3", optional = true, default-features = false }
 libloading = { version="0.8.0", optional = true }
 rustix = { version = "1.0.7", features = ["event", "fs", "mm", "net", "pipe", "process", "shm", "time", "param"] }
-rand = "0.9.0"
+rand = "0.10.0"
 scopeguard = { version = "1.1.0", optional = true }
 tracing = "0.1.37"
 tempfile = { version = "3.0", optional = true }


### PR DESCRIPTION
## Description

There appear to be no changes needed to smithay API-wise, and I don't see anything in https://rust-random.github.io/book/update-0.10.html that needs to be updated behavior-wise.  0.10's MSRV is 1.85.0, which is still below smithay's.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
