### PR TITLE
Fixing spelling error in GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -13,7 +13,7 @@ which talks about the protocol.
 
 Additionally it can help to familiarize yourself with the viewpoint of clients. The [wayland-book](https://wayland-book.com/) is a good resource here.
 
-There is also an (unfurtonately stalled - at the time of writing this document -) effort to write a [smithay book](https://smithay.github.io/book/) to
+There is also an (unfortunately stalled - at the time of writing this document -) effort to write a [smithay book](https://smithay.github.io/book/) to
 cover similar topics, but focused on [wayland-rs](https://github.com/Smithay/wayland-rs) (the underlying Rust-based Wayland implementation) rather than
 [libwayland](https://gitlab.freedesktop.org/wayland/wayland/). At least the client side of this is a worthwhile read as well.
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change -->

The word "unfortunately" was misspelled in the GETTING_STARTED.md document.

<!-- Any details that you think are important to review this PR? -->
No

<!-- Are there issues / other PRs related to this one? -->
No

<!-- If your work contains any usage of generative AI, please read our Policy (https://github.com/Smithay/smithay/blob/master/AI.md) and consider alternatives before submitting this PR. -->
I did not use an LLM to make this tiny fix.

## Checklist
<!-- You need to set this checkbox, for your PR to be considered. -->
* [ x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
