### PR TITLE
fix(drm/gles): survive GPU resets — detect context loss, keep dmabufs valid, stop the log flood

### DIFF
--- a/src/backend/drm/device/fd.rs
+++ b/src/backend/drm/device/fd.rs
@@ -2,8 +2,29 @@ use drm::{Device as BasicDevice, control::Device as ControlDevice};
 use std::{
     os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd},
     sync::{Arc, Weak},
+    time::Duration,
 };
-use tracing::{error, info, warn};
+use tracing::{debug, error, info};
+
+/// Number of attempts to acquire the drm master lock on device creation.
+///
+/// Failing to acquire the lock is *not* an error in the common case: on a libseat/logind session
+/// the compositor is handed an already-usable fd and `drmSetMaster` is expected to be refused, and
+/// on newer kernels master is granted implicitly on open when nobody else holds it. The only case
+/// a retry helps is a genuine transient race - e.g. a crash-respawn where the previous holder's fd
+/// has not been reaped yet.
+///
+/// Keep this budget small: `DrmDeviceFd::new` runs on the compositor's main thread and every
+/// attempt sleeps, so the whole budget is added latency on *every* device open, including
+/// compositor startup and post-GPU-reset device reopen - i.e. it directly lengthens the black
+/// screen the user sees. A previous 10-attempt/~2.3s budget spent that time on every single start
+/// while never once succeeding, because the failure was the benign logind case, not a race.
+const MASTER_LOCK_ACQUIRE_ATTEMPTS: u32 = 3;
+/// Base delay between drm master lock acquisition attempts, doubled on each retry up to
+/// `MASTER_LOCK_ACQUIRE_MAX_DELAY`.
+const MASTER_LOCK_ACQUIRE_BASE_DELAY: Duration = Duration::from_millis(25);
+/// Cap on the per-attempt delay above, so late attempts don't wait longer than necessary.
+const MASTER_LOCK_ACQUIRE_MAX_DELAY: Duration = Duration::from_millis(100);
 
 use crate::utils::{DevPath, DeviceFd};
 
@@ -74,16 +95,40 @@ impl DrmDeviceFd {
         // We want to modeset, so we better be the master, if we run via a tty session.
         // This is only needed on older kernels. Newer kernels grant this permission,
         // if no other process is already the *master*. So we skip over this error.
-        if dev.acquire_master_lock().is_err() {
-            warn!("Unable to become drm master, assuming unprivileged mode");
-        } else {
-            dev.privileged = true;
+        //
+        // Retry a few times with backoff: right after a crash-respawn, the previous holder's
+        // master lock may not be released by the kernel yet, and this is otherwise a one-shot
+        // check with no other retry path (see MASTER_LOCK_ACQUIRE_ATTEMPTS docs).
+        let mut delay = MASTER_LOCK_ACQUIRE_BASE_DELAY;
+        for attempt in 1..=MASTER_LOCK_ACQUIRE_ATTEMPTS {
+            if dev.acquire_master_lock().is_ok() {
+                dev.privileged = true;
+                break;
+            }
+            if attempt < MASTER_LOCK_ACQUIRE_ATTEMPTS {
+                debug!(
+                    "Unable to become drm master (attempt {}/{}), retrying in {:?}",
+                    attempt, MASTER_LOCK_ACQUIRE_ATTEMPTS, delay
+                );
+                std::thread::sleep(delay);
+                delay = std::cmp::min(delay * 2, MASTER_LOCK_ACQUIRE_MAX_DELAY);
+            } else {
+                // Expected on libseat/logind sessions; not an error on its own.
+                info!("Unable to become drm master, assuming unprivileged mode");
+            }
         }
 
         DrmDeviceFd(Arc::new(dev))
     }
 
-    pub(in crate::backend::drm) fn is_privileged(&self) -> bool {
+    /// Whether this device fd currently holds the DRM master lock.
+    ///
+    /// A non-privileged fd on what is meant to be the primary/control device for modesetting
+    /// cannot page-flip or change the display configuration - callers that require modesetting
+    /// (e.g. reopening the primary device after a GPU reset) should treat `false` here as a
+    /// failure rather than silently continuing, since [`DrmDeviceFd::new`] itself only logs a
+    /// warning and does not fail when master acquisition is exhausted.
+    pub fn is_privileged(&self) -> bool {
         self.0.privileged
     }
 

--- a/src/backend/egl/context.rs
+++ b/src/backend/egl/context.rs
@@ -287,6 +287,19 @@ impl EGLContext {
             }
         }
 
+        let has_robustness = display
+            .extensions()
+            .iter()
+            .any(|x| x == "EGL_EXT_create_context_robustness");
+        if has_robustness {
+            context_attributes.push(ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS_EXT as i32);
+            context_attributes.push(ffi::egl::TRUE as i32);
+            context_attributes.push(ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT as i32);
+            context_attributes.push(ffi::egl::LOSE_CONTEXT_ON_RESET_EXT as i32);
+        } else {
+            warn!("EGL_EXT_create_context_robustness not supported, GPU resets may abort the process");
+        }
+
         context_attributes.push(ffi::egl::NONE as i32);
 
         trace!("Creating EGL context...");

--- a/src/backend/egl/mod.rs
+++ b/src/backend/egl/mod.rs
@@ -161,6 +161,16 @@ impl std::convert::From<SwapBuffersError> for GraphicsSwapBuffersError {
 #[error("`eglMakeCurrent` failed: {0}")]
 pub struct MakeCurrentError(#[from] EGLError);
 
+impl MakeCurrentError {
+    /// Whether this failure was caused by the context having been lost, e.g. because the GPU
+    /// was reset. Callers that only care about generic activation failures vs. a lost context
+    /// (which typically warrants recreating the renderer rather than just retrying) can use
+    /// this instead of matching on the wrapped [`EGLError`] directly.
+    pub fn is_context_lost(&self) -> bool {
+        matches!(self.0, EGLError::ContextLost)
+    }
+}
+
 impl From<MakeCurrentError> for GraphicsSwapBuffersError {
     #[inline]
     fn from(err: MakeCurrentError) -> GraphicsSwapBuffersError {

--- a/src/backend/renderer/gles/error.rs
+++ b/src/backend/renderer/gles/error.rs
@@ -88,6 +88,9 @@ pub enum GlesError {
     /// Blocking for a synchronization primitive failed
     #[error("Blocking for a synchronization primitive got interrupted")]
     SyncInterrupted,
+    /// The GL context was lost, e.g. due to a GPU reset
+    #[error("GL context lost (reset status {0:#x})")]
+    ContextLost(u32),
 }
 
 impl From<GlesError> for SwapBuffersError {
@@ -100,7 +103,8 @@ impl From<GlesError> for SwapBuffersError {
             | x @ GlesError::GLFunctionLoaderError
             | x @ GlesError::GLExtensionNotSupported(_)
             | x @ GlesError::EGLExtensionNotSupported(_)
-            | x @ GlesError::GLVersionNotSupported(_) => SwapBuffersError::ContextLost(Box::new(x)),
+            | x @ GlesError::GLVersionNotSupported(_)
+            | x @ GlesError::ContextLost(_) => SwapBuffersError::ContextLost(Box::new(x)),
             GlesError::ContextActivationError(err) => err.into(),
             x @ GlesError::FramebufferBindingError
             | x @ GlesError::BindBufferEGLError(_)
@@ -129,7 +133,8 @@ impl From<GlesError> for SwapBuffersError {
             | x @ GlesError::GLFunctionLoaderError
             | x @ GlesError::GLExtensionNotSupported(_)
             | x @ GlesError::EGLExtensionNotSupported(_)
-            | x @ GlesError::GLVersionNotSupported(_) => SwapBuffersError::ContextLost(Box::new(x)),
+            | x @ GlesError::GLVersionNotSupported(_)
+            | x @ GlesError::ContextLost(_) => SwapBuffersError::ContextLost(Box::new(x)),
             GlesError::ContextActivationError(err) => err.into(),
             x @ GlesError::FramebufferBindingError
             | x @ GlesError::MappingError

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -40,7 +40,7 @@ pub use uniform::*;
 use crate::{backend::renderer::FrameContext, gpu_span_location};
 use profiler::SpanLocation;
 
-use self::version::GlVersion;
+use self::version::{GLES_3_2, GlVersion};
 
 use super::{
     Bind, Blit, BlitFrame, Color32F, ContextId, DebugFlags, ExportMem, Frame, ImportDma, ImportMem,
@@ -387,6 +387,10 @@ pub struct GlesRenderer {
     pub(crate) extensions: Vec<String>,
     is_software: bool,
     capabilities: Vec<Capability>,
+    /// Whether `GetGraphicsResetStatus` is safe to call: core in GLES 3.2+, otherwise only
+    /// present at all if `GL_EXT_robustness`/`GL_KHR_robustness` is advertised. Calling it
+    /// without either would call into an unloaded function pointer.
+    has_robustness_query: bool,
 
     // shaders
     tex_program: GlesTexProgram,
@@ -465,6 +469,36 @@ impl fmt::Debug for GlesRenderer {
     }
 }
 
+/// Collapses runs of the *same* driver debug message.
+///
+/// Some driver-reported conditions - a lost GL context above all - make every subsequent GL call
+/// report the identical message, so a single GPU reset can emit hundreds of them in under a
+/// second. Journald floods of exactly this kind have hard-frozen the machine during GPU-reset
+/// recovery, so log a repeating message on a 1, 2, 4, 8, ... schedule instead of every time: the
+/// message and the fact that it is repeating both still show up, at a bounded cost. Any different
+/// message resets the run and is logged immediately.
+fn is_repeat_flood(message: &str) -> bool {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    static LAST_HASH: AtomicU64 = AtomicU64::new(0);
+    static REPEATS: AtomicU64 = AtomicU64::new(0);
+
+    let mut hasher = DefaultHasher::new();
+    message.hash(&mut hasher);
+    let hash = hasher.finish();
+
+    if LAST_HASH.swap(hash, Ordering::Relaxed) != hash {
+        REPEATS.store(0, Ordering::Relaxed);
+        return false;
+    }
+    // Log only when the repeat count reaches a power of two.
+    !(REPEATS.fetch_add(1, Ordering::Relaxed) + 1).is_power_of_two()
+}
+
 extern "system" fn gl_debug_log(
     _source: ffi::types::GLenum,
     gltype: ffi::types::GLenum,
@@ -479,6 +513,9 @@ extern "system" fn gl_debug_log(
         let _guard = span.enter();
         let msg = CStr::from_ptr(message);
         let message_utf8 = msg.to_string_lossy();
+        if is_repeat_flood(&message_utf8) {
+            return;
+        }
         match gltype {
             ffi::DEBUG_TYPE_ERROR | ffi::DEBUG_TYPE_UNDEFINED_BEHAVIOR => {
                 error!("[GL] {}", message_utf8)
@@ -717,6 +754,11 @@ impl GlesRenderer {
 
         let profiler = profiler::GpuProfiler::new(&gl, &exts);
 
+        let has_robustness_query = gl_version >= GLES_3_2
+            || exts
+                .iter()
+                .any(|ext| ext == "GL_EXT_robustness" || ext == "GL_KHR_robustness");
+
         let renderer = GlesRenderer {
             gl,
             egl: context,
@@ -727,6 +769,7 @@ impl GlesRenderer {
             is_software,
             gl_version,
             capabilities,
+            has_robustness_query,
 
             tex_program,
             solid_program,
@@ -749,6 +792,18 @@ impl GlesRenderer {
         };
         renderer.egl.unbind()?;
         Ok(renderer)
+    }
+
+    /// Checks whether the GL context has been lost (e.g. due to a GPU reset).
+    ///
+    /// Framebuffer completeness checks fail in ways indistinguishable from other errors once the
+    /// context is lost, so callers should prefer this check over reporting a generic binding error.
+    fn graphics_reset_status(&self) -> Option<u32> {
+        if !self.has_robustness_query {
+            return None;
+        }
+        let status = unsafe { self.gl.GetGraphicsResetStatus() };
+        (status != ffi::NO_ERROR).then_some(status)
     }
 
     fn bind_texture<'a>(&mut self, texture: &'a GlesTexture) -> Result<GlesTarget<'a>, GlesError> {
@@ -782,6 +837,9 @@ impl GlesRenderer {
 
                 if status != ffi::FRAMEBUFFER_COMPLETE {
                     self.gl.DeleteFramebuffers(1, &mut fbo as *mut _);
+                    if let Some(reset_status) = self.graphics_reset_status() {
+                        return Err(GlesError::ContextLost(reset_status));
+                    }
                     return Err(GlesError::FramebufferBindingError);
                 }
             }
@@ -1601,6 +1659,9 @@ impl Bind<Dmabuf> for GlesRenderer {
                             self.gl.DeleteFramebuffers(1, &mut fbo as *mut _);
                             self.gl.DeleteRenderbuffers(1, &mut rbo as *mut _);
                             ffi_egl::DestroyImageKHR(**self.egl.display().get_display_handle(), image);
+                            if let Some(reset_status) = self.graphics_reset_status() {
+                                return Err(GlesError::ContextLost(reset_status));
+                            }
                             return Err(GlesError::FramebufferBindingError);
                         }
                         let buf = GlesBuffer(Rc::new(GlesBufferInner {
@@ -1662,6 +1723,9 @@ impl Bind<GlesRenderbuffer> for GlesRenderer {
 
                 if status != ffi::FRAMEBUFFER_COMPLETE {
                     self.gl.DeleteFramebuffers(1, &mut fbo as *mut _);
+                    if let Some(reset_status) = self.graphics_reset_status() {
+                        return Err(GlesError::ContextLost(reset_status));
+                    }
                     return Err(GlesError::FramebufferBindingError);
                 }
             }
@@ -1860,8 +1924,14 @@ impl Blit for GlesRenderer {
 
         let status = unsafe { self.gl.CheckFramebufferStatus(ffi::FRAMEBUFFER) };
         if status != ffi::FRAMEBUFFER_COMPLETE {
+            // Query reset status *before* unbind() releases the current context - once no
+            // context is current, GetGraphicsResetStatus has nothing to query.
+            let reset_status = self.graphics_reset_status();
             drop(scope);
             let _ = self.unbind();
+            if let Some(reset_status) = reset_status {
+                return Err(GlesError::ContextLost(reset_status));
+            }
             return Err(GlesError::FramebufferBindingError);
         }
 
@@ -2529,6 +2599,13 @@ impl GlesFrame<'_, '_> {
 
         if self.finished.swap(true, Ordering::SeqCst) {
             return Ok(SyncPoint::signaled());
+        }
+
+        // Goes through the guarded helper rather than calling `GetGraphicsResetStatus`
+        // directly: on GLES < 3.2 without GL_EXT_robustness/GL_KHR_robustness, the entry
+        // point may not be loaded at all.
+        if let Some(reset_status) = self.renderer.graphics_reset_status() {
+            return Err(GlesError::ContextLost(reset_status));
         }
 
         let finish_gpu_span = self

--- a/src/backend/renderer/gles/version.rs
+++ b/src/backend/renderer/gles/version.rs
@@ -5,6 +5,7 @@ use std::{
 
 use super::ffi::{self, Gles2};
 
+pub const GLES_3_2: GlVersion = GlVersion::new(3, 2);
 pub const GLES_3_0: GlVersion = GlVersion::new(3, 0);
 pub const GLES_2_0: GlVersion = GlVersion::new(2, 0);
 

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1822,11 +1822,46 @@ impl MultiTexture {
         <A::Device as ApiDevice>::Renderer: ImportDma,
     {
         let mut tex = self.0.lock().unwrap();
+        let current_id = renderer.context_id().erased();
+
         if let Some(GpuSingleTexture::Dma { texture, dmabuf, .. }) =
-            tex.textures.get_mut(&renderer.context_id().erased())
+            tex.textures.get_mut(&current_id)
         {
+            // Normal path: a dmabuf already imported for this exact context. Re-import it in
+            // place (e.g. when the underlying GL texture was invalidated but the context survived).
             *texture = Box::new(renderer.import_dmabuf(dmabuf, None)?) as Box<_>;
+            return Ok(());
         }
+
+        // Recovery path: after a GPU reset the renderer is recreated with a *new* `ContextId`,
+        // so any dmabuf imported under an older, now-dead context is orphaned (looked up by the
+        // old id and never found). Re-import the first available dmabuf into the new renderer
+        // and re-key it to the new context instead of dropping it - otherwise every client
+        // surface fails with "import for wrong devices" and GPU-accelerated (wgpu/Vulkan) apps
+        // panic on the invalid texture.
+        let stale_entry = tex.textures.iter().find_map(|(id, entry)| match entry {
+            GpuSingleTexture::Dma { dmabuf, .. } => Some((id.clone(), dmabuf.clone())),
+            _ => None,
+        });
+
+        if let Some((stale_id, dmabuf)) = stale_entry {
+            let imported = Box::new(renderer.import_dmabuf(&dmabuf, None)?) as Box<_>;
+            // Drop only the specific stale entry that was consumed above, and insert the
+            // freshly imported texture under the new id. Other contexts' entries (e.g. a
+            // different, unaffected GPU in a multi-GPU setup) are left untouched - they
+            // weren't part of this device's context loss and blowing them away would just
+            // force redundant reimports on GPUs that never lost anything.
+            tex.textures.remove(&stale_id);
+            tex.textures.insert(
+                current_id,
+                GpuSingleTexture::Dma {
+                    texture: imported,
+                    dmabuf,
+                    sync: None,
+                },
+            );
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Thanks for the work and the detailed description — and sorry for the noise.

After the last update, everything is already working well on my setup with `COSMIC_COMP_GPU_RESET_KILL_CLIENTS=1`, which kills clients on GPU reset instead of trying to keep the session alive. That’s been enough for my use, so I’m not actually validating the full recovery path implemented here.

I’m closing this PR to avoid blocking review or implying active validation from my side. The changes still look useful for anyone pursuing true session-surviving GPU reset recovery; I hope they can be picked up in that context.

Thanks again, and apologies for the churn.