### PR TITLE
renderer: add `Renderer::invalidate_caches` and clean up multi-GPU texture caches on every device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,11 @@ Added `Renderer::invalidate_caches`, which unconditionally drops all renderer-in
 including entries `Renderer::cleanup_texture_cache` retains while their source buffers are still
 alive.
 
+Added `GpuManager::cleanup_texture_cache` and `GpuManager::invalidate_caches`, which apply the
+corresponding `Renderer` method to every enumerated device. `GpuManager::invalidate_caches`
+additionally drops the buffers cached for copying between a render and a target node, which no
+`Renderer` owns.
+
 ### Bugfixes
 
 `SimpleCrtcMapper` (in `smithay-drm-extras`) now releases the CRTC reservation of any connector that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,12 @@ are emitted with a stale wl_output anymore.
 The XWayland WM implementation previously incorrectly prefixed large transfers from X11 windows with
 the four INCR bytes.
 
+`MultiRenderer::cleanup_texture_cache` now also cleans up the devices other than the render and
+target device. Buffers that cannot be imported on the render node directly are imported on their
+source device, so those devices accumulate cached imports that previously were never released.
+Cleanup is now also attempted on every device even if it fails on one of them, with every failure
+logged and the first error returned.
+
 ## 0.7.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,10 @@ default implementations, which result in skipping the new functionality. As such
 
 `Output` now has `owns_xdg_output()` which allows you to match an XDG output protocol object with an `Output`.
 
+Added `Renderer::invalidate_caches`, which unconditionally drops all renderer-internal caches,
+including entries `Renderer::cleanup_texture_cache` retains while their source buffers are still
+alive.
+
 ### Bugfixes
 
 `SimpleCrtcMapper` (in `smithay-drm-extras`) now releases the CRTC reservation of any connector that

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -2350,6 +2350,17 @@ impl Renderer for GlesRenderer {
         self.cleanup();
         Ok(())
     }
+
+    #[profiling::function]
+    fn invalidate_caches(&mut self) -> Result<(), Self::Error> {
+        unsafe {
+            self.egl.make_current()?;
+        }
+        self.dmabuf_cache.clear();
+        self.buffers.clear();
+        self.cleanup();
+        Ok(())
+    }
 }
 
 /// Vertices for instanced rendering.

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -283,6 +283,11 @@ impl Renderer for GlowRenderer {
     fn cleanup_texture_cache(&mut self) -> Result<(), Self::Error> {
         self.gl.as_mut().cleanup_texture_cache()
     }
+
+    #[profiling::function]
+    fn invalidate_caches(&mut self) -> Result<(), Self::Error> {
+        self.gl.as_mut().invalidate_caches()
+    }
 }
 
 impl Frame for GlowFrame<'_, '_> {

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -446,6 +446,19 @@ pub trait Renderer: RendererSuper {
     fn cleanup_texture_cache(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
+
+    /// Drop all internal caches, freeing their resources unconditionally
+    ///
+    /// Unlike [`Renderer::cleanup_texture_cache`], this also discards cached imports and bind
+    /// targets whose source buffers are still alive.
+    ///
+    /// Note: Caches held outside the renderer, like per-surface textures in surface user-data,
+    /// are unaffected.
+    ///
+    /// The default implementation falls back to [`Renderer::cleanup_texture_cache`].
+    fn invalidate_caches(&mut self) -> Result<(), Self::Error> {
+        self.cleanup_texture_cache()
+    }
 }
 
 /// Trait for renderers that support creating offscreen framebuffers to render into.

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -789,6 +789,11 @@ impl<'render, 'target, R: GraphicsApi, T: GraphicsApi> MultiRenderer<'render, 't
         self.target.as_mut().map(|data| data.device.renderer_mut())
     }
 
+    /// The devices of the render-api, starting with the render-device.
+    fn render_devices(&mut self) -> impl Iterator<Item = &mut R::Device> {
+        std::iter::once(&mut *self.render).chain(self.other_renderers.iter_mut().map(|dev| &mut **dev))
+    }
+
     /// Converts this `MultiRenderer` into a `single_renderer` for the provided target device.
     ///
     /// Will return the current renderer, if it is already a single-device render.
@@ -1348,26 +1353,20 @@ where
 
     #[profiling::function]
     fn cleanup_texture_cache(&mut self) -> Result<(), Self::Error> {
-        if let Some(target) = self.target.as_mut() {
-            target
-                .device
-                .renderer_mut()
-                .cleanup_texture_cache()
-                .map_err(Error::Target)?;
+        let mut result = Ok(());
+        for device in self.render_devices() {
+            result = result.and(cleanup_device_texture_cache(device).map_err(Error::Render));
         }
-        self.render
-            .renderer_mut()
-            .cleanup_texture_cache()
-            .map_err(Error::Render)?;
-        Ok(())
+        if let Some(target) = self.target.as_mut() {
+            result = result.and(cleanup_device_texture_cache(&mut *target.device).map_err(Error::Target));
+        }
+        result
     }
 
     #[profiling::function]
     fn invalidate_caches(&mut self) -> Result<(), Self::Error> {
         let mut result = Ok(());
-        let render_devices =
-            std::iter::once(&mut *self.render).chain(self.other_renderers.iter_mut().map(|dev| &mut **dev));
-        for device in render_devices {
+        for device in self.render_devices() {
             result = result.and(invalidate_device_caches(device).map_err(Error::Render));
         }
         if let Some(target) = self.target.as_mut() {
@@ -1380,8 +1379,7 @@ where
 
 /// Invalidate a single device's caches, logging a failure against the node it happened on.
 ///
-/// Callers apply this to every device they own and keep only the first error, so the log is what
-/// identifies any device that fails after that one.
+/// Callers keep only the first error, so the log is what identifies any device failing after it.
 fn invalidate_device_caches<D: ApiDevice>(
     device: &mut D,
 ) -> Result<(), <D::Renderer as RendererSuper>::Error> {
@@ -1390,6 +1388,19 @@ fn invalidate_device_caches<D: ApiDevice>(
         .renderer_mut()
         .invalidate_caches()
         .inspect_err(|err| warn!("Error invalidating caches of {}: {}", node, err))
+}
+
+/// Clean up a single device's texture cache, logging a failure against the node it happened on.
+///
+/// See [`invalidate_device_caches`] for why the error is logged as well as returned.
+fn cleanup_device_texture_cache<D: ApiDevice>(
+    device: &mut D,
+) -> Result<(), <D::Renderer as RendererSuper>::Error> {
+    let node = *device.node();
+    device
+        .renderer_mut()
+        .cleanup_texture_cache()
+        .inspect_err(|err| warn!("Error cleaning up texture cache of {}: {}", node, err))
 }
 
 fn create_shared_dma_framebuffer<R, T: GraphicsApi>(

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1361,6 +1361,35 @@ where
             .map_err(Error::Render)?;
         Ok(())
     }
+
+    #[profiling::function]
+    fn invalidate_caches(&mut self) -> Result<(), Self::Error> {
+        let mut result = Ok(());
+        let render_devices =
+            std::iter::once(&mut *self.render).chain(self.other_renderers.iter_mut().map(|dev| &mut **dev));
+        for device in render_devices {
+            result = result.and(invalidate_device_caches(device).map_err(Error::Render));
+        }
+        if let Some(target) = self.target.as_mut() {
+            *target.cached_buffer = None;
+            result = result.and(invalidate_device_caches(&mut *target.device).map_err(Error::Target));
+        }
+        result
+    }
+}
+
+/// Invalidate a single device's caches, logging a failure against the node it happened on.
+///
+/// Callers apply this to every device they own and keep only the first error, so the log is what
+/// identifies any device that fails after that one.
+fn invalidate_device_caches<D: ApiDevice>(
+    device: &mut D,
+) -> Result<(), <D::Renderer as RendererSuper>::Error> {
+    let node = *device.node();
+    device
+        .renderer_mut()
+        .invalidate_caches()
+        .inspect_err(|err| warn!("Error invalidating caches of {}: {}", node, err))
 }
 
 fn create_shared_dma_framebuffer<R, T: GraphicsApi>(
@@ -3483,6 +3512,10 @@ where
 
     fn cleanup_texture_cache(&mut self) -> Result<(), Self::Error> {
         self.guard.as_mut().cleanup_texture_cache().map_err(Error::Render)
+    }
+
+    fn invalidate_caches(&mut self) -> Result<(), Self::Error> {
+        self.guard.as_mut().invalidate_caches().map_err(Error::Render)
     }
 }
 

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -249,6 +249,37 @@ impl<A: GraphicsApi> GpuManager<A> {
         Ok(self.devices.iter_mut())
     }
 
+    /// Clean up the texture caches of every device enumerated by the API.
+    ///
+    /// See [`Renderer::cleanup_texture_cache`]. Cleanup is best-effort: every device is attempted
+    /// even if one of them fails, every failure is logged, and the first error is returned.
+    #[profiling::function]
+    pub fn cleanup_texture_cache(&mut self) -> Result<(), Error<A, A>> {
+        let mut result = Ok(());
+        for device in self.devices_mut().map_err(Error::RenderApiError)? {
+            result = result.and(cleanup_device_texture_cache(device).map_err(Error::Render));
+        }
+        result
+    }
+
+    /// Drop all caches held by this manager and by every device enumerated by the API.
+    ///
+    /// See [`Renderer::invalidate_caches`]. Beyond the per-device caches this also drops the
+    /// buffers cached for copying between a render- and a target-node.
+    ///
+    /// Invalidation is best-effort: every device is attempted even if one of them fails, every
+    /// failure is logged, and the first error is returned.
+    #[profiling::function]
+    pub fn invalidate_caches(&mut self) -> Result<(), Error<A, A>> {
+        self.dmabuf_cache.clear();
+
+        let mut result = Ok(());
+        for device in self.devices_mut().map_err(Error::RenderApiError)? {
+            result = result.and(invalidate_device_caches(device).map_err(Error::Render));
+        }
+        result
+    }
+
     /// Create a [`MultiRenderer`] from a single device.
     ///
     /// This a convenience function to deal with the same types even, if you only need one device.

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -892,6 +892,12 @@ impl Renderer for PixmanRenderer {
         self.cleanup();
         Ok(())
     }
+
+    fn invalidate_caches(&mut self) -> Result<(), Self::Error> {
+        self.dmabuf_cache.clear();
+        self.buffers.clear();
+        Ok(())
+    }
 }
 
 impl ImportMem for PixmanRenderer {
@@ -1316,5 +1322,85 @@ where
         PixmanFrameGuard {
             renderer: &mut self.renderer,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::allocator::dmabuf::DmabufFlags;
+
+    const SIZE: i32 = 4;
+    const BYTES_PER_PIXEL: u32 = 4;
+    const STRIDE: u32 = SIZE as u32 * BYTES_PER_PIXEL;
+
+    // A memfd stands in for a real dmabuf: `Dmabuf::builder` accepts any fd and
+    // `map_plane` is a plain mmap, which is all the cache entries below need.
+    fn memfd_dmabuf() -> Dmabuf {
+        let fd = rustix::fs::memfd_create("dmabuf-stand-in", rustix::fs::MemfdFlags::CLOEXEC).unwrap();
+        rustix::fs::ftruncate(&fd, (STRIDE * SIZE as u32) as u64).unwrap();
+        let mut builder = Dmabuf::builder(
+            (SIZE, SIZE),
+            DrmFourcc::Argb8888,
+            DrmModifier::Linear,
+            DmabufFlags::empty(),
+        );
+        builder.add_plane(fd, 0, STRIDE);
+        builder.build().unwrap()
+    }
+
+    fn cache_entry(dmabuf: &Dmabuf) -> PixmanImage {
+        let mapping = dmabuf.map_plane(0, DmabufMappingMode::READ).unwrap();
+        let image = pixman::Image::new(FormatCode::A8R8G8B8, SIZE as usize, SIZE as usize, false).unwrap();
+        PixmanImage(Arc::new(PixmanImageInner {
+            #[cfg(feature = "wayland_frontend")]
+            buffer: None,
+            dmabuf: Some(PixmanDmabufMapping {
+                dmabuf: dmabuf.weak(),
+                _mapping: mapping,
+            }),
+            image: Mutex::new(image),
+            _flipped: false,
+        }))
+    }
+
+    #[test]
+    fn cleanup_texture_cache_retains_live_entries() {
+        let mut renderer = PixmanRenderer::new().unwrap();
+        let dmabuf = memfd_dmabuf();
+        renderer.dmabuf_cache.push(cache_entry(&dmabuf));
+        renderer.buffers.push(cache_entry(&dmabuf));
+
+        renderer.cleanup_texture_cache().unwrap();
+
+        assert_eq!(renderer.dmabuf_cache.len(), 1);
+        assert_eq!(renderer.buffers.len(), 1);
+    }
+
+    #[test]
+    fn cleanup_texture_cache_drops_dead_entries() {
+        let mut renderer = PixmanRenderer::new().unwrap();
+        let dmabuf = memfd_dmabuf();
+        renderer.dmabuf_cache.push(cache_entry(&dmabuf));
+        renderer.buffers.push(cache_entry(&dmabuf));
+        drop(dmabuf);
+
+        renderer.cleanup_texture_cache().unwrap();
+
+        assert!(renderer.dmabuf_cache.is_empty());
+        assert!(renderer.buffers.is_empty());
+    }
+
+    #[test]
+    fn invalidate_caches_drops_live_entries() {
+        let mut renderer = PixmanRenderer::new().unwrap();
+        let dmabuf = memfd_dmabuf();
+        renderer.dmabuf_cache.push(cache_entry(&dmabuf));
+        renderer.buffers.push(cache_entry(&dmabuf));
+
+        renderer.invalidate_caches().unwrap();
+
+        assert!(renderer.dmabuf_cache.is_empty());
+        assert!(renderer.buffers.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Companion PR to pop-os/cosmic-comp#2500, which makes cache cleanup event-based.
`Renderer::invalidate_caches` lets a compositor drop cached imports it knows
won't be needed again soon; alongside it are leak fixes in `MultiRenderer` and
`GpuManager`.

## What's Changed

1. **New `Renderer::invalidate_caches`** — `cleanup_texture_cache` only frees
   resources whose source buffer is already gone, so a renderer that draws
   infrequently keeps every cached import (and its GPU memory) pinned between
   renders. `invalidate_caches` discards every cached import and bind target
   unconditionally; the trait method defaults to `cleanup_texture_cache`,
   keeping external implementors source-compatible. Caches held outside the
   renderer (e.g. per-surface textures in surface user-data) are unaffected.

2. **`MultiRenderer::cleanup_texture_cache` skipped the "other" devices** — it
   visited only the render and target device. Buffers that can't be imported on
   the render node are imported on their source device instead, so those devices
   accumulated `dmabuf_cache` entries and queued GL destructions that nothing
   ever released. Now every device is visited, best-effort, so one failing
   device can't leave the rest uncleaned.

3. **New `GpuManager::cleanup_texture_cache` / `invalidate_caches`** — outside a
   draw a compositor holds a `GpuManager`, not a `MultiRenderer`, so clearing
   caches across devices meant hand-rolling a loop over `devices_mut`. Such a
   loop can't reach the render→target copy buffers, which the manager keys by
   node pair — one full output-sized dmabuf per pair, left pinned.
   `GpuManager::invalidate_caches` clears those along with every device's caches.

   cosmic-comp currently works around this by iterating `devices_mut` itself at
   end-of-draw (f86cd933); this commit supersedes that workaround.

### Error handling across devices

All four multi-device methods are best-effort: every device is attempted even
if one fails, each failure is logged with its node, and the first error is
returned. The `MultiRenderer` methods visit the render node first, so its
failure — the one that breaks the next frame — takes precedence.

Smithay has no established convention here: `GpuManager::early_import` and
`import_surface_tree` keep the last error and log nothing, while
`DrmCompositor` discards the result outright. Happy to align with whichever
convention the maintainers prefer.

## Testing

Three pixman unit tests pin the retention-vs-invalidation contract that live entries survive `cleanup_texture_cache`,
dead ones don't, and live ones are dropped by `invalidate_caches`.

The `GpuManager` methods were also exercised end-to-end on an instrumented
cosmic-comp build that calls `GpuManager::invalidate_caches` after each
infrequent main-thread render (dual-output NVIDIA system). Across three
output-reconfiguration cycles the cycled output's swapchain advanced from
generation 4 to 112 with live slots pinned at 4 — every superseded
generation's imports were released — and the renderer's cleanup queues drained
at every census with no cache holding a dead entry.

Not covered by that run, verified by inspection and compilation only:

- **The multi-GPU path** — the machine has a single GPU, so `other_renderers`
  is always empty.
- **The error paths** — no device failed during the run.

`cargo test --features test_all_features` passes (74 unit, 96 doctests),
clippy is clean on the touched files, and each commit builds independently.

## AI assistance

Per Smithay's [AI policy](https://github.com/Smithay/smithay/blob/master/AI.md),
AI assistance (Claude Code) is disclosed in each commit message; the author
understands the changes and can respond to review.

## Checklist

* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
