### PR TITLE
wayland/pointer_constraints: reorganize call sequence to resolve deadlock issue

### DIFF
--- a/anvil/src/state.rs
+++ b/anvil/src/state.rs
@@ -65,7 +65,8 @@ use smithay::{
         },
         output::{OutputHandler, OutputManagerState},
         pointer_constraints::{
-            PointerConstraint, PointerConstraintsHandler, PointerConstraintsState, with_pointer_constraint,
+            ConstraintRemove, PointerConstraint, PointerConstraintsHandler, PointerConstraintsState,
+            with_pointer_constraint,
         },
         pointer_gestures::PointerGesturesState,
         presentation::PresentationState,
@@ -386,33 +387,41 @@ impl<BackendData: Backend> PointerConstraintsHandler for AnvilState<BackendData>
         &mut self,
         _surface: &WlSurface,
         pointer: &PointerHandle<Self>,
-        _constraint: Option<&PointerConstraint>,
+        constraint_remove: ConstraintRemove,
     ) {
+        // Clear cursor_position_hint to prevent a oneshot PointerLocked constraint
+        // from causing this function to be called again during PointerLeave and
+        // unexpectedly changing the cursor position.
         let Some((hint_surface, hint_location)) = self.cursor_position_hint.take() else {
             return;
         };
 
-        // If the constraint was broken by the pointer forcibly leaving the surface, then it doesn't
-        // make much sense to warp it.
-        //
-        // Furthermore, when the constraint is removed as part of the pointer leaving the surface,
-        // this call happens with locked pointer data, and calling set_location() will try to lock
-        // it again and deadlock.
-        if pointer.last_enter().is_none() {
-            return;
+        match constraint_remove {
+            ConstraintRemove::Destroyed(pointer_constraint) => match pointer_constraint {
+                PointerConstraint::Confined(_confined_pointer) => return,
+                PointerConstraint::Locked(locked_pointer) => {
+                    let origin = self
+                        .space
+                        .elements()
+                        .find_map(|window| {
+                            (window.wl_surface().as_deref() == Some(&hint_surface)).then(|| window.geometry())
+                        })
+                        .unwrap_or_default()
+                        .loc
+                        .to_f64();
+
+                    let surface_location = origin + hint_location;
+                    if let Some(region) = locked_pointer.region()
+                        && region.contains(hint_location.to_i32_floor())
+                    {
+                        pointer.set_location(surface_location);
+                    } else {
+                        pointer.set_location(surface_location);
+                    }
+                }
+            },
+            ConstraintRemove::PointerLeave(_region) => return,
         }
-
-        let origin = self
-            .space
-            .elements()
-            .find_map(|window| {
-                (window.wl_surface().as_deref() == Some(&hint_surface)).then(|| window.geometry())
-            })
-            .unwrap_or_default()
-            .loc
-            .to_f64();
-
-        pointer.set_location(origin + hint_location);
     }
 
     fn cursor_position_hint(

--- a/src/wayland/pointer_constraints.rs
+++ b/src/wayland/pointer_constraints.rs
@@ -30,6 +30,15 @@ use crate::{
 
 const VERSION: u32 = 1;
 
+/// Reason for Constraint remove
+#[derive(Debug)]
+pub enum ConstraintRemove {
+    /// Client call destroy
+    Destroyed(PointerConstraint),
+    /// Compositor pointer leave surface
+    PointerLeave(Option<RegionAttributes>),
+}
+
 /// Handler for pointer constraints
 pub trait PointerConstraintsHandler: SeatHandler {
     /// Pointer lock or confinement constraint created for `pointer` on `surface`
@@ -39,12 +48,12 @@ pub trait PointerConstraintsHandler: SeatHandler {
 
     /// Pointer constraint removed for `pointer` on `surface`
     ///
-    /// Don't use [`with_pointer_constraint`] to access the constraint
+    /// Use [`with_pointer_constraint`] to access the constraint.
     fn remove_constraint(
         &mut self,
         _surface: &WlSurface,
         _pointer: &PointerHandle<Self>,
-        _constraint: Option<&PointerConstraint>,
+        _constraint_remove: ConstraintRemove,
     ) {
     }
 
@@ -154,7 +163,7 @@ impl<D: SeatHandler + PointerConstraintsHandler + 'static> PointerConstraintRef<
     ///
     /// This is sent automatically when the surface loses pointer focus, but
     /// may also be invoked while the surface is focused.
-    pub fn deactivate(self, state: &mut D, surface: &WlSurface, pointer: &PointerHandle<D>) {
+    pub fn deactivate(self) {
         let deactivated = match self.entry.get() {
             PointerConstraint::Confined(confined) => {
                 if confined.active.swap(false, Ordering::SeqCst) {
@@ -173,11 +182,6 @@ impl<D: SeatHandler + PointerConstraintsHandler + 'static> PointerConstraintRef<
                 }
             }
         };
-
-        if deactivated {
-            let constraint = self.entry.get();
-            state.remove_constraint(surface, pointer, Some(constraint));
-        }
 
         if deactivated && self.lifetime() == WEnum::Value(Lifetime::Oneshot) {
             self.entry.remove_entry();
@@ -366,19 +370,17 @@ fn remove_constraint<D: SeatHandler + PointerConstraintsHandler + 'static>(
     surface: &WlSurface,
     pointer: &PointerHandle<D>,
 ) {
-    let (is_removed, constraint) = with_constraint_data::<D, _, _>(surface, |data| {
+    let is_removed = with_constraint_data::<D, _, _>(surface, |data| {
         if let Some(data) = data {
             if let Some(constraint) = data.constraints.remove(pointer) {
-                return (true, Some(constraint));
+                return Some(constraint);
             }
         }
-        (false, None)
+        None
     });
 
-    if is_removed {
-        if let Some(constraint) = constraint {
-            state.remove_constraint(surface, pointer, Some(&constraint));
-        }
+    if let Some(constraint) = is_removed {
+        state.remove_constraint(surface, pointer, ConstraintRemove::Destroyed(constraint));
     }
 }
 

--- a/src/wayland/seat/pointer.rs
+++ b/src/wayland/seat/pointer.rs
@@ -27,7 +27,7 @@ use crate::{
     utils::{Client as ClientCoords, Point, Serial, iter::new_locked_obj_iter_from_vec},
     wayland::{
         Dispatch2, compositor,
-        pointer_constraints::{PointerConstraintsHandler, with_pointer_constraint},
+        pointer_constraints::{ConstraintRemove, PointerConstraintsHandler, with_pointer_constraint},
     },
 };
 
@@ -277,11 +277,21 @@ where
             pointer.wp_pointer_gestures.leave::<D>(self, serial, time);
             pointer.wl_pointer.leave(self, serial, time);
 
-            with_pointer_constraint(self, &pointer, |constraint| {
+            if let Some(region) = with_pointer_constraint(self, &pointer, |constraint| {
                 if let Some(constraint) = constraint {
-                    constraint.deactivate(data, self, &pointer);
+                    if constraint.is_active() {
+                        let region = constraint.region().cloned();
+                        constraint.deactivate();
+                        Some(region)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
                 }
-            });
+            }) {
+                data.remove_constraint(self, &pointer, ConstraintRemove::PointerLeave(region));
+            }
         }
 
         compositor::with_states(self, |states| {


### PR DESCRIPTION
## Description

This avoids deadlocks while restoring the interface requirements for `PointerConstraintsHandler::remove_constraint`.


## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
