### PR TITLE
renderer: add finish_without_export for GLES frames

### DIFF
--- a/src/backend/drm/compositor/frame_result.rs
+++ b/src/backend/drm/compositor/frame_result.rs
@@ -343,7 +343,7 @@ where
                 .clear(Color32F::BLACK, &clear_damage)
                 .map_err(BlitFrameResultError::Rendering)?;
 
-            sync = Some(frame.finish().map_err(BlitFrameResultError::Rendering)?);
+            sync = Some(frame.finish(true).map_err(BlitFrameResultError::Rendering)?);
         }
 
         // first do the potential blit
@@ -410,7 +410,7 @@ where
                     .map_err(BlitFrameResultError::Rendering)?;
             }
 
-            Ok(frame.finish().map_err(BlitFrameResultError::Rendering)?)
+            Ok(frame.finish(true).map_err(BlitFrameResultError::Rendering)?)
         } else {
             Ok(sync.unwrap_or_default())
         }

--- a/src/backend/drm/compositor/mod.rs
+++ b/src/backend/drm/compositor/mod.rs
@@ -3358,7 +3358,7 @@ where
                             element.transform(),
                             element.alpha(),
                         )?;
-                        let _ = frame.finish()?.wait(); // what can we do?
+                        let _ = frame.finish(true)?.wait(); // what can we do?
                         Ok(())
                     },
                 )

--- a/src/backend/renderer/damage/mod.rs
+++ b/src/backend/renderer/damage/mod.rs
@@ -953,7 +953,7 @@ impl OutputDamageTracker {
             // return the element damage so that we can re-use the allocation
             std::mem::swap(&mut self.element_damage, &mut element_damage);
             std::mem::swap(&mut self.element_opaque_regions, &mut element_opaque_regions);
-            frame.finish()
+            frame.finish(true)
         })();
 
         match render_res {

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -2529,17 +2529,32 @@ impl Frame for GlesFrame<'_, '_> {
 
     #[profiling::function]
     fn finish(mut self) -> Result<SyncPoint, Self::Error> {
-        self.finish_internal()
+        self.finish_internal_impl(true)
+            .map(|opt| opt.unwrap_or_else(SyncPoint::signaled))
     }
 }
 
 impl GlesFrame<'_, '_> {
     #[profiling::function]
-    fn finish_internal(&mut self) -> Result<SyncPoint, GlesError> {
+    pub fn finish_without_export(mut self) -> Result<(), GlesError> {
+        self.finish_internal_impl(false).map(|_| ())
+    }
+
+    #[profiling::function]
+    pub(crate) fn finish_internal(&mut self) -> Result<SyncPoint, GlesError> {
+        self.finish_internal_impl(true)
+            .map(|opt| opt.unwrap_or_else(SyncPoint::signaled))
+    }
+
+    fn finish_internal_impl(&mut self, export_fence: bool) -> Result<Option<SyncPoint>, GlesError> {
         let _guard = self.span.enter();
 
         if self.finished.swap(true, Ordering::SeqCst) {
-            return Ok(SyncPoint::signaled());
+            return Ok(if export_fence {
+                Some(SyncPoint::signaled())
+            } else {
+                None
+            });
         }
 
         let finish_gpu_span = self
@@ -2570,20 +2585,26 @@ impl GlesFrame<'_, '_> {
             self.renderer.profiler.exit(&self.renderer.gl, span);
         }
 
-        // if we support egl fences we should use it
-        if let Some(sync_point) = self.renderer.export_sync_point() {
-            // Sync after glFlush in export_sync_point() and right before returning.
-            self.renderer.profiler.sync_gpu(&self.renderer.gl);
-            return Ok(sync_point);
+        if export_fence {
+            // if we support egl fences we should use it
+            if let Some(sync_point) = self.renderer.export_sync_point() {
+                // Sync after glFlush in export_sync_point() and right before returning.
+                self.renderer.profiler.sync_gpu(&self.renderer.gl);
+                return Ok(Some(sync_point));
+            }
         }
 
         self.renderer.profiler.sync_gpu(&self.renderer.gl);
 
-        // as a last option we force finish, this is unlikely to happen
-        unsafe {
-            self.renderer.gl.Finish();
+        if export_fence {
+            // as a last option we force finish, this is unlikely to happen
+            unsafe {
+                self.renderer.gl.Finish();
+            }
+            Ok(Some(SyncPoint::signaled()))
+        } else {
+            Ok(None)
         }
-        Ok(SyncPoint::signaled())
     }
 
     /// Overrides the default texture shader used, if none is specified.

--- a/src/backend/renderer/gles/mod.rs
+++ b/src/backend/renderer/gles/mod.rs
@@ -2528,21 +2528,16 @@ impl Frame for GlesFrame<'_, '_> {
     }
 
     #[profiling::function]
-    fn finish(mut self) -> Result<SyncPoint, Self::Error> {
-        self.finish_internal_impl(true)
+    fn finish(mut self, exportable: bool) -> Result<SyncPoint, Self::Error> {
+        self.finish_internal_impl(exportable)
             .map(|opt| opt.unwrap_or_else(SyncPoint::signaled))
     }
 }
 
 impl GlesFrame<'_, '_> {
     #[profiling::function]
-    pub fn finish_without_export(mut self) -> Result<(), GlesError> {
-        self.finish_internal_impl(false).map(|_| ())
-    }
-
-    #[profiling::function]
-    pub(crate) fn finish_internal(&mut self) -> Result<SyncPoint, GlesError> {
-        self.finish_internal_impl(true)
+    pub(crate) fn finish_internal(&mut self, exportable: bool) -> Result<SyncPoint, GlesError> {
+        self.finish_internal_impl(exportable)
             .map(|opt| opt.unwrap_or_else(SyncPoint::signaled))
     }
 
@@ -3294,7 +3289,7 @@ impl GlesFrame<'_, '_> {
 
 impl Drop for GlesFrame<'_, '_> {
     fn drop(&mut self) {
-        match self.finish_internal() {
+        match self.finish_internal(false) {
             Ok(sync) => {
                 let _ = sync.wait(); // nothing we can do
             }

--- a/src/backend/renderer/glow.rs
+++ b/src/backend/renderer/glow.rs
@@ -373,16 +373,16 @@ impl Frame for GlowFrame<'_, '_> {
     }
 
     #[profiling::function]
-    fn finish(mut self) -> Result<sync::SyncPoint, Self::Error> {
-        self.finish_internal()
+    fn finish(mut self, exportable: bool) -> Result<sync::SyncPoint, Self::Error> {
+        self.finish_internal(exportable)
     }
 }
 
 impl GlowFrame<'_, '_> {
     #[profiling::function]
-    fn finish_internal(&mut self) -> Result<sync::SyncPoint, GlesError> {
+    fn finish_internal(&mut self, exportable: bool) -> Result<sync::SyncPoint, GlesError> {
         if let Some(frame) = self.frame.take() {
-            frame.finish()
+            frame.finish(exportable)
         } else {
             Ok(sync::SyncPoint::default())
         }
@@ -391,7 +391,7 @@ impl GlowFrame<'_, '_> {
 
 impl Drop for GlowFrame<'_, '_> {
     fn drop(&mut self) {
-        if let Err(err) = self.finish_internal() {
+        if let Err(err) = self.finish_internal(false) {
             warn!("Ignored error finishing GlowFrame on drop: {}", err);
         }
     }

--- a/src/backend/renderer/mod.rs
+++ b/src/backend/renderer/mod.rs
@@ -359,7 +359,7 @@ pub trait Frame {
     /// Leaking the frame instead will leak resources and can cause any of the previous effects.
     /// Leaking might make the renderer return Errors and force it's recreation.
     /// Leaking may not cause otherwise undefined behavior and program execution will always continue normally.
-    fn finish(self) -> Result<sync::SyncPoint, Self::Error>;
+    fn finish(self, exportable: bool) -> Result<sync::SyncPoint, Self::Error>;
 }
 
 /// Helper trait for [`Frame`]s, that allow referencing the underlying renderer

--- a/src/backend/renderer/multigpu/mod.rs
+++ b/src/backend/renderer/multigpu/mod.rs
@@ -1511,7 +1511,7 @@ where
 {
     fn flush_frame(&mut self) -> Result<(), Error<R, T>> {
         if self.target.is_some() {
-            let _ = self.finish_internal()?;
+            let _ = self.finish_internal(false)?;
             // now the frame is gone, lets use our unholy ptr till the end of this call:
             // SAFETY:
             // - The renderer will never be invalid because the lifetime of the frame must be shorter than the renderer.
@@ -1545,9 +1545,9 @@ where
 
     #[instrument(level = "trace", parent = &self.span, skip(self))]
     #[profiling::function]
-    fn finish_internal(&mut self) -> Result<sync::SyncPoint, Error<R, T>> {
+    fn finish_internal(&mut self, exportable: bool) -> Result<sync::SyncPoint, Error<R, T>> {
         if let Some(frame) = self.frame.take() {
-            let sync = frame.finish().map_err(Error::Render)?;
+            let sync = frame.finish(exportable).map_err(Error::Render)?;
 
             // now the frame is gone, lets use our unholy ptr till the end of this call:
             // SAFETY:
@@ -1592,7 +1592,7 @@ where
                             1.0,
                         )
                         .map_err(Error::Target)?;
-                    let sync = frame.finish().map_err(Error::Target)?;
+                    let sync = frame.finish(true).map_err(Error::Target)?;
                     render
                         .renderer_mut()
                         .cleanup_texture_cache()
@@ -1700,7 +1700,7 @@ where
                             .map_err(Error::Target)?;
                     }
                 }
-                let sync = frame.finish().map_err(Error::Target)?;
+                let sync = frame.finish(true).map_err(Error::Target)?;
                 render
                     .renderer_mut()
                     .cleanup_texture_cache()
@@ -1730,7 +1730,7 @@ where
     <<T::Device as ApiDevice>::Renderer as RendererSuper>::Error: 'static,
 {
     fn drop(&mut self) {
-        if let Err(err) = self.finish_internal() {
+        if let Err(err) = self.finish_internal(false) {
             warn!("Ignored error finishing MultiFrame on drop: {}", err);
         }
     }
@@ -2128,8 +2128,8 @@ where
     }
 
     #[profiling::function]
-    fn finish(mut self) -> Result<sync::SyncPoint, Self::Error> {
-        self.finish_internal()
+    fn finish(mut self, exportable: bool) -> Result<sync::SyncPoint, Self::Error> {
+        self.finish_internal(exportable)
     }
 }
 
@@ -2567,7 +2567,7 @@ where
             1.0,
         )
         .map_err(Error::Render)?;
-    *existing_sync_point = Some(frame.finish().map_err(Error::Render)?);
+    *existing_sync_point = Some(frame.finish(true).map_err(Error::Render)?);
 
     // shadow buffer contains our copy and is readable by target and the original buffer was never migrated
     Ok(())

--- a/src/backend/renderer/pixman/mod.rs
+++ b/src/backend/renderer/pixman/mod.rs
@@ -658,14 +658,14 @@ impl Frame for PixmanFrame<'_, '_> {
     }
 
     #[profiling::function]
-    fn finish(mut self) -> Result<SyncPoint, Self::Error> {
-        self.finish_internal()
+    fn finish(mut self, exportable: bool) -> Result<SyncPoint, Self::Error> {
+        self.finish_internal(exportable)
     }
 }
 
 impl PixmanFrame<'_, '_> {
     #[profiling::function]
-    fn finish_internal(&mut self) -> Result<SyncPoint, PixmanError> {
+    fn finish_internal(&mut self, _exportable: bool) -> Result<SyncPoint, PixmanError> {
         if self.finished.swap(true, Ordering::SeqCst) {
             return Ok(SyncPoint::signaled());
         }
@@ -685,7 +685,7 @@ impl PixmanFrame<'_, '_> {
 
 impl Drop for PixmanFrame<'_, '_> {
     fn drop(&mut self) {
-        match self.finish_internal() {
+        match self.finish_internal(false) {
             Ok(sync) => {
                 let _ = sync.wait();
             }

--- a/src/backend/renderer/test.rs
+++ b/src/backend/renderer/test.rs
@@ -276,7 +276,7 @@ impl Frame for DummyFrame {
         sync.wait().map_err(|_| DummyError::SyncInterrupted)
     }
 
-    fn finish(self) -> Result<SyncPoint, Self::Error> {
+    fn finish(self, _exportable: bool) -> Result<SyncPoint, Self::Error> {
         Ok(SyncPoint::default())
     }
 }


### PR DESCRIPTION
## Description

This PR adds `GlesFrame::finish_without_export()` to Smithay's GLES renderer.

The new method allows a GLES frame to be finalized without exporting an EGL `SyncPoint` or falling back to `glFinish()`, while still performing the normal frame finalization and texture synchronization required by Smithay.

This is useful for rendering pipelines that perform multiple intermediate passes where exporting a native EGL fence after every pass is unnecessary. The final rendering pass can still use the existing `finish()` method when a `SyncPoint` is required for synchronization outside the intermediate pipeline.

The implementation keeps the existing `finish()` behavior unchanged and factors the common finalization logic into `finish_internal_impl()` with an option controlling whether an export fence should be produced.

This change is intended to be used by COSMIC's blur rendering pipeline to avoid unnecessary synchronization overhead between intermediate blur passes. The corresponding COSMIC PR has not yet been submitted.

This PR was developed with assistance from generative AI.

## Checklist

* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).