### PR TITLE
foreign-toplevel-list: allow compositor to pick the toplevel identifier.

### DIFF
--- a/src/wayland/foreign_toplevel_list/mod.rs
+++ b/src/wayland/foreign_toplevel_list/mod.rs
@@ -128,11 +128,16 @@ pub struct ForeignToplevelHandle {
 }
 
 impl ForeignToplevelHandle {
-    fn new(title: String, app_id: String, instances: Vec<Weak<ExtForeignToplevelHandleV1>>) -> Self {
+    fn new(
+        title: String,
+        app_id: String,
+        identifier: String,
+        instances: Vec<Weak<ExtForeignToplevelHandleV1>>,
+    ) -> Self {
         Self {
             inner: Arc::new((
                 Mutex::new(ForeignToplevelHandleInner {
-                    identifier: Alphanumeric.sample_string(&mut rand::rng(), 32),
+                    identifier,
                     title,
                     app_id,
                     instances,
@@ -337,9 +342,40 @@ impl ForeignToplevelListState {
     where
         D: ForeignToplevelListHandler + Dispatch<ExtForeignToplevelHandleV1, ForeignToplevelHandle>,
     {
+        self.new_toplevel_with_identifier::<D>(
+            title,
+            app_id,
+            Alphanumeric.sample_string(&mut rand::rng(), 32),
+        )
+    }
+
+    /// Create a new [`ForeignToplevelHandle`] using an arbitrary identifier.
+    ///
+    /// This function is similar to [`new_toplevel`], but lets the compositor specify the toplevel
+    /// identifier. The identifier should be a non-empty string composed of up to 32 printable ascii
+    /// characters.
+    ///
+    /// [`new_toplevel`]: ForeignToplevelListState::new_toplevel
+    pub fn new_toplevel_with_identifier<D>(
+        &mut self,
+        title: impl Into<String>,
+        app_id: impl Into<String>,
+        identifier: impl Into<String>,
+    ) -> ForeignToplevelHandle
+    where
+        D: ForeignToplevelListHandler + Dispatch<ExtForeignToplevelHandleV1, ForeignToplevelHandle>,
+    {
+        let identifier = identifier.into();
+        assert!(
+            !identifier.is_empty() && identifier.len() <= 32 && identifier.is_ascii(),
+            "{} is not a valid identifier",
+            identifier
+        );
+
         let handle = ForeignToplevelHandle::new(
             title.into(),
             app_id.into(),
+            identifier,
             Vec::with_capacity(self.list_instances.len()),
         );
 


### PR DESCRIPTION
## Description
Smithay generates the identifier using a random 32 character alphanumeric string.

This is generally fine, although it doesn't check for collisions. There are however two issue with having Smithay generate the id on toplevel_handle creation:
- A compositor wanting a special generation scheme must re-implement the whole protocol instead of the generation only.
- Since `ext_foreign_toplevel_handle_v1` are meant to represent a mapped toplevel, it's not possible for a compositor to make use of the identifier before the toplevel is mapped (e.g. for configuration-as-code purpose) without risking weird edge cases. As it is, the compositor either need to create the toplevel handle before the toplevel is mapped (and risk weird ordering of operation) , or re-implement the protocol.

This PR address both by providing an API for compositors to specify the identifier on handle creation.

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
