### PR TITLE
xwayland: forward unrecognized X11 property changes to the compositor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ is used for timestamps for synthesized events.
 
 ### Additions
 
+- Add `WmWindowProperty::Other` to forward unrecognized X11 property changes to the compositor.
+
 - ExtBackgroundEffect protocol is now available in `smithay::wayland::background_effect` module.
 
 `crate::input::dnd` was introduced to enable implementation of Drag&Drop operations on custom types.

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -293,6 +293,9 @@ pub enum WmWindowProperty {
     Pid,
     Opacity,
     FrameExtents,
+    /// An unrecognized atom changed; forwarded so the compositor can react to
+    /// compositor/application-specific properties.
+    Other(Atom),
 }
 
 /// https://x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#input_focus
@@ -1612,7 +1615,7 @@ impl X11Surface {
                 Ok(Some(WmWindowProperty::FrameExtents))
             }
 
-            _ => Ok(None), // unknown
+            _ => Ok(Some(WmWindowProperty::Other(atom))),
         }
     }
 


### PR DESCRIPTION
## Description
Hi 👋 , thanks for this great project first of all. For my project ([moonshine](https://github.com/hgaiser/moonshine)) I needed access to a custom atom (`STEAM_OVERLAY` from Steam), but this was never passed to my compositor.

This PR adds a fallback so that if an atom is not known, it still passes it to the compositor as an `Other` atom.

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
