### PR TITLE
xwayland: support window bounding shapes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ use_system_lib = ["wayland_frontend", "wayland-backend/server_system", "wayland-
 use_bindgen = ["drm-ffi/use_bindgen", "gbm/use_bindgen", "input/use_bindgen"]
 wayland_frontend = ["wayland-server", "wayland-protocols", "wayland-protocols-wlr", "wayland-protocols-misc", "tempfile"]
 x11rb_event_source = ["x11rb"]
-xwayland = ["encoding_rs", "wayland_frontend", "x11rb/composite", "x11rb/xfixes", "x11rb/randr", "x11rb_event_source", "scopeguard"]
+xwayland = ["encoding_rs", "wayland_frontend", "x11rb/composite", "x11rb/shape", "x11rb/xfixes", "x11rb/randr", "x11rb_event_source", "scopeguard"]
 test_all_features = ["default", "use_system_lib", "renderer_glow", "renderer_test"]
 
 [[example]]

--- a/src/backend/renderer/element/mod.rs
+++ b/src/backend/renderer/element/mod.rs
@@ -709,7 +709,7 @@ where
 ///
 /// See [`Id::namespaced`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct NamespacedElement<E: Element> {
+pub struct NamespacedElement<E> {
     inner: E,
     namespace: Id,
 }

--- a/src/backend/renderer/element/surface.rs
+++ b/src/backend/renderer/element/surface.rs
@@ -226,6 +226,18 @@ pub enum WaylandSurfaceTexture<R: Renderer> {
     SolidColor(Color32F),
 }
 
+impl<R: Renderer> Clone for WaylandSurfaceTexture<R>
+where
+    R::TextureId: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Texture(texture) => Self::Texture(texture.clone()),
+            Self::SolidColor(color) => Self::SolidColor(*color),
+        }
+    }
+}
+
 /// A single surface render element
 pub struct WaylandSurfaceRenderElement<R: Renderer> {
     id: Id,
@@ -241,6 +253,28 @@ pub struct WaylandSurfaceRenderElement<R: Renderer> {
     damage: DamageSnapshot<i32, BufferCoords>,
     opaque_regions: OpaqueRegions<i32, Logical>,
     texture: WaylandSurfaceTexture<R>,
+}
+
+impl<R: Renderer> Clone for WaylandSurfaceRenderElement<R>
+where
+    R::TextureId: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id.clone(),
+            location: self.location,
+            alpha: self.alpha,
+            kind: self.kind,
+            view: self.view,
+            buffer: self.buffer.clone(),
+            buffer_scale: self.buffer_scale,
+            buffer_transform: self.buffer_transform,
+            buffer_dimensions: self.buffer_dimensions,
+            damage: self.damage.clone(),
+            opaque_regions: OpaqueRegions::from_slice(&self.opaque_regions),
+            texture: self.texture.clone(),
+        }
+    }
 }
 
 impl<R: Renderer> fmt::Debug for WaylandSurfaceRenderElement<R> {

--- a/src/desktop/space/wayland/window.rs
+++ b/src/desktop/space/wayland/window.rs
@@ -1,8 +1,10 @@
+#[cfg(feature = "xwayland")]
+use crate::backend::renderer::element::utils::CropRenderElement;
 use crate::{
     backend::renderer::{
         ImportAll, Renderer,
         element::{
-            AsRenderElements, Kind,
+            AsRenderElements, Kind, NamespacedElement,
             surface::{WaylandSurfaceRenderElement, render_elements_from_surface_tree},
         },
     },
@@ -13,6 +15,15 @@ use crate::{
 };
 
 use super::{WindowOutputUserData, output_update};
+
+crate::backend::renderer::element::render_elements! {
+    /// Render elements produced by a desktop window.
+    #[derive(Debug)]
+    pub WindowRenderElement<R> where R: ImportAll;
+    Wayland=WaylandSurfaceRenderElement<R>,
+    #[cfg(feature = "xwayland")]
+    X11=NamespacedElement<CropRenderElement<WaylandSurfaceRenderElement<R>>>,
+}
 
 impl SpaceElement for Window {
     fn geometry(&self) -> Rectangle<i32, Logical> {
@@ -89,10 +100,10 @@ where
     R: Renderer + ImportAll,
     R::TextureId: Clone + 'static,
 {
-    type RenderElement = WaylandSurfaceRenderElement<R>;
+    type RenderElement = WindowRenderElement<R>;
 
     #[profiling::function]
-    fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
+    fn render_elements<C: From<Self::RenderElement>>(
         &self,
         renderer: &mut R,
         location: Point<i32, Physical>,
@@ -101,7 +112,7 @@ where
     ) -> Vec<C> {
         match self.underlying_surface() {
             WindowSurface::Wayland(s) => {
-                let mut render_elements: Vec<C> = Vec::new();
+                let mut render_elements = Vec::new();
                 let surface = s.wl_surface();
                 let popup_render_elements =
                     PopupManager::popups_for_surface(surface).flat_map(|(popup, popup_offset)| {
@@ -118,21 +129,30 @@ where
                         )
                     });
 
-                render_elements.extend(popup_render_elements);
+                render_elements.extend(popup_render_elements.map(WindowRenderElement::Wayland));
 
-                render_elements.extend(render_elements_from_surface_tree(
-                    renderer,
-                    surface,
-                    location,
-                    scale,
-                    alpha,
-                    Kind::Unspecified,
-                ));
+                render_elements.extend(
+                    render_elements_from_surface_tree(
+                        renderer,
+                        surface,
+                        location,
+                        scale,
+                        alpha,
+                        Kind::Unspecified,
+                    )
+                    .into_iter()
+                    .map(WindowRenderElement::Wayland),
+                );
 
-                render_elements
+                render_elements.into_iter().map(C::from).collect()
             }
             #[cfg(feature = "xwayland")]
-            WindowSurface::X11(s) => AsRenderElements::render_elements(s, renderer, location, scale, alpha),
+            WindowSurface::X11(s) => AsRenderElements::render_elements::<WindowRenderElement<R>>(
+                s, renderer, location, scale, alpha,
+            )
+            .into_iter()
+            .map(C::from)
+            .collect(),
         }
     }
 }

--- a/src/desktop/space/wayland/x11.rs
+++ b/src/desktop/space/wayland/x11.rs
@@ -2,8 +2,9 @@ use crate::{
     backend::renderer::{
         ImportAll, Renderer,
         element::{
-            Kind,
+            Element, Kind, NamespacedElement,
             surface::{WaylandSurfaceRenderElement, render_elements_from_surface_tree},
+            utils::CropRenderElement,
         },
     },
     desktop::{WindowSurfaceType, space::SpaceElement},
@@ -12,6 +13,16 @@ use crate::{
 };
 
 use super::{WindowOutputUserData, output_update};
+
+fn physical_shape_clip(
+    shape: Rectangle<i32, Logical>,
+    location: Point<i32, Physical>,
+    scale: Scale<f64>,
+) -> Rectangle<i32, Physical> {
+    let mut clip = shape.to_f64().to_physical(scale).to_i32_up();
+    clip.loc += location;
+    clip
+}
 
 impl SpaceElement for X11Surface {
     fn bbox(&self) -> Rectangle<i32, Logical> {
@@ -83,10 +94,10 @@ where
     R: Renderer + ImportAll,
     R::TextureId: Clone + 'static,
 {
-    type RenderElement = WaylandSurfaceRenderElement<R>;
+    type RenderElement = NamespacedElement<CropRenderElement<WaylandSurfaceRenderElement<R>>>;
 
     #[profiling::function]
-    fn render_elements<C: From<WaylandSurfaceRenderElement<R>>>(
+    fn render_elements<C: From<Self::RenderElement>>(
         &self,
         renderer: &mut R,
         location: Point<i32, Physical>,
@@ -99,6 +110,38 @@ where
         if let Some(opacity) = self.state.lock().unwrap().opacity {
             alpha *= (opacity as f32) / (u32::MAX as f32);
         }
-        render_elements_from_surface_tree(renderer, &surface, location, scale, alpha, Kind::Unspecified)
+        let elements = render_elements_from_surface_tree::<R, WaylandSurfaceRenderElement<R>>(
+            renderer,
+            &surface,
+            location,
+            scale,
+            alpha,
+            Kind::Unspecified,
+        );
+        if let Some(shape) = self.render_shape() {
+            let mut cropped = Vec::new();
+            for (shape_index, shape_rect) in shape.iter().copied().enumerate() {
+                let clip = physical_shape_clip(shape_rect, location, scale);
+                cropped.extend(
+                    elements
+                        .iter()
+                        .cloned()
+                        .filter_map(|element| CropRenderElement::from_element(element, scale, clip))
+                        .map(|element| NamespacedElement::new(element, shape_index))
+                        .map(C::from),
+                );
+            }
+            cropped
+        } else {
+            elements
+                .into_iter()
+                .filter_map(|element| {
+                    let geometry = element.geometry(scale);
+                    CropRenderElement::from_element(element, scale, geometry)
+                })
+                .map(|element| NamespacedElement::new(element, 0))
+                .map(C::from)
+                .collect()
+        }
     }
 }

--- a/src/xwayland/xwm/mod.rs
+++ b/src/xwayland/xwm/mod.rs
@@ -167,7 +167,7 @@ use wayland_server::{DisplayHandle, Resource};
 
 pub use x11rb::protocol::xproto::Window as X11Window;
 use x11rb::{
-    connection::Connection as _,
+    connection::{Connection as _, RequestConnection as _},
     errors::{ReplyError, ReplyOrIdError},
     properties::{WmHints, WmHintsState},
     protocol::{
@@ -175,6 +175,7 @@ use x11rb::{
         composite::{ConnectionExt as _, Redirect},
         randr::{ConnectionExt as _, Notify, NotifyMask},
         render::{ConnectionExt as _, CreatePictureAux, PictureWrapper},
+        shape::{self, ConnectionExt as _},
         sync::{ConnectionExt as _, Counter},
         xfixes::ConnectionExt as _,
         xproto::{
@@ -421,6 +422,10 @@ pub trait XwmHandler {
     /// A window property has changed.
     fn property_notify(&mut self, xwm: XwmId, window: X11Surface, property: WmWindowProperty) {
         let _ = (xwm, window, property);
+    }
+    /// The X Shape bounding region of a window has changed.
+    fn shape_notify(&mut self, xwm: XwmId, window: X11Surface) {
+        let _ = (xwm, window);
     }
     /// Window requests to be maximized.
     fn maximize_request(&mut self, xwm: XwmId, window: X11Surface) {
@@ -1606,6 +1611,11 @@ where
                 geometry,
                 xwm.dnd.xdnd_active.clone(),
             );
+            surface.set_depth(geo.depth);
+            if conn.extension_information(shape::X11_EXTENSION_NAME)?.is_some() {
+                conn.shape_select_input(n.window, true)?;
+                surface.update_bounding_shape(None)?;
+            }
             surface.update_properties()?;
             xwm.windows.push(surface.clone());
 
@@ -2293,6 +2303,25 @@ where
             } else {
                 // selection was denied
                 send_selection_notify_resp(&conn, &n, false)?;
+            }
+        }
+        Event::ShapeNotify(n) => {
+            if n.shape_kind == shape::SK::BOUNDING
+                && let Some(surface) = xwm
+                    .windows
+                    .iter()
+                    .find(|x| x.window_id() == n.affected_window)
+                    .cloned()
+            {
+                surface.update_bounding_shape(Some((
+                    n.shaped,
+                    Rectangle::new(
+                        (n.extents_x as i32, n.extents_y as i32).into(),
+                        (n.extents_width as i32, n.extents_height as i32).into(),
+                    ),
+                )))?;
+                drop(_guard);
+                state.shape_notify(xwm_id, surface);
             }
         }
         Event::PropertyNotify(n) => {

--- a/src/xwayland/xwm/surface.rs
+++ b/src/xwayland/xwm/surface.rs
@@ -52,6 +52,7 @@ use x11rb::{
     properties::{WmClass, WmHints, WmSizeHints},
     protocol::{
         res::{ClientIdSpec, query_client_ids},
+        shape::{self, ConnectionExt as _},
         sync::{Alarm, ConnectionExt as _, Counter, CreateAlarmAux, Int64, TESTTYPE, VALUETYPE},
         xproto::{
             Atom, AtomEnum, ClientMessageEvent, ConfigureWindowAux, ConnectionExt as _, EventMask,
@@ -64,6 +65,9 @@ use x11rb::{
 };
 
 use super::{X11Wm, XwmId, send_configure_notify};
+
+const MAX_RENDER_SHAPE_RECTS: usize = 256;
+const MAX_STORED_SHAPE_RECTS: usize = 4096;
 
 /// X11 window managed by an [`X11Wm`](super::X11Wm)
 #[derive(Debug, Clone)]
@@ -169,6 +173,9 @@ pub(crate) struct SharedSurfaceState {
     pub(crate) opacity: Option<u32>,
     opaque_region: Option<RegionAttributes>,
     opaque_region_dirty: bool,
+    depth: Option<u8>,
+    bounding_shape: Option<Arc<[Rectangle<i32, Logical>]>>,
+    bounding_shape_extents: Option<Rectangle<i32, Logical>>,
     frame_extents: FrameExtents<i32, Physical>,
     pending_enter: Option<(
         Box<dyn std::any::Any + Send + 'static>,
@@ -377,6 +384,9 @@ impl X11Surface {
                 opacity: None,
                 opaque_region: None,
                 opaque_region_dirty: true,
+                depth: None,
+                bounding_shape: None,
+                bounding_shape_extents: None,
                 frame_extents: Default::default(),
                 pending_enter: None,
                 pending_ping_timestamp: None,
@@ -395,6 +405,91 @@ impl X11Surface {
     /// X11 protocol id of the underlying window
     pub fn window_id(&self) -> X11Window {
         self.window
+    }
+
+    pub(crate) fn set_depth(&self, depth: u8) {
+        self.state.lock().unwrap().depth = Some(depth);
+    }
+
+    /// Returns the X Shape bounding rectangles, if the window is shaped.
+    pub fn bounding_shape(&self) -> Option<Arc<[Rectangle<i32, Logical>]>> {
+        self.state.lock().unwrap().bounding_shape.clone()
+    }
+
+    /// Returns the X Shape bounding rectangles when they are needed to clip
+    /// a window without an alpha channel.
+    pub fn render_shape(&self) -> Option<Arc<[Rectangle<i32, Logical>]>> {
+        let state = self.state.lock().unwrap();
+        if state.depth == Some(32) {
+            return None;
+        }
+        let shape = state.bounding_shape.clone()?;
+        if shape.len() > MAX_RENDER_SHAPE_RECTS {
+            return state.bounding_shape_extents.map(|extents| Arc::from([extents]));
+        }
+        Some(shape)
+    }
+
+    pub(crate) fn update_bounding_shape(
+        &self,
+        notify: Option<(bool, Rectangle<i32, Physical>)>,
+    ) -> Result<(), ReplyError> {
+        let Some(conn) = self.conn.upgrade() else {
+            return Ok(());
+        };
+        let client_scale = self
+            .client_scale
+            .as_ref()
+            .map(|scale| scale.load(Ordering::Acquire))
+            .unwrap_or(1.);
+        let (shaped, extents) = if let Some((shaped, extents)) = notify {
+            (shaped, extents.to_f64().to_logical(client_scale).to_i32_round())
+        } else {
+            let reply = conn.shape_query_extents(self.window)?.reply()?;
+            let extents = Rectangle::<i32, Physical>::new(
+                (
+                    reply.bounding_shape_extents_x as i32,
+                    reply.bounding_shape_extents_y as i32,
+                )
+                    .into(),
+                (
+                    reply.bounding_shape_extents_width as i32,
+                    reply.bounding_shape_extents_height as i32,
+                )
+                    .into(),
+            )
+            .to_f64()
+            .to_logical(client_scale)
+            .to_i32_round();
+            (reply.bounding_shaped, extents)
+        };
+        let shape = if shaped {
+            let rectangles = conn
+                .shape_get_rectangles(self.window, shape::SK::BOUNDING)?
+                .reply()?;
+            let mut rectangles = rectangles
+                .rectangles
+                .into_iter()
+                .filter_map(|rect| {
+                    let rect = Rectangle::<i32, Physical>::new(
+                        (rect.x as i32, rect.y as i32).into(),
+                        (rect.width as i32, rect.height as i32).into(),
+                    );
+                    (!rect.is_empty()).then(|| rect.to_f64().to_logical(client_scale).to_i32_round())
+                })
+                .collect::<Vec<_>>();
+            if rectangles.len() > MAX_STORED_SHAPE_RECTS {
+                rectangles.clear();
+                rectangles.push(extents);
+            }
+            Some(rectangles.into())
+        } else {
+            None
+        };
+        let mut state = self.state.lock().unwrap();
+        state.bounding_shape = shape;
+        state.bounding_shape_extents = shaped.then_some(extents);
+        Ok(())
     }
 
     /// X11 protocol id of the reparented window, if any
@@ -2057,10 +2152,18 @@ impl X11Surface {
         location: impl Into<Point<i32, Logical>>,
         surface_type: WindowSurfaceType,
     ) -> Option<(WlSurface, Point<i32, Logical>)> {
+        let location = location.into();
         if !surface_type.contains(WindowSurfaceType::TOPLEVEL) {
             return None;
         }
         if self.xdnd_active.load(Ordering::Acquire) && self.is_override_redirect() {
+            return None;
+        }
+        if let Some(shape) = self.bounding_shape()
+            && !shape
+                .iter()
+                .any(|rect| rect.to_f64().contains(point - location.to_f64()))
+        {
             return None;
         }
         if let Some(surface) = X11Surface::wl_surface(self).as_ref() {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there issues / other PRs related to this one? -->

Adds support for the X11 Shape extension's bounding region on Xwayland windows, cropping non-alpha toplevels to their boundary rectangles at render time and excluding points outside the shape from hit-testing. Tracks shape updates via ShapeNotify, caps rectangle counts to keep element lists manageable, and exposes a shape_notify hook for compositors.

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
