### PR TITLE
wayland/compositor: add schedule_barrier handler for commit timing

### DIFF
--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -598,6 +598,14 @@ pub trait CompositorHandler {
     /// using a pre-commit hook (see [`add_pre_commit_hook`]).
     fn commit(&mut self, surface: &WlSurface);
 
+    /// Surface barrier handler
+    ///
+    /// When this is called, there is likely at least one blocker in a cancelled or pending state,
+    /// preventing the surface commit from calling [`CompositorHandler::commit`].
+    ///
+    /// This allows compositor to check `CommitTimerBarrierStateUserData` and release it at the appropriate time.
+    fn schedule_barrier(&mut self, _surface: &WlSurface) {}
+
     /// The surface was destroyed.
     ///
     /// This allows the compositor to clean up any uses of the surface.

--- a/src/wayland/compositor/mod.rs
+++ b/src/wayland/compositor/mod.rs
@@ -648,7 +648,7 @@ impl CompositorClientState {
     /// surface belonging to this client.
     pub fn blocker_cleared<D: CompositorHandler + 'static>(&self, state: &mut D, dh: &DisplayHandle) {
         let transactions = if let Some(queue) = self.queue.lock().unwrap().as_mut() {
-            queue.take_ready()
+            queue.take_ready().0
         } else {
             Vec::new()
         };

--- a/src/wayland/compositor/transaction.rs
+++ b/src/wayland/compositor/transaction.rs
@@ -290,9 +290,10 @@ impl TransactionQueue {
         self.transactions.push(t);
     }
 
-    pub(crate) fn take_ready(&mut self) -> Vec<Transaction> {
+    pub(crate) fn take_ready(&mut self) -> (Vec<Transaction>, u32) {
         // FIXME: Get rid of this allocation here
         let mut ready_transactions = Vec::new();
+        let mut pending_transactions_count = 0u32;
         // this is a very non-optimized implementation
         // we just iterate over the queue of transactions, keeping track of which
         // surface we have seen as they encode transaction dependencies
@@ -311,6 +312,7 @@ impl TransactionQueue {
                     continue;
                 }
                 BlockerState::Pending => {
+                    pending_transactions_count += 1;
                     skip = true;
                 }
                 BlockerState::Released => {}
@@ -346,6 +348,6 @@ impl TransactionQueue {
             }
         }
 
-        ready_transactions
+        (ready_transactions, pending_transactions_count)
     }
 }

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -324,18 +324,18 @@ impl PrivateSurfaceData {
             // release the mutex, as applying the transaction will try to lock it
             std::mem::drop(my_data);
             // trigger the queue
-            let transactions = queue.take_ready();
+            let (transactions, pending_transactions_count) = queue.take_ready();
             // release the queue lock
             std::mem::drop(queue_guard);
 
-            // If empty, there is likely at least one blocker that has been cancelled or is pending, so notify compositor to handle it.
-            if transactions.is_empty() {
+            // apply might call commit, which might call blocker_cleared, so we need to free the queue before applying
+            for transaction in transactions {
+                transaction.apply(dh, state)
+            }
+
+            // there is likely at least one blocker is pending, so notify compositor to handle it.
+            if pending_transactions_count > 0 {
                 state.schedule_barrier(surface);
-            } else {
-                // apply might call commit, which might call blocker_cleared, so we need to free the queue before applying
-                for transaction in transactions {
-                    transaction.apply(dh, state)
-                }
             }
         }
     }

--- a/src/wayland/compositor/tree.rs
+++ b/src/wayland/compositor/tree.rs
@@ -327,9 +327,15 @@ impl PrivateSurfaceData {
             let transactions = queue.take_ready();
             // release the queue lock
             std::mem::drop(queue_guard);
-            // apply might call commit, which might call blocker_cleared, so we need to free the queue before applying
-            for transaction in transactions {
-                transaction.apply(dh, state)
+
+            // If empty, there is likely at least one blocker that has been cancelled or is pending, so notify compositor to handle it.
+            if transactions.is_empty() {
+                state.schedule_barrier(surface);
+            } else {
+                // apply might call commit, which might call blocker_cleared, so we need to free the queue before applying
+                for transaction in transactions {
+                    transaction.apply(dh, state)
+                }
             }
         }
     }


### PR DESCRIPTION
When the surface has pending transaction, at least one blocker may be in a pending or cancelled state, preventing the commit from proceeding.

This PR adds a `CompositorHandler::schedule_barrier` hook to notify the compositor when there are no ready transactions, allowing it to inspect and release the corresponding barrier state.

I’ve tried various approaches, but I couldn’t get `commit-timing-v1` to work correctly with the existing Smithay. The main issue was the lack of a proper point in time to handle blockers.

I implemented `commit-timing` on top of this approach, and it is currently working well in my tests. I’d like to propose this approach as a basis for implementing commit-timing. There may be better approaches, but I think this could be a reasonable short-term solution.

## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
