### PR TITLE
fix(tablet): deadlock when using the tool handle in `with_tools`

### DIFF
--- a/src/input/tablet/mod.rs
+++ b/src/input/tablet/mod.rs
@@ -560,14 +560,9 @@ impl<D: TabletSeatHandler + 'static> TabletSeat<D> {
         self.arc.lock().unwrap().tools.len()
     }
 
-    /// Run a callback on all available tablet tools
-    pub fn with_tools<T>(
-        &self,
-        callback: impl FnOnce(&HashMap<TabletToolDescriptor, TabletToolHandle<D>>) -> T,
-    ) -> T {
-        let guard = self.arc.lock().unwrap();
-
-        callback(&guard.tools)
+    /// Get a map of all tablet tools known by this [`TabletSeat`].
+    pub fn get_tools(&self) -> HashMap<TabletToolDescriptor, TabletToolHandle<D>> {
+        self.arc.lock().unwrap().tools.clone()
     }
 
     /// Remove tablet tool device


### PR DESCRIPTION
## Description
TabletSeat::with_tools was initially meant as a way to run some code on the `TabletSeat` known tools without needing to clone them. The original goal was so user can extract the tools by filtering them inside the callback, and return a new container with only the tools they needed.

However this is error prone, as using the tool handle may result in a deadlock. This side effect was introduced when a reference to the seat was added to the TabletToolHandle API, since fetching the seat need to probe the TabletSeats tools as well.

This PR drop the function altogether, in favor of a `get_tools` function that clone the internal storage. The rationale for doing so is that cloning the storage and its content should be somewhat cheap in most case, and the compositor can remove the excess tools that aren't in use anymore.

### Alternative
It's possible to resolve the issue by swapping the `TabletSeat`'s `Mutex` with a `RwLock`, and keeping the `with_tools` function. I'm not sure I see the point in avoiding the clone in this specific case as I don't expect the map to contains that many tools, hence the choice of dropping the function. I'm not against that implementation however, so let me know if it's preferred.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).

Fixes #2133

cc @YaLTeR if this is merged as-is, it'll be a small breaking change for niri