### PR TITLE
README: add Parallax to the list of compositors using Smithay

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Rust.
 - [Local Desktop](https://github.com/localdesktop/localdesktop): An Android app for running GUI Linux via PRoot and Wayland.
 - [Otto](https://github.com/nongio/otto): A gesture-driven stacking compositor.
 - [DriftWM](https://github.com/malbiruk/driftwm): A trackpad-first infinite canvas Wayland compositor.
+- [Parallax](https://github.com/YoungEscapist/parallax-wm): Windows on one infinite canvas, with the screen as a camera over it
 
 ## System Dependencies
 


### PR DESCRIPTION
Parallax is a Wayland compositor built on Smithay: windows live on one infinite canvas and the output is a camera over it — workspaces are places on that plane rather than separate worlds, and tiling happens inside a region of the canvas.

https://github.com/YoungEscapist/parallax-wm

It is a beta (first tagged release today), GPL-3.0-or-later, running daily on the author's machine with Xwayland, Steam, screen sharing and two monitors. One line added at the end of the list; nothing else touched.

Full disclosure, since it is unusual and the repository says so on its front page: the code is written by an LLM (Claude), with a human setting the tasks and reviewing. If that puts it outside what you want listed, no hard feelings — close it.