### PR TITLE
input/dnd: add Source::accepted so proxying sources can relay the target's choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,12 @@ operations (see below).
 types, which can be targets of DnD operations. `Source` is a new trait for types that represent
 sources of data for DnD operations.
 
+`Source::accepted` is called when a target accepts a mime-type, or rejects the offer with `None`.
+Sources that proxy an upstream offer need it: a nested compositor forwarding a drag to its own
+clients only receives `drop` from the host compositor once it has itself accepted on the upstream
+offer, and previously had no way to know when a nested client had done so. It has a default no-op
+implementation, so sources that originate their own data are unaffected.
+
 The Xwayland WM can now handle XDND operations and bridge them over to the new generic DnD interface
 allowing DnD operations between X11 and Wayland clients (both directions).
 

--- a/src/input/dnd/mod.rs
+++ b/src/input/dnd/mod.rs
@@ -64,6 +64,15 @@ pub trait Source: IsAlive + Send + Sync + 'static {
     ///
     /// If this returns `None` the source is not managed by smithay (e.g. client_local)
     fn metadata(&self) -> Option<SourceMetadata>;
+    /// The target accepted a mime-type, or rejected the offer when `None`
+    ///
+    /// Proxying implementations, such as a nested compositor forwarding a
+    /// drag to its own clients, need this to relay the target's choice to
+    /// the upstream source. Sources that originate their own data can
+    /// ignore it.
+    fn accepted(&self, mime_type: Option<String>) {
+        let _ = mime_type;
+    }
     /// An action was selected by the target
     fn choose_action(&self, action: DndAction);
     /// The target requests data to be transferred to the given file descriptor for the given mime-type

--- a/src/wayland/selection/data_device/mod.rs
+++ b/src/wayland/selection/data_device/mod.rs
@@ -259,13 +259,13 @@ fn handle_dnd<D, S>(
     match request {
         Request::Accept { mime_type, .. } => {
             if let Some(source) = source.as_ref() {
-                if let Some(mtype) = mime_type {
-                    data.accepted = source
+                data.accepted = match &mime_type {
+                    Some(mtype) => source
                         .metadata()
-                        .is_some_and(|meta| meta.mime_types.contains(&mtype));
-                } else {
-                    data.accepted = false;
-                }
+                        .is_some_and(|meta| meta.mime_types.contains(mtype)),
+                    None => false,
+                };
+                source.accepted(mime_type);
             } else if data.finished {
                 offer.post_error(
                     wl_data_offer::Error::InvalidFinish,


### PR DESCRIPTION
`Source` has hooks for the other two target->source requests — `send` for `receive`, `choose_action` for `set_actions` — but nothing for `accept`. `handle_dnd` sets `data.accepted` and that's the end of it.

That breaks proxying sources. A nested compositor forwarding a drag to its own clients implements `Source`, and the host compositor only sends `drop` once that nested compositor has accepted on the *upstream* offer. It currently has no way to know when to do that, so the drop never arrives and the drag just ends in `leave`.

This adds `Source::accepted(Option<String>)`, called from the `Accept` arm. Default no-op, so nothing existing changes.

Found while fixing drag-and-drop onto cosmic-panel applets, which is broken for exactly this reason: pop-os/cosmic-panel#675, which uses this hook and is tested working against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCQQAWhxyYJwT49Zvcko6z