### PR TITLE
input: separate input-method keyboard interception from routing grabs

### DIFF
--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -224,6 +224,41 @@ impl KeyboardSource {
     }
 }
 
+#[cfg(any(feature = "wayland_frontend", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KeyboardInputInterception {
+    Forward,
+    Intercept,
+}
+
+#[cfg(any(feature = "wayland_frontend", test))]
+/// Intercepts keyboard input after [`KeyboardGrab`] routing.
+///
+/// If a press is intercepted, its matching release remains assigned to the same interceptor if it
+/// reaches this stage; the compositor filter or a routing grab may consume the release earlier.
+/// Replacing or removing the interceptor while the key is held causes such a release to be dropped.
+pub(crate) trait KeyboardInputInterceptor<D: SeatHandler> {
+    #[allow(clippy::too_many_arguments)]
+    fn input(
+        &mut self,
+        data: &mut D,
+        seat: &Seat<D>,
+        source: KeyboardSource,
+        keycode: Keycode,
+        state: KeyState,
+        modifiers: Option<ModifiersState>,
+        serial: Serial,
+        time: InputTime,
+    ) -> KeyboardInputInterception;
+}
+
+#[cfg(any(feature = "wayland_frontend", test))]
+#[derive(Debug, Clone, Copy)]
+enum InterceptedPressOwner {
+    Active(KeyboardSource),
+    Detached,
+}
+
 pub(crate) struct KbdInternal<D: SeatHandler> {
     pub(crate) focus: Option<(<D as SeatHandler>::KeyboardFocus, Serial)>,
     pending_focus: Option<<D as SeatHandler>::KeyboardFocus>,
@@ -237,6 +272,12 @@ pub(crate) struct KbdInternal<D: SeatHandler> {
     led_mapping: LedMapping,
     pub(crate) led_state: LedState,
     grab: GrabStatus<dyn KeyboardGrab<D>>,
+    #[cfg(any(feature = "wayland_frontend", test))]
+    input_interceptor: Option<Box<dyn KeyboardInputInterceptor<D>>>,
+    #[cfg(any(feature = "wayland_frontend", test))]
+    intercepted_pressed_keys: HashMap<Keycode, InterceptedPressOwner>,
+    #[cfg(any(feature = "wayland_frontend", test))]
+    forwarded_modifiers_dirty: bool,
 }
 
 // focus_hook does not implement debug, so we have to impl Debug manually
@@ -294,6 +335,12 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
             led_mapping,
             led_state,
             grab: GrabStatus::None,
+            #[cfg(any(feature = "wayland_frontend", test))]
+            input_interceptor: None,
+            #[cfg(any(feature = "wayland_frontend", test))]
+            intercepted_pressed_keys: HashMap::new(),
+            #[cfg(any(feature = "wayland_frontend", test))]
+            forwarded_modifiers_dirty: false,
         })
     }
 
@@ -314,6 +361,12 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
                     return (false, false, false);
                 }
                 self.pressed_keys.insert(keycode);
+                #[cfg(any(feature = "wayland_frontend", test))]
+                {
+                    // A release can be consumed before post-routing dispatch. A fresh combined
+                    // key-down starts a new cycle, so any leftover owner is necessarily stale.
+                    self.intercepted_pressed_keys.remove(&keycode);
+                }
                 xkb::KeyDirection::Down
             }
             KeyState::Released => {
@@ -368,7 +421,7 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
         transitioned
     }
 
-    fn with_grab<F>(&mut self, data: &mut D, seat: &Seat<D>, f: F)
+    fn with_grab<F>(&mut self, data: &mut D, seat: &Seat<D>, _source: KeyboardSource, f: F)
     where
         F: FnOnce(&mut D, &mut KeyboardInnerHandle<'_, D>, &mut dyn KeyboardGrab<D>),
     {
@@ -383,7 +436,12 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
                         self.grab = GrabStatus::None;
                         f(
                             data,
-                            &mut KeyboardInnerHandle { inner: self, seat },
+                            &mut KeyboardInnerHandle {
+                                inner: self,
+                                seat,
+                                #[cfg(any(feature = "wayland_frontend", test))]
+                                source: _source,
+                            },
                             &mut DefaultGrab,
                         );
                         return;
@@ -391,14 +449,24 @@ impl<D: SeatHandler + 'static> KbdInternal<D> {
                 }
                 f(
                     data,
-                    &mut KeyboardInnerHandle { inner: self, seat },
+                    &mut KeyboardInnerHandle {
+                        inner: self,
+                        seat,
+                        #[cfg(any(feature = "wayland_frontend", test))]
+                        source: _source,
+                    },
                     &mut **handler,
                 );
             }
             GrabStatus::None => {
                 f(
                     data,
-                    &mut KeyboardInnerHandle { inner: self, seat },
+                    &mut KeyboardInnerHandle {
+                        inner: self,
+                        seat,
+                        #[cfg(any(feature = "wayland_frontend", test))]
+                        source: _source,
+                    },
                     &mut DefaultGrab,
                 );
             }
@@ -975,6 +1043,27 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         inner.grab = GrabStatus::None;
     }
 
+    #[cfg(any(feature = "wayland_frontend", test))]
+    pub(crate) fn set_input_interceptor<I>(&self, interceptor: I)
+    where
+        I: KeyboardInputInterceptor<D> + 'static,
+    {
+        let mut inner = self.arc.internal.lock().unwrap();
+        for owner in inner.intercepted_pressed_keys.values_mut() {
+            *owner = InterceptedPressOwner::Detached;
+        }
+        inner.input_interceptor = Some(Box::new(interceptor));
+    }
+
+    #[cfg(any(feature = "wayland_frontend", test))]
+    pub(crate) fn unset_input_interceptor(&self) {
+        let mut inner = self.arc.internal.lock().unwrap();
+        for owner in inner.intercepted_pressed_keys.values_mut() {
+            *owner = InterceptedPressOwner::Detached;
+        }
+        inner.input_interceptor = None;
+    }
+
     /// Check if this keyboard is currently grabbed with this serial
     pub fn has_grab(&self, serial: Serial) -> bool {
         let guard = self.arc.internal.lock().unwrap();
@@ -984,7 +1073,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         }
     }
 
-    /// Check if this keyboard is currently being grabbed
+    /// Check if this keyboard currently has a [`KeyboardGrab`]
     pub fn is_grabbed(&self) -> bool {
         let guard = self.arc.internal.lock().unwrap();
         !matches!(guard.grab, GrabStatus::None)
@@ -1080,7 +1169,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
             return Some(val);
         }
 
-        self.input_forward(data, keycode, state, serial, time, mods_changed);
+        self.input_forward_from_source(source, data, keycode, state, serial, time, mods_changed);
         None
     }
 
@@ -1101,7 +1190,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         for keycode in transitioned {
             // modifiers may have changed as a modifier key was released; let input_forward
             // re-derive and send the current state.
-            self.input_forward(data, keycode, KeyState::Released, serial, time, true);
+            self.input_forward_from_source(source, data, keycode, KeyState::Released, serial, time, true);
         }
     }
 
@@ -1157,7 +1246,31 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         time: InputTime,
         mods_changed: bool,
     ) {
+        self.input_forward_from_source(
+            KeyboardSource::MAIN,
+            data,
+            keycode,
+            state,
+            serial,
+            time,
+            mods_changed,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn input_forward_from_source(
+        &self,
+        source: KeyboardSource,
+        data: &mut D,
+        keycode: Keycode,
+        state: KeyState,
+        serial: Serial,
+        time: InputTime,
+        mods_changed: bool,
+    ) {
         let mut guard = self.arc.internal.lock().unwrap();
+
+        #[cfg(not(any(feature = "wayland_frontend", test)))]
         match state {
             KeyState::Pressed => {
                 guard.forwarded_pressed_keys.insert(keycode);
@@ -1167,16 +1280,23 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
             }
         };
 
-        // forward to client if no keybinding is triggered.
-        // Modifiers are only sent when the shared seat state actually changed; the client
-        // resolves the following key event against them, so they must precede the key (handled
-        // in `KeyboardInnerHandle::input`).
+        // With interception enabled, releases stay visible until routing completes so an
+        // interceptor cannot steal a release for a key that was already forwarded.
         let seat = self.get_seat(data);
         let mods = guard.mods_state;
         let modifiers = mods_changed.then_some(mods);
-        guard.with_grab(data, &seat, |data, handle, grab| {
+        guard.with_grab(data, &seat, source, |data, handle, grab| {
             grab.input(data, handle, keycode, state, modifiers, serial, time);
         });
+
+        #[cfg(any(feature = "wayland_frontend", test))]
+        // A consumed release must not remain advertised to a later focus or keep stale
+        // interception ownership.
+        if state == KeyState::Released {
+            guard.forwarded_pressed_keys.remove(&keycode);
+            guard.intercepted_pressed_keys.remove(&keycode);
+        }
+
         if guard.focus.is_some() {
             trace!("Input forwarded to client");
         } else {
@@ -1195,7 +1315,7 @@ impl<D: SeatHandler + 'static> KeyboardHandle<D> {
         let mut guard = self.arc.internal.lock().unwrap();
         guard.pending_focus.clone_from(&focus);
         let seat = self.get_seat(data);
-        guard.with_grab(data, &seat, |data, handle, grab| {
+        guard.with_grab(data, &seat, KeyboardSource::MAIN, |data, handle, grab| {
             grab.set_focus(data, handle, focus, serial);
         });
     }
@@ -1472,14 +1592,19 @@ where
 pub struct KeyboardInnerHandle<'a, D: SeatHandler> {
     inner: &'a mut KbdInternal<D>,
     seat: &'a Seat<D>,
+    #[cfg(any(feature = "wayland_frontend", test))]
+    source: KeyboardSource,
 }
 
 impl<D: SeatHandler> fmt::Debug for KeyboardInnerHandle<'_, D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("KeyboardInnerHandle")
+        let mut debug = f.debug_struct("KeyboardInnerHandle");
+        debug
             .field("inner", &self.inner)
-            .field("seat", &self.seat.arc.name)
-            .finish()
+            .field("seat", &self.seat.arc.name);
+        #[cfg(any(feature = "wayland_frontend", test))]
+        debug.field("source", &self.source);
+        debug.finish()
     }
 }
 
@@ -1546,10 +1671,84 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
         serial: Serial,
         time: InputTime,
     ) {
-        let (focus, _) = match self.inner.focus.as_mut() {
-            Some(focus) => focus,
-            None => return,
+        #[cfg(any(feature = "wayland_frontend", test))]
+        {
+            // Keep releases paired with the sink that received the corresponding press.
+            let release_for_forwarded_press =
+                key_state == KeyState::Released && self.inner.forwarded_pressed_keys.contains(&keycode);
+
+            if key_state == KeyState::Released {
+                if let Some(owner) = self.inner.intercepted_pressed_keys.remove(&keycode) {
+                    if let InterceptedPressOwner::Active(owner_source) = owner {
+                        if let Some(interceptor) = self.inner.input_interceptor.as_mut() {
+                            // The intercepted press owns this release; it cannot be retargeted.
+                            let _ = interceptor.input(
+                                data,
+                                self.seat,
+                                owner_source,
+                                keycode,
+                                key_state,
+                                modifiers,
+                                serial,
+                                time,
+                            );
+                        }
+                    }
+                    if modifiers.is_some() {
+                        self.inner.forwarded_modifiers_dirty = true;
+                    }
+                    return;
+                }
+            }
+
+            if release_for_forwarded_press {
+                self.inner.forwarded_pressed_keys.remove(&keycode);
+            } else if let Some(interceptor) = self.inner.input_interceptor.as_mut() {
+                let result = interceptor.input(
+                    data,
+                    self.seat,
+                    self.source,
+                    keycode,
+                    key_state,
+                    modifiers,
+                    serial,
+                    time,
+                );
+
+                if result == KeyboardInputInterception::Intercept {
+                    if key_state == KeyState::Pressed {
+                        self.inner
+                            .intercepted_pressed_keys
+                            .insert(keycode, InterceptedPressOwner::Active(self.source));
+                    }
+                    // Resync modifiers before the next event delivered to the target.
+                    if modifiers.is_some() {
+                        self.inner.forwarded_modifiers_dirty = true;
+                    }
+                    return;
+                }
+            }
+
+            // A press that reached the normal keyboard path stays part of the logical pressed
+            // state even when there is no current focus. A later focus must advertise it in enter.
+            if key_state == KeyState::Pressed {
+                self.inner.forwarded_pressed_keys.insert(keycode);
+            }
+        }
+
+        if self.inner.focus.is_none() {
+            return;
+        }
+
+        #[cfg(any(feature = "wayland_frontend", test))]
+        // Send the current modifier state if an intercepted transition made the target stale.
+        let modifiers = if self.inner.forwarded_modifiers_dirty && modifiers.is_none() {
+            Some(self.inner.mods_state)
+        } else {
+            modifiers
         };
+
+        let (focus, _) = self.inner.focus.as_mut().unwrap();
 
         #[cfg(feature = "wayland_frontend")]
         if let Some(keyboard_handle) = self.seat.get_keyboard() {
@@ -1567,6 +1766,10 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
         // updated modifier state.
         if let Some(mods) = modifiers {
             focus.modifiers(self.seat, data, mods, serial);
+            #[cfg(any(feature = "wayland_frontend", test))]
+            {
+                self.inner.forwarded_modifiers_dirty = false;
+            }
         }
         focus.key(self.seat, data, key, key_state, serial, time);
     }
@@ -1625,6 +1828,10 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
                     let (keys, mods) = self.focus_enter_state();
 
                     focus.replace(old_focus, self.seat, data, keys, mods, serial);
+                    #[cfg(any(feature = "wayland_frontend", test))]
+                    {
+                        self.inner.forwarded_modifiers_dirty = false;
+                    }
                     data.focus_changed(self.seat, Some(&focus));
                 }
                 (focus, None) => {
@@ -1632,6 +1839,10 @@ impl<D: SeatHandler + 'static> KeyboardInnerHandle<'_, D> {
 
                     focus.enter(self.seat, data, keys, serial);
                     focus.modifiers(self.seat, data, mods, serial);
+                    #[cfg(any(feature = "wayland_frontend", test))]
+                    {
+                        self.inner.forwarded_modifiers_dirty = false;
+                    }
                     data.focus_changed(self.seat, Some(&focus));
                 }
             }

--- a/src/input/keyboard/mod.rs
+++ b/src/input/keyboard/mod.rs
@@ -1886,3 +1886,6 @@ impl<D: SeatHandler + 'static> KeyboardGrab<D> for DefaultGrab {
 
     fn unset(&mut self, _data: &mut D) {}
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/input/keyboard/tests.rs
+++ b/src/input/keyboard/tests.rs
@@ -1,0 +1,878 @@
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use super::*;
+use crate::input::{
+    SeatState,
+    pointer::{
+        AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
+        GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
+        GestureSwipeUpdateEvent, MotionEvent, PointerTarget, RelativeMotionEvent,
+    },
+    touch::{
+        DownEvent, FrameMarker, MotionEvent as TouchMotionEvent, OrientationEvent, ShapeEvent, TouchTarget,
+        UpEvent,
+    },
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TestTarget;
+
+impl IsAlive for TestTarget {
+    fn alive(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetEvent {
+    Modifiers,
+    Key(Keycode, KeyState),
+}
+
+struct TestState {
+    seat_state: SeatState<Self>,
+    target_events: Vec<TargetEvent>,
+    entered_keys: Vec<Vec<Keycode>>,
+}
+
+impl TestState {
+    fn new() -> Self {
+        Self {
+            seat_state: SeatState::new(),
+            target_events: Vec::new(),
+            entered_keys: Vec::new(),
+        }
+    }
+}
+
+impl SeatHandler for TestState {
+    type KeyboardFocus = TestTarget;
+    type PointerFocus = TestTarget;
+    type TouchFocus = TestTarget;
+
+    fn seat_state(&mut self) -> &mut SeatState<Self> {
+        &mut self.seat_state
+    }
+}
+
+impl KeyboardTarget<TestState> for TestTarget {
+    fn enter(
+        &self,
+        _seat: &Seat<TestState>,
+        data: &mut TestState,
+        keys: Vec<KeysymHandle<'_>>,
+        _serial: Serial,
+    ) {
+        data.entered_keys
+            .push(keys.into_iter().map(|key| key.raw_code()).collect());
+    }
+
+    fn leave(&self, _seat: &Seat<TestState>, _data: &mut TestState, _serial: Serial) {}
+
+    fn key(
+        &self,
+        _seat: &Seat<TestState>,
+        data: &mut TestState,
+        key: KeysymHandle<'_>,
+        state: KeyState,
+        _serial: Serial,
+        _time: InputTime,
+    ) {
+        data.target_events.push(TargetEvent::Key(key.raw_code(), state));
+    }
+
+    fn modifiers(
+        &self,
+        _seat: &Seat<TestState>,
+        data: &mut TestState,
+        _modifiers: ModifiersState,
+        _serial: Serial,
+    ) {
+        data.target_events.push(TargetEvent::Modifiers);
+    }
+}
+
+impl PointerTarget<TestState> for TestTarget {
+    fn enter(&self, _seat: &Seat<TestState>, _data: &mut TestState, _event: &MotionEvent) {}
+    fn motion(&self, _seat: &Seat<TestState>, _data: &mut TestState, _event: &MotionEvent) {}
+    fn relative_motion(&self, _seat: &Seat<TestState>, _data: &mut TestState, _event: &RelativeMotionEvent) {}
+    fn button(&self, _seat: &Seat<TestState>, _data: &mut TestState, _event: &ButtonEvent) {}
+    fn axis(&self, _seat: &Seat<TestState>, _data: &mut TestState, _frame: AxisFrame) {}
+    fn frame(&self, _seat: &Seat<TestState>, _data: &mut TestState) {}
+    fn gesture_swipe_begin(
+        &self,
+        _seat: &Seat<TestState>,
+        _data: &mut TestState,
+        _event: &GestureSwipeBeginEvent,
+    ) {
+    }
+    fn gesture_swipe_update(
+        &self,
+        _seat: &Seat<TestState>,
+        _data: &mut TestState,
+        _event: &GestureSwipeUpdateEvent,
+    ) {
+    }
+    fn gesture_swipe_end(
+        &self,
+        _seat: &Seat<TestState>,
+        _data: &mut TestState,
+        _event: &GestureSwipeEndEvent,
+    ) {
+    }
+    fn gesture_pinch_begin(
+        &self,
+        _seat: &Seat<TestState>,
+        _data: &mut TestState,
+        _event: &GesturePinchBeginEvent,
+    ) {
+    }
+    fn gesture_pinch_update(
+        &self,
+        _seat: &Seat<TestState>,
+        _data: &mut TestState,
+        _event: &GesturePinchUpdateEvent,
+    ) {
+    }
+    fn gesture_pinch_end(
+        &self,
+        _seat: &Seat<TestState>,
+        _data: &mut TestState,
+        _event: &GesturePinchEndEvent,
+    ) {
+    }
+    fn gesture_hold_begin(
+        &self,
+        _seat: &Seat<TestState>,
+        _data: &mut TestState,
+        _event: &GestureHoldBeginEvent,
+    ) {
+    }
+    fn gesture_hold_end(&self, _seat: &Seat<TestState>, _data: &mut TestState, _event: &GestureHoldEndEvent) {
+    }
+    fn leave(&self, _seat: &Seat<TestState>, _data: &mut TestState, _serial: Serial, _time: InputTime) {}
+}
+
+impl TouchTarget<TestState> for TestTarget {
+    fn down(&self, _seat: &Seat<TestState>, _data: &mut TestState, _event: &DownEvent) {}
+    fn up(&self, _seat: &Seat<TestState>, _data: &mut TestState, _event: &UpEvent) {}
+    fn motion(&self, _seat: &Seat<TestState>, _data: &mut TestState, _event: &TouchMotionEvent) {}
+    fn frame(&self, _seat: &Seat<TestState>, _data: &mut TestState, _marker: FrameMarker) {}
+    fn cancel(&self, _seat: &Seat<TestState>, _data: &mut TestState, _marker: FrameMarker) {}
+    fn shape(&self, _seat: &Seat<TestState>, _data: &mut TestState, _event: &ShapeEvent) {}
+    fn orientation(&self, _seat: &Seat<TestState>, _data: &mut TestState, _event: &OrientationEvent) {}
+    fn last_frame(&self, _seat: &Seat<TestState>, _data: &mut TestState) -> Option<FrameMarker> {
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct InterceptorEvent {
+    source: KeyboardSource,
+    keycode: Keycode,
+    state: KeyState,
+    modifiers: bool,
+}
+
+struct RecordingInterceptor {
+    events: Arc<Mutex<Vec<InterceptorEvent>>>,
+    results: VecDeque<KeyboardInputInterception>,
+}
+
+impl RecordingInterceptor {
+    fn new(
+        events: Arc<Mutex<Vec<InterceptorEvent>>>,
+        results: impl IntoIterator<Item = KeyboardInputInterception>,
+    ) -> Self {
+        Self {
+            events,
+            results: results.into_iter().collect(),
+        }
+    }
+}
+
+impl KeyboardInputInterceptor<TestState> for RecordingInterceptor {
+    fn input(
+        &mut self,
+        _data: &mut TestState,
+        _seat: &Seat<TestState>,
+        source: KeyboardSource,
+        keycode: Keycode,
+        state: KeyState,
+        modifiers: Option<ModifiersState>,
+        _serial: Serial,
+        _time: InputTime,
+    ) -> KeyboardInputInterception {
+        self.events.lock().unwrap().push(InterceptorEvent {
+            source,
+            keycode,
+            state,
+            modifiers: modifiers.is_some(),
+        });
+        self.results
+            .pop_front()
+            .unwrap_or(KeyboardInputInterception::Forward)
+    }
+}
+
+struct TestRoutingGrab {
+    start_data: GrabStartData<TestState>,
+    calls: Arc<AtomicUsize>,
+    forward: bool,
+}
+
+impl TestRoutingGrab {
+    fn new(calls: Arc<AtomicUsize>, forward: bool) -> Self {
+        Self {
+            start_data: GrabStartData {
+                focus: Some(TestTarget),
+            },
+            calls,
+            forward,
+        }
+    }
+}
+
+impl KeyboardGrab<TestState> for TestRoutingGrab {
+    fn input(
+        &mut self,
+        data: &mut TestState,
+        handle: &mut KeyboardInnerHandle<'_, TestState>,
+        keycode: Keycode,
+        state: KeyState,
+        modifiers: Option<ModifiersState>,
+        serial: Serial,
+        time: InputTime,
+    ) {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        if self.forward {
+            handle.input(data, keycode, state, modifiers, serial, time);
+        }
+    }
+
+    fn set_focus(
+        &mut self,
+        data: &mut TestState,
+        handle: &mut KeyboardInnerHandle<'_, TestState>,
+        focus: Option<TestTarget>,
+        serial: Serial,
+    ) {
+        handle.set_focus(data, focus, serial);
+    }
+
+    fn start_data(&self) -> &GrabStartData<TestState> {
+        &self.start_data
+    }
+
+    fn unset(&mut self, _data: &mut TestState) {}
+}
+
+fn setup() -> (TestState, Seat<TestState>, KeyboardHandle<TestState>) {
+    let mut state = TestState::new();
+    let mut seat = state.seat_state.new_seat("test-seat");
+    let keyboard = seat
+        .add_keyboard(XkbConfig::default(), 200, 25)
+        .expect("failed to initialize test keyboard");
+    keyboard.set_focus(&mut state, Some(TestTarget), SERIAL_COUNTER.next_serial());
+    state.target_events.clear();
+    state.entered_keys.clear();
+    (state, seat, keyboard)
+}
+
+fn forward_input_from_source(
+    state: &mut TestState,
+    keyboard: &KeyboardHandle<TestState>,
+    source: KeyboardSource,
+    keycode: Keycode,
+    key_state: KeyState,
+) {
+    keyboard.input_from_source(
+        source,
+        state,
+        keycode,
+        key_state,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        |_, _, _| FilterResult::<()>::Forward,
+    );
+}
+
+#[test]
+fn input_interceptor_does_not_change_grab_state() {
+    let (mut state, _seat, keyboard) = setup();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        events.clone(),
+        [KeyboardInputInterception::Intercept],
+    ));
+
+    assert!(!keyboard.is_grabbed());
+
+    let serial = SERIAL_COUNTER.next_serial();
+    let calls = Arc::new(AtomicUsize::new(0));
+    keyboard.set_grab(&mut state, TestRoutingGrab::new(calls, true), serial);
+    assert!(keyboard.is_grabbed());
+    assert!(keyboard.has_grab(serial));
+
+    keyboard.unset_grab(&mut state);
+    assert!(!keyboard.is_grabbed());
+    assert!(!keyboard.has_grab(serial));
+
+    keyboard.input_forward(
+        &mut state,
+        Keycode::new(29),
+        KeyState::Pressed,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+    assert_eq!(events.lock().unwrap().len(), 1);
+    assert!(state.target_events.is_empty());
+}
+
+#[test]
+fn forwarded_press_without_focus_is_advertised_on_later_enter() {
+    let (mut state, _seat, keyboard) = setup();
+    keyboard.set_focus(&mut state, None, SERIAL_COUNTER.next_serial());
+
+    let keycode = Keycode::new(43);
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Pressed,
+    );
+
+    assert!(state.target_events.is_empty());
+    assert!(state.entered_keys.is_empty());
+    assert!(
+        keyboard
+            .arc
+            .internal
+            .lock()
+            .unwrap()
+            .forwarded_pressed_keys
+            .contains(&keycode)
+    );
+
+    keyboard.set_focus(&mut state, Some(TestTarget), SERIAL_COUNTER.next_serial());
+    assert_eq!(state.entered_keys, vec![vec![keycode]]);
+    state.target_events.clear();
+
+    let interceptor_events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        interceptor_events.clone(),
+        [KeyboardInputInterception::Intercept],
+    ));
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Released,
+    );
+
+    assert!(interceptor_events.lock().unwrap().is_empty());
+    assert_eq!(
+        state.target_events,
+        vec![TargetEvent::Key(keycode, KeyState::Released)]
+    );
+    assert!(
+        !keyboard
+            .arc
+            .internal
+            .lock()
+            .unwrap()
+            .forwarded_pressed_keys
+            .contains(&keycode)
+    );
+}
+
+#[test]
+fn routing_grab_forwards_into_interceptor() {
+    let (mut state, _seat, keyboard) = setup();
+    let interceptor_events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        interceptor_events.clone(),
+        [KeyboardInputInterception::Intercept],
+    ));
+
+    let routing_calls = Arc::new(AtomicUsize::new(0));
+    keyboard.set_grab(
+        &mut state,
+        TestRoutingGrab::new(routing_calls.clone(), true),
+        SERIAL_COUNTER.next_serial(),
+    );
+
+    let keycode = Keycode::new(30);
+    keyboard.input_forward(
+        &mut state,
+        keycode,
+        KeyState::Pressed,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+
+    assert_eq!(routing_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        *interceptor_events.lock().unwrap(),
+        vec![InterceptorEvent {
+            source: KeyboardSource::Physical,
+            keycode,
+            state: KeyState::Pressed,
+            modifiers: false,
+        }]
+    );
+    assert!(state.target_events.is_empty());
+}
+
+#[test]
+fn routing_grab_can_consume_before_interceptor() {
+    let (mut state, _seat, keyboard) = setup();
+    let interceptor_events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        interceptor_events.clone(),
+        [KeyboardInputInterception::Intercept],
+    ));
+
+    let routing_calls = Arc::new(AtomicUsize::new(0));
+    keyboard.set_grab(
+        &mut state,
+        TestRoutingGrab::new(routing_calls.clone(), false),
+        SERIAL_COUNTER.next_serial(),
+    );
+
+    keyboard.input_forward(
+        &mut state,
+        Keycode::new(31),
+        KeyState::Pressed,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+
+    assert_eq!(routing_calls.load(Ordering::Relaxed), 1);
+    assert!(interceptor_events.lock().unwrap().is_empty());
+    assert!(state.target_events.is_empty());
+}
+
+#[test]
+fn routing_grab_consumed_release_clears_intercepted_pressed_state() {
+    let (mut state, _seat, keyboard) = setup();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        events.clone(),
+        [KeyboardInputInterception::Intercept],
+    ));
+
+    let keycode = Keycode::new(41);
+    keyboard.input_forward(
+        &mut state,
+        keycode,
+        KeyState::Pressed,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+    assert!(
+        keyboard
+            .arc
+            .internal
+            .lock()
+            .unwrap()
+            .intercepted_pressed_keys
+            .contains_key(&keycode)
+    );
+
+    let routing_calls = Arc::new(AtomicUsize::new(0));
+    keyboard.set_grab(
+        &mut state,
+        TestRoutingGrab::new(routing_calls.clone(), false),
+        SERIAL_COUNTER.next_serial(),
+    );
+    keyboard.input_forward(
+        &mut state,
+        keycode,
+        KeyState::Released,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+
+    assert_eq!(routing_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(events.lock().unwrap().len(), 1);
+    assert!(state.target_events.is_empty());
+    assert!(
+        !keyboard
+            .arc
+            .internal
+            .lock()
+            .unwrap()
+            .intercepted_pressed_keys
+            .contains_key(&keycode)
+    );
+}
+
+#[test]
+fn consumed_release_clears_forwarded_pressed_state() {
+    let (mut state, _seat, keyboard) = setup();
+    let keycode = Keycode::new(32);
+
+    keyboard.input_forward(
+        &mut state,
+        keycode,
+        KeyState::Pressed,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+    assert!(
+        keyboard
+            .arc
+            .internal
+            .lock()
+            .unwrap()
+            .forwarded_pressed_keys
+            .contains(&keycode)
+    );
+
+    keyboard.set_grab(
+        &mut state,
+        TestRoutingGrab::new(Arc::new(AtomicUsize::new(0)), false),
+        SERIAL_COUNTER.next_serial(),
+    );
+    keyboard.input_forward(
+        &mut state,
+        keycode,
+        KeyState::Released,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+
+    assert!(
+        !keyboard
+            .arc
+            .internal
+            .lock()
+            .unwrap()
+            .forwarded_pressed_keys
+            .contains(&keycode)
+    );
+    assert_eq!(
+        state.target_events,
+        vec![TargetEvent::Key(keycode, KeyState::Pressed)]
+    );
+}
+
+#[test]
+fn interceptor_does_not_steal_release_for_forwarded_press() {
+    let (mut state, _seat, keyboard) = setup();
+    let keycode = Keycode::new(33);
+
+    keyboard.input_forward(
+        &mut state,
+        keycode,
+        KeyState::Pressed,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+
+    let interceptor_events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        interceptor_events.clone(),
+        [KeyboardInputInterception::Intercept],
+    ));
+
+    keyboard.input_forward(
+        &mut state,
+        keycode,
+        KeyState::Released,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+
+    assert!(interceptor_events.lock().unwrap().is_empty());
+    assert_eq!(
+        state.target_events,
+        vec![
+            TargetEvent::Key(keycode, KeyState::Pressed),
+            TargetEvent::Key(keycode, KeyState::Released),
+        ]
+    );
+
+    let intercepted_key = Keycode::new(34);
+    keyboard.input_forward(
+        &mut state,
+        intercepted_key,
+        KeyState::Pressed,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+    assert_eq!(interceptor_events.lock().unwrap().len(), 1);
+    assert_eq!(state.target_events.len(), 2);
+}
+
+#[test]
+fn intercepted_release_does_not_leak_after_interceptor_is_unset() {
+    let (mut state, _seat, keyboard) = setup();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        events.clone(),
+        [KeyboardInputInterception::Intercept],
+    ));
+
+    let keycode = Keycode::new(37);
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Pressed,
+    );
+    keyboard.unset_input_interceptor();
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Released,
+    );
+
+    assert_eq!(events.lock().unwrap().len(), 1);
+    assert!(state.target_events.is_empty());
+    assert!(
+        !keyboard
+            .arc
+            .internal
+            .lock()
+            .unwrap()
+            .intercepted_pressed_keys
+            .contains_key(&keycode)
+    );
+}
+
+#[test]
+fn filtered_release_does_not_poison_next_key_cycle() {
+    let (mut state, _seat, keyboard) = setup();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        events.clone(),
+        [KeyboardInputInterception::Intercept],
+    ));
+
+    let keycode = Keycode::new(42);
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Pressed,
+    );
+
+    let intercepted = keyboard.input_from_source(
+        KeyboardSource::Physical,
+        &mut state,
+        keycode,
+        KeyState::Released,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        |_, _, _| FilterResult::Intercept(()),
+    );
+    assert_eq!(intercepted, Some(()));
+    assert_eq!(events.lock().unwrap().len(), 1);
+    assert!(state.target_events.is_empty());
+
+    // The release never reached post-routing dispatch, so ownership is cleaned when the next
+    // actual down transition starts rather than being allowed to capture the next cycle's release.
+    keyboard.unset_input_interceptor();
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Pressed,
+    );
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Released,
+    );
+
+    assert_eq!(
+        state.target_events,
+        vec![
+            TargetEvent::Key(keycode, KeyState::Pressed),
+            TargetEvent::Key(keycode, KeyState::Released),
+        ]
+    );
+    assert!(
+        !keyboard
+            .arc
+            .internal
+            .lock()
+            .unwrap()
+            .intercepted_pressed_keys
+            .contains_key(&keycode)
+    );
+}
+
+#[test]
+fn replacing_interceptor_does_not_rehome_held_release() {
+    let (mut state, _seat, keyboard) = setup();
+    let old_events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        old_events.clone(),
+        [KeyboardInputInterception::Intercept],
+    ));
+
+    let keycode = Keycode::new(38);
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Pressed,
+    );
+
+    let new_events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        new_events.clone(),
+        [KeyboardInputInterception::Intercept],
+    ));
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Released,
+    );
+
+    assert_eq!(old_events.lock().unwrap().len(), 1);
+    assert!(new_events.lock().unwrap().is_empty());
+    assert!(state.target_events.is_empty());
+
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        Keycode::new(39),
+        KeyState::Pressed,
+    );
+    assert_eq!(new_events.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn intercepted_press_release_stays_paired_across_sources() {
+    let (mut state, _seat, keyboard) = setup();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        events.clone(),
+        [
+            KeyboardInputInterception::Intercept,
+            KeyboardInputInterception::Forward,
+        ],
+    ));
+
+    let keycode = Keycode::new(40);
+    let auxiliary = KeyboardSource::new_auxiliary();
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Pressed,
+    );
+    forward_input_from_source(&mut state, &keyboard, auxiliary, keycode, KeyState::Pressed);
+    forward_input_from_source(
+        &mut state,
+        &keyboard,
+        KeyboardSource::Physical,
+        keycode,
+        KeyState::Released,
+    );
+    forward_input_from_source(&mut state, &keyboard, auxiliary, keycode, KeyState::Released);
+
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![
+            InterceptorEvent {
+                source: KeyboardSource::Physical,
+                keycode,
+                state: KeyState::Pressed,
+                modifiers: false,
+            },
+            InterceptorEvent {
+                source: KeyboardSource::Physical,
+                keycode,
+                state: KeyState::Released,
+                modifiers: false,
+            },
+        ]
+    );
+    assert!(state.target_events.is_empty());
+}
+
+#[test]
+fn intercepted_modifiers_resync_and_source_survives_routing() {
+    let (mut state, _seat, keyboard) = setup();
+    let interceptor_events = Arc::new(Mutex::new(Vec::new()));
+    keyboard.set_input_interceptor(RecordingInterceptor::new(
+        interceptor_events.clone(),
+        [
+            KeyboardInputInterception::Intercept,
+            KeyboardInputInterception::Forward,
+        ],
+    ));
+
+    keyboard.input_forward(
+        &mut state,
+        Keycode::new(35),
+        KeyState::Pressed,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        true,
+    );
+    assert!(state.target_events.is_empty());
+
+    let source = KeyboardSource::new_auxiliary();
+    let keycode = Keycode::new(36);
+    keyboard.input_forward_from_source(
+        source,
+        &mut state,
+        keycode,
+        KeyState::Pressed,
+        SERIAL_COUNTER.next_serial(),
+        InputTime::now(),
+        false,
+    );
+
+    let events = interceptor_events.lock().unwrap();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].source, KeyboardSource::Physical);
+    assert!(events[0].modifiers);
+    assert_eq!(events[1].source, source);
+    assert!(!events[1].modifiers);
+    drop(events);
+
+    assert_eq!(
+        state.target_events,
+        vec![
+            TargetEvent::Modifiers,
+            TargetEvent::Key(keycode, KeyState::Pressed)
+        ]
+    );
+}

--- a/src/wayland/input_method/input_method_handle.rs
+++ b/src/wayland/input_method/input_method_handle.rs
@@ -93,7 +93,7 @@ impl InputMethodHandle {
         f(&mut inner);
     }
 
-    /// Indicates that an input method has grabbed a keyboard
+    /// Whether the input-method client currently holds a protocol keyboard grab
     pub fn keyboard_grabbed(&self) -> bool {
         let inner = self.inner.lock().unwrap();
         let keyboard = inner.keyboard_grab.inner.lock().unwrap();
@@ -274,22 +274,20 @@ where
                 }
             }
             zwp_input_method_v2::Request::GrabKeyboard { keyboard } => {
-                let input_method = self.handle.inner.lock().unwrap();
-                self.keyboard_handle.set_grab(
-                    state,
-                    input_method.keyboard_grab.clone(),
-                    SERIAL_COUNTER.next_serial(),
-                );
+                let keyboard_grab = self.handle.inner.lock().unwrap().keyboard_grab.clone();
                 let instance = data_init.init(
                     keyboard,
                     InputMethodKeyboardUserData {
-                        handle: input_method.keyboard_grab.clone(),
+                        handle: keyboard_grab.clone(),
                         keyboard_handle: self.keyboard_handle.clone(),
                     },
                 );
-                let mut keyboard = input_method.keyboard_grab.inner.lock().unwrap();
-                keyboard.grab = Some(instance.clone());
-                keyboard.text_input_handle = self.text_input_handle.clone();
+                {
+                    let mut keyboard = keyboard_grab.inner.lock().unwrap();
+                    keyboard.grab = Some(instance.clone());
+                    keyboard.text_input_handle = self.text_input_handle.clone();
+                }
+                self.keyboard_handle.set_input_interceptor(keyboard_grab);
                 let guard = self.keyboard_handle.arc.internal.lock().unwrap();
                 instance.repeat_info(guard.repeat_rate, guard.repeat_delay);
                 let keymap_file = self.keyboard_handle.arc.keymap.lock().unwrap();
@@ -319,8 +317,24 @@ where
         }
     }
 
-    fn destroyed(&self, _state: &mut D, _client: ClientId, _input_method: &ZwpInputMethodV2) {
-        self.handle.inner.lock().unwrap().instance = None;
+    fn destroyed(&self, _state: &mut D, _client: ClientId, input_method: &ZwpInputMethodV2) {
+        let keyboard_grab = {
+            let mut inner = self.handle.inner.lock().unwrap();
+            let is_current = inner
+                .instance
+                .as_ref()
+                .is_some_and(|instance| instance.object == *input_method);
+
+            if !is_current {
+                return;
+            }
+
+            inner.instance = None;
+            inner.keyboard_grab.clone()
+        };
+
+        keyboard_grab.inner.lock().unwrap().grab = None;
+        self.keyboard_handle.unset_input_interceptor();
         self.text_input_handle.leave();
     }
 }

--- a/src/wayland/input_method/input_method_keyboard_grab.rs
+++ b/src/wayland/input_method/input_method_keyboard_grab.rs
@@ -9,10 +9,9 @@ use wayland_protocols_misc::zwp_input_method_v2::server::zwp_input_method_keyboa
 use wayland_server::backend::ClientId;
 
 use crate::input::{
-    SeatHandler,
+    Seat, SeatHandler,
     keyboard::{
-        GrabStartData as KeyboardGrabStartData, KeyboardGrab, KeyboardHandle, KeyboardInnerHandle,
-        ModifiersState,
+        KeyboardHandle, KeyboardInputInterception, KeyboardInputInterceptor, KeyboardSource, ModifiersState,
     },
 };
 use crate::wayland::text_input::TextInputHandle;
@@ -34,53 +33,50 @@ pub struct InputMethodKeyboardGrab {
     pub(crate) inner: Arc<Mutex<InputMethodKeyboard>>,
 }
 
-impl<D> KeyboardGrab<D> for InputMethodKeyboardGrab
+impl<D> KeyboardInputInterceptor<D> for InputMethodKeyboardGrab
 where
     D: SeatHandler + 'static,
 {
     fn input(
         &mut self,
         _data: &mut D,
-        _handle: &mut KeyboardInnerHandle<'_, D>,
+        _seat: &Seat<D>,
+        source: KeyboardSource,
         keycode: Keycode,
         key_state: KeyState,
         modifiers: Option<ModifiersState>,
         serial: Serial,
         time: InputTime,
-    ) {
-        let inner = self.inner.lock().unwrap();
-        let keyboard = inner.grab.as_ref().unwrap();
-        inner
-            .text_input_handle
-            .active_text_input_serial_or_default(serial.0, |serial| {
-                keyboard.key(serial, time.millis(), keycode.raw() - 8, key_state.into());
-                if let Some(serialized) = modifiers.map(|m| m.serialized) {
-                    keyboard.modifiers(
-                        serial,
-                        serialized.depressed,
-                        serialized.latched,
-                        serialized.locked,
-                        serialized.layout_effective,
-                    )
-                }
-            });
-    }
+    ) -> KeyboardInputInterception {
+        // The protocol grab only applies to physical keyboard input.
+        if source != KeyboardSource::Physical {
+            return KeyboardInputInterception::Forward;
+        }
 
-    fn set_focus(
-        &mut self,
-        data: &mut D,
-        handle: &mut KeyboardInnerHandle<'_, D>,
-        focus: Option<<D as SeatHandler>::KeyboardFocus>,
-        serial: crate::utils::Serial,
-    ) {
-        handle.set_focus(data, focus, serial)
-    }
+        let (keyboard, text_input_handle) = {
+            let inner = self.inner.lock().unwrap();
+            let Some(keyboard) = inner.grab.clone() else {
+                // The grab may have been destroyed before the interceptor is cleared.
+                return KeyboardInputInterception::Forward;
+            };
+            (keyboard, inner.text_input_handle.clone())
+        };
 
-    fn start_data(&self) -> &KeyboardGrabStartData<D> {
-        &KeyboardGrabStartData { focus: None }
-    }
+        text_input_handle.active_text_input_serial_or_default(serial.0, |serial| {
+            keyboard.key(serial, time.millis(), keycode.raw() - 8, key_state.into());
+            if let Some(serialized) = modifiers.map(|m| m.serialized) {
+                keyboard.modifiers(
+                    serial,
+                    serialized.depressed,
+                    serialized.latched,
+                    serialized.locked,
+                    serialized.layout_effective,
+                )
+            }
+        });
 
-    fn unset(&mut self, _data: &mut D) {}
+        KeyboardInputInterception::Intercept
+    }
 }
 
 /// User data of ZwpInputKeyboardGrabV2 object
@@ -99,9 +95,20 @@ impl<D: SeatHandler> fmt::Debug for InputMethodKeyboardUserData<D> {
 }
 
 impl<D: SeatHandler + 'static> Dispatch2<ZwpInputMethodKeyboardGrabV2, D> for InputMethodKeyboardUserData<D> {
-    fn destroyed(&self, state: &mut D, _client: ClientId, _object: &ZwpInputMethodKeyboardGrabV2) {
-        self.handle.inner.lock().unwrap().grab = None;
-        self.keyboard_handle.unset_grab(state);
+    fn destroyed(&self, _state: &mut D, _client: ClientId, object: &ZwpInputMethodKeyboardGrabV2) {
+        let was_current = {
+            let mut inner = self.handle.inner.lock().unwrap();
+            if inner.grab.as_ref().is_some_and(|grab| grab == object) {
+                inner.grab = None;
+                true
+            } else {
+                false
+            }
+        };
+
+        if was_current {
+            self.keyboard_handle.unset_input_interceptor();
+        }
     }
 
     fn request(


### PR DESCRIPTION
It's a pain to use libreoffice on systems with IME on COSMIC right now. GTK popups do not open at all if IME is running. It's been quite infuriating, so I'm pretty desperate to fix the situation.

### Summary
Input-method v2 currently implements grab_keyboard as a Smithay KeyboardGrab. This makes it mutually exclusive with compositor routing grabs, such as popup grabs: installing one replaces the other.

This PR moves the input-method keyboard grab to a post-routing input interceptor instead. Routing grabs still decide where keyboard input goes, while the input method can intercept physical keyboard events after that decision.

This allows popup and input-method grabs to coexist without changing KeyboardGrab semantics.

### Changes

- add a crate-internal post-routing keyboard input interceptor
- move zwp_input_method_v2.grab_keyboard to that interceptor
- keep KeyboardHandle::is_grabbed() describing Smithay routing grabs only
- preserve press/release ownership across interceptor changes and multiple keyboard sources
- clean up the interceptor when the input-method or keyboard-grab resource is destroyed
- keep the new infrastructure behind wayland_frontend
- add regression tests for grab ordering, focus changes, modifier synchronization, lifecycle cleanup, and press/release pairing

### Issues

This addresses the overlapping popup/IME keyboard-grab limitation described in niri-wm/niri#3899, which can cause popups to stop working while an IME keyboard grab is active.

### Testing
I have confirmed libreoffice popups work correctly with a running IME after the change. They also grab keyboard input and after closing return it properly.

### Downstream note

Compositors that used KeyboardHandle::is_grabbed() to detect an input-method protocol grab should use InputMethodHandle::keyboard_grabbed() for that purpose instead.

In particular, I've found cosmic-comp's XWayland eavesdropping path to be requiring this, and this will need a companion PR.

niri already distinguishes the input-method protocol grab through InputMethodHandle::keyboard_grabbed(), but has a workaround that avoids installing popup keyboard grabs while an IME grab is active. That workaround can be removed once using this change.

## AI disclosure
The code has been generated by ChatGPT, since Rust isn't my forte. But it's been thoroughly read, understood, and architecturally improved by me quite a few times before arriving here.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
