### PR TITLE
desktop: don't send frame callbacks to unmapped surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,9 @@ source device, so those devices accumulate cached imports that previously were n
 Cleanup is now also attempted on every device even if it fails on one of them, with every failure
 logged and the first error returned.
 
+`send_frames_surface_tree` (and `Window::send_frame`, `LayerSurface::send_frame`) no longer sends frame
+callbacks to surfaces whose renderer state has no buffer, or to their subsurfaces.
+
 ## 0.7.0
 
 ### Breaking changes

--- a/src/desktop/wayland/utils.rs
+++ b/src/desktop/wayland/utils.rs
@@ -215,6 +215,9 @@ where
 /// throttle threshold. If the threshold is `None` this will never send frame callbacks
 /// for a surface that is not visible. Specifying [`Duration::ZERO`] as the throttle threshold
 /// will always send frame callbacks for non visible surfaces.
+///
+/// Surfaces the renderer knows to have no buffer, and their subsurfaces, never receive frame
+/// callbacks, the same way they are not rendered.
 pub fn send_frames_surface_tree<T, F>(
     surface: &wl_surface::WlSurface,
     output: &Output,
@@ -230,8 +233,19 @@ pub fn send_frames_surface_tree<T, F>(
     with_surface_tree_downward(
         surface,
         (),
-        |_, _, &()| TraversalAction::DoChildren(()),
+        |_, states, &()| {
+            if surface_is_unmapped(states) {
+                TraversalAction::SkipChildren
+            } else {
+                TraversalAction::DoChildren(())
+            }
+        },
         |surface, states, &()| {
+            // the processor still runs for a surface whose children were skipped
+            if surface_is_unmapped(states) {
+                return;
+            }
+
             states
                 .data_map
                 .insert_if_missing_threadsafe(SurfaceFrameThrottlingState::default);
@@ -486,6 +500,15 @@ pub fn surface_presentation_feedback_flags_from_states(
     } else {
         wp_presentation_feedback::Kind::empty()
     }
+}
+
+/// Whether the renderer state shows no buffer to draw. Surfaces without renderer state are
+/// not considered unmapped, so compositors managing buffers themselves keep receiving callbacks.
+fn surface_is_unmapped(states: &SurfaceData) -> bool {
+    states
+        .data_map
+        .get::<RendererSurfaceStateUserData>()
+        .is_some_and(|d| d.lock().unwrap().surface_view.is_none())
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
## Description
`send_frames_surface_tree` sends frame callbacks to surfaces without a buffer, which the renderer never draws. Firefox with `gfx.webrender.compositor.force-enabled=true` takes such a callback as proof its layer-root subsurface is presented, never attaches a buffer to it, and shows a black window.

This skips surfaces whose renderer state has no view, together with their children. Surfaces without renderer state keep the old behaviour, and mapped but hidden surfaces still get the throttled fallback (unlike #2138).

AI assistance is disclosed in the commit message, per the [AI policy](https://github.com/Smithay/smithay/blob/master/AI.md).

## Checklist
* [x] I agree to smithay's [Developer Certificate of Origin](https://github.com/Smithay/smithay/blob/master/DCO.md).
