### PR TITLE
renderer/gles: disable fence export after runtime failure

### DIFF
--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -833,13 +833,20 @@ impl GlesRenderer {
         self.is_software
     }
 
-    fn export_sync_point(&self) -> Option<SyncPoint> {
+    fn export_sync_point(&mut self) -> Option<SyncPoint> {
         if self.capabilities.contains(&Capability::ExportFence) {
-            if let Ok(fence) = EGLFence::create(self.egl.display()) {
-                unsafe {
-                    self.gl.Flush();
+            match EGLFence::create(self.egl.display()) {
+                Ok(fence) => {
+                    unsafe {
+                        self.gl.Flush();
+                    }
+                    return Some(SyncPoint::from(fence));
                 }
-                return Some(SyncPoint::from(fence));
+                Err(err) => {
+                    warn!(?err, "Disabling EGL fence export after runtime failure");
+                    self.capabilities
+                        .retain(|capability| *capability != Capability::ExportFence);
+                }
             }
         }
         None

--- a/src/wayland/shell/xdg/handlers/surface.rs
+++ b/src/wayland/shell/xdg/handlers/surface.rs
@@ -172,6 +172,7 @@ where
                 let shell = &self.wm_base;
 
                 let attributes = XdgPopupSurfaceRoleAttributes {
+                    active: true,
                     parent: parent_surface,
                     server_pending: Some(PopupState {
                         // Set the positioner data as the popup geometry

--- a/src/wayland/shell/xdg/mod.rs
+++ b/src/wayland/shell/xdg/mod.rs
@@ -436,6 +436,8 @@ xdg_role!(
     /// for the xdg_popup state to take effect.
     #[derive(Debug)]
     XdgPopupSurfaceRoleAttributes {
+        active: bool,
+
         /// Holds the parent for the xdg_popup.
         ///
         /// The parent is allowed to remain unset as long
@@ -1971,6 +1973,9 @@ impl PopupSurface {
                 .unwrap()
                 .lock()
                 .unwrap();
+            if !role.active {
+                return Ok(None);
+            }
             if role.parent.is_none() {
                 return Err((
                     xdg_surface::Error::NotConstructed,


### PR DESCRIPTION
## Description

- disable ExportFence after EGLFence::create fails at runtime
- use the existing synchronized glFinish fallback for the failed frame and subsequent frames
- avoid retrying a broken eglCreateSync call on every rendered frame

Some context:
GlesRenderer enables ExportFence when the required GL extension is advertised. Some drivers advertise support but still fail when Smithay attempts to create the EGL fence, occasionally without setting an EGL error.

export_sync_point currently returns None after that failure but retains the capability, causing the same failing EGL call and warning to repeat every frame.

Once fence creation fails for a renderer context, this change removes ExportFence from that renderer’s capabilities. Smithay then follows its existing glFinish fallback path, preserving synchronization and correctness without repeated EGL calls.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
