### PR TITLE
Update winit to 0.31-beta.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ wayland-protocols-misc = { version = "0.3.12", features = ["server"], optional =
 wayland-server = { version = "0.31.13", optional = true }
 wayland-sys = { version = "0.31.11", optional = true }
 wayland-backend = { version = "0.3.15", optional = true }
-winit = { version = "0.31.0-beta.2", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
+winit = { version = "=0.31.0-beta.3", default-features = false, features = ["wayland", "wayland-dlopen", "x11"], optional = true }
 x11rb = { version = "0.13.0", optional = true, features = ["res", "sync"]}
 xkbcommon = { version = "0.9.0", features = ["wayland"]}
 encoding_rs = { version = "0.8.33", optional = true }

--- a/src/backend/winit/input.rs
+++ b/src/backend/winit/input.rs
@@ -137,6 +137,7 @@ impl PointerAxisEvent<WinitInput> for WinitMouseWheelEvent {
         match self.delta {
             MouseScrollDelta::LineDelta(_, _) => AxisSource::Wheel,
             MouseScrollDelta::PixelDelta(_) => AxisSource::Continuous,
+            _ => AxisSource::Continuous,
         }
     }
 
@@ -144,7 +145,7 @@ impl PointerAxisEvent<WinitInput> for WinitMouseWheelEvent {
         match (axis, self.delta) {
             (Axis::Horizontal, MouseScrollDelta::PixelDelta(delta)) => Some(-delta.x),
             (Axis::Vertical, MouseScrollDelta::PixelDelta(delta)) => Some(-delta.y),
-            (_, MouseScrollDelta::LineDelta(_, _)) => None,
+            _ => None,
         }
     }
 
@@ -153,7 +154,7 @@ impl PointerAxisEvent<WinitInput> for WinitMouseWheelEvent {
         match (axis, self.delta) {
             (Axis::Horizontal, MouseScrollDelta::LineDelta(x, _)) => Some(-x as f64 * 120.),
             (Axis::Vertical, MouseScrollDelta::LineDelta(_, y)) => Some(-y as f64 * 120.),
-            (_, MouseScrollDelta::PixelDelta(_)) => None,
+            _ => None,
         }
     }
 

--- a/src/backend/winit/mod.rs
+++ b/src/backend/winit/mod.rs
@@ -557,7 +557,7 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
                     }
                     // TODO Handle tablet events
                     PointerSource::TabletTool { .. } => {}
-                    PointerSource::Unknown => {}
+                    _ => (),
                 }
             }
             WindowEvent::MouseWheel { delta, .. } => {
@@ -629,7 +629,7 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
                     },
                     // TODO Handle tablet events
                     ButtonSource::TabletTool { .. } => {}
-                    ButtonSource::Unknown(_) => {}
+                    _ => {}
                 }
             }
             WindowEvent::PointerLeft {
@@ -644,25 +644,7 @@ impl<F: FnMut(WinitEvent)> ApplicationHandler for WinitEventLoopApp<'_, F> {
                 };
                 (self.callback)(WinitEvent::Input(event));
             }
-            WindowEvent::DragDropped { .. }
-            | WindowEvent::Destroyed
-            | WindowEvent::PointerEntered { .. }
-            | WindowEvent::PointerLeft { .. }
-            | WindowEvent::ModifiersChanged(_)
-            | WindowEvent::KeyboardInput { .. }
-            | WindowEvent::DragEntered { .. }
-            | WindowEvent::DragLeft { .. }
-            | WindowEvent::DragMoved { .. }
-            | WindowEvent::Ime(_)
-            | WindowEvent::Moved(_)
-            | WindowEvent::Occluded(_)
-            | WindowEvent::DoubleTapGesture { .. }
-            | WindowEvent::ThemeChanged(_)
-            | WindowEvent::PinchGesture { .. }
-            | WindowEvent::TouchpadPressure { .. }
-            | WindowEvent::RotationGesture { .. }
-            | WindowEvent::PanGesture { .. }
-            | WindowEvent::ActivationTokenDone { .. } => (),
+            _ => (),
         }
     }
 }


### PR DESCRIPTION
## Description

Upstream API breaks:

* `WindowEvent`, `PointerSource`, `ButtonSource`, and `MouseScrollDelta` have been marked `#[non_exhaustive]`.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
