### PR TITLE
wayland: apply subsurface position on parent commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ clap = { version = "4", features = ["derive"] }
 criterion = { version = "0.5" }
 image = "0.25"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+wayland-client = "0.31.14"
 
 [build-dependencies]
 gl_generator = { version = "0.14", optional = true }

--- a/src/wayland/compositor/cache.rs
+++ b/src/wayland/compositor/cache.rs
@@ -90,6 +90,14 @@ impl<T> CachedState<T> {
     pub fn pending(&mut self) -> &mut T {
         &mut self.pending
     }
+
+    pub(crate) fn update_all(&mut self, mut update: impl FnMut(&mut T)) {
+        update(&mut self.pending);
+        for (_, state) in &mut self.cache {
+            update(state);
+        }
+        update(&mut self.current);
+    }
 }
 
 trait Cache: Downcast {

--- a/src/wayland/compositor/handlers.rs
+++ b/src/wayland/compositor/handlers.rs
@@ -1,5 +1,5 @@
 use std::sync::{
-    Mutex,
+    Arc, Mutex,
     atomic::{AtomicBool, Ordering},
 };
 
@@ -23,8 +23,8 @@ use crate::utils::{
 use crate::wayland::{Dispatch2, GlobalData, GlobalDispatch2};
 
 use super::{
-    AlreadyHasRole, BufferAssignment, CompositorHandler, Damage, Rectangle, RectangleKind, RegionAttributes,
-    SurfaceAttributes,
+    AlreadyHasRole, BufferAssignment, CompositorHandler, Damage, HookId, Rectangle, RectangleKind,
+    RegionAttributes, SurfaceAttributes,
     cache::Cacheable,
     tree::{Location, PrivateSurfaceData},
 };
@@ -458,12 +458,51 @@ where
                     return;
                 }
 
-                data_init.init(
+                let pending_position = Arc::new(Mutex::new(None));
+                let subsurface = data_init.init(
                     id,
                     SubsurfaceUserData {
                         surface: surface.clone(),
+                        pending_position: pending_position.clone(),
+                        pre_commit_hook: Mutex::new(None),
                     },
                 );
+
+                let weak_subsurface = subsurface.downgrade();
+                let weak_surface = surface.downgrade();
+                let weak_parent = parent.downgrade();
+                let hook = PrivateSurfaceData::add_pre_commit_hook(&parent, move |_, _, parent| {
+                    let Some(location) = pending_position.lock().unwrap().take() else {
+                        return;
+                    };
+                    let Ok(subsurface) = weak_subsurface.upgrade() else {
+                        return;
+                    };
+                    let Ok(surface) = weak_surface.upgrade() else {
+                        return;
+                    };
+                    let Ok(expected_parent) = weak_parent.upgrade() else {
+                        return;
+                    };
+                    if parent != &expected_parent
+                        || PrivateSurfaceData::get_parent(&surface).as_ref() != Some(parent)
+                    {
+                        return;
+                    }
+                    PrivateSurfaceData::with_states(parent, |state| {
+                        state
+                            .cached_state
+                            .get::<ParentCommitSubsurfaceState>()
+                            .pending()
+                            .set_position(&subsurface, &surface, parent, location);
+                    });
+                });
+                *subsurface
+                    .data::<SubsurfaceUserData>()
+                    .unwrap()
+                    .pre_commit_hook
+                    .lock()
+                    .unwrap() = Some(hook);
 
                 super::with_states(&surface, |states| {
                     states.data_map.insert_if_missing_threadsafe(SubsurfaceState::new)
@@ -485,6 +524,8 @@ where
 #[derive(Debug)]
 pub struct SubsurfaceUserData {
     surface: WlSurface,
+    pending_position: Arc<Mutex<Option<Point<i32, Logical>>>>,
+    pre_commit_hook: Mutex<Option<HookId>>,
 }
 
 impl SubsurfaceUserData {
@@ -499,6 +540,75 @@ pub struct SubsurfaceCachedState {
     /// Location of the top-left corner of this subsurface
     /// relative to its parent coordinate space
     pub location: Point<i32, Logical>,
+}
+
+#[derive(Debug, Default)]
+struct ParentCommitSubsurfaceState {
+    positions: Vec<(
+        wayland_server::Weak<WlSubsurface>,
+        wayland_server::Weak<WlSurface>,
+        wayland_server::Weak<WlSurface>,
+        Point<i32, Logical>,
+    )>,
+}
+
+impl ParentCommitSubsurfaceState {
+    fn set_position(
+        &mut self,
+        subsurface: &WlSubsurface,
+        surface: &WlSurface,
+        parent: &WlSurface,
+        location: Point<i32, Logical>,
+    ) {
+        if let Some(pending) = self
+            .positions
+            .iter_mut()
+            .find(|(_, pending, _, _)| pending == surface)
+        {
+            *pending = (
+                subsurface.downgrade(),
+                surface.downgrade(),
+                parent.downgrade(),
+                location,
+            );
+        } else {
+            self.positions.push((
+                subsurface.downgrade(),
+                surface.downgrade(),
+                parent.downgrade(),
+                location,
+            ));
+        }
+    }
+}
+
+impl Cacheable for ParentCommitSubsurfaceState {
+    fn commit(&mut self, _dh: &DisplayHandle) -> Self {
+        Self {
+            positions: std::mem::take(&mut self.positions),
+        }
+    }
+
+    fn merge_into(self, _into: &mut Self, _dh: &DisplayHandle) {
+        for (subsurface, surface, parent, location) in self.positions {
+            if subsurface.upgrade().is_err() {
+                continue;
+            }
+            let Ok(surface) = surface.upgrade() else {
+                continue;
+            };
+            let Ok(parent) = parent.upgrade() else {
+                continue;
+            };
+            if PrivateSurfaceData::get_parent(&surface).as_ref() != Some(&parent) {
+                continue;
+            }
+            PrivateSurfaceData::with_states(&surface, |state| {
+                let mut state = state.cached_state.get::<SubsurfaceCachedState>();
+                state.update_all(|state| state.location = location);
+            });
+        }
+    }
 }
 
 impl Default for SubsurfaceCachedState {
@@ -569,16 +679,12 @@ where
         match request {
             wl_subsurface::Request::SetPosition { x, y } => {
                 let client_scale = state.client_compositor_state(client).client_scale();
-                PrivateSurfaceData::with_states(&self.surface, |state| {
-                    state
-                        .cached_state
-                        .get::<SubsurfaceCachedState>()
-                        .pending()
-                        .location = Point::<i32, Client>::from((x, y))
+                *self.pending_position.lock().unwrap() = Some(
+                    Point::<i32, Client>::from((x, y))
                         .to_f64()
                         .to_logical(client_scale)
-                        .to_i32_round();
-                })
+                        .to_i32_round(),
+                );
             }
             wl_subsurface::Request::PlaceAbove { sibling } => {
                 if let Err(()) = PrivateSurfaceData::reorder(&self.surface, Location::After, &sibling) {
@@ -625,6 +731,11 @@ where
         _client_id: wayland_server::backend::ClientId,
         _object: &WlSubsurface,
     ) {
+        if let Some(parent) = PrivateSurfaceData::get_parent(&self.surface)
+            && let Some(hook) = self.pre_commit_hook.lock().unwrap().take()
+        {
+            PrivateSurfaceData::remove_pre_commit_hook(&parent, &hook);
+        }
         PrivateSurfaceData::unset_parent(&self.surface);
         PrivateSurfaceData::with_states(&self.surface, |state| {
             state

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -785,4 +785,171 @@ mod tests {
         assert!(region.contains((5, 5)));
         assert!(region.contains((2, 2)));
     }
+
+    #[test]
+    fn subsurface_position_applies_with_delayed_parent_transaction() {
+        use std::{
+            os::unix::net::UnixStream,
+            sync::{
+                Arc, Mutex,
+                atomic::{AtomicBool, Ordering},
+            },
+            thread,
+        };
+
+        use wayland_client::{
+            Connection, Dispatch, QueueHandle,
+            globals::{GlobalListContents, registry_queue_init},
+            protocol::{
+                wl_callback::WlCallback, wl_compositor::WlCompositor, wl_registry::WlRegistry,
+                wl_subcompositor::WlSubcompositor, wl_subsurface::WlSubsurface, wl_surface::WlSurface,
+            },
+        };
+        use wayland_server::{
+            Display,
+            backend::{ClientData, ClientId, DisconnectReason},
+        };
+
+        #[derive(Default)]
+        struct TestClientData {
+            compositor_state: CompositorClientState,
+        }
+
+        impl ClientData for TestClientData {
+            fn initialized(&self, _client_id: ClientId) {}
+            fn disconnected(&self, _client_id: ClientId, _reason: DisconnectReason) {}
+        }
+
+        struct TestState {
+            compositor_state: CompositorState,
+            surfaces: Vec<wayland_server::protocol::wl_surface::WlSurface>,
+            blocker: Barrier,
+            observed_locations: Arc<Mutex<Vec<(bool, Point<i32, Logical>)>>>,
+        }
+
+        impl CompositorHandler for TestState {
+            fn compositor_state(&mut self) -> &mut CompositorState {
+                &mut self.compositor_state
+            }
+
+            fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState {
+                &client.get_data::<TestClientData>().unwrap().compositor_state
+            }
+
+            fn new_surface(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {
+                if self.surfaces.is_empty() {
+                    add_blocker(surface, self.blocker.clone());
+                }
+                self.surfaces.push(surface.clone());
+            }
+
+            fn commit(&mut self, surface: &wayland_server::protocol::wl_surface::WlSurface) {
+                if let Some(child) = self.surfaces.get(1) {
+                    let location = with_states(child, |states| {
+                        states
+                            .cached_state
+                            .get::<SubsurfaceCachedState>()
+                            .current()
+                            .location
+                    });
+                    self.observed_locations
+                        .lock()
+                        .unwrap()
+                        .push((self.surfaces.first() == Some(surface), location));
+                }
+            }
+        }
+
+        crate::delegate_dispatch2!(TestState);
+
+        struct ClientState;
+
+        impl Dispatch<WlRegistry, GlobalListContents> for ClientState {
+            fn event(
+                _state: &mut Self,
+                _proxy: &WlRegistry,
+                _event: wayland_client::protocol::wl_registry::Event,
+                _data: &GlobalListContents,
+                _conn: &Connection,
+                _qh: &QueueHandle<Self>,
+            ) {
+            }
+        }
+
+        wayland_client::delegate_noop!(ClientState: ignore WlCallback);
+        wayland_client::delegate_noop!(ClientState: ignore WlCompositor);
+        wayland_client::delegate_noop!(ClientState: ignore WlSubcompositor);
+        wayland_client::delegate_noop!(ClientState: ignore WlSubsurface);
+        wayland_client::delegate_noop!(ClientState: ignore WlSurface);
+
+        let (server_socket, client_socket) = UnixStream::pair().unwrap();
+        let observed_locations = Arc::new(Mutex::new(Vec::new()));
+        let server_result = observed_locations.clone();
+        let release_blocker = Arc::new(AtomicBool::new(false));
+        let server_release = release_blocker.clone();
+
+        let server = thread::spawn(move || {
+            let mut display = Display::<TestState>::new().unwrap();
+            let mut dh = display.handle();
+            let compositor_state = CompositorState::new::<TestState>(&dh);
+            let client_data = Arc::new(TestClientData::default());
+            dh.insert_client(server_socket, client_data.clone()).unwrap();
+            let mut state = TestState {
+                compositor_state,
+                surfaces: Vec::new(),
+                blocker: Barrier::new(false),
+                observed_locations: server_result,
+            };
+
+            while state
+                .observed_locations
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|(is_parent, _)| *is_parent)
+                .count()
+                < 2
+            {
+                display.dispatch_clients(&mut state).unwrap();
+                if server_release.load(Ordering::Acquire) && !state.blocker.is_signaled() {
+                    state.blocker.signal();
+                    client_data.compositor_state.blocker_cleared(&mut state, &dh);
+                }
+                display.flush_clients().unwrap();
+                thread::yield_now();
+            }
+        });
+
+        let conn = Connection::from_socket(client_socket).unwrap();
+        let (globals, mut event_queue) = registry_queue_init::<ClientState>(&conn).unwrap();
+        let qh = event_queue.handle();
+        let compositor = globals.bind::<WlCompositor, _, _>(&qh, 1..=6, ()).unwrap();
+        let subcompositor = globals.bind::<WlSubcompositor, _, _>(&qh, 1..=1, ()).unwrap();
+        let parent = compositor.create_surface(&qh, ());
+        let child = compositor.create_surface(&qh, ());
+        let subsurface = subcompositor.get_subsurface(&child, &parent, &qh, ());
+
+        subsurface.set_desync();
+        child.commit();
+        subsurface.set_position(37, 23);
+        parent.commit();
+        child.commit();
+        subsurface.set_sync();
+        child.commit();
+        parent.commit();
+        event_queue.roundtrip(&mut ClientState).unwrap();
+        release_blocker.store(true, Ordering::Release);
+
+        server.join().unwrap();
+        assert_eq!(
+            *observed_locations.lock().unwrap(),
+            vec![
+                (false, (0, 0).into()),
+                (false, (0, 0).into()),
+                (true, (37, 23).into()),
+                (false, (37, 23).into()),
+                (true, (37, 23).into()),
+            ]
+        );
+    }
 }

--- a/src/wayland/compositor/transaction.rs
+++ b/src/wayland/compositor/transaction.rs
@@ -259,15 +259,19 @@ impl Transaction {
     }
 
     pub(crate) fn apply<C: CompositorHandler + 'static>(self, dh: &DisplayHandle, state: &mut C) {
-        for (surface, id) in self.surfaces {
-            let Ok(surface) = surface.upgrade() else {
-                continue;
-            };
+        let surfaces = self
+            .surfaces
+            .into_iter()
+            .filter_map(|(surface, id)| surface.upgrade().ok().map(|surface| (surface, id)))
+            .collect::<Vec<_>>();
 
-            PrivateSurfaceData::with_states(&surface, |states| {
-                states.cached_state.apply_state(id, dh);
+        for (surface, id) in &surfaces {
+            PrivateSurfaceData::with_states(surface, |states| {
+                states.cached_state.apply_state(*id, dh);
             });
+        }
 
+        for (surface, _) in surfaces {
             PrivateSurfaceData::invoke_post_commit_hooks::<C>(state, dh, &surface);
 
             tracing::trace!("Calling user implementation for wl_surface.commit");


### PR DESCRIPTION
Queue wl_subsurface position changes on the parent surface and apply transaction state before commit callbacks.

Fixes #1894.

AI-assisted: OpenAI Codex (code review and implementation assistance).
Signed-off-by: VibeCodeBlogger <289294152+VibeCodeBlogger@users.noreply.github.com>

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
